### PR TITLE
#139: family ZWJ emoji — GetGlyphPlacements advance/offset 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ zig-cache/
 .claude/
 build.zig.tmp.*
 
+# Local analysis worktree (Windows Terminal source mirror for #136/#137 — 임시)
+.wt-src/
+
 # vendored ConPTY runtime (MS MIT) — shipped alongside tildaz.exe
 !vendor/conpty/OpenConsole.exe
 !vendor/conpty/conpty.dll

--- a/src/d3d11_renderer.zig
+++ b/src/d3d11_renderer.zig
@@ -5,7 +5,8 @@ const std = @import("std");
 const ghostty = @import("ghostty-vt");
 const d3d = @import("d3d11.zig");
 const dw = @import("directwrite.zig");
-const DWriteFontContext = @import("dwrite_font.zig").DWriteFontContext;
+const dwrite_font = @import("dwrite_font.zig");
+const DWriteFontContext = dwrite_font.DWriteFontContext;
 const ui_metrics = @import("ui_metrics.zig");
 const GlyphAtlas = @import("glyph_atlas.zig").GlyphAtlas;
 const ATLAS_SIZE = @import("glyph_atlas.zig").ATLAS_SIZE;
@@ -986,11 +987,12 @@ pub const D3d11Renderer = struct {
                     text_count = 0;
                 }
 
