### PR TITLE
feat(stress): 측정 자동화용 -e / -size 옵션 (#382)

### DIFF
--- a/dist/stress/compare-terminals.sh
+++ b/dist/stress/compare-terminals.sh
@@ -11,9 +11,9 @@
 #
 #   dist/stress/compare-terminals.sh --mb 64 --workload plain --cols 120 --rows 40
 #
-# TildaZ 자신은 CLI 로 명령을 주입할 방법이 없어서 (`--instance` / `--autostart` /
-# `--toggle` 만 받는다) **손으로 한 줄 붙여넣어야 한다.** 스크립트가 그 명령을 찍어 준다.
-# 다른 터미널과 같은 조건 (렌더 포함) 으로 재려면 그게 유일한 방법이다.
+# TildaZ 도 자동이다 — 측정 내부용 `-e` · `-size` 옵션을 쓴다 (#382). 그 인스턴스는
+# worker lock 을 잡지 않고 전역 핫키도 등록하지 않아서, 평소 쓰는 TildaZ 가 떠 있어도
+# 충돌하지 않는다.
 
 set -eu
 
@@ -187,6 +187,35 @@ EOF
     fi
 fi
 
+# TildaZ — `-e` · `-size` 로 자동 측정한다 (#382). 그 두 옵션은 **측정 내부용**이라
+# 문서화하지 않는다 (`src/run_options.zig`).
+#
+# 측정용 인스턴스는 worker lock 을 잡지 않고 전역 핫키도 등록하지 않으므로, 평소 쓰는
+# TildaZ 가 떠 있어도 충돌하지 않는다 (macOS 실측 확인). 명령이 끝나면 스스로 종료한다.
+#
+# 저장소 빌드본을 쓴다 — 설치본은 버전이 다를 수 있다.
+TILDAZ_BIN=""
+for candidate in \
+    "$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz" \
+    "$REPO_ROOT/zig-out/bin/tildaz" \
+    "$REPO_ROOT/zig-out/bin/tildaz.exe"
+do
+    [ -x "$candidate" ] && TILDAZ_BIN="$candidate" && break
+done
+
+if [ -n "$TILDAZ_BIN" ]; then
+    T="$WORK_DIR/tildaz.timing"
+    # producer 파라미터는 TildaZ 프로세스의 환경변수로 준다 — 자식(producer)이 상속한다.
+    # `-e` 는 실행파일 경로만 받는다 (POSIX 는 PTY 자식의 argv 가 고정이다).
+    run_terminal tildaz env \
+        "TILDAZ_STRESS_WORKLOAD=$WORKLOAD" \
+        "TILDAZ_STRESS_BYTES=$BYTES" \
+        "TILDAZ_STRESS_TIMING_FILE=$T" \
+        "$TILDAZ_BIN" -e "$PRODUCER" -size "${COLS}x${ROWS}"
+else
+    echo "tildaz         빌드본이 없어요 — zig build 로 먼저 빌드해 주세요"
+fi
+
 # foot 은 Wayland 전용이라 Linux 에서만 있다.
 if command -v foot >/dev/null 2>&1; then
     T="$WORK_DIR/foot.timing"
@@ -216,23 +245,8 @@ while IFS="$(printf '\t')" read -r name ns cols rows cols0 rows0; do
     printf '%-14s %12s %10s %10s  %s\n' "$name" "$ms" "$rate" "${cols}x${rows}" "$note"
 done < "$RESULTS"
 
-# --- 손으로 재는 터미널 ---
-#
-# TildaZ 와 (macOS 의) ghostty 는 CLI 로 명령을 주입할 수 없다. 그래도 그리드는 producer
-# 가 스스로 기록하므로 공정성은 유지된다 — 창을 목표 그리드로 맞춰 열고 한 줄 붙여넣으면
-# 다른 터미널과 같은 조건 (렌더 포함) 이 된다.
+# --- 마무리 ---
 
 echo ""
-echo "=== 손으로 재는 터미널 ==="
-echo ""
-echo "TildaZ — CLI 로 명령을 주입할 방법이 없어요 (--instance / --autostart / --toggle 만 받아요)."
-echo "  창을 열고 아래 한 줄을 붙여넣어 주세요."
-echo ""
-echo "  $(producer_cmd "$HOME/tildaz.timing")"
-echo ""
-echo "  결과: cat ~/tildaz.timing"
-echo "  그리드 맞추기: config 의 width_percent / height_percent 와 font.size"
-echo ""
-
-echo "timing 파일의 cols/rows 가 ${COLS}x${ROWS} 인지 확인해 주세요 — 다르면 그 숫자는"
-echo "위 표와 비교할 수 없어요. 탭이 2 개 이상이면 탭바 (28 pt) 가 들어가 rows 가 줄어요."
+echo "timing 파일의 cols/rows 가 ${COLS}x${ROWS} 인지 표에서 확인해 주세요 — 다르면 그"
+echo "숫자는 비교할 수 없어요. 탭이 2 개 이상이면 탭바 (28 pt) 가 들어가 rows 가 줄어요."

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -25,6 +25,7 @@ const messages = @import("../../messages.zig");
 const command_menu = @import("../../command_menu.zig");
 const config_mod = @import("../../config.zig");
 const software_terminal = @import("software_terminal.zig");
+const run_options = @import("../../run_options.zig");
 const dialog_layout = @import("dialog_layout.zig");
 const xkb = @import("xkb.zig");
 const gbm = @import("gbm.zig");
@@ -1146,6 +1147,8 @@ const Client = struct {
     // heap stable address는 D-Bus filter user_data가 참조하며, dbus_session보다
     // 먼저 deinit해야 한다.
     kglobalaccel_client: ?*kglobalaccel.Client = null,
+    /// #382 — 측정용 실행 옵션. 셸 · 창 크기 · 표시 정책 · 핫키 등록이 이 값을 본다.
+    run_opts: run_options.RunOptions = .{},
     // KGlobalAccel filter 안에서는 Wayland roundtrip을 시작하지 않는다. Pressed
     // callback은 이 flag만 세우고 main loop가 D-Bus dispatch 반환 뒤 toggle한다.
     kglobalaccel_toggle_pending: bool = false,
@@ -1267,7 +1270,7 @@ const Client = struct {
     /// `session.reorderTabs` (mac 패턴 그대로, host hook 추가 안 함).
     tab_drag: tab_interaction.DragState = .{},
 
-    fn init(allocator: std.mem.Allocator, cfg: *const config_mod.Config) !Client {
+    fn init(allocator: std.mem.Allocator, cfg: *const config_mod.Config, opts: run_options.RunOptions) !Client {
         const path = try waylandSocketPath(allocator);
         defer allocator.free(path);
         // 첫 init 시점엔 wp_fractional_scale_v1 의 preferred_scale event 가
@@ -1296,6 +1299,7 @@ const Client = struct {
             .stream = stream,
             .renderer = renderer,
             .config = cfg,
+            .run_opts = opts,
             .extra_env_storage = .{
                 .{ .name = "TERM", .value = "xterm-256color" },
                 // Linux 는 `C.UTF-8` — POSIX 표준 portable UTF-8 locale, 모든
@@ -2334,8 +2338,36 @@ const Client = struct {
         const sw_f: f32 = @floatFromInt(sw_i);
         const sh_f: f32 = @floatFromInt(sh_i);
         const off_pct = std.math.clamp(cfg.offset_percent, 0.0, 100.0);
-        const want_w: u32 = pctToPx(sw_f, cfg.width_percent);
-        const want_h: u32 = pctToPx(sh_f, cfg.height_percent);
+        var want_w: u32 = pctToPx(sw_f, cfg.width_percent);
+        var want_h: u32 = pctToPx(sh_f, cfg.height_percent);
+
+        // #382 — `-size COLSxROWS` 는 퍼센트를 무시하고 **셀 개수**로 창을 만든다. 셀 크기는
+        // 폰트에서 나오므로 renderer 가 준비된 뒤에만 유효하다 — 그 전 호출은 퍼센트로 두고,
+        // 준비 후 layout 을 다시 계산할 때 이 분기가 걸린다.
+        //
+        // 여기 계산은 **logical 단위**다 (layer-shell 의 native 단위). 셀 크기는 physical
+        // px 이라 scale 로 나눈다.
+        if (self.run_opts.grid) |want| {
+            // `gridSize` 가 쓰는 것과 같은 값들이다 — 그 함수의 역방향이라 같은 출처를
+            // 써야 창 크기와 격자가 어긋나지 않는다.
+            const cw = self.renderer.cellWidth();
+            const ch = self.renderer.cellHeight();
+            if (cw > 0 and ch > 0) {
+                const vp = ui_metrics.viewportForGrid(
+                    want.cols,
+                    want.rows,
+                    self.renderer.paddingPx(),
+                    self.renderer.scrollbarWPx(),
+                    0, // 측정은 탭 1 개 — 탭바가 없다 (`effectiveTabBarHeightPx` 가 0).
+                    cw,
+                    ch,
+                );
+                // 위 값들은 physical px 이고 layer-shell 은 logical 단위다.
+                const scale_f: f32 = if (self.renderer.scale > 0.0) self.renderer.scale else 1.0;
+                want_w = @intFromFloat(@min(sw_f, @ceil(@as(f32, @floatFromInt(vp.w)) / scale_f)));
+                want_h = @intFromFloat(@min(sh_f, @ceil(@as(f32, @floatFromInt(vp.h)) / scale_f)));
+            }
+        }
         const want_w_i: i32 = @intCast(@min(want_w, @as(u32, std.math.maxInt(i32))));
         const want_h_i: i32 = @intCast(@min(want_h, @as(u32, std.math.maxInt(i32))));
         // 점유율 100% 는 특수 분기가 필요 없다 (#351) — logical 로 계산하면
@@ -2895,7 +2927,8 @@ const Client = struct {
         const theme = self.config.theme orelse fallback_theme;
         self.session = session_core.SessionCore.init(
             self.allocator,
-            self.config.shell,
+            // `-e <실행파일>` 이면 셸 대신 그것을 띄운다 (#382).
+            self.run_opts.command orelse self.config.shell,
             self.config.max_scroll_lines,
             theme,
             &self.extra_env_storage,
@@ -7980,14 +8013,22 @@ fn linuxTabTerminate(host: *tab_actions.Host) void {
     client.shell_exited.store(true, .release);
 }
 
-pub fn runBaselineWindow(allocator: std.mem.Allocator, cfg: *const config_mod.Config) !void {
+pub fn runBaselineWindow(
+    allocator: std.mem.Allocator,
+    cfg: *const config_mod.Config,
+    opts: run_options.RunOptions,
+) !void {
     // #198 / #230 — single-instance. 이미 살아있는 인스턴스가 있으면 toggle 신호만
     // 보내고 종료해 기존 인스턴스를 보여준다. #267 이후 중복 재실행(앱 아이콘 /
     // autostart)은 launcher 의 advisory lock 이 먼저 차단하므로, 이 분기는 lock
     // 파일 훼손 같은 edge 에서만 도달하는 잔존 방어층이다. socket 을 빼앗지
     // 않으므로 orphan/hotkey 라우팅 깨짐 없음. Client.init(wayland 연결) *전에*
     // 검사 — 두 번째 인스턴스가 창을 안 만든다.
-    const listener_fd = single_instance.createListener() catch |err| switch (err) {
+    // #382 — 측정 모드는 single-instance 검사를 건너뛴다. 그러지 않으면 평소 쓰는
+    // TildaZ 가 이미 있을 때 toggle 만 보내고 종료해서 (아래 `AlreadyRunning` 분기)
+    // 측정용 창이 아예 뜨지 않는다. socket 도 만들지 않아 기존 인스턴스의 hotkey
+    // 라우팅을 건드리지 않는다.
+    const listener_fd: posix.fd_t = if (opts.isStressRun()) -1 else single_instance.createListener() catch |err| switch (err) {
         error.AlreadyRunning => {
             log.appendLine("toggle-ipc", "already running — sending toggle to existing instance + exiting", .{});
             single_instance.sendToggle(@import("../../instance_context.zig").requireWorkerIndex()) catch |e| {
@@ -8001,16 +8042,18 @@ pub fn runBaselineWindow(allocator: std.mem.Allocator, cfg: *const config_mod.Co
             break :blk @as(posix.fd_t, -1);
         },
     };
-    var client = try Client.init(allocator, cfg);
+    var client = try Client.init(allocator, cfg, opts);
     defer client.deinit();
     client.toggle_listener_fd = listener_fd;
     // #207 — toggle listener가 준비된 직후, sway 세션이면 `tildaz --toggle`을 sway의
     // `bindsym` 으로 자동 등록 (config = source of truth). 비-sway 면 no-op.
-    sway_ipc.registerToggleIfSway(allocator, cfg);
+    // 측정 모드는 자기 단축키를 DE 에 등록하지 않는다 (#382) — 사용자의 기존 binding 을
+    // 덮어쓰면 측정이 끝난 뒤에도 그 상태가 남는다.
+    if (!opts.isStressRun()) sway_ipc.registerToggleIfSway(allocator, cfg);
     // #207 / #229 — GNOME · Cinnamon 세션이면 `tildaz --toggle`을
     // custom keybinding (GSettings)
     // 으로 자동 등록. 그 외 DE 면 no-op.
-    gsettings_hotkey.registerToggleHotkey(allocator, cfg);
+    if (!opts.isStressRun()) gsettings_hotkey.registerToggleHotkey(allocator, cfg);
     try client.run();
 }
 

--- a/src/host/linux_wayland.zig
+++ b/src/host/linux_wayland.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const run_options = @import("../run_options.zig");
 const build_options = @import("build_options");
 const log = @import("../log.zig");
 const messages = @import("../messages.zig");
@@ -63,7 +64,7 @@ pub fn showFatalRunError(err: anyerror) void {
     std.process.exit(1);
 }
 
-pub fn run() !void {
+pub fn run(opts: run_options.RunOptions) !void {
     log.logStart(build_options.version);
     defer log.logStop(build_options.version);
     // #197 — env TILDAZ_VERBOSE 면 protocol/timing/detail 로그까지 (기본은 lifecycle).
@@ -105,7 +106,7 @@ pub fn run() !void {
         log.appendLine("autostart", "{s} + extension — hidden_start override (extension handles show/hide via minimize)", .{owner.displayName()});
     }
 
-    try wayland.runBaselineWindow(gpa.allocator(), &g_config.?);
+    try wayland.runBaselineWindow(gpa.allocator(), &g_config.?, opts);
 }
 
 fn runPtySmoke(allocator: std.mem.Allocator) !void {

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -16,6 +16,7 @@
 //   #75 가 6번 시도해도 못 풀던 \"드래그 중 잔상\" 시나리오를 원천 회피.
 
 const std = @import("std");
+const run_options = @import("../run_options.zig");
 const build_options = @import("build_options");
 const objc = @import("../macos_objc.zig");
 const config = @import("../config.zig");
@@ -333,6 +334,10 @@ var g_gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
 /// 렌더링 + 입력 받으니 동일 — 단 closeTab 은 read thread 가 살아 있을 때
 /// 위험하므로 후속 milestone 에서 join 처리.
 var g_session: session_core.SessionCore = undefined;
+
+/// #382 — 측정용 실행 옵션. `run()` 이 받아 여기 저장하고, 아래 네 지점이 참조한다:
+/// 전역 핫키 등록 · 창 표시 · 창 크기 (`dockRect`) · 첫 탭의 셸.
+var g_run_opts: run_options.RunOptions = .{};
 /// PTY 자식 종료 시 read thread 가 enqueue, main thread (renderFrameTick) 가
 /// drain. session_core 의 tab_exit_fn 이 read thread context 에서 불리는데
 /// 거기서 closeTabByPtr 직접 호출하면 self-join deadlock — read thread 가
@@ -2697,7 +2702,8 @@ fn resolveShell(allocator: std.mem.Allocator) []const u8 {
     return allocator.dupe(u8, config.Defaults.shell) catch config.Defaults.shell;
 }
 
-pub fn run() !void {
+pub fn run(opts: run_options.RunOptions) !void {
+    g_run_opts = opts;
     // 통합 로그 파일에 boot/exit 라인을 남긴다 (`log.zig`). macOS 는
     // `~/Library/Logs/tildaz_N.log` — Console.app 이 자동 인덱싱해 GUI 에서
     // 바로 열람 가능.
@@ -2880,7 +2886,9 @@ pub fn run() !void {
     //    윈도우는 unmapped, F1 처음 눌렀을 때 첫 노출. Windows windows_host.run
     //    의 `if (!config.hidden_start) app.window.show();` 와 동등).
     repositionWindow();
-    if (!g_config.hidden_start) {
+    // 측정 모드는 `hidden_start` 를 무시한다 (#382) — 창이 숨겨져 있으면 렌더가
+    // 일어나지 않아 측정이 무의미하다.
+    if (!g_config.hidden_start or g_run_opts.isStressRun()) {
         showWindow();
     }
 
@@ -2914,7 +2922,8 @@ pub fn run() !void {
     // layer geometry 동기화. additionalSafeAreaInsets 로 시스템 inset 무력화
     // 했으므로 layer 가 cv_bounds 전체 (titlebar 영역 포함) 를 그대로 사용.
     const get_rect = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) NSRect);
-    const cv_bounds = get_rect(content_view, objc.sel("bounds"));
+    // #382 — `-size` 가 있으면 renderer 초기화 뒤에 창을 격자에 맞추고 이 값을 다시 읽는다.
+    var cv_bounds = get_rect(content_view, objc.sel("bounds"));
     const set_layer_frame = objc.objcSend(fn (objc.id, objc.SEL, NSRect) callconv(.c) void);
     set_layer_frame(layer, objc.sel("setFrame:"), cv_bounds);
 
@@ -2934,7 +2943,9 @@ pub fn run() !void {
     //    Carbon RegisterEventHotKey 는 우리 환경 (macOS Tahoe + ad-hoc sign) 에서
     //    silently fail 하므로 Apple DTS 권장 modern API 인 CGEventTap 사용.
     //    Input Monitoring 권한 필요 — 사용자가 시스템 설정에서 활성화.
-    try installEventTap();
+    // 측정 모드는 전역 핫키를 등록하지 않는다 (#382) — 평소 쓰는 TildaZ 와 F1 이
+    // 겹쳐 두 프로세스가 같은 키에 반응한다.
+    if (!g_run_opts.isStressRun()) try installEventTap();
 
     const allocator = g_gpa.allocator();
 
@@ -2975,6 +2986,19 @@ pub fn run() !void {
         },
         else => return err,
     };
+    // #382 — renderer 가 생겨 셀 크기를 알므로 여기서 `-size` 를 적용한다. 창을 격자에
+    // 맞추고 layer / drawable / bounds 를 새 크기로 되돌린다. 아래 `terminalGrid` 가 그
+    // 창에서 격자를 다시 계산하므로, 요청한 셀 수가 그대로 나오는지 그 값으로 확인된다.
+    if (g_run_opts.grid != null) {
+        repositionWindow();
+        cv_bounds = get_rect(content_view, objc.sel("bounds"));
+        set_layer_frame(layer, objc.sel("setFrame:"), cv_bounds);
+        set_drawable_size(layer, objc.sel("setDrawableSize:"), .{
+            .width = cv_bounds.size.width * scale_pt,
+            .height = cv_bounds.size.height * scale_pt,
+        });
+    }
+
     // viewport / cell metrics 모두 pixel 단위로 통일 — pt/px mixing 시 글리프
     // 가 cell 일부만 차지해 깨져 보이는 문제 회피 (#75 댓글 6 의 정정 패턴).
     const vp_w_px: u32 = @intFromFloat(cv_bounds.size.width * scale_pt);
@@ -3025,7 +3049,9 @@ pub fn run() !void {
 
     g_session = session_core.SessionCore.init(
         allocator,
-        g_shell_path,
+        // `-e <실행파일>` 이면 셸 대신 그것을 띄운다 (#382). 인자는 넘길 수 없다 —
+        // POSIX 는 PTY 자식의 argv 가 고정이다 (`terminal/posix/pty.zig`).
+        g_run_opts.command orelse g_shell_path,
         g_config.max_scroll_lines,
         g_config.theme,
         &g_extra_env,
@@ -3484,8 +3510,32 @@ fn repositionWindow() void {
     const height_percent: f64 = @floatCast(g_config.height_percent);
     const offset_percent: f64 = @floatCast(g_config.offset_percent);
 
-    const w = sw * width_percent / 100.0;
-    const h = usable_height * height_percent / 100.0;
+    var w = sw * width_percent / 100.0;
+    var h = usable_height * height_percent / 100.0;
+
+    // #382 — `-size COLSxROWS` 는 config 의 퍼센트를 무시하고 **셀 개수**로 창을 만든다.
+    // 셀 크기는 폰트 metrics 에서 나오므로 renderer 초기화 뒤에만 계산할 수 있다. 그
+    // 전에 불린 호출은 퍼센트로 두고 (창이 잠깐 다른 크기로 뜬다), 초기화 직후 이 함수를
+    // 다시 불러 맞춘다 — `run()` 의 renderer init 뒤 블록이 그 일을 한다.
+    if (g_run_opts.grid) |want| {
+        if (g_renderer) |r| {
+            const backing = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) f64);
+            const scale = backing(g_window, objc.sel("backingScaleFactor"));
+            const scale_f: f32 = @floatCast(scale);
+            const vp = ui_metrics.viewportForGrid(
+                want.cols,
+                want.rows,
+                ui_metrics.scaledPx(i64, TERMINAL_PADDING_PT, scale_f),
+                ui_metrics.scaledPx(i64, ui_metrics.SCROLLBAR_W_PT, scale_f),
+                tabBarHeightPx(scale_f),
+                r.font.cell_width_px,
+                r.font.cell_height_px,
+            );
+            // viewport 는 physical px, 창 frame 은 logical pt 다.
+            w = @as(f64, @floatFromInt(vp.w)) / scale;
+            h = @as(f64, @floatFromInt(vp.h)) / scale;
+        }
+    }
 
     // dock_position 별로 x / y 결정. macOS 의 bottom-up 좌표계 주의.
     const x: f64 = switch (g_config.dock_position) {

--- a/src/host/unsupported.zig
+++ b/src/host/unsupported.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const run_options = @import("../run_options.zig");
 
 pub fn showPanic(msg: []const u8, addr: usize, _: ?*std.builtin.StackTrace) noreturn {
     std.debug.print("panic: {s}\nreturn address: 0x{x}\n", .{ msg, addr });
@@ -9,6 +10,8 @@ pub fn showFatalRunError(err: anyerror) void {
     std.debug.print("TildaZ failed to start.\n\nError: {s}\n", .{@errorName(err)});
 }
 
-pub fn run() !void {
+pub fn run(opts: run_options.RunOptions) !void {
+    // 이 platform 은 애초에 실행되지 않는다 — 측정 옵션도 의미가 없다 (#382).
+    _ = opts;
     return error.UnsupportedPlatform;
 }

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const run_options = @import("../run_options.zig");
 const App = @import("../app_controller.zig").App;
 const SessionCore = @import("../session_core.zig").SessionCore;
 const RendererBackend = @import("../renderer.zig").RendererBackend;
@@ -14,6 +15,7 @@ const windows_pty = @import("../terminal/windows/pty.zig");
 const themes = @import("../themes.zig");
 const instance_context = @import("../instance_context.zig");
 const instances = @import("../instances.zig");
+const ui_metrics = @import("../ui_metrics.zig");
 const build_options = @import("build_options");
 
 const WCHAR = u16;
@@ -40,7 +42,7 @@ pub fn showFatalRunError(err: anyerror) void {
     dialog.showError(messages.error_title, text);
 }
 
-pub fn run() !void {
+pub fn run(opts: run_options.RunOptions) !void {
     // Enable per-monitor DPI awareness (must be before any window/GDI calls)
     _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
@@ -88,9 +90,16 @@ pub fn run() !void {
         .allocator = alloc,
         .shell = config.shell, // #248 — 런타임 새 탭 재검증용 (config 생존 동안 유효).
     };
+    // #382 — `-e <실행파일>` 이면 셸 대신 그것을 띄운다. Windows 의 `ShellCommand` 는
+    // UTF-16 이라 변환한다 (`run()` 이 끝날 때까지 살아 있어야 해서 여기서 free 하지
+    // 않는다 — 프로세스 수명과 같다).
+    const stress_shell_w: ?[:0]const u16 = if (opts.command) |cmd|
+        std.unicode.utf8ToUtf16LeAllocZ(alloc, cmd) catch null
+    else
+        null;
     app.session = SessionCore.init(
         alloc,
-        config.windowsShellUtf16(),
+        if (stress_shell_w) |w| w.ptr else config.windowsShellUtf16(),
         config.max_scroll_lines,
         config.theme,
         buildExtraEnv(config.theme),
@@ -152,7 +161,15 @@ pub fn run() !void {
     // `createTab()` 까지 hwnd 를 다시 검사할 필요가 없다. `app_controller` 의
     // `getTerminalGridSize` 는 이 불변식을 assert 로만 밝히고 가짜 fallback 을
     // 두지 않는다.
-    try app.window.init(font_chain, terminal_font, config.opacity_alpha, config.hotkey.vkey, config.hotkey.modifiers);
+    try app.window.init(
+        font_chain,
+        terminal_font,
+        config.opacity_alpha,
+        // 측정 모드는 전역 핫키를 등록하지 않는다 (#382) — 평소 쓰는 TildaZ 와 같은
+        // 키에 두 프로세스가 반응한다. vkey 0 이 그 뜻이다 (`window.zig`).
+        if (opts.isStressRun()) 0 else config.hotkey.vkey,
+        config.hotkey.modifiers,
+    );
     log.appendLine("startup", "window initialized: dpi={d} cell={}x{}", .{
         app.window.current_dpi,
         app.window.cell_width_px,
@@ -187,14 +204,39 @@ pub fn run() !void {
     log.appendLine("startup", "render_path={s}", .{app.renderer.?.renderPath()});
     defer if (app.renderer) |*r| r.deinit();
 
-    // Apply position from config
-    app.window.setPosition(config.dock_position, config.width_percent, config.height_percent, config.offset_percent);
+    // Apply position from config.
+    //
+    // #382 — `-size COLSxROWS` 는 퍼센트를 무시하고 셀 개수로 창을 만든다. 이 시점에
+    // `window.init` 이 이미 셀 크기를 확정했으므로 (위 로그의 `cell=WxH`) 바로 환산할
+    // 수 있다. 셀 절반을 여유로 더하는 이유는 `percentForPixels` 주석 참고.
+    var want_w_pct = config.width_percent;
+    var want_h_pct = config.height_percent;
+    if (opts.grid) |want| {
+        const cell_w: i64 = @intCast(app.window.cell_width_px);
+        const cell_h: i64 = @intCast(app.window.cell_height_px);
+        const vp = ui_metrics.viewportForGrid(
+            want.cols,
+            want.rows,
+            app.TERMINAL_PADDING,
+            app.SCROLLBAR_W,
+            0, // 측정은 탭 1 개 — 탭바가 없다 (`tabBarHeightPx` 는 count < 2 에서 0).
+            cell_w,
+            cell_h,
+        );
+        if (app.window.percentForPixels(vp.w + @divTrunc(cell_w, 2), vp.h + @divTrunc(cell_h, 2))) |pct| {
+            want_w_pct = pct.w;
+            want_h_pct = pct.h;
+        }
+    }
+    app.window.setPosition(config.dock_position, want_w_pct, want_h_pct, config.offset_percent);
 
     // Create initial tab
     try app.createTab();
     log.appendLine("startup", "initial tab created: count={d}", .{app.session.count()});
 
-    if (!config.hidden_start) {
+    // 측정 모드는 `hidden_start` 를 무시한다 (#382) — 숨겨져 있으면 렌더가 일어나지
+    // 않아 측정이 무의미하다.
+    if (!config.hidden_start or opts.isStressRun()) {
         log.appendLine("startup", "show window", .{});
         app.window.show();
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,7 @@ const instance_context = @import("instance_context.zig");
 const instance_request = @import("instance_request.zig");
 const instances = @import("instances.zig");
 const messages = @import("messages.zig");
+const run_options = @import("run_options.zig");
 const shortcut_sync = @import("shortcut_sync.zig");
 
 /// `std.log` 호출 (ghostty-vt 의 `unimplemented mode` 등) 을 우리 통합 로그로
@@ -49,6 +50,8 @@ pub fn main() void {
     var worker_index: ?u32 = null;
     var autostart_launch = false;
     var toggle_index: ?u32 = null;
+    // #382 — 측정용 내부 옵션. 문서화하지 않는다 (`run_options.zig` 참고).
+    var run_opts: run_options.RunOptions = .{};
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
@@ -56,6 +59,14 @@ pub fn main() void {
             if (i + 1 >= args.len) std.process.exit(2);
             i += 1;
             worker_index = std.fmt.parseInt(u32, args[i], 10) catch std.process.exit(2);
+        } else if (std.mem.eql(u8, arg, "-e")) {
+            if (i + 1 >= args.len) std.process.exit(2);
+            i += 1;
+            run_opts.command = args[i];
+        } else if (std.mem.eql(u8, arg, "-size")) {
+            if (i + 1 >= args.len) std.process.exit(2);
+            i += 1;
+            run_opts.grid = run_options.parseGrid(args[i]) orelse std.process.exit(2);
         } else if (std.mem.eql(u8, arg, "--autostart")) {
             autostart_launch = true;
         } else if (std.mem.eql(u8, arg, "--toggle")) {
@@ -92,6 +103,15 @@ pub fn main() void {
         }
     }
 
+    // #382 — 측정 모드. worker lock · launcher · 전역 핫키를 모두 건너뛴다. 그러지 않으면
+    // 평소 쓰는 TildaZ 의 lock 을 뺏거나 F1 이 두 프로세스에 걸린다. config 는 그대로
+    // 읽지만 (읽기 전용이라 안전) 창 크기는 `-size` 가 덮는다.
+    if (run_opts.isStressRun()) {
+        instance_context.setWorkerIndex(worker_index orelse 0);
+        host.run(run_opts) catch |err| host.showFatalRunError(err);
+        return;
+    }
+
     if (worker_index) |index| {
         instance_context.setWorkerIndex(index);
         var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
@@ -101,7 +121,7 @@ pub fn main() void {
             return;
         }) orelse return;
         defer worker_lock.deinit();
-        host.run() catch |err| host.showFatalRunError(err);
+        host.run(run_opts) catch |err| host.showFatalRunError(err);
         return;
     }
 

--- a/src/run_options.zig
+++ b/src/run_options.zig
@@ -1,0 +1,75 @@
+//! 측정용 실행 옵션 ([#382](https://github.com/ensky0/tildaz/issues/382)).
+//!
+//! **내부용이다.** `README` · `CONFIG.md` · `KEYBINDINGS.md` 에 넣지 않고, 쓰는 곳은
+//! `dist/stress/compare-terminals.sh` 하나다. 사용자 기능으로 만들려면 "이미 떠 있는
+//! 인스턴스와의 관계", "drop-down 을 어떻게 표시하나", "탭을 더 열면 그 탭은 무엇인가"
+//! 를 다 정해야 하는데, 측정용으로 한정하면 그것들이 필요 없다.
+//!
+//! ## 왜 필요한가
+//!
+//! [#371](https://github.com/ensky0/tildaz/issues/371) 의 터미널 비교에서 우리만 손으로
+//! 재야 했다. 다른 넷은 명령 실행 옵션(`-e`)과 셀 단위 창 크기 지정을 갖고 있다.
+//! 그것이 없으면 측정 한 번에 config 를 고치고 재시작하고 명령을 붙여넣는 절차가 든다.
+
+const std = @import("std");
+
+pub const Grid = struct { cols: u16, rows: u16 };
+
+pub const RunOptions = struct {
+    /// `-e <실행파일>` — 셸 대신 이 실행파일을 띄우고, 그것이 끝나면 앱도 끝낸다.
+    ///
+    /// **인자를 넘길 수 없다.** POSIX 는 PTY 자식의 argv 가 `{shell}` 로 고정이라
+    /// (`terminal/posix/pty.zig`) 실행파일 경로 하나만 의미가 있다. 측정에는 충분하다 —
+    /// producer 가 파라미터를 환경변수로 받는다 (`src/stress.zig`).
+    command: ?[]const u8 = null,
+
+    /// `-size <COLS>x<ROWS>` — config 의 `window.width_percent` / `height_percent` 를
+    /// 무시하고 **셀 개수**로 창을 만든다. 다른 터미널이 모두 갖고 있는 방식이다
+    /// (kitty 의 `initial_window_width=120c`, ghostty 의 `window-width = 120`).
+    ///
+    /// 셀 크기는 폰트 metrics 에서 나오므로 renderer 초기화 뒤에야 안다. 그래서 각 host
+    /// 는 창을 먼저 띄우고 그 뒤에 `ui_metrics.viewportForGrid` 로 크기를 다시 맞춘다.
+    grid: ?Grid = null,
+
+    /// 측정 모드인가. `-e` 가 기준이다 — 그때만 아래를 건너뛴다.
+    ///
+    /// - **worker lock**: 잡으면 평소 쓰는 TildaZ 와 충돌한다.
+    /// - **전역 핫키 등록**: 등록하면 F1 이 두 프로세스에 걸린다.
+    /// - **launcher 경로**: 다른 worker 를 spawn 하거나 새 instance 를 요청하면 안 된다.
+    ///
+    /// 그리고 창을 **표시한 채** 시작한다 (`hidden_start` 무시) — 숨김이면 렌더가 일어나지
+    /// 않아 측정이 무의미하다.
+    pub fn isStressRun(self: RunOptions) bool {
+        return self.command != null;
+    }
+};
+
+/// `<COLS>x<ROWS>` 를 읽는다. 잘못된 형식이면 `null`.
+pub fn parseGrid(text: []const u8) ?Grid {
+    const sep = std.mem.indexOfScalar(u8, text, 'x') orelse return null;
+    const cols = std.fmt.parseInt(u16, text[0..sep], 10) catch return null;
+    const rows = std.fmt.parseInt(u16, text[sep + 1 ..], 10) catch return null;
+    if (cols == 0 or rows == 0) return null;
+    return .{ .cols = cols, .rows = rows };
+}
+
+test "parseGrid 는 COLSxROWS 를 읽는다" {
+    try std.testing.expectEqual(Grid{ .cols = 120, .rows = 40 }, parseGrid("120x40").?);
+    try std.testing.expectEqual(Grid{ .cols = 1, .rows = 1 }, parseGrid("1x1").?);
+    try std.testing.expectEqual(Grid{ .cols = 424, .rows = 113 }, parseGrid("424x113").?);
+}
+
+test "parseGrid 는 잘못된 형식을 거른다" {
+    for ([_][]const u8{
+        "", "120", "120x", "x40", "120x40x2", "0x40", "120x0",
+        "-1x40", "120 x 40", "abcxdef", "999999x40",
+    }) |bad| {
+        try std.testing.expectEqual(@as(?Grid, null), parseGrid(bad));
+    }
+}
+
+test "isStressRun 은 -e 를 기준으로 한다" {
+    try std.testing.expect(!(RunOptions{}).isStressRun());
+    try std.testing.expect(!(RunOptions{ .grid = .{ .cols = 120, .rows = 40 } }).isStressRun());
+    try std.testing.expect((RunOptions{ .command = "/bin/echo" }).isStressRun());
+}

--- a/src/ui_metrics.zig
+++ b/src/ui_metrics.zig
@@ -61,6 +61,67 @@ pub fn terminalRows(viewport_h: i64, tab_bar_h: i64, pad: i64, cell_h: i64) u16 
     return @intCast(@min(@divTrunc(usable, cell_h), @as(i64, std.math.maxInt(u16))));
 }
 
+/// `terminalCols` · `terminalRows` 의 **역함수** — 원하는 격자를 담는 viewport 크기를
+/// 낸다 ([#382](https://github.com/ensky0/tildaz/issues/382) 의 `-size` 옵션).
+///
+/// 앱은 보통 창 크기에서 격자를 구하지만, 측정할 때는 반대 방향이 필요하다. 터미널마다
+/// 폰트 해석이 달라 같은 창 크기가 다른 셀 수를 주므로, 다른 터미널과 비교하려면 **셀
+/// 수를 직접 맞춰야** 한다 ([#371](https://github.com/ensky0/tildaz/issues/371) L4).
+///
+/// 위 두 함수가 `@divTrunc` 로 내림하므로 그 결과가 정확히 `cols` · `rows` 가 되는 가장
+/// 작은 크기를 낸다. 인자 단위와 의미는 두 함수와 같다 (physical px).
+///
+/// 셀 크기는 폰트 metrics 에서 나오므로 **renderer 초기화 뒤에야** 알 수 있다. 즉 호출처는
+/// 창을 먼저 띄우고 그 뒤에 이 값으로 크기를 다시 맞춰야 한다.
+pub fn viewportForGrid(
+    cols: u16,
+    rows: u16,
+    pad: i64,
+    scrollbar_w: i64,
+    tab_bar_h: i64,
+    cell_w: i64,
+    cell_h: i64,
+) struct { w: i64, h: i64 } {
+    return .{
+        .w = @as(i64, cols) * cell_w + 2 * pad + scrollbar_w,
+        .h = @as(i64, rows) * cell_h + tab_bar_h + 2 * pad,
+    };
+}
+
+test "viewportForGrid 는 terminalCols/Rows 의 역함수다" {
+    // 실기에서 나온 값 (macOS: cell=19x39px, pad=12px, scrollbar=20px, 탭 1개라 탭바 0).
+    const pad: i64 = 12;
+    const sb: i64 = 20;
+    const tab: i64 = 0;
+    const cw: i64 = 19;
+    const ch: i64 = 39;
+
+    for ([_]u16{ 1, 40, 77, 120, 424 }) |cols| {
+        for ([_]u16{ 1, 24, 40, 113 }) |rows| {
+            const vp = viewportForGrid(cols, rows, pad, sb, tab, cw, ch);
+            try std.testing.expectEqual(cols, terminalCols(vp.w, pad, sb, cw));
+            try std.testing.expectEqual(rows, terminalRows(vp.h, tab, pad, ch));
+        }
+    }
+}
+
+test "viewportForGrid 는 가장 작은 크기를 낸다 — 1px 줄면 격자가 준다" {
+    const vp = viewportForGrid(120, 40, 12, 20, 0, 19, 39);
+    try std.testing.expectEqual(@as(u16, 120), terminalCols(vp.w, 12, 20, 19));
+    try std.testing.expectEqual(@as(u16, 119), terminalCols(vp.w - 1, 12, 20, 19));
+    try std.testing.expectEqual(@as(u16, 40), terminalRows(vp.h, 0, 12, 39));
+    try std.testing.expectEqual(@as(u16, 39), terminalRows(vp.h - 1, 0, 12, 39));
+}
+
+test "viewportForGrid 는 탭바 높이를 더한다" {
+    const without = viewportForGrid(120, 40, 12, 20, 0, 19, 39);
+    const with = viewportForGrid(120, 40, 12, 20, 56, 19, 39);
+    try std.testing.expectEqual(without.w, with.w);
+    try std.testing.expectEqual(without.h + 56, with.h);
+    // 탭바가 있는 창에서도 같은 rows 가 나와야 한다.
+    try std.testing.expectEqual(@as(u16, 40), terminalRows(with.h, 56, 12, 39));
+}
+
 // --- pt → px 변환 (#350) ---
 //
 // 이 모듈의 `*_PT` 상수는 logical point 단위이고, 그리는 쪽은 현재 화면 scale 을

--- a/src/window.zig
+++ b/src/window.zig
@@ -580,6 +580,14 @@ pub const Window = struct {
         // fatal dialog 로 종료 + config 파일 경로 + 알려진 reservation 안내.
         self.hotkey_vkey = hotkey_vkey;
         self.hotkey_modifiers = hotkey_modifiers;
+        // #382 — vkey 0 은 "등록하지 않는다" 는 뜻이다. 측정 모드가 쓰는 통로로,
+        // 등록하면 평소 쓰는 TildaZ 와 같은 키에 두 프로세스가 반응한다. 사용자
+        // config 로는 0 이 들어올 수 없다 (`config.zig` 가 hotkey 이름을 vkey 로
+        // 바꾸고 유효하지 않으면 fatal 이다).
+        if (hotkey_vkey == 0) {
+            log.appendLine("hotkey", "global hotkey not registered (stress run)", .{});
+            return;
+        }
         if (RegisterHotKey(self.hwnd, HOTKEY_ID, hotkey_modifiers, hotkey_vkey) == 0) {
             var alloc_buf: [4096]u8 = undefined;
             var fba = std.heap.FixedBufferAllocator.init(&alloc_buf);
@@ -845,6 +853,24 @@ pub const Window = struct {
         self.offset_percent = offset_percent;
         self.position_set = true;
         self.applyDockedRect(dock, width_percent, height_percent, offset_percent, .cursor);
+    }
+
+    /// #382 — 셀 개수로 창을 잡을 때 쓰는 환산. 창 크기 경로는 퍼센트 기반이고 (DPI ·
+    /// 해상도 변경 시 그 값으로 재적용된다) 그 구조를 그대로 두는 게 안전하므로, 필요한
+    /// 픽셀을 현재 모니터 작업영역 대비 퍼센트로 바꿔 기존 경로에 넣는다.
+    ///
+    /// 호출자는 **여유를 더한 픽셀**을 넘겨야 한다. `viewportForGrid` 는 요청한 격자가
+    /// 나오는 *가장 작은* 크기를 내는데, 퍼센트 환산에서 1 px 이라도 줄면 격자가 한 칸
+    /// 줄어든다. 셀 크기의 절반을 더하면 내림이 흡수한다.
+    pub fn percentForPixels(self: *Window, w_px: i64, h_px: i64) ?struct { w: f32, h: f32 } {
+        const mi = self.monitorInfoFor(.cursor) orelse return null;
+        const sw: i64 = mi.rcWork.right - mi.rcWork.left;
+        const sh: i64 = mi.rcWork.bottom - mi.rcWork.top;
+        if (sw <= 0 or sh <= 0) return null;
+        return .{
+            .w = @min(100.0, @as(f32, @floatFromInt(w_px)) / @as(f32, @floatFromInt(sw)) * 100.0),
+            .h = @min(100.0, @as(f32, @floatFromInt(h_px)) / @as(f32, @floatFromInt(sh)) * 100.0),
+        };
     }
 
     fn applyDockedRect(


### PR DESCRIPTION
## 무엇을

측정용 내부 옵션 두 개를 추가한다. [#382](https://github.com/ensky0/tildaz/issues/382)

```sh
tildaz -e <실행파일> -size 120x40
```

[#371](https://github.com/ensky0/tildaz/issues/371) 의 터미널 비교에서 **우리만 손으로 재야 했다.** 다른 넷은 명령 실행 옵션과 셀 단위 창 크기 지정이 있어서 스크립트가 자동으로 돌린다. 우리는 측정 한 번에 이 절차가 들었다.

> 로그의 셀 크기로 퍼센트 역산 → `config_0.json` 수정 → 재시작 → 로그로 격자 확인 → F1 로 열어 명령 붙여넣기 → 측정 후 config 되돌리기

두 옵션으로 그 전부가 사라진다. 스크립트가 이제 **다섯 터미널을 전부 자동으로** 돌린다.

## 측정 내부용이다

`README` · `CONFIG.md` · `KEYBINDINGS.md` 에 넣지 않고, 쓰는 곳은 `dist/stress/compare-terminals.sh` 하나다. 사용자 기능으로 만들려면 "이미 떠 있는 인스턴스와의 관계", "drop-down 을 어떻게 표시하나", "탭을 더 열면 그 탭은 무엇인가" 를 정해야 하는데 측정용으로 한정하면 필요가 없다 (2026-08-04 결정).

## 측정 모드가 건너뛰는 것

`-e` 가 기준이다. 그러지 않으면 평소 쓰는 TildaZ 를 방해한다.

| 건너뛰는 것 | 안 건너뛰면 |
|---|---|
| worker lock | 기존 인스턴스의 lock 과 충돌 |
| 전역 핫키 등록 | 같은 키에 두 프로세스가 반응 |
| launcher 경로 | 다른 worker 를 spawn 하거나 새 instance 를 요청 |
| **Linux 의 single-instance 검사** | 기존 인스턴스가 있을 때 toggle 만 보내고 종료 — **측정용 창이 아예 안 뜬다** |
| **Linux 의 DE 단축키 자동 등록** (sway `bindsym` / GSettings) | 사용자의 기존 binding 을 덮어써서 측정 후에도 남는다 |

그리고 `hidden_start` 를 무시하고 창을 표시한 채 시작한다 — 숨겨져 있으면 렌더가 일어나지 않아 측정이 무의미하다.

## `-size` 는 격자 계산의 역방향이다

`ui_metrics.viewportForGrid` 를 새로 뒀다. `terminalCols` · `terminalRows` 의 역함수이고 (그 둘이 내림하므로 요청한 격자가 나오는 **가장 작은** 크기를 낸다) 세 host 가 같은 함수를 쓴다. 계산이 한 곳에 있어야 창 크기와 격자가 어긋나지 않는다. 테스트 3 개로 역함수 관계와 "1 px 줄면 격자가 준다" 를 고정했다.

적용은 host 마다 다르다 — 창 크기 API 가 다르기 때문이다.

| host | 방식 | 주의 |
|---|---|---|
| macOS | `dockRect` 에서 셀 기반 크기 | 셀 크기가 renderer 초기화 뒤에 확정돼서, 창을 먼저 띄우고 그 뒤에 다시 맞춘다 |
| Windows | 필요 픽셀을 퍼센트로 환산해 기존 `setPosition` 에 넣는다 (`Window.percentForPixels`) | 순서가 유리하다 — `window.init` 이 셀 크기를 먼저 확정한다. 반올림으로 격자가 한 칸 줄지 않게 셀 절반을 여유로 더한다 |
| Linux | layer-shell layout 계산에서 셀 기반 크기 | layer-shell 은 logical 단위라 physical 셀 크기를 `renderer.scale` 로 나눈다 |

Windows 의 전역 핫키는 `vkey 0` 을 "등록하지 않는다" 는 뜻으로 쓴다. 사용자 config 로는 0 이 들어올 수 없다 (`config.zig` 가 유효하지 않은 hotkey 이름을 fatal 로 막는다).

## 검증

| 항목 | 결과 |
|---|---|
| `zig build test` | ✅ (`viewportForGrid` 3 개 + `run_options` 3 개 추가) |
| `zig build check` (6 target × 2 root) | ✅ |
| **macOS 실기** | ✅ `-size 120x40` → producer 가 남긴 격자 `cols=120 rows=40` (시작·끝 동일, resize 없음). 측정용 인스턴스는 명령이 끝나자 스스로 종료 (`last tab closed, terminating tildaz`), 평소 쓰던 TildaZ 는 그대로 살아 있었다 |
| 스크립트 5 종 자동 | ✅ alacritty 131.1 · tildaz 129.8 · ghostty 128.0 · kitty 102.3 · wezterm 43.6 MiB/s (64 MiB · plain · 전부 격자 120x40) |
| **Linux 실기** | ⬜ 미검증 |
| **Windows 실기** | ⬜ 미검증 |

**Linux · Windows 는 실기로 돌리지 않았다** (이 머신이 macOS 다). `zig build check` 는 컴파일 검증이라 부족하다 — #371 에서 Windows 가 컴파일은 통과하고 실행에서 `ConptyRuntimeUnavailable` 로 실패한 적이 있다.

각 platform 에서 확인할 것:

```sh
zig build -Doptimize=ReleaseFast -Dsimd=true
zig build stress -Doptimize=ReleaseFast -Dsimd=true -- throughput --layer parser --mb 1
dist/stress/compare-terminals.sh --mb 64 --cols 120 --rows 40
```

- `tildaz` 줄의 격자가 `120x40` 인지 (다르면 `-size` 환산이 어긋난 것)
- 평소 쓰는 TildaZ 가 떠 있는 상태에서 돌려도 그것이 영향받지 않는지 (lock · 핫키)
- 창이 표시된 상태로 뜨는지, 명령이 끝나면 종료되는지
- Linux 는 DE 단축키가 덮어써지지 않았는지 (sway `bindsym` / GSettings)
