### PR TITLE
#142: 탭 rename 중 paste — rename buffer 로 라우팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ zig-cache/
 .claude/
 build.zig.tmp.*
 
+# Local analysis worktree (Windows Terminal source mirror for #136/#137 — 임시)
+.wt-src/
+
 # vendored ConPTY runtime (MS MIT) — shipped alongside tildaz.exe
 !vendor/conpty/OpenConsole.exe
 !vendor/conpty/conpty.dll

--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -712,6 +712,27 @@ pub const App = struct {
                 if (self.isRenaming()) return true; // swallow rename editing keys
                 return false;
             },
+            .paste => |bytes| {
+                // rename 활성 시 paste 텍스트를 rename buffer 로 라우팅 (#142).
+                // printable codepoint 만 (cp >= 0x20) — newline / tab 등 control
+                // 문자는 탭 이름에 안 맞으므로 제외. host 가 false 일 땐 PTY 로 직접 write.
+                if (!self.isRenaming()) return false;
+                var i: usize = 0;
+                while (i < bytes.len) {
+                    const seq_len = std.unicode.utf8ByteSequenceLength(bytes[i]) catch {
+                        i += 1;
+                        continue;
+                    };
+                    if (i + seq_len > bytes.len) break;
+                    const cp = std.unicode.utf8Decode(bytes[i .. i + seq_len]) catch {
+                        i += seq_len;
+                        continue;
+                    };
+                    if (cp >= 0x20) self.handleRenameChar(cp);
+                    i += seq_len;
+                }
+                return true;
+            },
             .shortcut => |shortcut| {
                 switch (shortcut) {
                     .new_tab => {

--- a/src/app_event.zig
+++ b/src/app_event.zig
@@ -2,6 +2,10 @@ pub const Event = union(enum) {
     text_input: u21,
     key_input: KeyInput,
     shortcut: Shortcut,
+    /// 클립보드 paste (#142). UTF-8 bytes. 탭 rename 활성 시
+    /// `app_controller` 가 rename buffer 로 라우팅 (true 반환), 아니면 false
+    /// 반환해서 host 가 PTY 로 쓴다.
+    paste: []const u8,
     scroll: ScrollEvent,
     mouse_down: MouseEvent,
     mouse_double_click: MouseEvent,

--- a/src/macos_host.zig
+++ b/src/macos_host.zig
@@ -1370,6 +1370,16 @@ fn handlePaste() void {
     const get_utf8 = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) [*:0]const u8);
     const cstr = get_utf8(ns_text, objc.sel("UTF8String"));
 
+    // rename 진행 중이면 PTY 대신 rename buf 로 라우팅 (#142). printable
+    // codepoint 만 (cp >= 0x20) — newline / tab 등 control 문자 제외.
+    if (g_rename.isActive()) {
+        var iter = std.unicode.Utf8Iterator{ .bytes = cstr[0..len], .i = 0 };
+        while (iter.nextCodepoint()) |cp| {
+            if (cp >= 0x20) _ = g_rename.insertCodepoint(cp);
+        }
+        return;
+    }
+
     _ = tab.pty.write(cstr[0..len]) catch |err| {
         macos_log.appendLine("paste", "PTY write failed: {s}", .{@errorName(err)});
     };

--- a/src/window.zig
+++ b/src/window.zig
@@ -1478,15 +1478,19 @@ pub const Window = struct {
         }
         if (len == 0) return;
 
-        // Convert UTF-16 to UTF-8 and send to PTY
-        var buf: [4]u8 = undefined;
+        // UTF-16 → UTF-8. paste text 통째로 buffer 에 모아서 #142 의 paste event
+        // dispatch — rename 활성 시 app_controller 가 rename buffer 로 라우팅,
+        // 아니면 PTY 로 한 번에 write.
+        const alloc = std.heap.page_allocator;
+        var u8_buf = alloc.alloc(u8, len * 3 + 4) catch return; // BMP=3, 짝꿍=4
+        defer alloc.free(u8_buf);
+        var u8_len: usize = 0;
         var i: usize = 0;
         while (i < len) {
             const unit = wide_ptr[i];
             i += 1;
             var cp: u21 = undefined;
             if (unit >= 0xD800 and unit <= 0xDBFF) {
-                // Surrogate pair
                 if (i < len) {
                     const low = wide_ptr[i];
                     i += 1;
@@ -1495,9 +1499,14 @@ pub const Window = struct {
             } else {
                 cp = @intCast(unit);
             }
-            const n = std.unicode.utf8Encode(cp, &buf) catch continue;
-            write_fn(buf[0..n], self.userdata);
+            const n = std.unicode.utf8Encode(cp, u8_buf[u8_len..]) catch continue;
+            u8_len += n;
         }
+        if (u8_len == 0) return;
+
+        const utf8 = u8_buf[0..u8_len];
+        if (self.dispatchAppEvent(.{ .paste = utf8 })) return; // app handled (rename)
+        write_fn(utf8, self.userdata);
     }
 
     pub fn copyToClipboard(self: *Window, text: [:0]const u8) void {


### PR DESCRIPTION
## Summary

탭 rename 진행 중에 Ctrl+Shift+V / 우클릭 paste 가 PTY 로 새던 버그 fix.
rename 활성 시 paste 텍스트를 탭 이름 buffer 로 라우팅.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/app_event.zig` | `Event.paste: []const u8` 추가 |
| `src/app_controller.zig` | `.paste` handler — rename 시 UTF-8 decode + insertCodepoint per cp |
| `src/window.zig` | `pasteClipboard` 가 UTF-8 buffer 모은 뒤 `dispatchAppEvent(.paste)`. false 면 PTY write |
| `src/macos_host.zig` | `handlePaste` 가 `g_rename.isActive()` 시 insertCodepoint 라우팅 |

## 동작

| 상황 | 동작 |
|---|---|
| rename 비활성 + paste | 기존대로 PTY 로 write (regression 없음) |
| rename 활성 + paste | 탭 이름 buffer 에 codepoint insert (`cp >= 0x20` printable 만) |
| rename 활성 + 다중 line paste | 줄바꿈 (\\n) 무시 — 탭 이름은 단일 line |

## 디자인 노트

- Windows 는 기존 `dispatchAppEvent` 패턴에 맞춰 새 event variant 추가.
- macOS 는 app_event dispatch 패턴 없이 `g_rename` 글로벌 직접 접근 (기존 IME
  path 와 일관, line 720-725 가 같은 패턴).
- printable filter (`cp >= 0x20`) — 탭 이름은 단일 line 이므로 newline/tab 등
  control 문자는 무시. WM_CHAR text_input handler 의 `cp >= 0x20` filter 와
  동일 정책.
- paste 의 raw bytes 는 `app_event.Event.paste` 의 lifetime 동안 유효 (host 가
  dispatch 후 즉시 release 가능 — handler 가 동기적으로 모든 codepoint 처리).

## Test plan

- [x] Windows: 탭 rename → Ctrl+Shift+V → 탭 이름 입력됨 (사용자 확인)
- [x] Windows: rename 비활성 + paste → 터미널 입력 (regression 없음)
- [ ] macOS: 탭 rename → Cmd+V → 탭 이름 입력 (코드 변경만 — 별도 macOS 환경 테스트 필요)
- [ ] macOS: rename 비활성 + 우클릭 paste → 터미널 입력

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
