### PR TITLE
feat(tab): 새 탭이 활성 탭의 현재 디렉토리에서 시작한다 (#366)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -119,7 +119,7 @@ Every numeric field name carries its unit (`_percent`, `_point`, `_ratio`). Stri
 | `font.cell_width_ratio` | float | 0.5–2.0 | 1.0 | 1.0 | 1.0 | Cell-width multiplier (1.0 = font's own advance) |
 | `font.line_height_ratio` | float | 0.5–2.0 | 1.1 | 1.1 | 1.1 | Line-height multiplier (1.0 = font's own ascent + descent + leading) |
 | `theme` | string | see Built-in themes below | "Tilda" | "Tilda" | "Tilda" | Color theme |
-| `shell` | string | — | `$SHELL` env (or `/bin/bash`) | `$SHELL` env (or `/bin/bash`) | "cmd.exe" | Shell to spawn. It always starts in your home directory; WSL tabs start in the *Linux* home (TildaZ adds `--cd ~` to `wsl.exe` automatically — skipped if your command already has `--cd`). Windows accepts arguments — e.g. `"wsl.exe -d Debian"`. macOS / Linux expect an absolute binary path; for argv beyond the binary, configure your shell via `~/.zshrc`, `~/.bashrc`, etc. |
+| `shell` | string | — | `$SHELL` env (or `/bin/bash`) | `$SHELL` env (or `/bin/bash`) | "cmd.exe" | Shell to spawn. A new tab starts in the **active tab's current directory**, falling back to your home directory when that location can't be determined or entered (see "New tab working directory" below). WSL tabs use *Linux* paths — TildaZ passes `--cd` to `wsl.exe` automatically, skipped if your command already has `--cd`. Windows accepts arguments — e.g. `"wsl.exe -d Debian"`. macOS / Linux expect an absolute binary path; for argv beyond the binary, configure your shell via `~/.zshrc`, `~/.bashrc`, etc. |
 | `hotkey` | string | "F1", "Ctrl+Space", "Shift+Cmd+T", … | "F1" | "F1" | "F1" | Global toggle hotkey. `cmd` token = Win key on Windows / Cmd on macOS / Super on Linux |
 | `auto_start` | bool | — | true | true | true | Start on login (Registry Run on Windows, LaunchAgent on macOS, XDG autostart `.desktop` on Linux) |
 | `hidden_start` | bool | — | false | false | false | Start hidden (first toggle reveals) |
@@ -141,6 +141,41 @@ invalid value shows an error dialog and exits):
 - Key names cover letters, digits, `Space`, `` ` `` (backtick / grave), and
   `F1`–`F12`. macOS and Windows accept a slightly narrower modifier-alias set
   than Linux; the tokens above work on all three.
+
+### New tab working directory
+
+A new tab starts in the **active tab's current directory**. When that location
+can't be determined or entered, it falls back to your **home directory**. There is
+no config switch — to start clean, run `cd ~` in the new tab.
+
+TildaZ finds the location in two ways, in order:
+
+1. **The shell tells us** via the `OSC 7` escape sequence. Shells that already do
+   this need no setup (fish, and bash/zsh with a prompt hook installed).
+2. **We ask the OS** for the shell process's working directory. This works on
+   Linux and macOS regardless of which shell you use, so **no shell configuration
+   is required there**.
+
+On **Windows** the second way is not possible (PowerShell keeps its location
+per-runspace, and the `cmd`-only alternative relies on an undocumented API), so
+TildaZ makes the shell report instead:
+
+| Shell | What TildaZ sets |
+|---|---|
+| `cmd` | Prepends a reporting fragment to the `PROMPT` environment variable. Your existing prompt is preserved — it is only added in front, so `echo %PROMPT%` shows the extra fragment |
+| PowerShell / pwsh | Appends `-NoExit -EncodedCommand …` to the command line, which wraps the existing `prompt` function **after your profile loads**. Custom prompts (oh-my-posh, Starship, …) keep working. Skipped if your `shell` value already passes `-Command`, `-EncodedCommand`, or `-File` |
+| WSL (bash) | Passes `PROMPT_COMMAND` through `WSLENV` |
+| WSL (fish) | Nothing — fish reports on its own |
+
+Combinations that fall back to the home directory:
+
+| Situation | Why |
+|---|---|
+| Inside **tmux** | tmux absorbs the escape sequence, so the new tab opens where the shell was **before** tmux started. Other terminals share this limitation; use tmux's own `#{pane_current_path}` for tmux windows |
+| **zsh inside WSL** | Requires placing a file inside the WSL filesystem, which TildaZ does not do |
+| **Over ssh** | The remote host name doesn't match this machine, so the remote path is ignored (it wouldn't exist locally) |
+| The directory was deleted, or isn't a directory | Checked before spawning |
+| A shell whose prompt hook was overwritten by your rc file | For bash, assigning `PROMPT_COMMAND=` in `.bashrc` replaces what TildaZ passed in |
 
 **Ligatures** require a ligature-capable `font.family` (e.g. Fira Code or
 JetBrains Mono — both free). The Windows default (Cascadia Code) includes them;

--- a/SPEC.md
+++ b/SPEC.md
@@ -784,18 +784,54 @@ binding은 같은 accelerator를 재사용하면 새 TildaZ command로 덮이고
 - `setShortcutKeys`와 `shortcutKeys`의 각 `(ai)` QKeySequence는 항상 int 4개다. single key의 나머지 세 slot은 0이다.
 - 정상 종료에는 `unregister`가 아니라 `setInactive(as)`를 사용한다. `unregister`는 persistent action 자체를 제거하므로 config에서 사라진 numbered identity 정리에만 쓴다.
 
-### 7.2 셸 시작 디렉토리 ([#265](https://github.com/ensky0/tildaz/issues/265))
+### 7.2 셸 시작 디렉토리 ([#265](https://github.com/ensky0/tildaz/issues/265), [#366](https://github.com/ensky0/tildaz/issues/366) 2026-08-03 개정)
 
-새 탭의 셸은 모든 platform 에서 **홈 디렉토리에서 시작**한다. 지정하지 않으면 자식 셸이 부모 (앱) 의 현재 디렉토리를 물려받아, 앱을 어떻게 실행했는지 (Finder / 런처 / 개발 중 셸) 에 따라 시작 위치가 달라진다.
+새 탭은 **활성 탭 셸의 현재 위치에서 시작**한다. 그 위치를 알 수 없거나 그리로 들어갈 수 없으면 **홈 디렉토리**로 열화한다 (#265 의 기존 동작). config 옵션은 두지 않는다 — 상속이 항상 기본이고, 홈으로 가려면 새 탭에서 `cd ~` 한 번이면 된다 (반대 방향은 경로를 입력해야 하므로 복구 비용이 비대칭이다).
 
-| platform | 방법 | 구현 | 상태 |
+> **이전 사양의 "항상 홈에서 시작" 은 폐기됐다.** #265 는 시작 디렉토리를 *지정하지 않으면* 자식 셸이 부모 (앱) 의 현재 디렉토리를 물려받아 실행 경로 (Finder / 런처 / 개발 중 셸) 에 따라 위치가 달라지는 문제를 홈 고정으로 막았다. 그 문제 자체는 여전히 유효해서, 상속할 위치가 없을 때의 fallback 이 **앱의 cwd 가 아니라 홈**이라는 점은 그대로 유지한다.
+
+**위치를 얻는 순서** — 세 단계로 내려간다.
+
+| 순위 | 소스 | 특징 |
+|---|---|---|
+| ① | 셸이 보낸 **OSC 7** (`report_pwd`) | 셸의 논리 경로 (`$PWD`) 라 symlink 를 따라 들어간 사용자의 기대에 맞는다. `Terminal.pwd` 에 raw payload 로 보관되고 스킴 해석은 우리 몫이다 ([`src/pwd_uri.zig`](src/pwd_uri.zig)) |
+| ② | **프로세스 cwd 조회** | 셸 · rc 구성과 무관하게 동작한다. Linux · macOS 만 ([`src/process_cwd.zig`](src/process_cwd.zig)) |
+| ③ | 홈 | #265 의 동작 |
+
+**platform 별 처리** — 얻는 쪽과 쓰는 쪽이 다르다.
+
+| platform / 탭 | 위치를 얻는 방법 | 새 탭에 넘기는 방법 | 상태 |
 |---|---|---|---|
-| Windows — 일반 exe (`cmd.exe` / PowerShell 등) | `CreateProcessW` 의 `lpCurrentDirectory` 에 `%USERPROFILE%` (환경변수 없으면 null = 부모 디렉토리 상속) | [src/terminal/windows/pty.zig](src/terminal/windows/pty.zig) | ✅ |
-| Windows — 셸이 `wsl` / `wsl.exe` | 명령줄에 `--cd ~` 삽입 → **Linux 홈**에서 시작. Windows Terminal 의 `MangleStartingDirectoryForWSL` 과 동일 규칙 ([microsoft/terminal PR #9223](https://github.com/microsoft/terminal/pull/9223)) — 사용자가 이미 `--cd` 나 단독 `~` 인자를 넣었으면 삽입 안 함 (사용자 값이 이김) | 동일 파일 `wslCdInsertion` | ✅ |
-| macOS | fork 자식에서 `execve` 전 `chdir(getenv("HOME"))` — 실패 시 무시하고 진행 | 공통 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `childExec` | ✅ |
-| Linux | 동일 — `chdir(getenv("HOME"))` | 공통 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `childExec` | ✅ |
+| Linux | `readlink /proc/<셸 pid>/cwd` (셸이 OSC 7 을 보내면 그쪽 우선) | fork 자식에서 `execve` 전 `chdir` — 실패하면 홈으로 되돌린다 | ✅ |
+| macOS | `proc_pidinfo(PROC_PIDVNODEPATHINFO)` (동일) | 동일 — 공통 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig) 의 `childExec` | ✅ |
+| Windows — 일반 exe (`cmd.exe` / PowerShell 등) | **OSC 7 뿐.** 프로세스 cwd 조회가 원리적으로 불가해서 셸에 주입한다 (아래) | `CreateProcessW` 의 `lpCurrentDirectory`. 그 디렉토리가 없으면 `CreateProcessW` 자체가 실패하므로 **홈으로 한 번 재시도**한다 (아니면 새 탭이 아예 안 열린다) | ✅ |
+| Windows — 셸이 `wsl` / `wsl.exe` | OSC 7 (WSL 안 셸이 보고하는 **Linux 경로**) | 명령줄에 `--cd "<경로>"` 삽입 → wsl 에게 위임. 없으면 `--cd ~` (Linux 홈). Windows Terminal 의 `MangleStartingDirectoryForWSL` 과 동일 규칙 ([microsoft/terminal PR #9223](https://github.com/microsoft/terminal/pull/9223)) — 사용자가 이미 `--cd` 나 단독 `~` 인자를 넣었으면 삽입하지 않는다 | ✅ |
 
 > Windows 에서 Linux 홈을 `lpCurrentDirectory` 로 지정할 수 없는 이유 (Windows 경로만 표현 가능 + Linux 홈 위치는 distro 안에서만 알 수 있음) 와 `\\wsl$\...` 대안이 기각된 근거는 [#265 코멘트](https://github.com/ensky0/tildaz/issues/265#issuecomment-4910677101) 참조.
+
+**경로 표기는 host OS 가 아니라 탭의 셸로 결정한다.** WSL 탭은 host 가 Windows 여도 Linux 경로 (`/home/me`) 를 주고받는다. 그래서 일반 Windows 탭에서 `wsl` 을 직접 실행한 경우처럼 표기가 어긋나면 파서가 거부하고 홈에서 시작한다 (Windows 실기 확인).
+
+**Windows 는 셸에 OSC 7 을 주입한다** — 프로세스 cwd 조회가 불가하기 때문이다. PowerShell 은 `Set-Location` 이 runspace 별 위치만 바꿔서 프로세스 cwd 가 시작값에 고정되고, `cmd` 만 되는 PEB 읽기는 MS 가 *"may be altered or unavailable in future versions"* 로 표기한 비공개 API 다. 조립은 [`src/shell_integration.zig`](src/shell_integration.zig) 가 한다.
+
+| 셸 | 주입 | 사용자 환경 보존 |
+|---|---|---|
+| `cmd` | `PROMPT` 환경변수 | 기존 `%PROMPT%` **앞에만** 덧붙여 프롬프트 모양을 유지한다. 값이 없으면 cmd 기본값 `$P$G` 를 명시해 이어 붙인다 |
+| PowerShell · pwsh | 명령줄 맨 끝에 `-NoExit -EncodedCommand` (UTF-16LE Base64) | **프로필 로드 뒤** 기존 `prompt` 를 감싼다. 사용자가 이미 `-Command` / `-EncodedCommand` / `-File` 을 지정했으면 주입하지 않는다. `$PWD.Provider.Name -eq 'FileSystem'` 일 때만 보고하므로 `HKLM:` 같은 레지스트리 위치는 알리지 않는다 |
+| WSL 안 bash | `WSLENV` 로 `PROMPT_COMMAND` 전달 | 사용자 rc 가 `PROMPT_COMMAND=` 로 **대입**하면 무력화된다 (rc 는 자식이 읽어 우리가 볼 수 없다) |
+| WSL 안 fish | 없음 — 기본으로 OSC 7 을 보낸다 | — |
+
+스킴은 `kitty-shell-cwd://` (raw) 를 쓴다. 셸의 프롬프트 기능으로는 퍼센트 인코딩을 할 수 없어서 `file://` 로 보내면 `C:\50%20x` 가 `C:\50 x` 로 잘못 디코딩된다. 경로를 URI 로 바꿔 주는 표준 라이브러리는 없다 — 조립이 셸이 프롬프트를 그리는 시점에 일어나기 때문이다 (VTE 는 이 때문에 `vte-urlencode-cwd` 헬퍼 바이너리를 따로 설치하고, ghostty · kitty 는 인코딩을 피하려고 이 raw 스킴을 만들었다).
+
+**동작하지 않는 조합** — 모두 홈 (또는 아래 tmux 처럼 옛 위치) 으로 열화하고, 탭 자체는 정상적으로 열린다.
+
+| 조합 | 결과 | 이유 |
+|---|---|---|
+| **tmux 안** | tmux 실행 **직전** 위치 ⚠️ | tmux 가 자체 터미널 에뮬레이터로서 OSC 7 을 흡수한다 (tmux 3.7b 실측). 프로세스 조회도 tmux 서버가 별도 프로세스 트리라 통하지 않는다. ghostty · kitty 도 같은 한계이고, tmux 자신은 `#{pane_current_path}` 로 따로 해결한다 |
+| **WSL 안 zsh** | 홈 | `ZDOTDIR` 로 파일을 끼워야 하는데 Windows 쪽에서 VM 안에 파일을 만들어야 한다 |
+| **ssh 원격** | 홈 | 원격 hostname 이 우리와 달라 파서가 거부한다. 우리 주입도 ssh 를 넘지 못한다 (ssh 는 기본적으로 환경변수를 전달하지 않는다) |
+| 지워진 디렉토리 · 디렉토리가 아닌 경로 | 홈 | spawn 전에 `openDirAbsolute` 로 확인한다 (`access` 는 파일도 통과시켜 spawn 이 `ENOTDIR` 로 실패한다) |
+
+어느 단계에서 걸렸는지는 로그 (`cwd` 카테고리) 에 새 탭 하나당 한 줄로 남는다.
 
 **셸 login 모드 — 각 OS 터미널 관례를 따르는 의도적 차이** (2026-07-12 결정, #282 D5). macOS 는 자식 셸을 **login shell** (`argv = {shell, "-l"}`) 로 띄우고 (Terminal.app / iTerm2 표준 — `~/.zprofile`·`~/.bash_profile` 로드; padding 비대칭 원인이던 non-login + `~/.hushlogin` 문제 해결, 커밋 d801d4c), Linux 는 **비-login** 으로 띄운다 (GNOME Terminal / Konsole 표준 — `~/.zshrc`·`~/.bashrc` 만 로드). 어느 dotfile 이 로드되는지가 platform 간 다르지만, 각 OS 터미널의 관례와 일치시킨 의도된 차이다 (cross-platform 동등성 룰의 명시 예외).
 

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -230,7 +230,7 @@ fn buildExtraEnv(theme: ?*const themes.Theme) ?[]const terminal.ExtraEnv {
         var wslenv_buf: [768]u8 = undefined;
         var wslenv_len: usize = 0;
         var prompt_buf: [1024]u8 = undefined;
-        var vars: [3]terminal.ExtraEnv = undefined;
+        var vars: [4]terminal.ExtraEnv = undefined;
     };
 
     S.vars[0] = .{
@@ -251,7 +251,8 @@ fn buildExtraEnv(theme: ?*const themes.Theme) ?[]const terminal.ExtraEnv {
             pos += 1;
         }
     }
-    const suffix = "COLORFGBG";
+    // `PROMPT_COMMAND` 도 WSL 안까지 넘겨야 bash 가 OSC 7 을 보낸다 (#366).
+    const suffix = "COLORFGBG:PROMPT_COMMAND";
     if (pos + suffix.len <= S.wslenv_buf.len) {
         @memcpy(S.wslenv_buf[pos..][0..suffix.len], suffix);
         pos += suffix.len;
@@ -274,9 +275,16 @@ fn buildExtraEnv(theme: ?*const themes.Theme) ?[]const terminal.ExtraEnv {
         const utf8_len = std.unicode.utf16LeToUtf8(&existing_storage, pbuf[0..existing_wide]) catch 0;
         existing = existing_storage[0..utf8_len];
     }
+    // PROMPT_COMMAND — WSL 안 bash 용 (#366). 위 WSLENV 가 이 이름을 넘기게 해 두었다.
+    // cmd / PowerShell 은 이 변수를 쓰지 않으므로 무해하다.
+    S.vars[2] = .{
+        .name = "PROMPT_COMMAND",
+        .value = shell_integration.bash_prompt_command,
+    };
+
     if (shell_integration.cmdPrompt(&S.prompt_buf, existing)) |value| {
-        S.vars[2] = .{ .name = "PROMPT", .value = value };
-        return S.vars[0..3];
+        S.vars[3] = .{ .name = "PROMPT", .value = value };
+        return S.vars[0..4];
     }
-    return S.vars[0..2];
+    return S.vars[0..3];
 }

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -7,6 +7,7 @@ const Config = config_mod.Config;
 const log = @import("../log.zig");
 const dialog = @import("../dialog.zig");
 const messages = @import("../messages.zig");
+const shell_integration = @import("../shell_integration.zig");
 const shell_validate = @import("../shell_validate.zig");
 const terminal = @import("../terminal.zig");
 const windows_pty = @import("../terminal/windows/pty.zig");
@@ -215,6 +216,11 @@ pub fn run() !void {
 ///   - `WSLENV` — WSL 자식 프로세스에 어떤 env 를 forward 할지 hint. 부모의
 ///     기존 WSLENV (있으면) 에 ":COLORFGBG" 를 append. WSL 환경 외에서는
 ///     무해.
+///   - `PROMPT` — cmd 가 프롬프트를 그릴 때마다 OSC 7 로 현재 위치를 알리게 (#366).
+///     새 탭이 그 위치에서 시작한다. 조립은 `shell_integration.cmdPrompt` 가 하고,
+///     **기존 값 앞에만 덧붙이므로** 사용자 프롬프트 모양이 유지된다. PowerShell 은
+///     이 변수를 쓰지 않고 (별도 주입), WSLENV 에 넣지 않으므로 WSL 안 셸에도 전달되지
+///     않는다 — cmd 탭에만 효과가 있다.
 ///
 /// Buffer lifetime: process lifetime static (다음 호출 시 덮어쓰지만 SessionCore
 /// 가 슬라이스를 들고 있는 동안 유효).
@@ -223,7 +229,8 @@ fn buildExtraEnv(theme: ?*const themes.Theme) ?[]const terminal.ExtraEnv {
     const S = struct {
         var wslenv_buf: [768]u8 = undefined;
         var wslenv_len: usize = 0;
-        var vars: [2]terminal.ExtraEnv = undefined;
+        var prompt_buf: [1024]u8 = undefined;
+        var vars: [3]terminal.ExtraEnv = undefined;
     };
 
     S.vars[0] = .{
@@ -255,5 +262,21 @@ fn buildExtraEnv(theme: ?*const themes.Theme) ?[]const terminal.ExtraEnv {
         .value = S.wslenv_buf[0..S.wslenv_len],
     };
 
-    return &S.vars;
+    // PROMPT — 부모의 기존 값을 읽어 보고 조각을 앞에 덧붙인다 (#366). 조립이 실패
+    // (버퍼 부족) 하면 이 항목만 빼고 나머지는 그대로 전달한다 — 새 탭이 홈에서
+    // 시작하는 기존 동작으로 열화한다.
+    var pbuf: [512]WCHAR = undefined;
+    const prompt_name = std.unicode.utf8ToUtf16LeStringLiteral("PROMPT");
+    const existing_wide = GetEnvironmentVariableW(prompt_name, &pbuf, pbuf.len);
+    var existing_storage: [1024]u8 = undefined;
+    var existing: []const u8 = &.{};
+    if (existing_wide > 0 and existing_wide < pbuf.len) {
+        const utf8_len = std.unicode.utf16LeToUtf8(&existing_storage, pbuf[0..existing_wide]) catch 0;
+        existing = existing_storage[0..utf8_len];
+    }
+    if (shell_integration.cmdPrompt(&S.prompt_buf, existing)) |value| {
+        S.vars[2] = .{ .name = "PROMPT", .value = value };
+        return S.vars[0..3];
+    }
+    return S.vars[0..2];
 }

--- a/src/local_hostname.zig
+++ b/src/local_hostname.zig
@@ -1,0 +1,52 @@
+//! 이 머신의 hostname. OSC 7 (`report_pwd`) 이 알려 준 host 가 우리 머신인지 검사하는
+//! 데 쓴다 (#366) — ssh 안의 셸이 보낸 경로는 이 머신에 없으므로 거부해야 한다.
+//!
+//! [`system_open.zig`](system_open.zig) 와 같은 성격의 작은 cross-platform helper.
+//! `std.posix.gethostname` 은 Windows 에서 `@compileError("TODO implement gethostname
+//! for this OS")` 라 쓸 수 없어서 Windows 만 `GetComputerNameW` 를 직접 부른다 (ghostty
+//! 의 `src/os/hostname.zig` 도 같은 이유로 `GetComputerNameA` 를 쓴다).
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// hostname 을 담을 버퍼 크기. RFC 1035 의 label 상한 (255) + NUL 여유.
+pub const max_len = 256;
+
+/// hostname 을 `buf` 에 담아 slice 로 돌려준다. 조회에 실패하면 **빈 slice** —
+/// 호출처 ([`pwd_uri.parse`](pwd_uri.zig)) 는 hostname 이 비면 빈 host / `localhost`
+/// 만 수락하므로, 원격 경로를 잘못 받아들이는 쪽이 아니라 상속을 포기하는 쪽으로
+/// 열화한다.
+pub fn get(buf: *[max_len]u8) []const u8 {
+    switch (builtin.os.tag) {
+        .windows => {
+            var wbuf: [max_len]u16 = undefined;
+            // nSize 는 in/out — 들어갈 때 버퍼 크기, 나올 때 NUL 을 뺀 실제 길이.
+            var size: u32 = wbuf.len;
+            if (GetComputerNameW(&wbuf, &size) == 0) return "";
+            if (size >= wbuf.len) return "";
+            const len = std.unicode.utf16LeToUtf8(buf, wbuf[0..size]) catch return "";
+            return buf[0..len];
+        },
+        else => {
+            // `gethostname` 은 정확히 `*[HOST_NAME_MAX]u8` 를 받으므로 별도 버퍼로
+            // 받아서 옮긴다 (HOST_NAME_MAX 는 OS 마다 다르고 max_len 과 무관).
+            var host_buf: [std.posix.HOST_NAME_MAX]u8 = undefined;
+            const name = std.posix.gethostname(&host_buf) catch return "";
+            if (name.len > buf.len) return "";
+            @memcpy(buf[0..name.len], name);
+            return buf[0..name.len];
+        },
+    }
+}
+
+extern "kernel32" fn GetComputerNameW(lpBuffer: [*]u16, nSize: *u32) callconv(.c) i32;
+
+test "local_hostname — 조회가 실패해도 안전한 값을 돌려준다" {
+    var buf: [max_len]u8 = undefined;
+    const name = get(&buf);
+    // 실패 시 빈 slice. 성공 시 버퍼 안의 값이어야 한다 (길이 검증만 — 실제 값은
+    // 실행 환경에 따라 다르다).
+    try std.testing.expect(name.len <= max_len);
+    // NUL 이 섞여 들어오면 이후 경로 비교가 어긋난다.
+    try std.testing.expect(std.mem.indexOfScalar(u8, name, 0) == null);
+}

--- a/src/process_cwd.zig
+++ b/src/process_cwd.zig
@@ -1,0 +1,131 @@
+//! 자식 셸 프로세스의 현재 디렉토리를 **OS 에게 직접 물어본다** (#366).
+//!
+//! 셸이 OSC 7 을 보내주지 않아도 되는 경로다. 사용자 rc / 프롬프트를 건드리지 않고 우리
+//! 코드 안에서만 해결하므로 [#265](https://github.com/ensky0/tildaz/issues/265) (홈 고정)
+//! 와 같은 성격이다 — #265 가 `$HOME` 을 부모 환경변수에서 읽어 넘겼듯이, 여기서는 현재
+//! 위치를 OS 에 물어 넘긴다.
+//!
+//! | platform | 방법 |
+//! |---|---|
+//! | Linux | `readlink /proc/<pid>/cwd` |
+//! | macOS | `proc_pidinfo(PROC_PIDVNODEPATHINFO)` — std 에 바인딩이 없어 직접 선언 (libSystem 은 이미 링크됨) |
+//! | Windows | **없음 — 항상 `null`** |
+//!
+//! **Windows 가 없는 이유** (2026-08-03 결정): PowerShell 은 `Set-Location` 이 runspace
+//! 별 위치만 바꾸고 프로세스 cwd 는 시작값에 고정돼서 원리적으로 안 된다
+//! ([MS 문서](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-location)).
+//! `cmd` 는 PEB 를 읽으면 되지만 `NtQueryInformationProcess` 는 MS 가 *"may be altered or
+//! unavailable in future versions"* 로 표기한 비공개 API 다. PowerShell 에 어차피 OSC 7
+//! 주입이 필요하므로 Windows 는 주입 한 방식으로 통일한다.
+//!
+//! **어느 pid 인가 — 셸 자신이다** (foreground process 아님). `sudo` / `ssh` 로
+//! foreground 가 바뀌면 엉뚱한 답이 나오고, root 소유 프로세스는 조회 자체가 `EPERM`
+//! 이다 (macOS 실측). 셸은 우리 직계 자식이라 항상 읽힌다. OSC 7 의 의미 (셸이 프롬프트를
+//! 그린 위치) 와도 같은 답이라 두 경로가 일관된다.
+//!
+//! **경로는 물리 경로다.** symlink 를 통해 `cd` 한 사용자는 셸의 `$PWD` (논리 경로) 와
+//! 다른 값을 보게 된다. 호출처가 OSC 7 값을 우선하므로 이 차이는 셸이 보고하지 않는
+//! 환경에서만 나타난다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// `pid` 셸의 현재 디렉토리를 `buf` 에 담아 돌려준다. 조회할 수 없으면 `null` —
+/// 호출자는 홈으로 안전하게 열화한다.
+pub fn ofPid(pid: i32, buf: []u8) ?[]const u8 {
+    switch (builtin.os.tag) {
+        .linux => {
+            // `/proc/<pid>/cwd` 는 실제 디렉토리를 가리키는 심볼릭 링크다.
+            var link_buf: [64]u8 = undefined;
+            const link = std.fmt.bufPrint(&link_buf, "/proc/{d}/cwd", .{pid}) catch return null;
+            const path = std.fs.readLinkAbsolute(link, buf) catch return null;
+            return if (path.len > 0) path else null;
+        },
+        .macos => {
+            var info: ProcVnodePathInfo = undefined;
+            const rc = proc_pidinfo(
+                pid,
+                PROC_PIDVNODEPATHINFO,
+                0,
+                &info,
+                @sizeOf(ProcVnodePathInfo),
+            );
+            // 성공하면 채운 바이트 수 (= 구조체 크기), 실패하면 0 + errno.
+            if (rc <= 0) return null;
+            const path = std.mem.sliceTo(&info.pvi_cdir.vip_path, 0);
+            if (path.len == 0 or path.len > buf.len) return null;
+            @memcpy(buf[0..path.len], path);
+            return buf[0..path.len];
+        },
+        else => return null,
+    }
+}
+
+// ── macOS `libproc` 바인딩
+//
+// 레이아웃은 macOS 26 에서 C 헤더로 직접 측정했다 (#366). 헤더가 바뀌면 아래 comptime
+// assert 가 잡는다 — 크기가 어긋난 채로 호출하면 `proc_pidinfo` 가 조용히 실패하거나
+// 엉뚱한 offset 에서 경로를 읽는다.
+
+const PROC_PIDVNODEPATHINFO: c_int = 9;
+const MAXPATHLEN = 1024;
+
+/// `vnode_info_path`. 앞쪽 `vnode_info` 는 stat 류 필드 뭉치인데 우리는 경로만 쓰므로
+/// 크기 (152 바이트, 8 바이트 정렬) 만 맞춰 둔다.
+const VnodeInfoPath = extern struct {
+    vip_vi: [19]u64,
+    vip_path: [MAXPATHLEN]u8,
+};
+
+/// `proc_vnodepathinfo`. `pvi_cdir` = 현재 디렉토리, `pvi_rdir` = 루트 디렉토리 (미사용).
+const ProcVnodePathInfo = extern struct {
+    pvi_cdir: VnodeInfoPath,
+    pvi_rdir: VnodeInfoPath,
+};
+
+comptime {
+    std.debug.assert(@sizeOf(VnodeInfoPath) == 1176);
+    std.debug.assert(@offsetOf(VnodeInfoPath, "vip_path") == 152);
+    std.debug.assert(@sizeOf(ProcVnodePathInfo) == 2352);
+    std.debug.assert(@offsetOf(ProcVnodePathInfo, "pvi_cdir") == 0);
+}
+
+extern "c" fn proc_pidinfo(
+    pid: c_int,
+    flavor: c_int,
+    arg: u64,
+    buffer: ?*anyopaque,
+    buffersize: c_int,
+) c_int;
+
+// ── 테스트
+
+test "process_cwd — 자기 프로세스의 cwd 를 조회한다 (Windows 는 미지원)" {
+    var buf: [4200]u8 = undefined;
+
+    if (comptime builtin.os.tag == .windows) {
+        // Windows 는 OSC 7 주입으로 간다 — 조회는 항상 null.
+        try std.testing.expect(ofPid(0, &buf) == null);
+        return;
+    }
+
+    const probed = ofPid(std.c.getpid(), &buf) orelse return error.ProbeFailed;
+    // `getcwd` 도 물리 경로를 주므로 문자열이 그대로 일치해야 한다.
+    var actual_buf: [4200]u8 = undefined;
+    const actual = try std.posix.getcwd(&actual_buf);
+    try std.testing.expectEqualStrings(actual, probed);
+}
+
+test "process_cwd — 없는 pid 는 null" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    var buf: [4200]u8 = undefined;
+    // pid 1 은 macOS 에서 EPERM (실측), Linux 에서도 readlink 가 막힌다. 어느 쪽이든
+    // 조회 실패는 null 로 나와야 한다 (호출자가 홈으로 열화).
+    try std.testing.expect(ofPid(1, &buf) == null);
+}
+
+test "process_cwd — 버퍼가 모자라면 null" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    var small: [4]u8 = undefined;
+    try std.testing.expect(ofPid(std.c.getpid(), &small) == null);
+}

--- a/src/process_cwd.zig
+++ b/src/process_cwd.zig
@@ -38,8 +38,13 @@ pub fn ofPid(pid: i32, buf: []u8) ?[]const u8 {
             // `/proc/<pid>/cwd` 는 실제 디렉토리를 가리키는 심볼릭 링크다.
             var link_buf: [64]u8 = undefined;
             const link = std.fmt.bufPrint(&link_buf, "/proc/{d}/cwd", .{pid}) catch return null;
-            const path = std.fs.readLinkAbsolute(link, buf) catch return null;
-            return if (path.len > 0) path else null;
+            // `readLinkAbsolute` 는 슬라이스가 아니라 정확히 `*[max_path_bytes]u8` 를
+            // 받으므로 (호출자 버퍼 크기와 무관) 따로 받아서 옮긴다.
+            var target: [std.fs.max_path_bytes]u8 = undefined;
+            const path = std.fs.readLinkAbsolute(link, &target) catch return null;
+            if (path.len == 0 or path.len > buf.len) return null;
+            @memcpy(buf[0..path.len], path);
+            return buf[0..path.len];
         },
         .macos => {
             var info: ProcVnodePathInfo = undefined;

--- a/src/pwd_uri.zig
+++ b/src/pwd_uri.zig
@@ -1,0 +1,305 @@
+//! OSC 7 (`report_pwd`) payload → 새 탭의 시작 디렉토리 경로 (#366). 순수 모듈 —
+//! ghostty / OS API 의존 없이 `zig test src/pwd_uri.zig` 로 단독 실행된다.
+//!
+//! # 왜 우리가 해석하나
+//!
+//! OSC 파싱 자체는 `ghostty-vt` 가 다 하고 우리는 결과를 읽기만 한다 (OSC 0/2 제목은
+//! `getTitle()`, OSC 11 배경색은 renderer). OSC 7 만 예외로 ghostty 가 **raw payload 를
+//! 그대로 보관**하고 해석을 embedder 에게 넘긴다 — `stream_terminal.zig` 의 `reportPwd`
+//! 주석: *"We store the raw payload unparsed. Embedders read it via getPwd() and are
+//! responsible for decoding any URI scheme."* 그래서 이 모듈이 필요하다.
+//!
+//! payload 형태는 두 가지다.
+//!
+//! - `file://host/path` — 표준. host 와 path 가 퍼센트 인코딩된다 (fish 가 그렇게 보냄).
+//! - `kitty-shell-cwd://host/path` — ghostty / kitty 셸 통합 스크립트가 쓰는 스킴.
+//!   인코딩하지 않은 raw 경로를 보내므로 디코딩하지 않는다.
+//!
+//! # 왜 `std.Uri.parse` 를 쓰지 않나
+//!
+//! 퍼센트 디코딩은 `std.Uri.percentDecodeBackwards` 를 그대로 재사용하지만, **URI 파싱은
+//! 직접 한다.** `std.Uri.parse` 를 쓰면 우리 입력에서 함정 두 개가 생기는 걸 실측으로
+//! 확인했다 (아래 "std 동작 근거" 테스트가 이 두 동작을 고정한다).
+//!
+//! 1. **host 가 MAC 주소면 파싱이 실패한다.** macOS 의 *Private Wi-Fi address* 를 켜면
+//!    hostname 이 회전하는 MAC 주소 (`12:34:56:78:90:aa`) 가 되고, `std.Uri.parse` 가
+//!    마지막 옥텟을 포트 번호로 읽어 `error.InvalidPort` 를 낸다. ghostty 는 이걸 위해
+//!    `src/os/uri.zig` 에 재파싱 wrapper 를 따로 뒀다 (그 모듈은 `ghostty-vt` 밖이라
+//!    우리가 import 할 수 없다).
+//! 2. **경로에 `?` 나 `#` 이 있으면 잘린다.** `file://h/dir/a?b` 의 path 가 `/dir/a` 가
+//!    되고 `?b` 는 query 로 빠진다. 셸이 escape 를 빠뜨리면 경로가 조용히 짧아진다.
+//!    ghostty 가 `raw_path` 옵션을 만든 이유가 이것이다.
+//!
+//! OSC 7 payload 에는 query / fragment 개념이 없고 규칙이 "스킴 → host → path" 세 조각뿐
+//! 이라, `://` 와 첫 `/` 로 직접 자르면 위 두 함정이 애초에 생기지 않는다.
+//!
+//! # 깨진 퍼센트 인코딩
+//!
+//! `%` 뒤가 hex 두 자리가 아니면 `std.Uri` 는 그 자리를 리터럴로 남긴다 (거부하지 않음).
+//! ghostty 도 같은 함수를 쓰므로 동작이 같다. 우리도 그대로 두고, 결과 경로가 실제로
+//! 있는지는 호출자가 확인해 없으면 홈으로 열화한다 — escape 를 빠뜨리고 경로에 실제로
+//! `%` 를 쓰는 셸이 있을 수 있어 여기서 거부하면 그 경로를 영영 못 쓴다.
+
+const std = @import("std");
+
+/// 결과 경로의 표기 방식. **탭의 셸 종류로 결정**되며 host OS 로 결정되지 않는다 —
+/// Windows 의 WSL 탭은 셸이 Linux 경로 (`/home/me`) 를 보고하고 새 탭도 `wsl --cd`
+/// 로 Linux 경로를 받으므로 `.posix` 다.
+pub const Style = enum {
+    /// `/home/me` 그대로.
+    posix,
+    /// `/C:/Users/me` → `C:\Users\me`.
+    windows,
+};
+
+/// 경로 버퍼 권장 크기. Linux PATH_MAX (4096) + 스킴 / 인코딩 여유. 호출처가 스택에
+/// 이만큼 잡아 `parse` 에 넘긴다.
+pub const max_path_len = 4200;
+
+pub const Options = struct {
+    /// 이 머신의 hostname. ssh 안에서 온 OSC 7 은 그 경로가 이 머신에 없으므로
+    /// 거부해야 한다. 빈 값이면 hostname 비교를 건너뛰고 빈 host / `localhost`
+    /// 만 수락한다.
+    hostname: []const u8 = "",
+    style: Style,
+};
+
+/// `payload` 를 해석해 절대 경로를 `out` 에 쓰고 그 slice 를 돌려준다. 수락할 수 없는
+/// payload 는 `null` — 호출자는 기존 동작 (홈 디렉토리) 으로 안전하게 열화한다.
+///
+/// 거부 조건: 모르는 스킴 / host 가 다른 머신 (ssh) / 절대 경로가 아님 / NUL 포함 /
+/// `out` 부족.
+pub fn parse(payload: []const u8, out: []u8, opts: Options) ?[]const u8 {
+    const sep = std.mem.indexOf(u8, payload, "://") orelse return null;
+    const scheme = payload[0..sep];
+    const rest = payload[sep + 3 ..];
+
+    // `file` 은 퍼센트 인코딩, `kitty-shell-cwd` 는 raw. 그 외 스킴은 우리가 의미를
+    // 모르므로 거부한다 (ghostty 의 `stream_handler.zig` 도 이 둘만 받는다).
+    const encoded = if (std.ascii.eqlIgnoreCase(scheme, "file"))
+        true
+    else if (std.ascii.eqlIgnoreCase(scheme, "kitty-shell-cwd"))
+        false
+    else
+        return null;
+
+    // host 는 첫 `/` 앞까지. `/` 가 없으면 경로가 아예 없는 payload 라 거부.
+    const slash = std.mem.indexOfScalar(u8, rest, '/') orelse return null;
+    if (!hostAccepted(rest[0..slash], opts.hostname, encoded)) return null;
+
+    const path_raw = rest[slash..];
+    // `percentDecodeBackwards` 는 출력 인덱스를 뒤에서 줄이며 채우므로 `out` 이
+    // 입력보다 짧으면 underflow 로 panic 한다. 미리 막는다.
+    if (path_raw.len > out.len) return null;
+
+    // 디코딩 결과는 `out` 의 **뒤쪽**에 정렬된다 (`percentDecodeBackwards` 의 계약).
+    // raw 스킴도 같은 자리에 두어 이후 처리가 한 갈래로 흐르게 한다.
+    const head = out.len - path_raw.len;
+    @memcpy(out[head..], path_raw);
+    const path = if (encoded)
+        std.Uri.percentDecodeBackwards(out, out[head..])
+    else
+        out[head..];
+
+    // NUL 은 경로로 쓸 수 없다 (`chdir` / `lpCurrentDirectory` 모두 NUL 종단).
+    // `%00` 으로 들어올 수 있어 디코딩 후에 검사한다.
+    if (std.mem.indexOfScalar(u8, path, 0) != null) return null;
+
+    return switch (opts.style) {
+        .posix => if (path.len > 0 and path[0] == '/') path else null,
+        .windows => toWindowsPath(path, out),
+    };
+}
+
+/// 우리 머신의 경로인지 판정. 수락: 빈 host (`file:///path`, 그리고 fish 가 Konsole
+/// 대상으로 host 를 비우는 경우) · `localhost` · 우리 hostname.
+///
+/// hostname 비교는 **첫 라벨까지만** 한다 — FQDN 과 짧은 이름이 갈리는 환경에서도 같은
+/// 머신의 경로를 살리기 위한 관용이다 (ghostty 의 `os/hostname.zig` `isLocal` 은 정확
+/// 일치만 수락한다).
+///
+/// **이 관용은 확인된 필요가 아니라 여분이다.** 실측한 두 환경에서는 정확 일치로도
+/// 통했다 (2026-08-03): macOS 26 에서 `hostname` · zsh `$HOST` · bash `$HOSTNAME` ·
+/// fish `$hostname` 이 모두 `gethostname` 과 같은 `…​.local` 값이었고, Windows 의
+/// `GetComputerNameW` 와 WSL Debian 안 `$hostname` 도 서로 같았다. 대가로 다른 머신인데
+/// 첫 라벨이 같은 경우 (`mymac` ↔ `mymac.example.com`) 를 수락할 수 있는데, 그건 호출자의
+/// 경로 존재 확인이 2차로 막는다 — 원격 경로가 이 머신에도 있어야 통과하기 때문이다.
+fn hostAccepted(host_raw: []const u8, hostname: []const u8, encoded: bool) bool {
+    var buf: [std.Uri.host_name_max]u8 = undefined;
+    if (host_raw.len > buf.len) return false;
+    @memcpy(buf[buf.len - host_raw.len ..], host_raw);
+    const host = if (encoded)
+        std.Uri.percentDecodeBackwards(&buf, buf[buf.len - host_raw.len ..])
+    else
+        buf[buf.len - host_raw.len ..];
+
+    if (host.len == 0) return true;
+    if (std.ascii.eqlIgnoreCase(host, "localhost")) return true;
+    if (hostname.len == 0) return false;
+    return std.ascii.eqlIgnoreCase(firstLabel(host), firstLabel(hostname));
+}
+
+fn firstLabel(host: []const u8) []const u8 {
+    const dot = std.mem.indexOfScalar(u8, host, '.') orelse return host;
+    return host[0..dot];
+}
+
+/// `/C:/Users/me` → `C:\Users\me`.
+///
+/// `path` 는 `out` 뒤쪽의 slice 라 결과를 `out` **앞쪽으로 당겨** 쓴다. 뒤쪽에 그대로
+/// 두면 드라이브 루트 정규화 (`C:` → `C:\`) 에서 한 바이트 늘릴 자리가 없다.
+///
+/// 드라이브 문자로 시작하지 않으면 거부한다 (Windows 탭에 POSIX 경로가 오면 쓸 수
+/// 없다). UNC (`file://server/share`) 는 host 가 우리 머신이 아니라 `hostAccepted`
+/// 에서 이미 걸린다.
+fn toWindowsPath(path: []const u8, out: []u8) ?[]const u8 {
+    // 선행 `/` 하나를 뺀 나머지가 `X:` 로 시작해야 한다.
+    if (path.len < 3 or path[0] != '/') return null;
+    const body = path[1..];
+    if (!std.ascii.isAlphabetic(body[0]) or body[1] != ':') return null;
+
+    std.mem.copyForwards(u8, out[0..body.len], body);
+    var result = out[0..body.len];
+    for (result) |*c| {
+        if (c.* == '/') c.* = '\\';
+    }
+
+    // `C:` 만 남으면 drive-relative 경로 (그 드라이브의 *현재* 위치) 라 시작
+    // 디렉토리로 쓰면 어디로 갈지 모른다. 드라이브 루트로 정규화한다.
+    if (result.len == 2) {
+        if (out.len < 3) return null;
+        out[2] = '\\';
+        result = out[0..3];
+    }
+    return result;
+}
+
+// ── 테스트
+
+const testing = std.testing;
+
+/// PATH_MAX (4096) + 여유. 실제 호출처도 이 정도 버퍼를 준다.
+var test_buf: [4200]u8 = undefined;
+
+fn parsePosix(payload: []const u8, hostname: []const u8) ?[]const u8 {
+    return parse(payload, &test_buf, .{ .hostname = hostname, .style = .posix });
+}
+
+fn parseWindows(payload: []const u8, hostname: []const u8) ?[]const u8 {
+    return parse(payload, &test_buf, .{ .hostname = hostname, .style = .windows });
+}
+
+test "pwd_uri — file:// 기본 형태" {
+    try testing.expectEqualStrings("/home/me", parsePosix("file://myhost/home/me", "myhost").?);
+    // 빈 host — `file:///path` 와 fish 의 Konsole 대상 출력이 모두 이 형태.
+    try testing.expectEqualStrings("/home/me", parsePosix("file:///home/me", "myhost").?);
+    try testing.expectEqualStrings("/home/me", parsePosix("file://localhost/home/me", "myhost").?);
+    // 루트도 유효한 경로.
+    try testing.expectEqualStrings("/", parsePosix("file://myhost/", "myhost").?);
+}
+
+test "pwd_uri — host 검사로 ssh 원격 경로를 거부" {
+    try testing.expect(parsePosix("file://otherbox/home/me", "myhost") == null);
+    // hostname 을 모르면 (빈 값) 빈 host / localhost 만 수락.
+    try testing.expect(parsePosix("file://myhost/home/me", "") == null);
+    try testing.expectEqualStrings("/home/me", parsePosix("file:///home/me", "").?);
+}
+
+test "pwd_uri — hostname 표기가 FQDN / 짧은 이름으로 갈려도 첫 라벨로 흡수" {
+    // 실측한 환경들에서는 양쪽이 같았다 (`hostAccepted` doc 참조) — 갈리는 환경을 위한
+    // 관용이라 여기서만 인위적으로 다르게 준다.
+    try testing.expectEqualStrings("/home/me", parsePosix("file://mymac/home/me", "mymac.local").?);
+    try testing.expectEqualStrings("/home/me", parsePosix("file://mymac.local/home/me", "mymac").?);
+    // 대소문자 무시 (DNS 규칙).
+    try testing.expectEqualStrings("/home/me", parsePosix("file://MyMac/home/me", "mymac").?);
+    // 첫 라벨이 다르면 여전히 거부.
+    try testing.expect(parsePosix("file://mymac2.local/home/me", "mymac") == null);
+}
+
+test "pwd_uri — 퍼센트 디코딩" {
+    try testing.expectEqualStrings("/home/me/my dir", parsePosix("file://myhost/home/me/my%20dir", "myhost").?);
+    // 한글 (UTF-8 3바이트) — 두 셸 모두 URL escape 해서 보낸다.
+    try testing.expectEqualStrings("/home/me/한글", parsePosix("file://myhost/home/me/%ED%95%9C%EA%B8%80", "myhost").?);
+    try testing.expectEqualStrings("/home/me/100%", parsePosix("file://myhost/home/me/100%25", "myhost").?);
+    // host 쪽 인코딩도 디코딩해서 비교.
+    try testing.expectEqualStrings("/home/me", parsePosix("file://my%68ost/home/me", "myhost").?);
+}
+
+test "pwd_uri — 깨진 퍼센트 인코딩은 리터럴로 남긴다" {
+    // std.Uri · ghostty 와 같은 동작. 결과 경로가 없으면 호출자가 홈으로 열화한다.
+    try testing.expectEqualStrings("/home/me/50%", parsePosix("file://myhost/home/me/50%", "myhost").?);
+    try testing.expectEqualStrings("/home/me/50%zz", parsePosix("file://myhost/home/me/50%zz", "myhost").?);
+}
+
+test "pwd_uri — kitty-shell-cwd 는 디코딩하지 않는다" {
+    try testing.expectEqualStrings("/home/me", parsePosix("kitty-shell-cwd://myhost/home/me", "myhost").?);
+    // 이 스킴은 raw 경로를 보내므로 `%20` 은 경로에 실제로 있는 문자다.
+    try testing.expectEqualStrings("/home/me/a%20b", parsePosix("kitty-shell-cwd://myhost/home/me/a%20b", "myhost").?);
+    try testing.expectEqualStrings("/home/me/한글", parsePosix("kitty-shell-cwd://myhost/home/me/한글", "myhost").?);
+}
+
+test "pwd_uri — 모르는 스킴 / 형태가 아닌 payload 는 거부" {
+    try testing.expect(parsePosix("", "myhost") == null);
+    try testing.expect(parsePosix("/home/me", "myhost") == null);
+    try testing.expect(parsePosix("http://myhost/home/me", "myhost") == null);
+    // 스킴은 대소문자 무시.
+    try testing.expectEqualStrings("/home/me", parsePosix("FILE://myhost/home/me", "myhost").?);
+    // host 뒤에 경로가 없음.
+    try testing.expect(parsePosix("file://myhost", "myhost") == null);
+    // 상대 경로 (path 가 `/` 로 시작하지 않는 형태는 host/path 분리에서 걸린다).
+    try testing.expect(parsePosix("file://home/me", "myhost") == null);
+}
+
+test "pwd_uri — NUL 은 거부" {
+    try testing.expect(parsePosix("file://myhost/home/%00me", "myhost") == null);
+    try testing.expect(parsePosix("kitty-shell-cwd://myhost/home/\x00me", "myhost") == null);
+}
+
+test "pwd_uri — out 버퍼가 모자라면 거부" {
+    var small: [8]u8 = undefined;
+    try testing.expect(parse("file://myhost/home/me/deep/path", &small, .{
+        .hostname = "myhost",
+        .style = .posix,
+    }) == null);
+}
+
+test "pwd_uri — Windows 경로 변환" {
+    try testing.expectEqualStrings("C:\\Users\\me", parseWindows("file:///C:/Users/me", "myhost").?);
+    try testing.expectEqualStrings("C:\\Users\\me", parseWindows("file://myhost/C:/Users/me", "myhost").?);
+    try testing.expectEqualStrings("D:\\work\\my dir", parseWindows("file:///D:/work/my%20dir", "myhost").?);
+    // 드라이브 루트.
+    try testing.expectEqualStrings("C:\\", parseWindows("file:///C:/", "myhost").?);
+    // `C:` 만 오면 drive-relative — 루트로 정규화.
+    try testing.expectEqualStrings("C:\\", parseWindows("file:///C:", "myhost").?);
+    // 드라이브 문자가 없으면 거부 (Windows 탭에 POSIX 경로가 오면 쓸 수 없다).
+    try testing.expect(parseWindows("file:///home/me", "myhost") == null);
+}
+
+test "pwd_uri — WSL 탭은 Linux 경로라 .posix 로 해석" {
+    // 셸이 WSL 안에 있으므로 host OS 가 Windows 여도 경로 표기는 POSIX 다.
+    try testing.expectEqualStrings("/home/me/work", parsePosix("file://myhost/home/me/work", "myhost").?);
+}
+
+// ── std 동작 근거 — 이 두 테스트는 모듈 doc 의 "왜 `std.Uri.parse` 를 쓰지 않나" 를
+// 고정한다. std 가 동작을 바꾸면 여기서 깨지고, 그때 직접 파싱을 유지할지 다시 판단할
+// 근거가 된다.
+
+test "pwd_uri — std.Uri.parse 는 MAC 주소 host 에서 실패하지만 우리는 수락한다" {
+    // macOS 의 Private Wi-Fi address 를 켜면 hostname 이 회전하는 MAC 주소가 된다.
+    const payload = "file://12:34:56:78:90:aa/home/me";
+    try testing.expectError(error.InvalidPort, std.Uri.parse(payload));
+    try testing.expectEqualStrings("/home/me", parsePosix(payload, "12:34:56:78:90:aa").?);
+}
+
+test "pwd_uri — std.Uri.parse 는 경로의 ? · # 를 잘라내지만 우리는 보존한다" {
+    {
+        const uri = try std.Uri.parse("file://myhost/home/me/a?b");
+        try testing.expectEqualStrings("/home/me/a", uri.path.percent_encoded);
+        try testing.expectEqualStrings("/home/me/a?b", parsePosix("file://myhost/home/me/a?b", "myhost").?);
+    }
+    {
+        const uri = try std.Uri.parse("file://myhost/home/me/a#b");
+        try testing.expectEqualStrings("/home/me/a", uri.path.percent_encoded);
+        try testing.expectEqualStrings("/home/me/a#b", parsePosix("file://myhost/home/me/a#b", "myhost").?);
+    }
+}

--- a/src/pwd_uri.zig
+++ b/src/pwd_uri.zig
@@ -106,7 +106,7 @@ pub fn parse(payload: []const u8, out: []u8, opts: Options) ?[]const u8 {
     if (std.mem.indexOfScalar(u8, path, 0) != null) return null;
 
     return switch (opts.style) {
-        .posix => if (path.len > 0 and path[0] == '/') path else null,
+        .posix => if (path.len > 0 and path[0] == '/') squeezeLeadingSlashes(path) else null,
         .windows => toWindowsPath(path, out),
     };
 }
@@ -137,6 +137,21 @@ fn hostAccepted(host_raw: []const u8, hostname: []const u8, encoded: bool) bool 
     if (std.ascii.eqlIgnoreCase(host, "localhost")) return true;
     if (hostname.len == 0) return false;
     return std.ascii.eqlIgnoreCase(firstLabel(host), firstLabel(hostname));
+}
+
+/// 선행 슬래시가 겹친 경로를 하나로 줄인다 (`//home/me` → `/home/me`).
+///
+/// 보내는 쪽 템플릿의 실수를 흡수하는 방어다. 셸마다 경로 형태가 달라서 (`cmd` 의 `$P`
+/// 는 `C:\…`, POSIX 의 `$PWD` 는 `/…`) `kitty-shell-cwd://` 뒤에 슬래시를 몇 개 두어야
+/// 하는지가 갈리는데, 이걸 손으로 맞추다 틀리면 `//home/me` 같은 값이 나간다. POSIX 는
+/// 선행 `//` 를 구현 정의로 두지만 Linux · macOS 는 `/` 와 같게 취급하므로 축약이 안전하다.
+///
+/// 경로 **안쪽**의 중복은 건드리지 않는다 — 우리가 만들 수 있는 실수는 앞부분에서만
+/// 생기고, 안쪽까지 정규화하면 파서가 경로를 고쳐 쓰는 범위가 넓어진다.
+fn squeezeLeadingSlashes(path: []const u8) []const u8 {
+    var i: usize = 0;
+    while (i + 1 < path.len and path[i] == '/' and path[i + 1] == '/') i += 1;
+    return path[i..];
 }
 
 fn firstLabel(host: []const u8) []const u8 {
@@ -196,6 +211,16 @@ test "pwd_uri — file:// 기본 형태" {
     try testing.expectEqualStrings("/home/me", parsePosix("file://localhost/home/me", "myhost").?);
     // 루트도 유효한 경로.
     try testing.expectEqualStrings("/", parsePosix("file://myhost/", "myhost").?);
+}
+
+test "pwd_uri — 선행 슬래시가 겹쳐도 경로가 깨지지 않는다" {
+    // 보내는 쪽 템플릿이 `:///` + `$PWD` 처럼 슬래시를 하나 더 두면 이런 값이 온다.
+    try testing.expectEqualStrings("/home/me", parsePosix("file://myhost//home/me", "myhost").?);
+    try testing.expectEqualStrings("/home/me", parsePosix("file://myhost///home/me", "myhost").?);
+    // 경로 안쪽 중복은 그대로 둔다 (파서가 경로를 고쳐 쓰는 범위를 앞부분으로 제한).
+    try testing.expectEqualStrings("/home//me", parsePosix("file://myhost/home//me", "myhost").?);
+    // 루트만 온 경우를 빈 문자열로 만들지 않는다.
+    try testing.expectEqualStrings("/", parsePosix("file://myhost//", "myhost").?);
 }
 
 test "pwd_uri — host 검사로 ssh 원격 경로를 거부" {

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -8,6 +8,9 @@ const terminal_interaction = @import("terminal_interaction.zig");
 const themes = @import("themes.zig");
 const perf = @import("perf.zig");
 const log = @import("log.zig");
+const pwd_uri = @import("pwd_uri.zig");
+const local_hostname = @import("local_hostname.zig");
+const process_cwd = @import("process_cwd.zig");
 
 /// Lock-free 링버퍼 (단일 생산자, 단일 소비자)
 const RingBuffer = struct {
@@ -247,6 +250,7 @@ pub const Tab = struct {
         max_scroll_lines: usize,
         theme: ?*const themes.Theme,
         extra_env: ?[]const terminal.ExtraEnv,
+        cwd: ?[]const u8,
         tab_exit_fn: SessionCore.TabExitNotify,
         tab_exit_userdata: ?*anyopaque,
     ) !*Tab {
@@ -287,6 +291,7 @@ pub const Tab = struct {
             .rows = rows,
             .shell = shell,
             .extra_env = extra_env,
+            .cwd = cwd,
         });
         errdefer backend.deinit();
         const title_clock = try std.time.Timer.start();
@@ -650,7 +655,72 @@ pub const SessionCore = struct {
         self.tabs.deinit(self.allocator);
     }
 
+    /// 새 탭이 물려받을 시작 디렉토리 (#366). 활성 탭의 셸이 OSC 7 로 알린 위치를
+    /// 쓴다. 값이 없거나 (셸이 OSC 7 을 안 보냄 / tmux 안이라 흡수됨 / ssh 원격
+    /// 경로라 거부됨) 그리로 들어갈 수 없으면 `null` — 각 backend 가 홈에서 시작한다
+    /// ([#265](https://github.com/ensky0/tildaz/issues/265) 의 기존 동작).
+    ///
+    /// 반환 slice 는 `buf` 안을 가리키므로 호출자의 `buf` 가 살아 있는 동안만 유효하다.
+    fn inheritedCwd(self: *SessionCore, buf: []u8) ?[]const u8 {
+        // 첫 탭은 물려받을 곳이 없다.
+        if (self.tabs.items.len == 0 or self.active_tab >= self.tabs.items.len) return null;
+        const tab = self.tabs.items[self.active_tab];
+
+        // 경로 표기는 **탭의 셸 기준** — WSL 탭은 host 가 Windows 여도 Linux 경로다.
+        const wsl = terminal.isWslShell(self.shell_command);
+        const style: pwd_uri.Style = if (builtin.os.tag == .windows and !wsl) .windows else .posix;
+
+        // ① 셸이 OSC 7 로 알린 위치. 셸의 논리 경로 (`$PWD`) 라 symlink 를 따라 들어간
+        //    사용자의 기대에 맞으므로 ② 보다 우선한다.
+        if (tab.terminal.getPwd()) |payload| {
+            var host_buf: [local_hostname.max_len]u8 = undefined;
+            const hostname = local_hostname.get(&host_buf);
+            if (pwd_uri.parse(payload, buf, .{ .hostname = hostname, .style = style })) |path| {
+                if (usableDir(path, wsl)) {
+                    log.appendLine("cwd", "새 탭 시작 위치 = {s} (셸이 알림)", .{path});
+                    return path;
+                }
+                log.appendLine("cwd", "셸이 알린 위치로 갈 수 없음. path={s}", .{path});
+            } else {
+                // 다른 머신 (ssh) 이거나 표기가 이 탭의 셸과 안 맞는 경우.
+                log.appendLine(
+                    "cwd",
+                    "셸이 알린 위치를 쓸 수 없음. payload={s} style={s} hostname={s}",
+                    .{ payload, @tagName(style), hostname },
+                );
+            }
+        }
+
+        // ② 셸이 알려주지 않으면 OS 에 직접 묻는다 (Linux · macOS 만 — Windows 는 항상
+        //    null 이라 OSC 7 주입에 의존한다). 셸 종류 / rc 구성과 무관하게 동작한다.
+        if (process_cwd.ofPid(tab.backend.childPid(), buf)) |path| {
+            if (usableDir(path, wsl)) {
+                log.appendLine("cwd", "새 탭 시작 위치 = {s} (프로세스 조회)", .{path});
+                return path;
+            }
+        }
+
+        log.appendLine("cwd", "물려받을 위치가 없어 홈에서 시작", .{});
+        return null;
+    }
+
+    /// 시작 디렉토리로 실제 쓸 수 있는지. `access` 는 **파일도 통과시켜** spawn 이
+    /// `ENOTDIR` 로 실패하므로 디렉토리로 열어 본다.
+    ///
+    /// WSL 탭만 예외로 확인 없이 통과시킨다 — 보고된 Linux 경로를 Windows 쪽에서 확인할
+    /// 방법이 없어서 `wsl --cd` 에 위임한다. 그 경로가 없으면 wsl 이 에러 한 줄을 찍고
+    /// 셸은 정상적으로 뜬다 (Windows 실기 확인, #366).
+    fn usableDir(path: []const u8, wsl: bool) bool {
+        if (builtin.os.tag == .windows and wsl) return true;
+        var dir = std.fs.openDirAbsolute(path, .{}) catch return false;
+        dir.close();
+        return true;
+    }
+
     pub fn createTab(self: *SessionCore, cols: u16, rows: u16) !void {
+        var cwd_buf: [pwd_uri.max_path_len]u8 = undefined;
+        const cwd = self.inheritedCwd(&cwd_buf);
+
         const tab = try Tab.init(
             self.allocator,
             cols,
@@ -659,6 +729,7 @@ pub const SessionCore = struct {
             self.max_scroll_lines,
             self.theme,
             self.extra_env,
+            cwd,
             self.tab_exit_fn,
             self.tab_exit_userdata,
         );
@@ -1186,6 +1257,68 @@ test "POSIX: new tab shows Tab N from creation, before any shell output" {
         try std.testing.expect(session.tabAt(0).?.title_len > 0);
         try std.testing.expect(session.tabAt(1).?.title_len > 0);
         std.Thread.sleep(10 * std.time.ns_per_ms);
+    }
+}
+
+test "POSIX: OSC 7 이 우선하고 쓸 수 없으면 프로세스 조회로 내려간다 (#366)" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Exit = struct {
+        fn notify(_: usize, _: ?*anyopaque) void {}
+    };
+    var session = SessionCore.init(
+        std.testing.allocator,
+        "/bin/sh",
+        100,
+        null,
+        null,
+        &Exit.notify,
+        null,
+    );
+    defer session.deinit();
+    try session.createTab(80, 24);
+
+    var cwd_buf: [pwd_uri.max_path_len]u8 = undefined;
+
+    // `/bin/sh` 는 OSC 7 을 보내지 않지만, POSIX 는 프로세스 조회 fallback 이 있어서
+    // 셸의 현재 위치를 얻는다. 구체적인 값은 spawn 타이밍 (자식이 `chdir` 하기 전일
+    // 수 있다) 에 따라 홈이거나 앱의 위치라 단정하지 않고, **절대 경로가 나온다**는
+    // 것만 본다.
+    {
+        const probed = session.inheritedCwd(&cwd_buf) orelse return error.FallbackMissing;
+        try std.testing.expect(std.fs.path.isAbsolute(probed));
+    }
+
+    // host 는 조회한 값을 그대로 써서 파서의 host 검사를 실제로 통과시킨다. 조회가
+    // 실패해 빈 문자열이면 `file:///…` 형태가 되고 그것도 수락 대상이다.
+    var host_buf: [local_hostname.max_len]u8 = undefined;
+    const host = local_hostname.get(&host_buf);
+    var payload: [local_hostname.max_len + 64]u8 = undefined;
+
+    const tab = session.tabAt(0).?;
+
+    // 셸이 알린 위치가 있으면 그것이 조회보다 우선한다. `/` 를 쓰는 이유는 어느 OS
+    // 에서도 심볼릭 링크가 아니고 항상 있기 때문이다.
+    tab.stream.nextSlice(try std.fmt.bufPrint(&payload, "\x1b]7;file://{s}/\x1b\\", .{host}));
+    try std.testing.expectEqualStrings("/", session.inheritedCwd(&cwd_buf).?);
+
+    // 파싱은 되지만 열 수 없는 경로 → 조회로 내려간다 (그 경로를 그대로 쓰지 않는다).
+    tab.stream.nextSlice(try std.fmt.bufPrint(
+        &payload,
+        "\x1b]7;file://{s}/tz366-does-not-exist\x1b\\",
+        .{host},
+    ));
+    {
+        const probed = session.inheritedCwd(&cwd_buf) orelse return error.FallbackMissing;
+        try std.testing.expect(!std.mem.eql(u8, probed, "/tz366-does-not-exist"));
+        try std.testing.expect(std.fs.path.isAbsolute(probed));
+    }
+
+    // 다른 머신 (ssh 원격) → 거부되고 조회로 내려간다.
+    tab.stream.nextSlice("\x1b]7;file://tz366-other-box/\x1b\\");
+    {
+        const probed = session.inheritedCwd(&cwd_buf) orelse return error.FallbackMissing;
+        try std.testing.expect(std.fs.path.isAbsolute(probed));
     }
 }
 

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -677,15 +677,15 @@ pub const SessionCore = struct {
             const hostname = local_hostname.get(&host_buf);
             if (pwd_uri.parse(payload, buf, .{ .hostname = hostname, .style = style })) |path| {
                 if (usableDir(path, wsl)) {
-                    log.appendLine("cwd", "새 탭 시작 위치 = {s} (셸이 알림)", .{path});
+                    log.appendLine("cwd", "new tab cwd={s} (shell reported)", .{path});
                     return path;
                 }
-                log.appendLine("cwd", "셸이 알린 위치로 갈 수 없음. path={s}", .{path});
+                log.appendLine("cwd", "shell-reported cwd unusable: {s}", .{path});
             } else {
                 // 다른 머신 (ssh) 이거나 표기가 이 탭의 셸과 안 맞는 경우.
                 log.appendLine(
                     "cwd",
-                    "셸이 알린 위치를 쓸 수 없음. payload={s} style={s} hostname={s}",
+                    "shell-reported pwd rejected: payload={s} style={s} hostname={s}",
                     .{ payload, @tagName(style), hostname },
                 );
             }
@@ -695,12 +695,12 @@ pub const SessionCore = struct {
         //    null 이라 OSC 7 주입에 의존한다). 셸 종류 / rc 구성과 무관하게 동작한다.
         if (process_cwd.ofPid(tab.backend.childPid(), buf)) |path| {
             if (usableDir(path, wsl)) {
-                log.appendLine("cwd", "새 탭 시작 위치 = {s} (프로세스 조회)", .{path});
+                log.appendLine("cwd", "new tab cwd={s} (process probe)", .{path});
                 return path;
             }
         }
 
-        log.appendLine("cwd", "물려받을 위치가 없어 홈에서 시작", .{});
+        log.appendLine("cwd", "no inheritable cwd, starting in home", .{});
         return null;
     }
 

--- a/src/shell_integration.zig
+++ b/src/shell_integration.zig
@@ -45,6 +45,137 @@ pub fn cmdPrompt(buf: []u8, existing: []const u8) ?[]const u8 {
     return buf[0..total];
 }
 
+// ── PowerShell
+//
+// `PROMPT` 같은 환경변수로는 PowerShell 의 프롬프트를 바꿀 수 없다 (`prompt` 함수가
+// 프롬프트를 만든다). 그래서 명령줄에 `-NoExit -EncodedCommand` 를 붙여 **프로필이
+// 로드된 뒤** 기존 `prompt` 를 감싼다 — Windows 실기에서 프로필의 원래 프롬프트가
+// 유지된 채 우리 조각만 앞에 붙는 것을 확인했다 (#366).
+//
+// `-Command "…"` 대신 `-EncodedCommand` 를 쓰는 이유: 셸 경계마다 인용 escape 규칙이
+// 달라서 (`cmd` → `powershell.exe` 에서는 `\"`, 우리는 `CreateProcessW` 로 직접 spawn)
+// 같은 문자열이 다르게 깨진다. Base64 는 그 문제가 원천적으로 없다.
+
+/// 기존 `prompt` 를 감싸 OSC 7 을 앞에 붙이는 스크립트.
+///
+/// `$PWD.Provider.Name -eq 'FileSystem'` 검사가 필요하다 — PowerShell 은 `HKLM:` 같은
+/// 레지스트리 위치로도 `cd` 할 수 있고, 그때 보고하면 파일시스템 경로가 아닌 값이 간다.
+/// 경로는 `$PWD.ProviderPath` (provider 안의 실제 경로) 를 쓴다.
+///
+/// 종료자는 **BEL** (`$([char]7)`) 이다. ST (`ESC \`) 도 표준이지만 PowerShell 문자열에
+/// `\` 를 넣으면 Zig · PowerShell 양쪽 escape 가 겹쳐 읽기 어려워지고, 파서는 둘 다
+/// 받는다 (cmd 는 BEL 을 만들 수 없어서 그쪽만 ST 를 쓴다).
+const ps_script =
+    "$global:tzOrig=(Get-Item function:prompt).ScriptBlock; " ++
+    "function global:prompt { $r=''; " ++
+    "if ($PWD.Provider.Name -eq 'FileSystem') " ++
+    "{ $r=\"$([char]27)]7;kitty-shell-cwd:///$($PWD.ProviderPath)$([char]7)\" }; " ++
+    "$r + (& $global:tzOrig) }";
+
+/// `-EncodedCommand` 가 받는 **UTF-16LE Base64**. 스크립트가 ASCII 뿐이라 각 바이트 뒤에
+/// 0 을 넣으면 UTF-16LE 가 되고, 전부 comptime 에 계산되므로 런타임 조립이 없다.
+pub const ps_encoded = blk: {
+    var utf16: [ps_script.len * 2]u8 = undefined;
+    for (ps_script, 0..) |c, i| {
+        utf16[i * 2] = c;
+        utf16[i * 2 + 1] = 0;
+    }
+    const Enc = std.base64.standard.Encoder;
+    var out: [Enc.calcSize(utf16.len)]u8 = undefined;
+    _ = Enc.encode(&out, &utf16);
+    break :blk out;
+};
+
+/// 명령줄 맨 끝에 붙일 인자. `-NoExit` 는 스크립트 실행 후에도 대화형으로 남기 위한
+/// 것이고, 사용자가 이미 줬어도 중복은 무해하다.
+pub const ps_args = " -NoExit -EncodedCommand " ++ ps_encoded;
+
+/// `CreateProcessW` 가 쓰는 UTF-16 형태. 여기서 미리 변환해 두므로 호출처 (Windows
+/// backend) 는 상수를 참조만 한다 — 호출처에서 변환하면 comptime 평가 한도를 늘리는
+/// `@setEvalBranchQuota` 가 Windows 전용 코드에 흩어진다.
+pub const ps_args_w = blk: {
+    @setEvalBranchQuota(10_000);
+    break :blk std.unicode.utf8ToUtf16LeStringLiteral(ps_args);
+};
+
+pub const PsInjection = struct {
+    /// 첫 토큰이 PowerShell 인가.
+    is_powershell: bool,
+    /// 주입해도 되는가. 사용자가 이미 실행할 명령 / 스크립트를 지정했으면 false —
+    /// 우리 `-EncodedCommand` 와 충돌한다.
+    inject: bool,
+};
+
+/// 이 명령줄이 PowerShell 탭인지, 주입해도 안전한지 판정한다. 첫 토큰 파싱 규칙은
+/// `wslCdInsertion` 과 같다 (선행 `"` 지원, basename 비교).
+///
+/// **대소문자를 무시한다.** `wslCdInsertion` 은 Windows Terminal 의 동작을 그대로 따라
+/// 정확 표기만 받지만, 여기는 따를 참조 대상이 없고 `PowerShell.exe` 같은 표기가 흔해서
+/// 무시하는 쪽이 사용자에게 이롭다.
+pub fn psInjection(cmd: []const u16) PsInjection {
+    if (cmd.len == 0) return .{ .is_powershell = false, .inject = false };
+
+    // 첫 토큰 경계 — `"` 로 시작하면 닫는 `"` 까지, 아니면 첫 공백까지.
+    const quoted = cmd[0] == '"';
+    const tok_start: usize = if (quoted) 1 else 0;
+    var tok_end = tok_start;
+    while (tok_end < cmd.len) : (tok_end += 1) {
+        const ch = cmd[tok_end];
+        if (quoted) {
+            if (ch == '"') break;
+        } else if (ch == ' ') break;
+    }
+
+    // 토큰의 파일 이름 = 마지막 경로 구분자 뒤.
+    var base_start = tok_start;
+    for (cmd[tok_start..tok_end], tok_start..) |ch, i| {
+        if (ch == '\\' or ch == '/') base_start = i + 1;
+    }
+    const basename = cmd[base_start..tok_end];
+    const is_powershell = eqlIgnoreCaseAscii(basename, "powershell") or
+        eqlIgnoreCaseAscii(basename, "powershell.exe") or
+        eqlIgnoreCaseAscii(basename, "pwsh") or
+        eqlIgnoreCaseAscii(basename, "pwsh.exe");
+    if (!is_powershell) return .{ .is_powershell = false, .inject = false };
+
+    // 나머지 인자에 실행할 명령 / 스크립트 지정이 있으면 주입하지 않는다.
+    var i = if (quoted and tok_end < cmd.len) tok_end + 1 else tok_end;
+    while (i < cmd.len) {
+        while (i < cmd.len and cmd[i] == ' ') i += 1;
+        if (i >= cmd.len) break;
+        const start = i;
+        while (i < cmd.len and cmd[i] != ' ') i += 1;
+        const tok = cmd[start..i];
+        if (tok.len >= 2 and tok[0] == '-' and isCommandSwitch(tok[1..])) {
+            return .{ .is_powershell = true, .inject = false };
+        }
+    }
+    return .{ .is_powershell = true, .inject = true };
+}
+
+/// PowerShell 스위치는 **접두어로 줄여 쓸 수 있다** (`-Command` → `-c`). 그래서 정확
+/// 비교가 아니라 "이름의 접두어인가" 로 판정한다. `-ExecutionPolicy` 처럼 접두어가 아닌
+/// 것은 걸리지 않으므로 (그 사용자도 주입을 받는다) 과잉 차단이 아니다.
+fn isCommandSwitch(name: []const u16) bool {
+    if (name.len == 0) return false;
+    for ([_][]const u8{ "command", "encodedcommand", "file" }) |full| {
+        if (name.len > full.len) continue;
+        if (eqlIgnoreCaseAscii(name, full[0..name.len])) return true;
+    }
+    return false;
+}
+
+/// UTF-16 (ASCII 범위) 과 ASCII 문자열의 대소문자 무시 비교. 비 ASCII 문자가 있으면
+/// 불일치로 본다 — 셸 이름 / 스위치 이름은 모두 ASCII 다.
+fn eqlIgnoreCaseAscii(wide: []const u16, ascii: []const u8) bool {
+    if (wide.len != ascii.len) return false;
+    for (wide, ascii) |w, a| {
+        if (w > 127) return false;
+        if (std.ascii.toLower(@intCast(w)) != std.ascii.toLower(a)) return false;
+    }
+    return true;
+}
+
 // ── 테스트
 
 const testing = std.testing;
@@ -87,6 +218,88 @@ test "shell_integration — cmd 가 보낼 payload 를 파서가 그대로 읽�
     try testing.expectEqualStrings(
         "C:\\",
         pwd_uri.parse("kitty-shell-cwd:///C:\\", &buf, opts).?,
+    );
+}
+
+const L = std.unicode.utf8ToUtf16LeStringLiteral;
+
+test "shell_integration — PowerShell 탭을 알아본다" {
+    for ([_][:0]const u16{
+        L("powershell.exe"),
+        L("pwsh"),
+        L("pwsh.exe"),
+        L("PowerShell.exe -NoLogo"), // 대소문자 무시
+        L("\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoLogo"),
+        L("C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"),
+    }) |cmd| {
+        const r = psInjection(cmd);
+        try testing.expect(r.is_powershell and r.inject);
+    }
+
+    for ([_][:0]const u16{
+        L(""),
+        L("cmd.exe"),
+        L("wsl.exe -d Debian"),
+        L("mypowershell.exe"), // basename 이 정확히 일치해야 한다
+    }) |cmd| {
+        try testing.expect(!psInjection(cmd).is_powershell);
+    }
+}
+
+test "shell_integration — 사용자가 명령 / 스크립트를 지정했으면 주입하지 않는다" {
+    for ([_][:0]const u16{
+        L("powershell.exe -Command \"echo hi\""),
+        L("powershell.exe -c foo"), // 접두어 축약
+        L("pwsh -File a.ps1"),
+        L("pwsh -f a.ps1"),
+        L("powershell.exe -EncodedCommand AAAA"),
+        L("powershell.exe -e AAAA"),
+        L("powershell.exe -NoLogo -Command x"), // 뒤쪽 인자도 본다
+    }) |cmd| {
+        const r = psInjection(cmd);
+        try testing.expect(r.is_powershell and !r.inject);
+    }
+
+    // 접두어가 아닌 스위치는 걸리지 않는다 — 이 사용자도 주입을 받는다.
+    for ([_][:0]const u16{
+        L("powershell.exe -ExecutionPolicy Bypass"),
+        L("powershell.exe -NoLogo -NoProfile"),
+        L("pwsh -WorkingDirectory C:\\"),
+    }) |cmd| {
+        const r = psInjection(cmd);
+        try testing.expect(r.is_powershell and r.inject);
+    }
+}
+
+test "shell_integration — PowerShell 스크립트가 UTF-16LE Base64 로 정확히 인코딩된다" {
+    // Base64 를 되돌려 원본 스크립트와 같은지 본다 (comptime 계산이 맞는지 검증).
+    const Dec = std.base64.standard.Decoder;
+    const n = try Dec.calcSizeForSlice(&ps_encoded);
+    var utf16_bytes: [ps_script.len * 2]u8 = undefined;
+    try testing.expectEqual(utf16_bytes.len, n);
+    try Dec.decode(&utf16_bytes, &ps_encoded);
+
+    // UTF-16LE — ASCII 뒤에 0 바이트.
+    for (ps_script, 0..) |c, i| {
+        try testing.expectEqual(c, utf16_bytes[i * 2]);
+        try testing.expectEqual(@as(u8, 0), utf16_bytes[i * 2 + 1]);
+    }
+    // 스크립트가 실제로 우리 스킴과 provider 검사를 담고 있는지.
+    try testing.expect(std.mem.indexOf(u8, ps_script, "kitty-shell-cwd:///") != null);
+    try testing.expect(std.mem.indexOf(u8, ps_script, "FileSystem") != null);
+    try testing.expect(std.mem.indexOf(u8, ps_script, "$global:tzOrig") != null);
+}
+
+test "shell_integration — PowerShell 이 보낼 payload 를 파서가 읽는다" {
+    var buf: [pwd_uri.max_path_len]u8 = undefined;
+    // `$PWD.ProviderPath` 확장 결과 + BEL 종료. payload 는 종료자를 뺀 부분이다
+    // (ghostty 가 OSC 를 잘라 넘긴다).
+    try testing.expectEqualStrings(
+        "C:\\Users\\me\\proj",
+        pwd_uri.parse("kitty-shell-cwd:///C:\\Users\\me\\proj", &buf, .{
+            .hostname = "MYPC",
+            .style = .windows,
+        }).?,
     );
 }
 

--- a/src/shell_integration.zig
+++ b/src/shell_integration.zig
@@ -1,0 +1,107 @@
+//! 셸이 OSC 7 (`report_pwd`) 로 현재 위치를 알리게 만드는 주입 문자열 (#366).
+//!
+//! 순수 모듈 — 문자열 조립만 하고 환경변수 조회 / 전달은 각 host 가 한다
+//! ([`host/windows.zig`](host/windows.zig) 의 `buildExtraEnv`). 조립을 host 안에 두면
+//! Windows 전용 코드가 되어 다른 머신에서 단위 테스트를 돌릴 수 없기 때문이다.
+//!
+//! # Windows 만 주입한다
+//!
+//! Linux · macOS 는 프로세스 cwd 조회 ([`process_cwd.zig`](process_cwd.zig)) 로 셸과
+//! 무관하게 위치를 얻으므로 **사용자 환경을 전혀 건드리지 않는다** (2026-08-03 결정).
+//! Windows 는 PowerShell 이 `Set-Location` 을 runspace 별로만 반영해서 프로세스 cwd
+//! 조회가 원리적으로 불가하고, `cmd` 만 되는 PEB 읽기는 비공개 API 라 주입이 유일한
+//! 길이다.
+//!
+//! # 스킴은 `kitty-shell-cwd://`
+//!
+//! 셸의 프롬프트 기능으로는 퍼센트 인코딩을 할 수 없다. `file://` 로 보내면 파서가
+//! 인코딩된 값으로 읽어서 `C:\50%20x` 같은 경로가 `C:\50 x` 로 **잘못 디코딩된다.**
+//! raw 스킴은 그 문제가 없다 (아래 왕복 테스트가 이 차이를 고정한다).
+
+const std = @import("std");
+
+/// cmd 가 프롬프트를 그릴 때마다 OSC 7 을 보내게 하는 조각.
+///
+/// `$E` = ESC, `$P` = 현재 드라이브+경로, `$E\` = ST (String Terminator). host 는 비워
+/// 둔다 (`:///` — 슬래시 셋) — 파서가 빈 host 를 수락한다. cmd 는 프롬프트를 그릴 때마다
+/// `PROMPT` 를 다시 확장하므로 `cd` 를 따라온다 (Windows 실기 확인, #366).
+const cmd_report = "$E]7;kitty-shell-cwd:///$P$E\\";
+
+/// cmd 의 기본 프롬프트. `PROMPT` 가 설정돼 있지 않을 때 이어 붙인다 — 환경변수를
+/// 설정하는 순간 cmd 의 기본값은 적용되지 않으므로, 우리가 명시하지 않으면 프롬프트에
+/// 경로도 `>` 도 남지 않는다.
+const cmd_default_prompt = "$P$G";
+
+/// cmd 의 `PROMPT` 값을 조립한다. 보고 조각을 **기존 값 앞에** 붙인다 — `PROMPT` 는
+/// 프롬프트 *모양* 자체라 덮어쓰면 사용자가 정해 둔 프롬프트가 사라진다.
+///
+/// 버퍼가 모자라면 `null` — 호출자는 주입을 건너뛰고 기존 동작 (홈에서 시작) 을 남긴다.
+pub fn cmdPrompt(buf: []u8, existing: []const u8) ?[]const u8 {
+    const tail = if (existing.len > 0) existing else cmd_default_prompt;
+    const total = cmd_report.len + tail.len;
+    if (total > buf.len) return null;
+    @memcpy(buf[0..cmd_report.len], cmd_report);
+    @memcpy(buf[cmd_report.len..][0..tail.len], tail);
+    return buf[0..total];
+}
+
+// ── 테스트
+
+const testing = std.testing;
+const pwd_uri = @import("pwd_uri.zig");
+
+test "shell_integration — cmd PROMPT 는 기존 값 앞에 보고 조각을 붙인다" {
+    var buf: [256]u8 = undefined;
+    // 사용자가 정해 둔 프롬프트 모양은 그대로 뒤에 남는다.
+    try testing.expectEqualStrings(
+        "$E]7;kitty-shell-cwd:///$P$E\\[$P]$G",
+        cmdPrompt(&buf, "[$P]$G").?,
+    );
+    // 설정돼 있지 않으면 cmd 기본값을 이어 붙인다.
+    try testing.expectEqualStrings(
+        "$E]7;kitty-shell-cwd:///$P$E\\$P$G",
+        cmdPrompt(&buf, "").?,
+    );
+}
+
+test "shell_integration — 버퍼가 모자라면 주입을 건너뛴다" {
+    var small: [8]u8 = undefined;
+    try testing.expect(cmdPrompt(&small, "") == null);
+}
+
+test "shell_integration — cmd 가 보낼 payload 를 파서가 그대로 읽는다" {
+    var buf: [pwd_uri.max_path_len]u8 = undefined;
+    const opts: pwd_uri.Options = .{ .hostname = "MYPC", .style = .windows };
+
+    // cmd 가 `$P` 를 확장한 결과 (Windows 경로, 인코딩 없음).
+    try testing.expectEqualStrings(
+        "C:\\Users\\me",
+        pwd_uri.parse("kitty-shell-cwd:///C:\\Users\\me", &buf, opts).?,
+    );
+    // 공백도 그대로 (cmd 는 escape 하지 않는다).
+    try testing.expectEqualStrings(
+        "D:\\my dir",
+        pwd_uri.parse("kitty-shell-cwd:///D:\\my dir", &buf, opts).?,
+    );
+    // 드라이브 루트.
+    try testing.expectEqualStrings(
+        "C:\\",
+        pwd_uri.parse("kitty-shell-cwd:///C:\\", &buf, opts).?,
+    );
+}
+
+test "shell_integration — raw 스킴을 쓰는 이유: file:// 이면 % 가 든 경로가 깨진다" {
+    var buf: [pwd_uri.max_path_len]u8 = undefined;
+    const opts: pwd_uri.Options = .{ .hostname = "MYPC", .style = .windows };
+
+    // 우리가 쓰는 스킴 — `%20` 이 경로에 실제로 있는 문자로 남는다.
+    try testing.expectEqualStrings(
+        "C:\\50%20x",
+        pwd_uri.parse("kitty-shell-cwd:///C:\\50%20x", &buf, opts).?,
+    );
+    // 같은 값을 `file://` 로 보냈다면 공백으로 디코딩돼 존재하지 않는 경로가 된다.
+    try testing.expectEqualStrings(
+        "C:\\50 x",
+        pwd_uri.parse("file:///C:\\50%20x", &buf, opts).?,
+    );
+}

--- a/src/shell_integration.zig
+++ b/src/shell_integration.zig
@@ -45,6 +45,28 @@ pub fn cmdPrompt(buf: []u8, existing: []const u8) ?[]const u8 {
     return buf[0..total];
 }
 
+// ── WSL 안의 bash
+//
+// WSL 탭은 `wsl.exe` 를 spawn 하고 실제 셸은 VM 안에 있어서 프로세스 cwd 조회가 통하지
+// 않는다. 대신 `WSLENV` 로 환경변수를 VM 안까지 전달할 수 있으므로 (`COLORFGBG` 가 이미
+// 그 경로를 쓴다) bash 의 `PROMPT_COMMAND` 를 넘긴다 — WSL Debian 실기에서 rc 로드 뒤에도
+// 값이 남고 `cd` 를 따라오는 것을 확인했다 (#366).
+//
+// fish 는 기본으로 OSC 7 을 보내므로 아무것도 필요 없다. **zsh 는 `ZDOTDIR` 로 파일을
+// 끼워야 해서 WSL 안에는 지원하지 않는다** (Windows 쪽에서 VM 안에 파일을 만들어야 한다) —
+// 그 조합은 홈에서 시작한다.
+
+/// bash 의 `PROMPT_COMMAND` 값. 프롬프트를 그릴 때마다 실행된다.
+///
+/// **경로 앞에 `/` 를 넣지 않는다.** POSIX 의 `$PWD` 는 이미 `/` 로 시작하므로
+/// `kitty-shell-cwd://` 뒤에 바로 붙이면 host 가 빈 payload 가 된다. cmd 쪽 (`:///$P`)
+/// 과 슬래시 개수가 다른 이유가 이것이다 — Windows 경로는 `C:\` 로 시작한다.
+///
+/// `$HOSTNAME` 을 host 로 넣는다. WSL 의 기본 hostname 은 Windows 컴퓨터 이름과 같아서
+/// (실기 확인) 파서의 host 검사를 통과하고, 비어 있어도 빈 host 로 수락된다. 종료자는
+/// BEL (`\007`).
+pub const bash_prompt_command = "printf '\\033]7;kitty-shell-cwd://%s%s\\007' \"$HOSTNAME\" \"$PWD\"";
+
 // ── PowerShell
 //
 // `PROMPT` 같은 환경변수로는 PowerShell 의 프롬프트를 바꿀 수 없다 (`prompt` 함수가
@@ -301,6 +323,31 @@ test "shell_integration — PowerShell 이 보낼 payload 를 파서가 읽는�
             .style = .windows,
         }).?,
     );
+}
+
+test "shell_integration — WSL bash 가 보낼 payload 를 파서가 읽는다" {
+    var buf: [pwd_uri.max_path_len]u8 = undefined;
+    // WSL 의 기본 hostname 은 Windows 컴퓨터 이름과 같다 (실기 확인).
+    const opts: pwd_uri.Options = .{ .hostname = "DESKTOP-L12ESI0", .style = .posix };
+
+    try testing.expectEqualStrings(
+        "/home/me/proj",
+        pwd_uri.parse("kitty-shell-cwd://DESKTOP-L12ESI0/home/me/proj", &buf, opts).?,
+    );
+    // `$HOSTNAME` 이 비어 있어도 빈 host 로 수락된다.
+    try testing.expectEqualStrings(
+        "/home/me",
+        pwd_uri.parse("kitty-shell-cwd:///home/me", &buf, opts).?,
+    );
+    // WSL 안에서 Windows 쪽으로 `cd` 한 경우도 Linux 경로다.
+    try testing.expectEqualStrings(
+        "/mnt/c/Users/me",
+        pwd_uri.parse("kitty-shell-cwd://DESKTOP-L12ESI0/mnt/c/Users/me", &buf, opts).?,
+    );
+
+    // 슬래시 개수 — 명령이 `://` 뒤에 `$PWD` 를 바로 붙이므로 payload 는 셋이 된다.
+    // cmd 처럼 `:///` 를 썼다면 `//home/me` 가 되어 지저분한 경로가 나간다.
+    try testing.expect(std.mem.indexOf(u8, bash_prompt_command, "kitty-shell-cwd://%s%s") != null);
 }
 
 test "shell_integration — raw 스킴을 쓰는 이유: file:// 이면 % 가 든 경로가 깨진다" {

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -43,7 +43,30 @@ pub const Options = struct {
     /// COLORFGBG / WSLENV (Windows) / 그 외 platform 자동 inject 와는 별개로
     /// 합쳐짐.
     extra_env: ?[]const ExtraEnv = null,
+    /// 셸의 시작 디렉토리 (#366). `null` 이면 홈 — [#265](https://github.com/ensky0/tildaz/issues/265)
+    /// 로 정한 기존 동작이다. 값이 있어도 그 경로로 시작하지 못하면 각 backend 가
+    /// 홈으로 열화한다 (경로가 spawn 직전에 사라질 수 있다).
+    ///
+    /// 표기는 **탭의 셸 기준**이다 — WSL 탭은 host 가 Windows 여도 Linux 경로다
+    /// (`isWslShell` 참조).
+    cwd: ?[]const u8 = null,
 };
+
+/// 이 셸 커맨드가 WSL 탭인지. WSL 안 셸은 Linux 경로를 보고하고 새 탭도
+/// `wsl --cd <Linux 경로>` 로 받으므로, OSC 7 경로의 표기 방식이 host OS 와 다르다
+/// (#366). Windows 아닌 platform 은 항상 false.
+///
+/// comptime 으로 고르는 이유: Windows 구현은 `wsl.exe` 명령줄 토큰을 UTF-16 으로
+/// 훑는 코드라 다른 platform 에서는 컴파일 자체가 안 된다 (`TerminalBackend` 와 같은
+/// 패턴).
+pub const isWslShell = if (builtin.os.tag == .windows)
+    @import("terminal/windows/pty.zig").isWslCommand
+else
+    struct {
+        fn notWsl(_: ShellCommand) bool {
+            return false;
+        }
+    }.notWsl;
 
 pub const TerminalBackend = switch (builtin.os.tag) {
     .windows => @import("terminal/windows.zig").Backend,
@@ -57,6 +80,10 @@ const UnsupportedTerminalBackend = struct {
     }
 
     pub fn deinit(_: *UnsupportedTerminalBackend) void {}
+
+    pub fn childPid(_: *UnsupportedTerminalBackend) i32 {
+        return 0;
+    }
 
     pub fn write(_: *UnsupportedTerminalBackend, _: []const u8) !usize {
         return error.UnsupportedTerminalBackend;

--- a/src/terminal/posix.zig
+++ b/src/terminal/posix.zig
@@ -28,12 +28,20 @@ pub const Backend = struct {
                 opts.rows,
                 opts.shell,
                 pty_env,
+                opts.cwd,
             ),
         };
     }
 
     pub fn deinit(self: *Backend) void {
         self.pty.deinit();
+    }
+
+    /// 자식 셸의 pid. 셸이 OSC 7 을 보내지 않을 때 OS 에 현재 디렉토리를 직접 묻는
+    /// 데 쓴다 (#366, `process_cwd.zig`). **foreground process 가 아니라 셸 자신**이라
+    /// `sudo` 같은 것에 흔들리지 않는다.
+    pub fn childPid(self: *Backend) i32 {
+        return self.pty.child_pid;
     }
 
     pub fn write(self: *Backend, data: []const u8) !usize {

--- a/src/terminal/posix/pty.zig
+++ b/src/terminal/posix/pty.zig
@@ -66,6 +66,7 @@ pub const Pty = struct {
         rows: u16,
         shell: []const u8,
         extra_env: ?[]const EnvVar,
+        cwd: ?[]const u8,
     ) !Pty {
         const pair = try openPtyPair(cols, rows);
         errdefer posix.close(pair.master);
@@ -100,9 +101,23 @@ pub const Pty = struct {
         };
         const envp: [*:null]const ?[*:0]const u8 = @ptrCast(envp_buf.ptr);
 
+        // fork 후 자식은 allocator 를 쓸 수 없으니 (#366) 시작 디렉토리도 미리
+        // NUL-term 으로 만들어 둔다 — `shell_z` 와 같은 패턴.
+        const cwd_z: ?[:0]u8 = if (cwd) |dir|
+            allocator.dupeZ(u8, dir) catch return error.EnvBuildFailed
+        else
+            null;
+        defer if (cwd_z) |z| allocator.free(z);
+
         const pid = posix.fork() catch return error.ForkFailed;
         if (pid == 0) {
-            childExec(pair.master, pair.slave, shell_z.ptr, envp);
+            childExec(
+                pair.master,
+                pair.slave,
+                shell_z.ptr,
+                envp,
+                if (cwd_z) |z| z.ptr else null,
+            );
         }
 
         posix.close(pair.slave);
@@ -238,6 +253,7 @@ fn childExec(
     slave_fd: posix.fd_t,
     shell: [*:0]const u8,
     envp: [*:null]const ?[*:0]const u8,
+    cwd: ?[*:0]const u8,
 ) noreturn {
     posix.close(master_fd);
 
@@ -254,11 +270,22 @@ fn childExec(
         _ = login_tty(slave_fd);
     }
 
-    // 시작 디렉토리를 홈으로 (#265). 지정하지 않으면 부모 (앱) 의 현재
-    // 디렉토리를 물려받아 실행 경로 (런처 / Finder / 셸) 에 따라 달라진다.
-    // `HOME` 이 없거나 chdir 실패면 그대로 진행 (기존 동작).
-    if (posix.getenv("HOME")) |home| {
-        posix.chdir(home) catch {};
+    // 시작 디렉토리 — 호출자가 준 경로 (#366, 활성 탭이 OSC 7 로 알린 위치) 를
+    // 먼저 쓰고, 없거나 그리로 못 가면 홈 (#265) 으로 간다. `HOME` 까지 실패하면
+    // 그대로 진행 (#265 이전 동작).
+    //
+    // cwd 실패를 그냥 넘기지 않고 홈으로 되돌리는 이유: 아무 곳도 안 가면 부모
+    // (앱) 의 현재 디렉토리를 물려받아 실행 경로 (런처 / Finder / 셸) 에 따라 시작
+    // 위치가 달라진다 — #265 가 고친 문제가 그대로 되살아난다. 호출자가 spawn 전에
+    // 디렉토리 존재를 확인하지만 그 사이에 지워질 수 있다.
+    const moved = if (cwd) |dir| blk: {
+        posix.chdirZ(dir) catch break :blk false;
+        break :blk true;
+    } else false;
+    if (!moved) {
+        if (posix.getenv("HOME")) |home| {
+            posix.chdir(home) catch {};
+        }
     }
 
     // macOS 만 login shell (`-l`) — "Last login" + ~/.zprofile 로드,
@@ -375,7 +402,7 @@ test "pty — /bin/sh spawn·echo 왕복·extra_env 우선·exit" {
 
     // extra_env 의 SHELL 이 부모값을 override 하는지 (#118 정책) 함께 검증.
     const extra = [_]Pty.EnvVar{.{ .name = "SHELL", .value = "/tmp/tz-pty-test-sentinel" }};
-    var pty = try Pty.init(std.testing.allocator, 80, 24, "/bin/sh", &extra);
+    var pty = try Pty.init(std.testing.allocator, 80, 24, "/bin/sh", &extra, null);
     try pty.startReadThread(TestCollector.onRead, TestCollector.onExit, null);
 
     _ = try pty.write("echo pty_roundtrip_$SHELL\n");
@@ -395,4 +422,54 @@ test "pty — /bin/sh spawn·echo 왕복·extra_env 우선·exit" {
     try std.testing.expect(TestCollector.exited.load(.acquire));
 
     pty.deinit();
+}
+
+// `cwd` 를 넘겼을 때 셸이 정말 그 디렉토리에서 시작하는지, 그리고 그 경로로 갈 수
+// 없을 때 홈으로 되돌아오는지 (#366 의 실패 방어) 를 실제 spawn 으로 확인한다.
+//
+// 비교 대상으로 `/` 를 쓰는 이유: macOS 의 `/tmp` 는 `/private/tmp` 심볼릭 링크라
+// 셸의 `$PWD` (시작 시 `getcwd`, 물리 경로) 와 문자열이 어긋난다. `/` 는 어느 OS
+// 에서도 링크가 아니다.
+test "pty — cwd 지정 시 그 디렉토리에서 시작, 갈 수 없으면 홈 (#366)" {
+    const waitFor = struct {
+        fn f(needle: []const u8) bool {
+            var waited_ms: u64 = 0;
+            while (waited_ms < 5000) : (waited_ms += 20) {
+                if (TestCollector.contains(needle)) return true;
+                std.Thread.sleep(20 * std.time.ns_per_ms);
+            }
+            return false;
+        }
+    }.f;
+
+    {
+        TestCollector.reset();
+        var pty = try Pty.init(std.testing.allocator, 80, 24, "/bin/sh", null, "/");
+        defer pty.deinit();
+        try pty.startReadThread(TestCollector.onRead, TestCollector.onExit, null);
+
+        _ = try pty.write("[ \"$PWD\" = \"/\" ] && echo tz366_root_ok\n");
+        try std.testing.expect(waitFor("tz366_root_ok"));
+    }
+
+    {
+        TestCollector.reset();
+        // 존재하지 않는 경로 — 호출자가 spawn 전에 확인하지만 그 사이에 지워지는
+        // race 가 있고, 그때 앱의 현재 디렉토리를 물려받으면 #265 가 되살아난다.
+        var pty = try Pty.init(
+            std.testing.allocator,
+            80,
+            24,
+            "/bin/sh",
+            null,
+            "/tz366-does-not-exist",
+        );
+        defer pty.deinit();
+        try pty.startReadThread(TestCollector.onRead, TestCollector.onExit, null);
+
+        // 현재 위치를 기억한 뒤 홈으로 이동해 같은 곳인지 본다 ($HOME 이 심볼릭
+        // 링크여도 양쪽 모두 `getcwd` 결과라 문자열이 일치한다).
+        _ = try pty.write("P=$PWD; cd \"$HOME\"; [ \"$P\" = \"$PWD\" ] && echo tz366_home_ok\n");
+        try std.testing.expect(waitFor("tz366_home_ok"));
+    }
 }

--- a/src/terminal/windows.zig
+++ b/src/terminal/windows.zig
@@ -36,13 +36,31 @@ pub const Backend = struct {
         }
 
         const env_slice: ?[]const ConPty.EnvVar = if (n > 0) combined[0..n] else null;
+
+        // 시작 디렉토리 (#366) 도 utf-8 → utf-16. 변환에 실패하거나 버퍼를 넘치면
+        // 상속을 포기하고 홈에서 시작한다 (null).
+        var cwd_buf: [4200]u16 = undefined;
+        const cwd: ?[:0]const u16 = if (opts.cwd) |dir| blk: {
+            const len = std.unicode.utf8ToUtf16Le(&cwd_buf, dir) catch break :blk null;
+            if (len >= cwd_buf.len) break :blk null;
+            cwd_buf[len] = 0;
+            break :blk cwd_buf[0..len :0];
+        } else null;
+
         return .{
-            .pty = try ConPty.init(opts.allocator, opts.cols, opts.rows, opts.shell, env_slice),
+            .pty = try ConPty.init(opts.allocator, opts.cols, opts.rows, opts.shell, env_slice, cwd),
         };
     }
 
     pub fn deinit(self: *Backend) void {
         self.pty.deinit();
+    }
+
+    /// Windows 는 프로세스 cwd 조회를 하지 않으므로 (#366 — PowerShell 은 원리적으로
+    /// 불가, cmd 만 되는 PEB 읽기는 비공개 API) 쓰이지 않는 값이다. 시작 위치는 OSC 7
+    /// 주입으로 얻는다.
+    pub fn childPid(_: *Backend) i32 {
+        return 0;
     }
 
     pub fn write(self: *Backend, data: []const u8) !usize {

--- a/src/terminal/windows/pty.zig
+++ b/src/terminal/windows/pty.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const windows = std.os.windows;
 const perf = @import("../../perf.zig");
 const log = @import("../../log.zig");
+const shell_integration = @import("../../shell_integration.zig");
 
 const HANDLE = windows.HANDLE;
 const INVALID_HANDLE_VALUE = windows.INVALID_HANDLE_VALUE;
@@ -462,34 +463,46 @@ pub const ConPty = struct {
         const L = std.unicode.utf8ToUtf16LeStringLiteral;
         const wsl_cd = wslCdInsertion(shell[0..shell_len]);
 
-        // WSL 탭에 끼워 넣을 인자 — 물려받은 경로가 있으면 그 경로, 없으면 Linux 홈.
-        // 공백이 있는 경로도 한 인자로 가도록 `"` 로 감싼다. 경로 안에 `"` 가 있으면
-        // 인용이 깨지므로 (그리고 Linux 파일 이름에 `"` 는 허용된다) 그때는 상속을
-        // 포기하고 홈으로 간다.
+        // 명령줄에 끼워 넣을 인자와 그 위치. 두 가지 경우가 있고 **첫 토큰이 다르므로
+        // 동시에 일어나지 않는다**:
+        //
+        //   - WSL 탭 → 첫 토큰 뒤에 `--cd "<경로>"` (위 문단).
+        //   - PowerShell 탭 → 맨 끝에 `-NoExit -EncodedCommand …` (#366). 프로필이
+        //     로드된 뒤 기존 `prompt` 를 감싸야 하고, `-EncodedCommand` 는 인자 하나만
+        //     받으므로 뒤에 다른 인자가 오지 않게 끝에 붙인다.
         var wsl_insert_buf: [wsl_insert_max]u16 = undefined;
-        const insert: []const u16 = blk: {
-            if (!wsl_cd.insert) break :blk &.{};
-            if (wsl_cd.is_wsl) if (cwd) |dir| {
-                const prefix = L(" --cd \"");
-                const total = prefix.len + dir.len + 1;
-                if (std.mem.indexOfScalar(u16, dir, '"') == null and total <= wsl_insert_buf.len) {
-                    @memcpy(wsl_insert_buf[0..prefix.len], prefix);
-                    @memcpy(wsl_insert_buf[prefix.len..][0..dir.len], dir);
-                    wsl_insert_buf[total - 1] = '"';
-                    break :blk wsl_insert_buf[0..total];
+        var insert: []const u16 = &.{};
+        var insert_at: usize = shell_len;
+        if (wsl_cd.insert) {
+            insert_at = wsl_cd.insert_at;
+            // 물려받은 경로가 있으면 그 경로, 없으면 Linux 홈. 공백이 있는 경로도 한
+            // 인자로 가도록 `"` 로 감싼다. 경로 안에 `"` 가 있으면 인용이 깨지므로
+            // (Linux 파일 이름에 `"` 는 허용된다) 그때는 상속을 포기하고 홈으로 간다.
+            insert = blk: {
+                if (cwd) |dir| {
+                    const prefix = L(" --cd \"");
+                    const total = prefix.len + dir.len + 1;
+                    if (std.mem.indexOfScalar(u16, dir, '"') == null and total <= wsl_insert_buf.len) {
+                        @memcpy(wsl_insert_buf[0..prefix.len], prefix);
+                        @memcpy(wsl_insert_buf[prefix.len..][0..dir.len], dir);
+                        wsl_insert_buf[total - 1] = '"';
+                        break :blk wsl_insert_buf[0..total];
+                    }
                 }
+                break :blk L(" --cd ~");
             };
-            break :blk L(" --cd ~");
-        };
+        } else if (shell_integration.psInjection(shell[0..shell_len]).inject) {
+            insert = shell_integration.ps_args_w;
+        }
 
         const cmd_len = shell_len + insert.len;
         const cmd_buf = try allocator.alloc(WCHAR, cmd_len + 1);
         defer allocator.free(cmd_buf);
-        @memcpy(cmd_buf[0..wsl_cd.insert_at], shell[0..wsl_cd.insert_at]);
-        @memcpy(cmd_buf[wsl_cd.insert_at..][0..insert.len], insert);
+        @memcpy(cmd_buf[0..insert_at], shell[0..insert_at]);
+        @memcpy(cmd_buf[insert_at..][0..insert.len], insert);
         @memcpy(
-            cmd_buf[wsl_cd.insert_at + insert.len ..][0 .. shell_len - wsl_cd.insert_at],
-            shell[wsl_cd.insert_at..shell_len],
+            cmd_buf[insert_at + insert.len ..][0 .. shell_len - insert_at],
+            shell[insert_at..shell_len],
         );
         cmd_buf[cmd_len] = 0;
 

--- a/src/terminal/windows/pty.zig
+++ b/src/terminal/windows/pty.zig
@@ -304,7 +304,9 @@ pub const ConPty = struct {
     pub const ExitCallback = *const fn (userdata: ?*anyopaque) void;
     pub const EnvVar = struct { name: [*:0]const u16, value: [*:0]const u16 };
 
-    pub fn init(allocator: std.mem.Allocator, cols: u16, rows: u16, shell: [*:0]const WCHAR, extra_env: ?[]const EnvVar) !ConPty {
+    /// `cwd` — 셸의 시작 디렉토리 (#366). `null` 이면 홈 (#265). 일반 셸은 Windows
+    /// 경로 (`C:\…`), WSL 탭은 Linux 경로 (`/home/me`) 를 받는다 (`isWslCommand`).
+    pub fn init(allocator: std.mem.Allocator, cols: u16, rows: u16, shell: [*:0]const WCHAR, extra_env: ?[]const EnvVar, cwd: ?[:0]const WCHAR) !ConPty {
         // ── Input pipe (익명, sync): 우리 = write, conhost = read
         var pipe_in_read: HANDLE = undefined;
         var pipe_in_write: HANDLE = undefined;
@@ -449,20 +451,36 @@ pub const ConPty = struct {
         // small fixed buffer.
         const shell_len = std.mem.len(shell);
 
-        // ── 시작 디렉토리를 홈으로 (#265)
+        // ── 시작 디렉토리 — 홈 (#265) 또는 활성 탭에서 물려받은 경로 (#366)
         //
-        // 일반 exe (cmd.exe / PowerShell 등) 는 lpCurrentDirectory 에
-        // %USERPROFILE% 를 넘기면 되지만, WSL 탭의 목표는 Linux 홈 (`~`) —
-        // Windows 경로로 표현 불가 + Windows 쪽에서는 그 위치를 알 수도 없다.
-        // Windows Terminal 과 같은 방식으로 wsl 명령줄에 `--cd ~` 를 끼워 넣어
-        // wsl 자신에게 위임한다 (microsoft/terminal PR #9223 의
-        // MangleStartingDirectoryForWSL 패턴). 사용자가 이미 `--cd` 나 단독
-        // `~` 인자를 넣었으면 충돌하므로 건드리지 않는다.
+        // 일반 exe (cmd.exe / PowerShell 등) 는 lpCurrentDirectory 로 넘기면 되지만,
+        // WSL 탭의 목표 위치는 Linux 쪽 경로 — Windows 경로로 표현 불가 + Windows
+        // 쪽에서는 그 위치를 확인할 수도 없다. Windows Terminal 과 같은 방식으로
+        // wsl 명령줄에 `--cd` 를 끼워 넣어 wsl 자신에게 위임한다
+        // (microsoft/terminal PR #9223 의 MangleStartingDirectoryForWSL 패턴).
+        // 사용자가 이미 `--cd` 나 단독 `~` 인자를 넣었으면 충돌하므로 건드리지 않는다.
+        const L = std.unicode.utf8ToUtf16LeStringLiteral;
         const wsl_cd = wslCdInsertion(shell[0..shell_len]);
-        const insert: []const u16 = if (wsl_cd.insert)
-            std.unicode.utf8ToUtf16LeStringLiteral(" --cd ~")
-        else
-            &.{};
+
+        // WSL 탭에 끼워 넣을 인자 — 물려받은 경로가 있으면 그 경로, 없으면 Linux 홈.
+        // 공백이 있는 경로도 한 인자로 가도록 `"` 로 감싼다. 경로 안에 `"` 가 있으면
+        // 인용이 깨지므로 (그리고 Linux 파일 이름에 `"` 는 허용된다) 그때는 상속을
+        // 포기하고 홈으로 간다.
+        var wsl_insert_buf: [wsl_insert_max]u16 = undefined;
+        const insert: []const u16 = blk: {
+            if (!wsl_cd.insert) break :blk &.{};
+            if (wsl_cd.is_wsl) if (cwd) |dir| {
+                const prefix = L(" --cd \"");
+                const total = prefix.len + dir.len + 1;
+                if (std.mem.indexOfScalar(u16, dir, '"') == null and total <= wsl_insert_buf.len) {
+                    @memcpy(wsl_insert_buf[0..prefix.len], prefix);
+                    @memcpy(wsl_insert_buf[prefix.len..][0..dir.len], dir);
+                    wsl_insert_buf[total - 1] = '"';
+                    break :blk wsl_insert_buf[0..total];
+                }
+            };
+            break :blk L(" --cd ~");
+        };
 
         const cmd_len = shell_len + insert.len;
         const cmd_buf = try allocator.alloc(WCHAR, cmd_len + 1);
@@ -475,8 +493,8 @@ pub const ConPty = struct {
         );
         cmd_buf[cmd_len] = 0;
 
-        // WSL 이 아닌 경우의 시작 디렉토리 = %USERPROFILE%. 환경변수가 없으면
-        // null (기존 동작 — 부모의 현재 디렉토리 상속).
+        // WSL 이 아닌 경우의 홈 = %USERPROFILE%. 환경변수가 없으면 null (기존 동작 —
+        // 부모의 현재 디렉토리 상속).
         var home_buf: ?[]u16 = null;
         defer if (home_buf) |b| allocator.free(b);
         if (!wsl_cd.is_wsl) {
@@ -493,7 +511,14 @@ pub const ConPty = struct {
                 }
             }
         }
-        const cwd: ?[*:0]const WCHAR = if (home_buf) |b| @ptrCast(b.ptr) else null;
+        const home_dir: ?[*:0]const WCHAR = if (home_buf) |b| @ptrCast(b.ptr) else null;
+        // 물려받은 경로는 일반 셸에서만 lpCurrentDirectory 로 쓴다 — WSL 탭은 위
+        // `--cd` 로 이미 넘겼고, Linux 경로를 Windows 쪽 시작 디렉토리로 줄 수 없다.
+        const inherited_dir: ?[*:0]const WCHAR = if (!wsl_cd.is_wsl)
+            if (cwd) |dir| dir.ptr else null
+        else
+            null;
+        const start_dir = inherited_dir orelse home_dir;
 
         // 자식 프로세스에 추가 환경변수 전달 (기존값 저장 → SetEnv → CreateProcess → 복원)
         const MAX_EXTRA_ENV = 8;
@@ -537,23 +562,60 @@ pub const ConPty = struct {
             }
         }.restore;
 
-        if (CreateProcessW(
-            null,
+        // CreateProcessW 는 lpCommandLine 을 제자리에서 고칠 수 있다 ([MS 문서]
+        // (https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw)
+        // — *"can modify the contents of this string"*). 재시도가 있을 수 있으니
+        // 원본 사본을 미리 떠 둔다.
+        const retry_buf: ?[]WCHAR = if (inherited_dir != null and home_dir != null)
+            try allocator.dupe(WCHAR, cmd_buf[0 .. cmd_len + 1])
+        else
+            null;
+        defer if (retry_buf) |b| allocator.free(b);
+
+        const spawn = struct {
+            fn f(
+                cmd: [*:0]WCHAR,
+                dir: ?[*:0]const WCHAR,
+                si: *STARTUPINFOEXW,
+                pi: *PROCESS_INFORMATION,
+            ) bool {
+                return CreateProcessW(
+                    null,
+                    cmd,
+                    null,
+                    null,
+                    0,
+                    EXTENDED_STARTUPINFO_PRESENT,
+                    null,
+                    dir,
+                    si,
+                    pi,
+                ) != 0;
+            }
+        }.f;
+
+        var spawned = spawn(
             @ptrCast(cmd_buf[0..cmd_len :0].ptr),
-            null,
-            null,
-            0,
-            EXTENDED_STARTUPINFO_PRESENT,
-            null,
-            cwd,
+            start_dir,
             &startup_info,
             &process_info,
-        ) == 0) {
-            restore_env(allocator, extra_env, &saved_vals);
-            return error.CreateProcessFailed;
+        );
+        if (!spawned) {
+            // 물려받은 경로가 spawn 직전에 사라졌을 수 있다 (#366). lpCurrentDirectory
+            // 가 없는 디렉토리면 CreateProcessW 자체가 실패하므로, 그대로 두면 새 탭이
+            // 아예 열리지 않는다. 홈으로 한 번 되돌려 다시 시도한다.
+            if (retry_buf) |b| {
+                spawned = spawn(
+                    @ptrCast(b[0..cmd_len :0].ptr),
+                    home_dir,
+                    &startup_info,
+                    &process_info,
+                );
+            }
         }
 
         restore_env(allocator, extra_env, &saved_vals);
+        if (!spawned) return error.CreateProcessFailed;
 
         // ── DA1 pre-response (번들 OpenConsole 3초 지연 회피)
         //
@@ -671,6 +733,17 @@ pub const ConPty = struct {
     }
 };
 
+/// WSL 탭에 끼워 넣는 `--cd "<경로>"` 인자의 최대 길이 (UTF-16 unit). Linux PATH_MAX
+/// (4096 바이트) 가 UTF-16 으로 늘어나도 담기게 여유를 둔다 — 넘치면 홈으로 열화한다.
+const wsl_insert_max = 4200;
+
+/// 이 명령줄이 WSL 탭인지 (#366). WSL 안 셸은 OSC 7 로 **Linux 경로**를 보고하고
+/// 새 탭도 `wsl --cd <Linux 경로>` 로 받으므로, 경로 표기를 host OS 기준으로 정하면
+/// 안 된다. `terminal.isWslShell` 이 comptime 으로 이 함수를 고른다.
+pub fn isWslCommand(cmd: [*:0]const WCHAR) bool {
+    return wslCdInsertion(std.mem.span(cmd)).is_wsl;
+}
+
 /// #265 — 명령줄이 WSL (`wsl` / `wsl.exe`) 인지 판정하고, WSL 이면 시작
 /// 디렉토리를 Linux 홈으로 만들 `--cd ~` 를 끼워 넣을 위치를 계산한다.
 /// Windows Terminal 의 `MangleStartingDirectoryForWSL` (microsoft/terminal
@@ -762,7 +835,7 @@ test "wslCdInsertion: wsl 판정 + 삽입 위치" {
 // 환경에서는 ConptyRuntimeUnavailable 로 skip 한다 (fallback 제거, #339).
 test "conpty create and destroy" {
     const shell = std.unicode.utf8ToUtf16LeStringLiteral("cmd.exe");
-    var pty = ConPty.init(std.testing.allocator, 80, 24, shell, null) catch |err| switch (err) {
+    var pty = ConPty.init(std.testing.allocator, 80, 24, shell, null, null) catch |err| switch (err) {
         error.ConptyRuntimeUnavailable => return error.SkipZigTest,
         else => return err,
     };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,7 +10,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 test "aggregate root imports every common and native-host test module" {
-    // Cross-platform modules (31 files).
+    // Cross-platform modules (32 files).
     _ = @import("about.zig");
     _ = @import("box_drawing.zig");
     _ = @import("chrome_palette.zig");
@@ -35,6 +35,7 @@ test "aggregate root imports every common and native-host test module" {
     _ = @import("root.zig");
     _ = @import("scrollbar.zig");
     _ = @import("session_core.zig");
+    _ = @import("shell_integration.zig");
     _ = @import("shortcut_sync.zig");
     _ = @import("tab_icons.zig");
     _ = @import("tab_interaction.zig");

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,7 +10,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 test "aggregate root imports every common and native-host test module" {
-    // Cross-platform modules (28 files).
+    // Cross-platform modules (31 files).
     _ = @import("about.zig");
     _ = @import("box_drawing.zig");
     _ = @import("chrome_palette.zig");
@@ -24,10 +24,13 @@ test "aggregate root imports every common and native-host test module" {
     _ = @import("input_policy.zig");
     _ = @import("instance_context.zig");
     _ = @import("instances.zig");
+    _ = @import("local_hostname.zig");
     _ = @import("log.zig");
     _ = @import("messages.zig");
     _ = @import("paths.zig");
     _ = @import("perf.zig");
+    _ = @import("process_cwd.zig");
+    _ = @import("pwd_uri.zig");
     _ = @import("renderer/cell_color.zig");
     _ = @import("root.zig");
     _ = @import("scrollbar.zig");


### PR DESCRIPTION
## 무엇을

새 탭이 **활성 탭 셸의 현재 위치에서 시작**한다. 그 위치를 알 수 없거나 들어갈 수 없으면 홈으로 열화한다. Closes #366.

지금까지는 항상 홈에서 시작했다 ([#265](https://github.com/ensky0/tildaz/issues/265)). 그 결정의 핵심 — *시작 디렉토리를 지정하지 않으면 앱의 cwd 를 물려받아 실행 경로에 따라 위치가 달라진다* — 는 여전히 유효해서, **fallback 이 앱의 cwd 가 아니라 홈**이라는 점은 그대로 유지한다.

## 왜 #265 처럼 못 했나

#265 는 셋 다 우리가 값을 몰라도 됐다. `$HOME` / `%USERPROFILE%` 은 정적 상수라 부모 환경변수에 있었고, WSL 탭은 `--cd ~` 로 값을 모른 채 **이름만 위임**했다. 현재 디렉토리는 둘 다 아니다 — 자식 셸 안에만 있는 동적 상태이고 `~` 에 해당하는 이름이 없어서 실제 경로를 알아내야만 한다. 그래서 길이 두 개뿐이다: 셸이 알려주기 (OSC 7) 또는 OS 에 묻기 (프로세스 cwd 조회).

## 어떻게

**얻는 쪽 — 세 단계로 내려간다.**

| 순위 | 소스 | 특징 |
|---|---|---|
| ① | 셸의 **OSC 7** | 셸의 논리 경로 (`$PWD`) 라 symlink 를 따라간 기대에 맞다. ghostty pin 이 이미 `Terminal.pwd` 에 raw payload 로 보관하고 스킴 해석만 우리에게 맡긴다 |
| ② | **프로세스 cwd 조회** | 셸 · rc 무관. Linux `readlink /proc/<pid>/cwd`, macOS `proc_pidinfo` |
| ③ | 홈 | #265 의 동작 |

**환경별 경계 — POSIX 는 조회, Windows 는 주입.**

| 환경 | 방법 | 사용자 환경 침범 |
|---|---|---|
| Linux · macOS (모든 셸) | 조회 | **없음** — 셸 설정이 전혀 필요 없다 |
| Windows cmd | `PROMPT` 주입 | 기존 값 **앞에만** 덧붙여 모양 보존 |
| Windows PowerShell | `-NoExit -EncodedCommand` 로 프로필 뒤 `prompt` 래핑 | 커스텀 프롬프트 유지 |
| WSL bash | `WSLENV` + `PROMPT_COMMAND` | rc 가 대입하면 무력화 (통제 불가) |
| WSL fish | 없음 (기본 동작) | 없음 |

Windows 를 조회로 하지 않는 이유: PowerShell 은 `Set-Location` 이 runspace 별 위치만 바꿔 원리적으로 불가하고, `cmd` 만 되는 PEB 읽기는 MS 가 *"may be altered or unavailable"* 로 표기한 비공개 API 다.

**쓰는 쪽 — #265 가 만든 자리에 값만 바꿨다.** POSIX 는 `chdir` 대상, Windows 는 `lpCurrentDirectory` / `--cd`. 실패 시 홈으로 되돌리는 방어를 넣었다 — POSIX 는 `chdir` 실패, Windows 는 `CreateProcessW` 가 없는 디렉토리에서 실패해 **새 탭이 아예 안 열리는** 것을 홈 재시도로 막는다.

## 구현에서 나온 판단

- **`std.Uri.parse` 를 쓰지 않는다.** host 가 MAC 주소면 `InvalidPort` 로 실패하고 (macOS Private Wi-Fi address) 경로의 `?` · `#` 를 잘라내는 것을 실측했다. 퍼센트 디코딩만 `std.Uri.percentDecodeBackwards` 로 재사용하고, 두 std 동작은 테스트로 고정했다.
- **스킴은 `kitty-shell-cwd://` (raw).** 셸 프롬프트로는 퍼센트 인코딩을 못 해서 `file://` 이면 `C:\50%20x` 가 `C:\50 x` 로 깨진다. 경로를 URI 로 바꿔 주는 표준 라이브러리는 없다 (조립이 셸이 프롬프트를 그리는 시점에 일어난다) — VTE 는 이 때문에 `vte-urlencode-cwd` 헬퍼를 따로 설치하고, ghostty · kitty 는 이 raw 스킴을 만들었다.
- **PowerShell 은 `-EncodedCommand`.** `-Command "…"` 는 셸 경계마다 인용 규칙이 달라 실기에서 파서 에러로 거부됐다. Base64 는 그 문제가 없고 comptime 에 계산되므로 런타임 조립이 없다.
- **경로 표기는 host OS 가 아니라 탭의 셸로 결정한다.** WSL 탭은 Windows 에서도 Linux 경로다. 덕분에 일반 cmd 탭에서 `wsl` 을 직접 실행한 경우가 자동으로 걸러진다.
- `proc_pidinfo` 구조체 레이아웃은 C 헤더로 실측해 **comptime assert** 로 고정했다.

## 검증

| | 결과 |
|---|---|
| `zig build test` | **203/205 통과** (2 skipped) |
| `zig build check` | 6 타겟 통과 |
| 단위 | 파서 23 · 조회 3 · 주입 문자열 13 · PTY spawn 2 · OSC 7 주입 4 |
| **macOS 실기** | 상속 · fish OSC 7 · 지워진 경로 → **3/3** |
| **Windows 실기** | cmd · PowerShell 프로필 보존 · `HKLM:` 거부 · WSL bash · WSL `/mnt/c` · WSL fish · 일반 cmd 탭의 `wsl` 거부 → **7/7** |

`zig build check` 가 macOS 에서 드러나지 않는 에러 셋을 잡았다: Linux `readLinkAbsolute` 인자 타입, 633 바이트 UTF-16 변환의 comptime 평가 한도, `vars` 배열 크기.

## 알려진 한계 (SPEC §7.2 에 명시)

| 조합 | 결과 |
|---|---|
| **tmux 안** | tmux 실행 **직전** 위치 — tmux 가 OSC 7 을 흡수하고 (3.7b 실측) 조회도 tmux 서버가 별도 트리다. ghostty · kitty 도 같은 한계 |
| WSL 안 zsh | 홈 (`ZDOTDIR` 파일을 VM 안에 만들어야 함) |
| ssh 원격 | 홈 (host 검사로 거부) |
| bash rc 가 `PROMPT_COMMAND=` 로 대입 | 홈 (rc 는 자식이 읽어 우리가 볼 수 없다) |

## config 옵션은 두지 않았다

상속이 항상 기본이다. 홈으로 가려면 새 탭에서 `cd ~` 한 번이면 되는데 반대 방향은 경로를 입력해야 해서 복구 비용이 비대칭이다. 나중에 필요해지면 배선은 한 줄이지만 (`inheritedCwd` 호출을 조건부로) schema 변경이라 신중히 결정한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
