### PR TITLE
refactor(macos): CAMetalLayer 색공간을 sRGB 로 명시 + 색 실측 절차 (#349)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,37 @@ printf '\xf0\x9f\x8e\x89\n'              # UTF-8 byte 직접 (🎉 = F0 9F 8E 89
 zsh -c "echo \$'\\U0001F389'"            # zsh unicode escape (macOS bash 3.2 미지원)
 ```
 
+# macOS — 색 실측 방법
+
+macOS 는 Metal layer 내용을 **sRGB 로 보고 디스플레이 색공간으로 변환해** 합성해요 ([#349](https://github.com/ensky0/tildaz/issues/349)). 그래서 `screencapture` 로 찍은 PNG 은 디스플레이 공간 값이고, 디스플레이 프리셋이 wide-gamut (`Apple XDR Display` 등) 이면 **앱이 그린 값과 다르게 읽혀요** — 실측에서 파생색 45개 중 30개가 어긋났고 (1비트 22개 · 2비트 8개), amber (`#F7A41D` → `#EBA842`) 는 37 차이였어요.
+
+**하지 말 것 — 캡처를 사후에 sRGB 로 역변환.** ImageMagick `-profile` 과 `sips --matchTo` 가 결과가 갈려서 신뢰할 수 없어요 ([#335](https://github.com/ensky0/tildaz/issues/335#issuecomment-5113614333) 에서 7건이 1비트씩 어긋나 보였고, 어느 도구도 전부 맞추지 못했어요).
+
+**할 것 — 출력 색공간을 sRGB 로 지정해 캡처.** [`dist/macos/color-capture.m`](dist/macos/color-capture.m) 이 `SCStreamConfiguration.colorSpaceName` 을 sRGB 로 두고 창을 캡처해요. 캡처 파이프라인이 출력 버퍼를 sRGB 로 만들어 주니, 다 찍은 PNG 을 사후에 변환하는 8-bit 왕복이 없어요.
+
+```sh
+clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit \
+      -framework ImageIO -framework UniformTypeIdentifiers \
+      -o /tmp/color-capture dist/macos/color-capture.m
+/tmp/color-capture --list                              # windowID 찾기
+/tmp/color-capture --window <id> out.png               # 출력 색공간 = sRGB
+magick out.png -format "%[pixel:p{40,40}]\n" info:     # 값 읽기
+```
+
+이러면 **디스플레이 프리셋을 바꾸지 않아도** raw 픽셀이 앱이 그린 값이에요 (#349 에서 46색 46/46 일치 확인). 결과 PNG 은 sRGB 로 태깅되니 ImageMagick / sips 로 읽어도 값이 같아요. 프리셋을 `Internet & Web (sRGB)` 로 바꾸는 예전 우회는 더 필요 없어요.
+
+측정 전제 (빠뜨리면 색이 안 나오거나 다른 색을 읽어요):
+
+- **탭바는 탭 2개 이상에서만** 그려져요.
+- **테마는 runtime 에 안 바뀌어요** — config 를 고치고 재시작한 뒤 로그의 `[startup] config loaded: theme=…` 로 실제 적용을 확인해요.
+- **hover 색은 포인터를 실제로 올려야** 나와요 (`ctrl_hover_bg` = `+` 위, `menu_hover_bg` = 메뉴 항목 위). 자동화로 포인터를 옮길 때 `CGWarpMouseCursorPosition` 만 쓰면 커서 위치만 바뀌고 **이동 이벤트가 없어서 hover 가 안 걸려요** — `kCGEventMouseMoved` 를 함께 보내야 해요.
+- **`arrow_disabled` 는 탭바 overflow 를 만들어야** 나와요. 필요한 탭 수는 창 폭에 따라 달라요 — 탭 하나가 `TAB_WIDTH_PT` (150pt) 라서 1512pt 짜리 외장 모니터 창에서는 8개로는 overflow 가 안 생겼어요 (#349 실측). `창 폭 ÷ 150` 보다 넉넉히 만들어요.
+- **색이 "있는지" 만 보는 검사는 오탐이 나요.** 밝은 테마에서는 글리프 안티에일리어싱이 `arrow_disabled` (`#828282`) 와 똑같은 회색을 만들어서, 화살표가 없는 2탭 화면에서도 "있음" 으로 읽혔어요 (#349). **해당 요소가 그려지는 영역** (화살표는 컨트롤 왼쪽 24pt × 2) 으로 좁히고, 그 요소가 없는 상태 캡처와 **비교** 해서 판정해요.
+- **기대값은 이슈 표를 베끼지 말고** [`chrome_palette.zig`](src/chrome_palette.zig) 의 `derive()` 를 임시 드라이버로 호출해 덤프해요 — ghostty 비의존 모듈이라 `zig run` 으로 단독 실행돼요. 측정이 끝나면 드라이버를 지우고 트리 clean 을 확인해요.
+- 화면이 절전으로 꺼져 있거나 잠금 화면이면 캡처가 실패해요 (`캡처 실패` / 창 목록에 `Display 1 Shield`).
+
+Linux 는 software renderer + 프로파일 없는 캡처라 이 절차가 아예 없고, Windows 는 swapchain 이 `DXGI_FORMAT_B8G8R8A8_UNORM` 이라 raw 픽셀이 곧 앱 출력이에요. **macOS 만 이 절차가 필요해요.**
+
 # 터미널 시각 회귀 테스트 (한 줄)
 
 색 emoji / 스킨톤 / ZWJ family / 라틴 / 한글 / block element 까지 한 번에 화면에 띄우는 표준 시연 입력. emoji path / ClearType path / wide char / block element 회귀 다 동시 확인 가능. WT 와 나란히 띄워 비교 시 표준 입력으로 사용.

--- a/dist/macos/color-capture.m
+++ b/dist/macos/color-capture.m
@@ -1,0 +1,182 @@
+// color-capture.m — 창을 sRGB 색공간으로 캡처하는 색 실측용 도구 (#349).
+//
+// macOS 는 layer 내용을 sRGB 로 보고 **디스플레이 색공간으로 변환해** 합성한다.
+// `screencapture` 는 출력 색공간을 고를 수 없어서 (`man screencapture` — 관련
+// 플래그 없음, `-r` 은 dpi 메타만 제거) 캡처 픽셀이 항상 디스플레이 공간 값이고,
+// 프리셋이 wide-gamut 이면 앱이 그린 값과 다르게 읽힌다. 그래서 예전에는 실측할
+// 때마다 디스플레이 프리셋을 `Internet & Web (sRGB)` 로 바꿔야 했다.
+//
+// ScreenCaptureKit 은 출력 색공간을 지정할 수 있다 —
+// `SCStreamConfiguration.colorSpaceName` 헤더 주석: "If not set the output buffer
+// uses the same color space as the display". sRGB 로 지정하면 출력 버퍼가 sRGB 로
+// 나오니, 다 찍은 PNG 을 사후에 변환하는 8-bit 왕복이 없다 (#349 에서 파생색 46개
+// 46/46 일치 확인, 프리셋 무관). 파이프라인 내부에서 어느 단계에 변환이 일어나는지는
+// 확인하지 않았다 — 확인한 것은 결과 픽셀이 authored 값과 같다는 것이다.
+//
+// 빌드 · 사용 (`AGENTS.md` 의 "macOS — 색 실측 방법" 절 참고):
+//
+//   clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit \
+//         -framework ImageIO -framework UniformTypeIdentifiers \
+//         -o /tmp/color-capture dist/macos/color-capture.m
+//   /tmp/color-capture --list                    # windowID 찾기
+//   /tmp/color-capture --window <id> out.png     # 출력 색공간 = sRGB
+//   magick out.png -format "%[pixel:p{40,40}]\n" info:
+//
+// 결과 PNG 은 sRGB 로 태깅되므로 ImageMagick / sips 로 읽어도 값이 같다 (#349
+// 확인). 색공간이 어긋난 캡처를 **사후에 역변환하는 방식은 쓰지 않는다** —
+// ImageMagick `-profile` 과 `sips --matchTo` 결과가 갈린다 (#335).
+//
+// `SCScreenshotManager.captureImageWithFilter:` 가 macOS 14+ 라 그 이상에서만
+// 동작한다. 앱에 들어가는 코드가 아니라 tildaz 의 최소 지원 버전과는 무관하다.
+
+#import <Cocoa/Cocoa.h>
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+/// 화면 기록 권한이 없으면 여기서 막힌다 (실행한 터미널의 권한을 따라가고,
+/// 재빌드해도 다시 묻지 않는다 — #349 확인).
+static SCShareableContent *shareableContentOrDie(void) {
+    __block SCShareableContent *result = nil;
+    __block NSError *err = nil;
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [SCShareableContent
+        getShareableContentWithCompletionHandler:^(SCShareableContent *c, NSError *e) {
+          result = c;
+          err = e;
+          dispatch_semaphore_signal(sem);
+        }];
+    if (dispatch_semaphore_wait(sem,
+                                dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC))) {
+        fprintf(stderr, "창 목록 조회 시간 초과 — 화면 기록 권한을 확인하세요\n");
+        exit(2);
+    }
+    if (!result) {
+        fprintf(stderr, "창 목록 조회 실패: %s\n", err.localizedDescription.UTF8String);
+        exit(2);
+    }
+    return result;
+}
+
+static void listWindows(void) {
+    SCShareableContent *content = shareableContentOrDie();
+    printf("%-8s %-24s %-12s %s\n", "id", "app", "크기(pt)", "제목");
+    for (SCWindow *w in content.windows) {
+        if (!w.onScreen) continue;
+        char size[32];
+        snprintf(size, sizeof(size), "%.0fx%.0f", w.frame.size.width,
+                 w.frame.size.height);
+        printf("%-8u %-24s %-12s %s\n", (unsigned)w.windowID,
+               w.owningApplication.applicationName.UTF8String ?: "(?)", size,
+               w.title.UTF8String ?: "");
+    }
+}
+
+static void writePNG(CGImageRef img, const char *path) {
+    NSURL *url = [NSURL fileURLWithPath:@(path)];
+    CGImageDestinationRef dst = CGImageDestinationCreateWithURL(
+        (__bridge CFURLRef)url, (__bridge CFStringRef)UTTypePNG.identifier, 1, NULL);
+    if (!dst) {
+        fprintf(stderr, "PNG 저장 대상 생성 실패: %s\n", path);
+        exit(3);
+    }
+    CGImageDestinationAddImage(dst, img, NULL);
+    if (!CGImageDestinationFinalize(dst)) {
+        fprintf(stderr, "PNG 저장 실패: %s\n", path);
+        exit(3);
+    }
+    CFRelease(dst);
+}
+
+int main(int argc, const char **argv) {
+    @autoreleasepool {
+        unsigned want_id = 0;
+        const char *out = NULL;
+        BOOL srgb = YES; // 기본 = sRGB 지정 (이 도구를 쓰는 이유)
+        for (int i = 1; i < argc; i++) {
+            if (strcmp(argv[i], "--list") == 0) {
+                listWindows();
+                return 0;
+            }
+            if (strcmp(argv[i], "--window") == 0 && i + 1 < argc) {
+                want_id = (unsigned)strtoul(argv[++i], NULL, 10);
+            } else if (strcmp(argv[i], "--space") == 0 && i + 1 < argc) {
+                // `display` 는 `screencapture` 와 같은 결과를 내는 비교용이다.
+                srgb = strcmp(argv[++i], "display") != 0;
+            } else {
+                out = argv[i];
+            }
+        }
+        if (!want_id || !out) {
+            fprintf(stderr,
+                    "사용법: color-capture --window <id> <out.png> [--space srgb|display]\n"
+                    "        color-capture --list\n");
+            return 1;
+        }
+
+        SCShareableContent *content = shareableContentOrDie();
+        SCWindow *target = nil;
+        for (SCWindow *w in content.windows) {
+            if (w.windowID == want_id) {
+                target = w;
+                break;
+            }
+        }
+        if (!target) {
+            fprintf(stderr, "windowID %u 를 찾지 못했습니다 (--list 로 확인)\n", want_id);
+            return 2;
+        }
+
+        // 창의 물리 픽셀 크기로 캡처한다 — scalesToFit 를 끄고 크기를 정확히 맞춰
+        // 리샘플링이 픽셀 값을 섞지 않게 한다 (색 실측에서는 치명적).
+        CGFloat scale = 1.0;
+        for (NSScreen *s in [NSScreen screens]) {
+            if (NSIntersectsRect(s.frame, target.frame)) {
+                scale = s.backingScaleFactor;
+                break;
+            }
+        }
+        SCStreamConfiguration *config = [[SCStreamConfiguration alloc] init];
+        config.width = (size_t)(target.frame.size.width * scale);
+        config.height = (size_t)(target.frame.size.height * scale);
+        config.scalesToFit = NO;
+        config.showsCursor = NO;
+        config.ignoreShadowsSingleWindow = YES;
+        config.captureResolution = SCCaptureResolutionBest;
+        if (srgb) config.colorSpaceName = kCGColorSpaceSRGB;
+
+        SCContentFilter *filter =
+            [[SCContentFilter alloc] initWithDesktopIndependentWindow:target];
+
+        __block CGImageRef image = NULL;
+        __block NSError *err = nil;
+        dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+        [SCScreenshotManager captureImageWithFilter:filter
+                                      configuration:config
+                                  completionHandler:^(CGImageRef img, NSError *e) {
+                                    if (img) image = (CGImageRef)CFRetain(img);
+                                    err = e;
+                                    dispatch_semaphore_signal(sem);
+                                  }];
+        if (dispatch_semaphore_wait(
+                sem, dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC))) {
+            fprintf(stderr, "캡처 시간 초과\n");
+            return 2;
+        }
+        if (!image) {
+            // 화면이 절전으로 꺼져 있으면 여기서 실패한다.
+            fprintf(stderr, "캡처 실패: %s\n", err.localizedDescription.UTF8String);
+            return 2;
+        }
+
+        CGColorSpaceRef cs = CGImageGetColorSpace(image);
+        CFStringRef name = cs ? CGColorSpaceCopyName(cs) : NULL;
+        printf("%s: %zux%zu px (scale %.2f), 색공간 %s\n", out, CGImageGetWidth(image),
+               CGImageGetHeight(image), scale,
+               name ? [(__bridge NSString *)name UTF8String] : "(디스플레이 공간)");
+        if (name) CFRelease(name);
+
+        writePNG(image, out);
+        CFRelease(image);
+    }
+    return 0;
+}

--- a/src/font/macos/coretext.zig
+++ b/src/font/macos/coretext.zig
@@ -213,6 +213,15 @@ pub extern "CoreGraphics" fn CGColorSpaceCreateDeviceGray() ?CGColorSpaceRef;
 pub extern "CoreGraphics" fn CGColorSpaceCreateDeviceRGB() ?CGColorSpaceRef;
 pub extern "CoreGraphics" fn CGColorSpaceRelease(space: CGColorSpaceRef) void;
 
+/// 이름으로 표준 색공간을 얻는다 (#349 — Metal layer 색공간 명시에 사용).
+/// 없는 이름이면 null 을 돌려준다 (실측 확인).
+pub extern "CoreGraphics" fn CGColorSpaceCreateWithName(name: CFStringRef) ?CGColorSpaceRef;
+
+/// sRGB 색공간 이름 상수. 이 이름으로 만든 색공간은 immortal singleton 이라
+/// `CFGetRetainCount` 가 `UINT_MAX` 고 `CGColorSpaceRelease` 는 no-op 이지만,
+/// Create/Release 쌍은 관례대로 맞춘다 (#349 실측).
+pub extern const kCGColorSpaceSRGB: CFStringRef;
+
 pub extern "CoreGraphics" fn CGBitmapContextCreate(
     data: ?[*]u8,
     width: usize,

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -372,6 +372,26 @@ pub const MetalRenderer = struct {
         objc.msgSendVoid1(layer, objc.sel("setDevice:"), device);
         objc.msgSendVoid1(layer, objc.sel("setPixelFormat:"), @as(objc.NSUInteger, 80)); // BGRA8Unorm
 
+        // #349 — layer 색공간을 sRGB 로 명시. 우리 색 상수는 sRGB 로 설계 · 튜닝됐고
+        // (#334 / #342 anchor, #335 파생식) window server 는 이 태그를 보고 디스플레이
+        // 색공간으로 변환한다.
+        //
+        // 명시하는 이유: 바로 위 `setPixelFormat:` 호출이 colorspace 를 자동으로
+        // `kCGColorSpaceSRGB` 로 채우는데 (실측) 이건 문서에 없는 동작이다. Apple 문서와
+        // `CAMetalLayer.h` 가 적어 둔 기본값은 `nil` = "no colormatching" 이라, 문서만
+        // 읽으면 우리가 색 변환을 안 한다고 정반대로 이해하게 된다. 자동 기본값에
+        // 색 정확성을 맡기지 않고 같은 값을 직접 넣는다 — 실측으로 자동값과 **같은
+        // 싱글턴 인스턴스**라 픽셀은 한 비트도 바뀌지 않는다.
+        //
+        // null 이면 지정하지 않는다: `colorspace = nil` 은 변환을 없애서 wide-gamut
+        // 디스플레이에서 실제로 색이 진해진다 (실측: amber `#F7A41D` 가 P3 원색으로).
+        if (ct.CGColorSpaceCreateWithName(ct.kCGColorSpaceSRGB)) |cs| {
+            defer ct.CGColorSpaceRelease(cs);
+            objc.msgSendVoid1(layer, objc.sel("setColorspace:"), cs);
+        } else {
+            std.log.warn("sRGB 색공간 생성 실패 — layer colorspace 를 그대로 둠", .{});
+        }
+
         return .{
             .alloc = alloc,
             .font = font_ctx,


### PR DESCRIPTION
[#349](https://github.com/ensky0/tildaz/issues/349) — 색이 바뀌는 변경이 아니에요. 지금까지 색 정확성이 **문서에 없는 기본값**에 걸려 있던 걸 코드로 명시해요.

## 무엇이 문제였나

`CAMetalLayer.colorspace` 는 [Apple 문서](https://developer.apple.com/documentation/quartzcore/cametallayer/colorspace)와 SDK 의 `CAMetalLayer.h` 가 기본값을 `nil` = "no colormatching" 으로 적어 뒀어요. 그런데 실측하면 `setPixelFormat:` (BGRA8Unorm) 호출 **직후** getter 가 `kCGColorSpaceSRGB` 를 돌려줘요.

| 시점 | `layer.colorspace` |
|---|---|
| `[CAMetalLayer layer]` 직후 | `nil` |
| `setDevice:` 후 | `nil` |
| **`setPixelFormat:` 후** | **`kCGColorSpaceSRGB`** |

즉 우리 layer 는 nil 인 적이 없고, window server 가 내용을 sRGB 로 보고 디스플레이 색공간으로 변환해 왔어요. **문서만 읽으면 우리가 색 변환을 안 한다고 정반대로 이해하게 되는 상태**였어요.

## 변경 내용

- [`renderer/macos.zig`](src/renderer/macos.zig) 가 `setPixelFormat:` 다음에 `setColorspace:` 로 sRGB 를 직접 넣어요. 자동값과 **같은 싱글턴 인스턴스**라 (실측: 포인터 동일) 픽셀은 바뀌지 않아요. 우리 색 상수는 sRGB 로 설계 · 튜닝돼 있어요 ([#334](https://github.com/ensky0/tildaz/issues/334) / [#342](https://github.com/ensky0/tildaz/issues/342) / [#335](https://github.com/ensky0/tildaz/issues/335)).
- `CGColorSpaceCreateWithName` 이 null 이면 **지정하지 않아요.** null 을 그대로 넣으면 `colorspace = nil` 이 되어 변환이 사라지고 wide-gamut 디스플레이에서 실제로 색이 진해져요 (실측: amber `#F7A41D` 가 P3 원색으로).
- [`dist/macos/color-capture.m`](dist/macos/color-capture.m) — 색 실측용 캡처 도구. `screencapture` 는 출력 색공간을 고를 수 없어서 캡처가 항상 디스플레이 공간 값이고, wide-gamut 프리셋에서는 파생색 45개 중 30개가 1~2비트 · amber 는 37 어긋나요. ScreenCaptureKit 의 `SCStreamConfiguration.colorSpaceName` 을 sRGB 로 두면 프리셋과 무관하게 authored 값이 나와요. 앱에 들어가는 코드가 아니에요 (`zig build` 가 컴파일하지 않아요).
- [`AGENTS.md`](AGENTS.md) — "macOS 색 실측 방법" 절. 절차와 함정 (사후 역변환 금지, hover 는 `kCGEventMouseMoved` 필요, 색 존재 검사만으로는 오탐).

## 검증

기대값은 이슈 표를 베끼지 않고 `chrome_palette.derive()` 를 임시 드라이버로 호출해 덤프했어요 (측정 후 삭제).

| 항목 | 결과 |
|---|---|
| 내장 디스플레이 4조합 — (프리셋 Apple XDR P3-1600 / Internet & Web sRGB) × (지정 전 / 후) × 5테마 | authored **200/200**, 지정 전↔후 탭바 픽셀 **40쌍 바이트 동일** |
| 프리셋만 바꾼 쌍 | **20/20 동일** |
| 외장 모니터 (DELL U2723QE, 자체 ICC 프로파일) | authored **100/100**, 픽셀 **20쌍 동일** |
| `arrow_disabled` 차등 재검증 (오탐 제거) | **30/30** |
| `zig build check` | 6타겟 통과 |
| `zig build test` | 156 + 4 passed / 2 skipped / 0 failed |
| `zig build package` universal | 통과, `lipo -archs` = `x86_64 arm64` (새 extern 심볼이 두 arch 모두 링크) |

측정 상세와 걸러낸 함정은 [이슈 코멘트](https://github.com/ensky0/tildaz/issues/349#issuecomment-5123888208)에 있어요.

**남은 미검증 (`확인 필요`)** — 검증에 쓴 두 화면이 모두 `backingScaleFactor` 2.00 이라 [`applyScale`](src/renderer/macos.zig) 경로는 타지 않았어요. "layer 는 한 번만 만들어지고 `applyScale` 이 색공간을 다시 만지지 않는다" 는 소스 읽기 판단이에요. 코드상 색공간이 풀릴 경로는 없어 보여요.

**rebase 시점 참고** — 위 실측은 rebase 이전 base (`64045c3`) 에서 측정했어요. 현재 base ([#350](https://github.com/ensky0/tildaz/issues/350) · [#353](https://github.com/ensky0/tildaz/issues/353) 포함) 로 rebase 한 뒤에는 `zig build check` / `test` 를 다시 통과했어요. 이 PR 의 주장("색공간 명시는 no-op")은 파생색 값이 무엇이든 성립해요 — 같은 싱글턴을 다시 넣는 것이니까요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
