### PR TITLE
fix(perf): `push` 가 안 넣은 양까지 세던 것 — Windows 의 16 byte 는 ConPTY teardown 이다 (#398)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -328,10 +328,27 @@ perf 스냅숏에 답이 있어요 (측정 인스턴스는 종료할 때 자동�
 | Linux · Intel i5-1240P (64 MiB) | `zwj` **6.1~6.2 %** (5/5) · `plain` **0.9~2.5 %** (5/5) | **0** (10/10) |
 | Windows · AMD Ryzen AI 7 350 (64 MiB) | `zwj` **6.3~6.5 %** (5/5) · `plain` 2/5 에서 265 KB~1.25 MB | **16 byte** |
 
-그래서 판정은 `== 0` 이 아니라 **수십 byte 이내**예요. **Windows 만** 고친 뒤에도 정확히 16 byte 가
-남아요 (크기 · 워크로드 · 커밋 · `HOLD` 를 바꿔도 항상 16 — 원인 미확정, #397). Linux · macOS 는
-0 이라 그 16 은 ConPTY 쪽 경로로 좁혀지고, 어느 쪽이든 실제 결함은 **수백 KB~수 MB** 규모라 이
+그래서 판정은 `== 0` 이 아니라 **수십 byte 이내**예요. 실제 결함은 **수백 KB~수 MB** 규모라 이
 경계로 충분히 갈려요.
+
+**Windows 의 16 byte 는 ConPTY teardown 이에요 — 결함이 아니에요**
+([#398](https://github.com/ensky0/tildaz/issues/398) 에서 확정). 자식이 끝날 때 ConPTY 가
+`ESC[?1004l` + `ESC[?9001l` (8+8 = **16 byte**) 를 보내요. 시작할 때 보내는 협상 preamble
+`…1004h` · `…9001h` 의 짝이고 ([#385](https://github.com/ensky0/tildaz/issues/385)), **창이 닫히는
+참의 모드 해제라 파싱할 것이 없어요.** ConPTY 가 없는 Linux · macOS 가 0 인 것도 이걸로 설명돼요.
+
+그래서 **`push bytes` 를 함께 봐요.**
+
+| 지표 | 뜻 | 정상값 |
+|---|---|---|
+| `readloop bytes` | PTY 에서 **읽은** 양 | teardown 16 을 포함해요 (Windows) |
+| `push bytes` | ring 에 **넣은** 양 | — |
+| `drain bytes` | **소화한** 양 | — |
+| **`push − drain`** | 진짜 손실 | **0 이어야 해요** |
+| `readloop − drain` | 위 + teardown | Windows 는 **16**, 나머지는 0 |
+
+`push` 가 예전에는 `data.len` 을 세어서 (실제로 넣은 양이 아니라) 이 구분이 안 됐어요 — 그때는
+`push bytes == readloop bytes` 라 teardown 이 손실처럼 보였어요.
 
 ⚠️ **`TILDAZ_STRESS_HOLD_MS` 를 주면 이 검사가 통째로 무의미해져요.** 유휴 시간이 드레인할 기회를
 줘서 **고치기 전 코드도 손실이 없어 보여요** (Windows 는 `HOLD=3000` 에서 고침 전에도 16 byte 였고,

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -25,10 +25,12 @@ const RingBuffer = struct {
 
     const SIZE = 4 * 1024 * 1024;
 
-    fn push(self: *RingBuffer, data: []const u8) void {
+    /// **실제로 ring 에 넣은 byte 수**를 돌려준다 (#398). `closed` 면 중간에 그만두므로
+    /// `data.len` 보다 작을 수 있고, 호출자는 이 값을 세야 카운터가 사실과 맞는다.
+    fn push(self: *RingBuffer, data: []const u8) usize {
         var i: usize = 0;
         while (i < data.len) {
-            if (self.closed.load(.acquire)) return;
+            if (self.closed.load(.acquire)) return i;
             const pos = self.head.load(.monotonic);
             const t = self.tail.load(.acquire);
             const free = if (t <= pos) (SIZE - pos + t - 1) else (t - pos - 1);
@@ -46,6 +48,7 @@ const RingBuffer = struct {
             self.head.store((pos + batch) % SIZE, .release);
             i += batch;
         }
+        return i;
     }
 
     fn close(self: *RingBuffer) void {
@@ -471,8 +474,19 @@ pub const Tab = struct {
     fn onPtyOutput(data: []const u8, userdata: ?*anyopaque) void {
         const tab: *Tab = @ptrCast(@alignCast(userdata.?));
         const t0 = perf.now();
-        tab.output_ring.push(data);
-        perf.addTimedBytes(&perf.push, t0, data.len);
+        // #398 — **넣은 양**을 센다. `closed` 면 `push` 가 중간에 그만두는데 예전에는
+        // `data.len` 을 그대로 세어서, 실제로는 한 byte 도 안 들어간 것까지 계상됐다.
+        //
+        // Windows 에서 `readloop bytes - drain bytes` 가 **항상 정확히 16** 이던 것이 이것이다.
+        // `Tab.deinit` 이 (deadlock 을 피하려고) `output_ring.close()` 를 먼저 부르고
+        // `backend.deinit()` 을 뒤에 하는데, 그 사이에 ConPTY 가 **teardown 시퀀스**
+        // `ESC[?1004l` + `ESC[?9001l` (8+8 = 16 byte) 를 보낸다 — 시작 때 보내는 협상
+        // preamble `…h` 의 짝이다 (#385). read thread 가 그것을 읽어 push 하지만 이미 closed 라
+        // 즉시 반환하고, 카운터만 16 이 올라갔다. ConPTY 가 없는 Linux · macOS 는 0 이었다.
+        //
+        // 그 16 byte 는 **손실이 아니다** — 창이 닫히는 참의 모드 해제라 파싱할 것이 없다.
+        const wrote = tab.output_ring.push(data);
+        perf.addTimedBytes(&perf.push, t0, wrote);
     }
 
     fn onPtyExit(userdata: ?*anyopaque) void {


### PR DESCRIPTION
`readloop bytes - drain bytes` 가 **Windows 에서만 정확히 16** 이던 것의 원인을 찾아 고칩니다.
크기 · 워크로드 · 커밋 · `HOLD` 를 바꿔도 항상 16 이라 ring 기하나 경합으로는 설명되지 않던 값입니다.

## 원인 — ConPTY teardown 시퀀스

조기 반환 지점에서 내용을 찍어 확정했습니다.

```
[ring] push aborted by close: total=16 written=0 remain=16
       bytes=1b 5b 3f 31 30 30 34 6c 1b 5b 3f 39 30 30 31 6c
```

| hex | 시퀀스 | 뜻 |
|---|---|---|
| `1b 5b 3f 31 30 30 34 6c` | `ESC[?1004l` | focus reporting 끄기 |
| `1b 5b 3f 39 30 30 31 6c` | `ESC[?9001l` | win32-input-mode 끄기 |

8 + 8 = 정확히 16 byte 이고, 시작할 때 ConPTY 가 보내는 협상 preamble `ESC[?1004h` · `ESC[?9001h`
의 **짝인 끄기 시퀀스**입니다 (#385 에서 raw 캡처로 preamble 을 확인해 둔 것과 맞습니다).
ConPTY 가 없는 Linux · macOS 가 0 인 것도 이걸로 설명됩니다 — 보낼 teardown 이 없습니다.

## 함께 있던 카운터 버그

`Tab.deinit` 은 deadlock 을 피하려고 `output_ring.close()` 를 먼저 부르고 `backend.deinit()` 을
뒤에 합니다 (ring full 상태에서 `read_thread.join` 이 안 끝나는 회귀를 막는 순서입니다). 그 사이에
teardown 이 도착하는데, `RingBuffer.push` 는 `closed` 면 즉시 반환하므로 **한 byte 도 안 들어가는데**
`onPtyOutput` 이 `data.len` 을 그대로 `perf.push` 에 더했습니다 (로그의 `written=0`).

그래서 `push` 가 **실제로 넣은 양**을 돌려주고 호출자가 그 값을 세게 했습니다.

| | readloop | push | drain | `push − drain` |
|---|---:|---:|---:|---:|
| before | 67,382,816 | **67,382,816** | 67,382,800 | **16** |
| after | 67,382,816 | **67,382,800** | 67,382,800 | **0** |

`readloop − drain = 16` 은 그대로 남지만 그것이 옳습니다 — "PTY 에서 읽었지만 ring 에 넣지 않은"
양이고, teardown 은 창이 닫히는 참의 모드 해제라 파싱할 것이 없습니다. 드레인하려면 `close()` 를
`backend.deinit()` 뒤로 옮겨야 하는데 그건 막아 둔 deadlock 을 되살리는 일이라 하지 않습니다.

## 문서

`dist/stress/README.md` 의 회차 유효성 기준에 **`push bytes` 를 함께 보는 표**를 넣었습니다.
진짜 손실은 `push − drain` 이고 `readloop − drain` 은 Windows 에서 teardown 16 을 포함한다는
구분입니다. *"원인 미확정"* 문구는 확정 사실로 바꿨고 판정 경계 (수십 byte 이내) 는 그대로입니다.

## 검증

- 노트북 **Intel Core i5-1240P · Windows 11 26200** · `zwj` 64 MiB — 이 기기에서도 16 byte 가
  재현됐고 (본문 표는 AMD 기기 값이었습니다) 수정 후 `push − drain = 0` 확인
- `zig build check` 6 타겟 · `zig build test` 통과 (rebase 후 재실행)

Closes #398