### PR TITLE
더블클릭 단어 선택 경계 문자 개선 (#71)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -265,7 +265,7 @@ const App = struct {
     TERMINAL_PADDING: c_int = 6,
 
     // Word boundary characters for double-click selection
-    const word_boundaries = [_]u21{ ' ', '\t', '"', '\'', '`', '|', ':', ';', ',', '.', '(', ')', '[', ']', '{', '}', '<', '>' };
+    const word_boundaries = [_]u21{ ' ', '\t', '"', '`', '|', ':', ';', '(', ')', '[', ']', '{', '}', '<', '>' };
 
     fn createTab(self: *App) !void {
         const grid = self.getTerminalGridSize();


### PR DESCRIPTION
## Summary

- `word_boundaries`에서 `,` `.` `'` 제거
- 문장 부호와 어퍼스트로피에서 단어 선택이 끊기지 않도록 개선
- `I'm`, `don't` 등 영어 축약형, `e.g.` 같은 약어 통째로 선택 가능

Closes #71