-                // Resolve glyph. grapheme cluster (VS-16 / skin tone modifier
-                // / ZWJ 시퀀스) 면 IDWriteTextAnalyzer.GetGlyphs 로 cluster 통째
-                // shape — 단일 (컬러 emoji) 글리프로 reduce. 일반 cell 은 빠른
-                // single-codepoint path 그대로. macOS resolveGrapheme 와 동등 패턴.
-                const result = blk: {
+                // Resolve glyph cluster. grapheme cluster (VS-16 / skin tone /
+                // ZWJ 시퀀스) 면 IDWriteTextAnalyzer.GetGlyphs 로 cluster 통째
+                // shape — single glyph (GSUB 합성 OK) 또는 multi-glyph (#139
+                // ZWJ family 등 합성 안 되는 cluster). 일반 cell 은 빠른 single-
+                // codepoint path. macOS resolveGrapheme 와 동등 패턴.
+                const result: dwrite_font.ClusterResult = blk: {
                     if (raw.hasGrapheme() and x < graphemes.len) {
                         var cluster: [16]u21 = undefined;
                         cluster[0] = cp;
@@ -999,9 +1001,14 @@ pub const D3d11Renderer = struct {
                         @memcpy(cluster[1..][0..take], extras[0..take]);
                         if (self.font.resolveGrapheme(cluster[0 .. 1 + take])) |r| break :blk r;
                     }
-                    break :blk self.font.resolveGlyph(cp) orelse continue;
+                    const single = self.font.resolveGlyph(cp) orelse continue;
+                    var indices = [_]u16{0} ** dwrite_font.MAX_CLUSTER_GLYPHS;
+                    indices[0] = single.index;
+                    const advances = [_]dw.FLOAT{0} ** dwrite_font.MAX_CLUSTER_GLYPHS;
+                    const offsets = [_]dw.DWRITE_GLYPH_OFFSET{.{ .advanceOffset = 0, .ascenderOffset = 0 }} ** dwrite_font.MAX_CLUSTER_GLYPHS;
+                    break :blk .{ .face = single.face, .indices = indices, .advances = advances, .offsets = offsets, .count = 1, .owned = single.owned };
                 };
-                var entry_opt = self.atlas.getOrInsert(result.face, result.index);
+                var entry_opt = self.atlas.getOrInsertCluster(result.face, result.indices[0..result.count], result.advances[0..result.count], result.offsets[0..result.count]);
 
                 // Atlas full: flush pending draws BEFORE reset so queued UV coords stay valid,
                 // then reset and retry once.
@@ -1015,7 +1022,7 @@ pub const D3d11Renderer = struct {
                         block_count = 0;
                     }
                     self.atlas.reset();
-                    entry_opt = self.atlas.getOrInsert(result.face, result.index);
+                    entry_opt = self.atlas.getOrInsertCluster(result.face, result.indices[0..result.count], result.advances[0..result.count], result.offsets[0..result.count]);
                 }
 
                 const entry = entry_opt orelse {

--- a/src/directwrite.zig
+++ b/src/directwrite.zig
@@ -271,7 +271,6 @@ pub const IDWriteTextAnalyzer = extern struct {
         QueryInterface: *const fn (*IDWriteTextAnalyzer, *const GUID, *?*anyopaque) callconv(.c) HRESULT,
         AddRef: *const fn (*IDWriteTextAnalyzer) callconv(.c) u32,
         Release: *const fn (*IDWriteTextAnalyzer) callconv(.c) u32,
-        // 4 analyze methods (we don't use them — opaque)
         AnalyzeScript: *const anyopaque,
         AnalyzeBidi: *const anyopaque,
         AnalyzeNumberSubstitution: *const anyopaque,
@@ -297,12 +296,56 @@ pub const IDWriteTextAnalyzer = extern struct {
             glyph_props: [*]DWRITE_SHAPING_GLYPH_PROPERTIES,
             actual_glyph_count: *UINT32,
         ) callconv(.c) HRESULT,
-        GetGlyphPlacements: *const anyopaque,
+        GetGlyphPlacements: *const fn (
+            *IDWriteTextAnalyzer,
+            text_string: [*]const WCHAR,
+            cluster_map: [*]const UINT16,
+            text_props: [*]DWRITE_SHAPING_TEXT_PROPERTIES,
+            text_length: UINT32,
+            glyph_indices: [*]const UINT16,
+            glyph_props: [*]const DWRITE_SHAPING_GLYPH_PROPERTIES,
+            glyph_count: UINT32,
+            font_face: *IDWriteFontFace,
+            font_em_size: FLOAT,
+            is_sideways: BOOL,
+            is_right_to_left: BOOL,
+            script_analysis: *const DWRITE_SCRIPT_ANALYSIS,
+            locale_name: ?[*:0]const WCHAR,
+            features: ?[*]const ?*const anyopaque,
+            feature_range_lengths: ?[*]const UINT32,
+            feature_ranges: UINT32,
+            glyph_advances: [*]FLOAT,
+            glyph_offsets: [*]DWRITE_GLYPH_OFFSET,
+        ) callconv(.c) HRESULT,
         GetGdiCompatibleGlyphPlacements: *const anyopaque,
     };
 
     pub fn Release(self: *IDWriteTextAnalyzer) u32 {
         return self.vtable.Release(self);
+    }
+
+    pub fn GetGlyphPlacements(
+        self: *IDWriteTextAnalyzer,
+        text_string: [*]const WCHAR,
+        cluster_map: [*]const UINT16,
+        text_props: [*]DWRITE_SHAPING_TEXT_PROPERTIES,
+        text_length: UINT32,
+        glyph_indices: [*]const UINT16,
+        glyph_props: [*]const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyph_count: UINT32,
+        font_face: *IDWriteFontFace,
+        font_em_size: FLOAT,
+        is_sideways: BOOL,
+        is_right_to_left: BOOL,
+        script_analysis: *const DWRITE_SCRIPT_ANALYSIS,
+        locale_name: ?[*:0]const WCHAR,
+        features: ?[*]const ?*const anyopaque,
+        feature_range_lengths: ?[*]const UINT32,
+        feature_ranges: UINT32,
+        glyph_advances: [*]FLOAT,
+        glyph_offsets: [*]DWRITE_GLYPH_OFFSET,
+    ) HRESULT {
+        return self.vtable.GetGlyphPlacements(self, text_string, cluster_map, text_props, text_length, glyph_indices, glyph_props, glyph_count, font_face, font_em_size, is_sideways, is_right_to_left, script_analysis, locale_name, features, feature_range_lengths, feature_ranges, glyph_advances, glyph_offsets);
     }
 
     pub fn GetGlyphs(

--- a/src/dwrite_font.zig
+++ b/src/dwrite_font.zig
@@ -17,6 +17,20 @@ pub const GlyphResult = struct {
     owned: bool, // true = caller must Release face
 };
 
+/// ZWJ family / VS-16 / skin tone modifier cluster 의 multi-glyph 결과 (#139).
+/// Segoe UI Emoji 가 family ZWJ chain 을 single glyph 로 GSUB 합성 못 하면
+/// `count > 1` 의 multi-glyph cluster 반환. atlas 가 multi-glyph DrawGlyphRun
+/// 으로 한 번에 그려서 single composite glyph 로 cache.
+pub const MAX_CLUSTER_GLYPHS: usize = 16;
+pub const ClusterResult = struct {
+    face: *dw.IDWriteFontFace,
+    indices: [MAX_CLUSTER_GLYPHS]dw.UINT16,
+    advances: [MAX_CLUSTER_GLYPHS]dw.FLOAT,
+    offsets: [MAX_CLUSTER_GLYPHS]dw.DWRITE_GLYPH_OFFSET,
+    count: u8,
+    owned: bool,
+};
+
 const CachedGlyph = struct {
     face: *dw.IDWriteFontFace,
     index: u16,
@@ -288,7 +302,7 @@ pub const DWriteFontContext = struct {
     /// `cps[0]` 은 base codepoint, `cps[1..]` 은 modifier (VS-16 / skin tone /
     /// ZWJ + secondary base 등). chain 순회 → system fallback 순. 첫 face 가
     /// non-zero glyph 를 만들면 그걸 반환.
-    pub fn resolveGrapheme(self: *DWriteFontContext, cps: []const u21) ?GlyphResult {
+    pub fn resolveGrapheme(self: *DWriteFontContext, cps: []const u21) ?ClusterResult {
         if (cps.len == 0 or self.text_analyzer == null) return null;
 
         // UTF-21 codepoint slice → UTF-16 buffer (surrogate pair 처리).
@@ -308,11 +322,16 @@ pub const DWriteFontContext = struct {
         }
         if (u16_len == 0) return null;
 
+        var indices_buf: [MAX_CLUSTER_GLYPHS]u16 = undefined;
+        var advances_buf: [MAX_CLUSTER_GLYPHS]dw.FLOAT = undefined;
+        var offsets_buf: [MAX_CLUSTER_GLYPHS]dw.DWRITE_GLYPH_OFFSET = undefined;
+
         // 1. user chain 순회 — face 별로 cluster shape 시도.
         for (self.chain_faces[0..self.chain_count]) |maybe_face| {
             const face = maybe_face orelse continue;
-            if (self.shapeOnFace(face, &u16_buf, u16_len)) |idx| {
-                return .{ .face = face, .index = idx, .owned = false };
+            const cnt = self.shapeOnFaceMulti(face, &u16_buf, u16_len, &indices_buf, &advances_buf, &offsets_buf);
+            if (cnt > 0) {
+                return .{ .face = face, .indices = indices_buf, .advances = advances_buf, .offsets = offsets_buf, .count = cnt, .owned = false };
             }
         }
 
@@ -341,14 +360,9 @@ pub const DWriteFontContext = struct {
                     var face_ptr: ?*dw.IDWriteFontFace = null;
                     if (mf.CreateFontFace(&face_ptr) >= 0) {
                         if (face_ptr) |face| {
-                            if (self.shapeOnFace(face, &u16_buf, u16_len)) |idx| {
-                                // owned=true — 호출처가 face 사용 후 Release.
-                                // (resolveGlyph 의 single-codepoint cache 패턴과
-                                // 다름 — cluster 를 cache key 로 쓰려면 hash 필요해
-                                // 일단 매번 새 face. 자주 호출되는 cluster 는 atlas
-                                // cache key 가 face 포인터라 cache miss 가능. 향후
-                                // 최적화 후보.)
-                                return .{ .face = face, .index = idx, .owned = true };
+                            const cnt = self.shapeOnFaceMulti(face, &u16_buf, u16_len, &indices_buf, &advances_buf, &offsets_buf);
+                            if (cnt > 0) {
+                                return .{ .face = face, .indices = indices_buf, .advances = advances_buf, .offsets = offsets_buf, .count = cnt, .owned = true };
                             }
                             _ = face.vtable.Release(face);
                         }
@@ -360,19 +374,24 @@ pub const DWriteFontContext = struct {
         return null;
     }
 
-    /// `face` 로 cluster 를 OpenType shape — non-zero (`.notdef` 아님) 첫 glyph
-    /// 반환. cluster 가 .notdef 또는 빈 결과면 null (다음 face / system fallback
-    /// 으로 넘어가도록).
-    fn shapeOnFace(self: *DWriteFontContext, face: *dw.IDWriteFontFace, text: [*]const WCHAR, text_len: dw.UINT32) ?u16 {
-        const analyzer = self.text_analyzer orelse return null;
+    /// `face` 로 cluster 를 OpenType shape — single glyph (가장 흔한 path) 또는
+    /// multi-glyph cluster (#139, ZWJ family 등 GSUB 미합성). 결과는 indices array
+    /// + count. .notdef 만 반환되면 null (다음 face / fallback).
+    /// out_indices 는 `[MAX_CLUSTER_GLYPHS]u16`. 리턴 = count (0 = fail).
+    fn shapeOnFaceMulti(self: *DWriteFontContext, face: *dw.IDWriteFontFace, text: [*]const WCHAR, text_len: dw.UINT32, out_indices: *[MAX_CLUSTER_GLYPHS]u16, out_advances: *[MAX_CLUSTER_GLYPHS]dw.FLOAT, out_offsets: *[MAX_CLUSTER_GLYPHS]dw.DWRITE_GLYPH_OFFSET) u8 {
+        const analyzer = self.text_analyzer orelse return 0;
 
         var cluster_map: [32]u16 = undefined;
         var text_props: [32]dw.DWRITE_SHAPING_TEXT_PROPERTIES = undefined;
         var glyph_indices: [64]u16 = undefined;
         var glyph_props: [64]dw.DWRITE_SHAPING_GLYPH_PROPERTIES = undefined;
+        var glyph_advances: [64]dw.FLOAT = undefined;
+        var glyph_offsets: [64]dw.DWRITE_GLYPH_OFFSET = undefined;
         var actual_count: dw.UINT32 = 0;
 
         const sa = dw.DWRITE_SCRIPT_ANALYSIS{ .script = 0, .shapes = 0 };
+        const locale_name = std.unicode.utf8ToUtf16LeStringLiteral("en-us");
+
         const hr = analyzer.GetGlyphs(
             text,
             text_len,
@@ -380,11 +399,11 @@ pub const DWriteFontContext = struct {
             0, // is_sideways
             0, // is_right_to_left
             &sa,
-            null, // locale_name
+            locale_name,
             null, // number_substitution
             null, // features
-            null, // feature_range_lengths
-            0, // feature_ranges
+            null,
+            0,
             glyph_indices.len,
             &cluster_map,
             &text_props,
@@ -392,9 +411,58 @@ pub const DWriteFontContext = struct {
             &glyph_props,
             &actual_count,
         );
-        if (hr < 0 or actual_count == 0) return null;
-        if (glyph_indices[0] == 0) return null; // .notdef
-        return glyph_indices[0];
+        if (hr < 0 or actual_count == 0) return 0;
+        // cluster 내 어떤 glyph 가 .notdef 면 face 가 cluster 의 모든 codepoint
+        // 를 글리프로 갖지 않음 — fallback (다음 face 또는 system fallback) 으로.
+        // 예: Cascadia 가 ZWJ family 받으면 emoji codepoint 가 .notdef → reject,
+        // Segoe UI Emoji fallback 으로 cluster 합성 시도.
+        const out_count: u8 = @intCast(@min(actual_count, MAX_CLUSTER_GLYPHS));
+        var i: u8 = 0;
+        while (i < out_count) : (i += 1) {
+            if (glyph_indices[i] == 0) return 0; // any .notdef → fail
+            out_indices[i] = glyph_indices[i];
+        }
+
+        // GetGlyphPlacements 로 advances + offsets 계산 (#139). emoji ZWJ family
+        // 는 GSUB 가 single glyph 로 ligation 안 되고 multi-glyph + 각자의
+        // advance/offset 으로 visual 결합되도록 design 되어 있음 (예: Segoe UI
+        // Emoji 의 family-mwg 는 man[adv=11.2 off=+3.4] + woman[adv=9.3] +
+        // girl[adv=0 off=-13.3] 로 left-pulled stack 으로 결합). advances=0 stack
+        // 으로 그리면 girl 만 위에 보이고 family 깨짐. WT 동등 path.
+        if (analyzer.GetGlyphPlacements(
+            text,
+            &cluster_map,
+            &text_props,
+            text_len,
+            &glyph_indices,
+            &glyph_props,
+            actual_count,
+            face,
+            self.font_em_size,
+            0, // is_sideways
+            0, // is_right_to_left
+            &sa,
+            locale_name,
+            null,
+            null,
+            0,
+            &glyph_advances,
+            &glyph_offsets,
+        ) >= 0) {
+            i = 0;
+            while (i < out_count) : (i += 1) {
+                out_advances[i] = glyph_advances[i];
+                out_offsets[i] = glyph_offsets[i];
+            }
+        } else {
+            i = 0;
+            while (i < out_count) : (i += 1) {
+                out_advances[i] = 0;
+                out_offsets[i] = .{ .advanceOffset = 0, .ascenderOffset = 0 };
+            }
+        }
+
+        return out_count;
     }
 
     /// Check if a font family is installed on the system via DirectWrite.

--- a/src/glyph_atlas.zig
+++ b/src/glyph_atlas.zig
@@ -38,9 +38,28 @@ const GlyphKey = struct {
     index: u16,
 };
 
+/// Multi-glyph cluster (#139) cache key — glyph_indices hash 만. face_ptr 은
+/// system fallback (MapCharacters + CreateFontFace) 마다 새 instance 라 매번
+/// 다름 → key 에 넣으면 항상 cache miss. 같은 cluster 의 glyph indices 가 같은
+/// 시퀀스면 같은 visual 이라 face 무관하게 cache 가능. (collision 위험은 FNV-1a
+/// + multi-glyph hash 로 사실상 무시 가능.)
+const ClusterKey = struct {
+    indices_hash: u64,
+};
+
+fn hashIndices(indices: []const u16) u64 {
+    var h: u64 = 0xcbf29ce484222325; // FNV-1a 64-bit offset basis
+    for (indices) |idx| {
+        h ^= @as(u64, idx);
+        h *%= 0x100000001b3;
+    }
+    return h;
+}
+
 pub const GlyphAtlas = struct {
     alloc: std.mem.Allocator,
     cache: std.AutoHashMap(GlyphKey, AtlasEntry),
+    cluster_cache: std.AutoHashMap(ClusterKey, AtlasEntry),
 
     // Atlas packing state (simple row-based)
     cursor_x: u32 = 0,
@@ -243,6 +262,7 @@ pub const GlyphAtlas = struct {
         return .{
             .alloc = alloc,
             .cache = std.AutoHashMap(GlyphKey, AtlasEntry).init(alloc),
+            .cluster_cache = std.AutoHashMap(ClusterKey, AtlasEntry).init(alloc),
             .dw_factory = dw_factory,
             .rendering_params = rp.?,
             .rendering_mode = sys_rendering_mode,
@@ -275,6 +295,7 @@ pub const GlyphAtlas = struct {
         self.alloc.free(self.ct_buf);
         self.alloc.free(self.temp_buf);
         self.cache.deinit();
+        self.cluster_cache.deinit();
         _ = self.srv.Release();
         _ = self.texture.Release();
         _ = self.rendering_params.Release();
@@ -291,15 +312,37 @@ pub const GlyphAtlas = struct {
         const key = GlyphKey{ .face = @intFromPtr(face), .index = glyph_index };
         if (self.cache.get(key)) |entry| return entry;
 
-        const entry = self.rasterizeColor(face, glyph_index) orelse
+        const single_indices = [_]u16{glyph_index};
+        const empty_advances = [_]dw.FLOAT{};
+        const empty_offsets = [_]dw.DWRITE_GLYPH_OFFSET{};
+        const entry = self.rasterizeColor(face, &single_indices, &empty_advances, &empty_offsets) orelse
             self.rasterize(face, glyph_index) orelse return null;
         self.cache.put(key, entry) catch return null;
+        return entry;
+    }
+
+    /// Multi-glyph cluster (#139, ZWJ family 등) atlas entry. GSUB 합성 안 된
+    /// cluster 의 모든 glyph 를 한 번에 D2D `DrawGlyphRun(glyphCount=N)` 으로
+    /// 라스터, single composite atlas entry 로 cache. count=1 이면 single
+    /// getOrInsert 로 redirect.
+    pub fn getOrInsertCluster(self: *GlyphAtlas, face: *dw.IDWriteFontFace, glyph_indices: []const u16, advances: []const dw.FLOAT, offsets: []const dw.DWRITE_GLYPH_OFFSET) ?AtlasEntry {
+        if (glyph_indices.len == 0) return null;
+        if (glyph_indices.len == 1) return self.getOrInsert(face, glyph_indices[0]);
+
+        const key = ClusterKey{ .indices_hash = hashIndices(glyph_indices) };
+        if (self.cluster_cache.get(key)) |entry| return entry;
+
+        // Color path 만 multi-glyph 지원 — mono ClearType 의 cluster 는 의미 작음
+        // (글자 cluster 는 single glyph 가 일반).
+        const entry = self.rasterizeColor(face, glyph_indices, advances, offsets) orelse return null;
+        self.cluster_cache.put(key, entry) catch return null;
         return entry;
     }
 
     /// Reset the atlas (clear cache and packing state). Call only after flushing all pending draws.
     pub fn reset(self: *GlyphAtlas) void {
         self.cache.clearRetainingCapacity();
+        self.cluster_cache.clearRetainingCapacity();
         self.cursor_x = 0;
         self.cursor_y = 0;
         self.row_height = 0;
@@ -441,7 +484,7 @@ pub const GlyphAtlas = struct {
     /// is_color=true 인 AtlasEntry 반환. 컬러 글리프 아닌 경우
     /// (`DWRITE_E_NOCOLOR`) 또는 D2D path 실패 시 null → caller 가 일반
     /// `rasterize` (mono ClearType) 로 fall-through.
-    fn rasterizeColor(self: *GlyphAtlas, face: *dw.IDWriteFontFace, glyph_index: u16) ?AtlasEntry {
+    fn rasterizeColor(self: *GlyphAtlas, face: *dw.IDWriteFontFace, glyph_indices: []const u16, in_advances: []const dw.FLOAT, in_offsets: []const dw.DWRITE_GLYPH_OFFSET) ?AtlasEntry {
         // atlas RT + DC + DC4 + brush + Factory4 모두 있어야 컬러 path 가능.
         // Win 10 1607+ 라 모두 사용 가능.
         const atlas_rt = self.atlas_d2d_rt orelse return null;
@@ -449,16 +492,30 @@ pub const GlyphAtlas = struct {
         const atlas_dc4 = self.atlas_dc4 orelse return null;
         const brush = self.atlas_brush orelse return null;
         const factory4 = self.dw_factory4 orelse return null;
+        if (glyph_indices.len == 0 or glyph_indices.len > 16) return null;
 
-        const indices = [1]dw.UINT16{glyph_index};
-        const advances = [1]dw.FLOAT{0};
+        // multi-glyph cluster (#139) — ZWJ family 등 GSUB 가 합성 못 한 cluster 의
+        // 모든 glyph 를 한 번에 D2D 에 전달. GetGlyphPlacements 로 받은 정확한
+        // advances + offsets 을 사용해 emoji 가 visual family 로 결합되게 함.
+        // single-glyph path 는 advances=0, offsets=null 으로 simple.
+        var indices_buf: [16]dw.UINT16 = undefined;
+        var advances_buf: [16]dw.FLOAT = undefined;
+        var offsets_buf: [16]dw.DWRITE_GLYPH_OFFSET = undefined;
+        const has_placements = in_advances.len == glyph_indices.len and in_offsets.len == glyph_indices.len;
+        for (glyph_indices, 0..) |gi, i| {
+            indices_buf[i] = gi;
+            advances_buf[i] = if (has_placements) in_advances[i] else 0;
+            offsets_buf[i] = if (has_placements) in_offsets[i] else .{ .advanceOffset = 0, .ascenderOffset = 0 };
+        }
+        const glyph_count: dw.UINT32 = @intCast(glyph_indices.len);
+        const offsets_ptr: ?[*]const dw.DWRITE_GLYPH_OFFSET = if (has_placements) &offsets_buf else null;
         const glyph_run = dw.DWRITE_GLYPH_RUN{
             .fontFace = face,
             .fontEmSize = self.font_em_size,
-            .glyphCount = 1,
-            .glyphIndices = &indices,
-            .glyphAdvances = &advances,
-            .glyphOffsets = null,
+            .glyphCount = glyph_count,
+            .glyphIndices = &indices_buf,
+            .glyphAdvances = &advances_buf,
+            .glyphOffsets = offsets_ptr,
             .isSideways = 0,
             .bidiLevel = 0,
         };


### PR DESCRIPTION
## Summary

- `👨‍👩‍👧` 같은 family ZWJ emoji 가 1 명만 표시되던 문제 fix.
- Segoe UI Emoji 의 family ZWJ 는 **single ligature 가 아닌 multi-glyph +
  정확한 advance/offset** 으로 visual 결합되도록 design 됨. WT 와 동등하게
  `IDWriteTextAnalyzer.GetGlyphPlacements` 호출해서 advances+offsets 받고
  `DWRITE_GLYPH_RUN` 에 그대로 전달.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/directwrite.zig` | `GetGlyphPlacements` 타입드 binding 추가 |
| `src/dwrite_font.zig` | `ClusterResult` 에 advances/offsets 필드, `shapeOnFaceMulti` 가 GetGlyphPlacements 호출 |
| `src/glyph_atlas.zig` | `cluster_cache` key 에서 face_ptr 제거 (face instance 가 매번 달라서 cache miss 되던 것 fix), `rasterizeColor` 가 multi-glyph + advances/offsets 받음 |
| `src/d3d11_renderer.zig` | `getOrInsertCluster` 호출 (single-glyph path 도 동일 API 로 통합) |

## 진단 데이터

`👨‍👩‍👧` (8 wchar) 를 paste 하면 Segoe UI Emoji 가 3 glyph 반환:

| glyph | index | advance | offset |
|---|---|---|---|
| man   | 1283 | 11.2 | (+3.4, 0) |
| woman | 1464 | 9.3  | (0, 0) |
| girl  | 1271 | 0.0  | (-13.3, 0) |

마지막 glyph 의 negative offset 으로 left-pulled stack 이 되어 visual family
형성. 우리는 advances=0 + offsets=null 로 그려서 girl 만 보였음.

## 시도해 본 실패 가설 (참고 — 모두 revert)

1. **Explicit OT features** (`ccmp`/`liga`/`rlig`/`rclt`/`calt`)을 GetGlyphs 에
   명시적으로 활성 → GSUB 결과 동일 (`actual=3 glyphs=[1283,1464,1271]`).
   default features 가 이미 적용됨.
2. **AnalyzeScript + SimpleTextAnalysisSink** 추가해서 정확한 script_analysis
   사용 → emoji 입력은 항상 `script=0 shapes=0` (Common script) 반환. 하드코딩
   동일.
3. **WT-aligned SimpleTextAnalysisSource** (`getTextBeforePosition` 정확히
   반환, `getNumberSubstitution` E_NOTIMPL): 결과 변화 없음.

이 정보는 추후 비슷한 디버깅 반복 안 하기 위해 commit message + PR 에 명시.

## WT source 비교

WT (`AtlasEngine._mapComplex` @ AtlasEngine.cpp:1032-1175) 도 동일하게:
1. `MapCharacters` → fallback face 찾기
2. `AnalyzeScript` → script 분석 (emoji 면 0)
3. `GetGlyphs` → glyph indices (3 glyph)
4. `GetGlyphPlacements` → advances + offsets ← **여기**
5. `DrawGlyphRun` 등 으로 정확한 advance/offset 으로 그리기

우리는 4 단계 가 빠져 있었음.

## Test plan

- [x] `👨‍👩‍👧` paste — visual family 정상 (사용자 확인)
- [x] 단순 emoji (skin tone, VS-16) — regression 없음
- [x] 한글/Latin — regression 없음 (single-codepoint path 변화 없음)

## 잔여 (별도 이슈)

- 다중 paste 시 visual 이상함 — 별도 이슈로 분리 예정 (cluster_cache 개선 후
  어느 정도 완화 기대 — face_ptr 마다 cache miss 하던 게 indices_hash 단일
  key 로 cache hit).

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
