### PR TITLE
fix(font): 설치된 폰트가 이름만 대체됐을 때 죽지 말고 띄운다 · 이유를 알린다 (#405 · #406)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -125,6 +125,58 @@ Every numeric field name carries its unit (`_percent`, `_point`, `_ratio`). Stri
 | `hidden_start` | bool | — | false | false | false | Start hidden (first toggle reveals) |
 | `max_scroll_lines` | int | 100–10,000,000 | 100,000 | 100,000 | 100,000 | Scrollback buffer (lines) |
 
+### Font names
+
+Every family in `font.family` and `font.glyph_fallback` must be installed, and the name must be
+**exactly** what the system calls it. A wrong name is fatal at startup, so it is worth checking
+before editing the config.
+
+**List the installed family names:**
+
+```sh
+# Linux
+fc-list : family | tr ',' '\n' | sort -u
+
+# macOS
+system_profiler SPFontsDataType | grep "Family:" | sort -u
+```
+
+```powershell
+# Windows
+[Reflection.Assembly]::LoadWithPartialName("System.Drawing")
+(New-Object System.Drawing.Text.InstalledFontCollection).Families | Select-Object -Expand Name
+```
+
+**Then confirm the name actually resolves to that font** — this second step matters more than it
+looks:
+
+```sh
+fc-match "Noto Color Emoji"          # Linux
+#   Noto Color Emoji  → correct
+#   twemoji.ttf       → this name cannot be used, see below
+```
+
+#### "Font not found" when the font *is* installed
+
+On Linux and macOS a font can be installed and still be unusable under the name you typed, because
+the system resolves that name to a **different** font. TildaZ rejects that case on purpose — silently
+drawing a different font than you asked for is worse — and the error dialog names the substitute:
+
+```
+Font not found: "Noto Color Emoji"
+...
+This family IS installed, but fontconfig resolves it to "Twemoji".
+A font package may have installed a system-wide alias rule.
+  check:  fc-match "Noto Color Emoji"
+  rules:  /etc/fonts/conf.d/
+```
+
+| Platform | Why it happens | Fix |
+|---|---|---|
+| **Linux** | An emoji font package (`ttf-twemoji`, `ttf-joypixels`, …) installs a system-wide fontconfig rule that claims emoji names. The rule file usually lives in `/etc/fonts/conf.d/` | Use the substitute's name instead, or disable the rule: `sudo rm /etc/fonts/conf.d/75-twemoji.conf && fc-cache -f` |
+| **macOS** | The name given is a **PostScript name** (`.SF NS Mono`) rather than a family name, so the font is found but its family differs | Use the family name shown in Font Book, or the one named in the dialog |
+| **Windows** | Not affected — family lookup is an exact match against the system font collection | — |
+
 ### Hotkey syntax
 
 `hotkey` accepts a single key optionally combined with modifiers, joined by `+`

--- a/src/font/linux/font.zig
+++ b/src/font/linux/font.zig
@@ -1094,11 +1094,36 @@ fn isGenericFamily(family: []const u8) bool {
 /// 의 skip 판정과 boot 검증 (`familyInstalled`) 이 공유하는 단일 규칙.
 /// generic family 는 substitution 이 의도이므로 항상 수용, specific family 는
 /// 반환 family/alias 중 한 항목과 대소문자 무시 exact match해야 한다.
+/// #406 — 이름 정규화. **macOS 판 (`font/macos/font.zig` 의 `normalizeFamily`) 과 같은 규칙**
+/// 이어야 두 platform 이 같은 이름을 받아 준다: 공백 · `-` · `_` 를 빼고 소문자로.
+///
+/// `DejaVuSansMono` · `dejavu sans mono` · `DejaVu-Sans-Mono` 가 모두 같아진다. 사용자가 폰트
+/// 이름을 어떤 표기로 적든 통과시키기 위한 것이다.
+fn normalizeFamily(name: []const u8, buf: []u8) []const u8 {
+    var n: usize = 0;
+    for (name) |c| {
+        if (c == ' ' or c == '-' or c == '_') continue;
+        if (n >= buf.len) break;
+        buf[n] = std.ascii.toLower(c);
+        n += 1;
+    }
+    return buf[0..n];
+}
+
+fn normalizedEql(a: []const u8, b: []const u8) bool {
+    var buf_a: [128]u8 = undefined;
+    var buf_b: [128]u8 = undefined;
+    return std.mem.eql(u8, normalizeFamily(a, &buf_a), normalizeFamily(b, &buf_b));
+}
+
 fn matchResolvesFamily(requested: []const u8, primary_family: []const u8, additional_families: anytype) bool {
     if (isGenericFamily(requested)) return true;
-    if (std.ascii.eqlIgnoreCase(requested, primary_family)) return true;
+    // #406 — 정규화해서 본다. `DejaVuSansMono` 처럼 붙여 쓴 이름을 fontconfig 가 알아서
+    // `DejaVu Sans Mono` 로 맞춰 주는데, 예전에는 `eqlIgnoreCase` 라 그것을 **대체로 오분류**
+    // 해서 "(system alias)" 라는 사실과 다른 로그를 남겼다. macOS 판과 같은 규칙이다.
+    if (normalizedEql(requested, primary_family)) return true;
     for (additional_families) |family| {
-        if (std.ascii.eqlIgnoreCase(requested, family)) return true;
+        if (normalizedEql(requested, family)) return true;
     }
     return false;
 }
@@ -1167,6 +1192,19 @@ pub fn familyInstalledDetail(
     if (matchResolvesFamily(family, fc_result.family, fc_result.additional_families)) {
         return .{ .availability = .installed, .substitute = null };
     }
+
+    // #406 — 여기부터가 "요청과 다른 폰트가 왔다" 인데, 두 경우가 섞여 있어서 갈라야 한다.
+    //
+    //   Noto Color Emoji -> Twemoji      : 설치돼 있는데 별칭 규칙이 가로챔 -> 띄운다
+    //   NoSuchFont12345  -> Noto Sans    : 아예 없음 -> fatal
+    //
+    // `FcFontMatch` 는 없는 이름에도 항상 무언가를 돌려주므로 (실측: 오타에도 `Noto Sans` 가
+    // 나왔다) 반환값만으로는 못 가른다. **설치 목록에 있는지**로 가른다.
+    //
+    // 목록을 못 얻으면 (`error.*`) 예전처럼 대체로 본다 — 판정 불가를 미설치로 오판해 사용자를
+    // 막지 않는다 (`.unknown` 주석과 같은 방향).
+    const listed = fontconfig.familyListed(family, normalizedEql) catch true;
+    if (!listed) return .{ .availability = .missing, .substitute = null };
 
     // substitution 이다 — 무엇으로 바뀌었는지 남긴다. #406 이후 이것은 **시작을 막지 않는다**.
     var sub: ?[]const u8 = null;

--- a/src/font/linux/font.zig
+++ b/src/font/linux/font.zig
@@ -307,11 +307,16 @@ pub const Context = struct {
         // 판단 + skip. 이름 내부의 부분 문자열은 설치 증거가 아니다.
         // (config 명시 chain 은 boot 검증 — `familyInstalled`, 같은 판정 규칙 —
         // 을 이미 통과했으므로 여기 skip 은 face 로드 실패류만 남는다, #289 B6.)
+        // #406 — 예전에는 여기서 skip 했지만 (`error.FontconfigFallbackSubstitution`) 이제
+        // **그 폰트로 로드한다.** 대체됐다는 것은 요청한 이름이 시스템에 없다는 뜻이 아니라
+        // (그건 위 `lookup` 이 `FontconfigNoMatch` 로 걸러 낸다) 별칭 규칙이 다른 폰트를
+        // 가리키게 했다는 뜻이다. 그 폰트는 실재하므로 글자는 그려진다.
+        //
+        // 사용자가 나중에 "왜 다른 폰트로 보이지" 를 추적할 수 있도록 로그를 남긴다.
         if (!matchResolvesFamily(family, fc_result.family, fc_result.additional_families)) {
-            log.appendLine("font", "chain[{d}] skip family={s} (fontconfig substituted to {s})", .{
+            log.appendLine("font", "chain[{d}] \"{s}\" resolved to \"{s}\" (system alias) — using it", .{
                 log_idx, family, fc_result.family,
             });
-            return error.FontconfigFallbackSubstitution;
         }
 
         // 같은 path 가 chain 안 이미 있으면 dedup. log 인덱스 = 매치된 face 의
@@ -1119,6 +1124,11 @@ test "generic family resolution keeps fontconfig substitution" {
 /// `isFontAvailable` / macOS `CTFontCopyFamilyName` 검증과 동등.
 pub const FamilyAvailability = enum {
     installed,
+    /// #406 — 폰트는 **실재하는데** fontconfig 가 다른 family 로 해석한 경우. 시작을 막지
+    /// 않고 그 폰트로 띄운다 — 사용자 의도는 대개 "이 글자를 표시하고 싶다" 이지 "반드시 이
+    /// 이름이어야 한다" 가 아니다. 이름이 아예 없는 경우 (`missing`) 와는 갈라야 한다:
+    /// 그건 오타일 수 있어 조용히 넘어가면 다른 폰트로 그려진 것을 사용자가 모른다.
+    substituted,
     missing,
     /// libfontconfig 자체를 못 열거나 lookup 인프라 실패 — 미설치로 오판해
     /// "Font not found" 를 내지 않고 loader 의 기존 에러 경로에 맡긴다.
@@ -1158,7 +1168,7 @@ pub fn familyInstalledDetail(
         return .{ .availability = .installed, .substitute = null };
     }
 
-    // substitution 이다 — 무엇으로 바뀌었는지 남긴다.
+    // substitution 이다 — 무엇으로 바뀌었는지 남긴다. #406 이후 이것은 **시작을 막지 않는다**.
     var sub: ?[]const u8 = null;
     if (substitute_buf) |buf| {
         const n = @min(buf.len, fc_result.family.len);
@@ -1167,7 +1177,7 @@ pub fn familyInstalledDetail(
             sub = buf[0..n];
         }
     }
-    return .{ .availability = .missing, .substitute = sub };
+    return .{ .availability = .substituted, .substitute = sub };
 }
 
 /// 이름만 보는 기존 형태 — 대체 폰트가 필요 없는 호출처용.

--- a/src/font/linux/font.zig
+++ b/src/font/linux/font.zig
@@ -1128,18 +1128,51 @@ pub const FamilyAvailability = enum {
 /// `family` 가 시스템에 설치되어 있는지 — fontconfig lookup + substitution
 /// 판정 (`matchResolvesFamily`). caller (Linux host boot 검증) 는 `.missing`
 /// 일 때만 fatal.
-pub fn familyInstalled(allocator: std.mem.Allocator, family: []const u8) FamilyAvailability {
-    const family_z = allocator.allocSentinel(u8, family.len, 0) catch return .unknown;
+///
+/// `substitute_buf` 를 주면 **substitution 때문에 `.missing` 인 경우** 그 자리에 fontconfig 가
+/// 실제로 돌려준 family 를 채우고 그 slice 를 돌려준다 (#405). 그러지 않으면 사용자는
+/// *"설치했는데 왜 not found 인가"* 를 알 길이 없다 — 파일도 있고 `fc-list` 에도 나오는데
+/// `/etc/fonts/conf.d/` 의 규칙이 다른 폰트로 바꿔치기한 상황이기 때문이다. 실제로
+/// `ttf-twemoji` 가 `Noto Color Emoji` 요청을 가로채 부팅이 막혔다.
+///
+/// 폰트가 아예 없어서 `.missing` 인 경우에는 채우지 않는다 (`null` 반환) — 그때는 이름이
+/// 틀렸거나 미설치라는 기존 안내가 맞다.
+pub fn familyInstalledDetail(
+    allocator: std.mem.Allocator,
+    family: []const u8,
+    substitute_buf: ?[]u8,
+) struct { availability: FamilyAvailability, substitute: ?[]const u8 } {
+    const family_z = allocator.allocSentinel(u8, family.len, 0) catch
+        return .{ .availability = .unknown, .substitute = null };
     defer allocator.free(family_z);
     @memcpy(family_z[0..family.len], family);
 
     const fc_result = fontconfig.lookup(allocator, family_z.ptr) catch |err| switch (err) {
         // 시스템에 매치가 아예 없는 경우만 미설치 확정.
-        error.FontconfigNoMatch => return .missing,
-        else => return .unknown,
+        error.FontconfigNoMatch => return .{ .availability = .missing, .substitute = null },
+        else => return .{ .availability = .unknown, .substitute = null },
     };
     defer fc_result.deinit(allocator);
-    return if (matchResolvesFamily(family, fc_result.family, fc_result.additional_families)) .installed else .missing;
+
+    if (matchResolvesFamily(family, fc_result.family, fc_result.additional_families)) {
+        return .{ .availability = .installed, .substitute = null };
+    }
+
+    // substitution 이다 — 무엇으로 바뀌었는지 남긴다.
+    var sub: ?[]const u8 = null;
+    if (substitute_buf) |buf| {
+        const n = @min(buf.len, fc_result.family.len);
+        if (n > 0) {
+            @memcpy(buf[0..n], fc_result.family[0..n]);
+            sub = buf[0..n];
+        }
+    }
+    return .{ .availability = .missing, .substitute = sub };
+}
+
+/// 이름만 보는 기존 형태 — 대체 폰트가 필요 없는 호출처용.
+pub fn familyInstalled(allocator: std.mem.Allocator, family: []const u8) FamilyAvailability {
+    return familyInstalledDetail(allocator, family, null).availability;
 }
 
 /// face 의 per-cp cache 에서 lookup, 미스면 raster + insert. raster / OOM

--- a/src/font/linux/fontconfig.zig
+++ b/src/font/linux/fontconfig.zig
@@ -65,6 +65,22 @@ const FcPatternAddCharSet = *const fn (
     cs: *const FcCharSet,
 ) callconv(.c) c_int;
 
+// #406 — 설치된 family **목록**을 얻는다. `FcFontMatch` 는 요청한 이름이 시스템에 없어도
+// 항상 무언가를 돌려주므로 (오타 `NoSuchFont12345` 에도 `Noto Sans` 가 나온다) 그것만으로는
+// "설치돼 있는데 별칭이 가로챈 것" 과 "아예 없는 것" 을 가를 수 없다. 목록에 있는지로 가른다 —
+// macOS 의 `CTFontManagerCopyAvailableFontFamilyNames` 에 해당한다.
+const FcObjectSet = opaque {};
+const FcFontSet = extern struct {
+    nfont: c_int,
+    sfont: c_int,
+    fonts: ?[*]?*FcPattern,
+};
+const FcObjectSetCreate = *const fn () callconv(.c) ?*FcObjectSet;
+const FcObjectSetAdd = *const fn (os: *FcObjectSet, object: [*:0]const u8) callconv(.c) c_int;
+const FcObjectSetDestroy = *const fn (os: *FcObjectSet) callconv(.c) void;
+const FcFontList = *const fn (config: ?*anyopaque, p: *FcPattern, os: *FcObjectSet) callconv(.c) ?*FcFontSet;
+const FcFontSetDestroy = *const fn (s: *FcFontSet) callconv(.c) void;
+
 const Api = struct {
     handle: *anyopaque,
     init: FcInit,
@@ -81,6 +97,11 @@ const Api = struct {
     charset_destroy: FcCharSetDestroy,
     charset_add_char: FcCharSetAddChar,
     pattern_add_charset: FcPatternAddCharSet,
+    object_set_create: FcObjectSetCreate,
+    object_set_add: FcObjectSetAdd,
+    object_set_destroy: FcObjectSetDestroy,
+    font_list: FcFontList,
+    font_set_destroy: FcFontSetDestroy,
 
     fn load() !Api {
         const handle = std.c.dlopen("libfontconfig.so.1", .{ .LAZY = true }) orelse return error.FontconfigLibraryMissing;
@@ -102,6 +123,11 @@ const Api = struct {
             .charset_destroy = lookupSym(handle, FcCharSetDestroy, "FcCharSetDestroy") orelse return error.FontconfigSymbolMissing,
             .charset_add_char = lookupSym(handle, FcCharSetAddChar, "FcCharSetAddChar") orelse return error.FontconfigSymbolMissing,
             .pattern_add_charset = lookupSym(handle, FcPatternAddCharSet, "FcPatternAddCharSet") orelse return error.FontconfigSymbolMissing,
+            .object_set_create = lookupSym(handle, FcObjectSetCreate, "FcObjectSetCreate") orelse return error.FontconfigSymbolMissing,
+            .object_set_add = lookupSym(handle, FcObjectSetAdd, "FcObjectSetAdd") orelse return error.FontconfigSymbolMissing,
+            .object_set_destroy = lookupSym(handle, FcObjectSetDestroy, "FcObjectSetDestroy") orelse return error.FontconfigSymbolMissing,
+            .font_list = lookupSym(handle, FcFontList, "FcFontList") orelse return error.FontconfigSymbolMissing,
+            .font_set_destroy = lookupSym(handle, FcFontSetDestroy, "FcFontSetDestroy") orelse return error.FontconfigSymbolMissing,
         };
     }
 
@@ -169,6 +195,52 @@ fn sharedApi() !*Api {
         cached_api = api;
     }
     return &cached_api.?;
+}
+
+/// #406 — `family` 가 **설치된 family 목록에 있는지**. 이름 비교는 `eql` 이 판정한다
+/// (호출자가 정규화 규칙을 정한다 — 대소문자 · 띄어쓰기 무시 등).
+///
+/// **왜 목록을 보나** — `FcFontMatch` 는 요청 이름이 시스템에 없어도 항상 무언가를 돌려준다
+/// (오타 `NoSuchFont12345` 에도 `Noto Sans` 가 나온다). 그래서 그 반환값만으로는 아래 둘을
+/// 가를 수 없는데, 우리는 갈라야 한다.
+///
+///   - `Noto Color Emoji` -> `Twemoji`  : 설치돼 있는데 별칭 규칙이 가로챈 것 -> 띄운다
+///   - `NoSuchFont12345`  -> `Noto Sans`: 아예 없는 것 -> fatal
+///
+/// 목록 조회에 실패하면 `error.FontconfigListUnavailable` — 호출자는 **미설치로 오판하지 않고**
+/// 기존 경로에 맡긴다 (판정 불가는 거절 사유가 아니다).
+pub fn familyListed(
+    family: []const u8,
+    eql: *const fn (a: []const u8, b: []const u8) bool,
+) !bool {
+    var api = try Api.load();
+    defer api.deinit();
+    if (api.init() == 0) return error.FontconfigInitFailed;
+
+    const pattern = api.pattern_create() orelse return error.FontconfigListUnavailable;
+    defer api.pattern_destroy(pattern);
+
+    const os = api.object_set_create() orelse return error.FontconfigListUnavailable;
+    defer api.object_set_destroy(os);
+    if (api.object_set_add(os, "family") == 0) return error.FontconfigListUnavailable;
+
+    const set = api.font_list(null, pattern, os) orelse return error.FontconfigListUnavailable;
+    defer api.font_set_destroy(set);
+
+    const fonts = set.fonts orelse return error.FontconfigListUnavailable;
+    var i: usize = 0;
+    while (i < @as(usize, @intCast(set.nfont))) : (i += 1) {
+        const pat = fonts[i] orelse continue;
+        // 한 pattern 이 family 를 여러 개 가진다 (별칭 · 번역된 이름). 전부 본다.
+        var n: c_int = 0;
+        while (true) : (n += 1) {
+            var value: [*:0]FcChar8 = undefined;
+            if (api.pattern_get_string(pat, "family", n, &value) != 0) break;
+            const name = std.mem.span(@as([*:0]const u8, @ptrCast(value)));
+            if (eql(family, name)) return true;
+        }
+    }
+    return false;
 }
 
 pub fn lookup(allocator: std.mem.Allocator, family: [*:0]const u8) !MatchResult {

--- a/src/font/macos/coretext.zig
+++ b/src/font/macos/coretext.zig
@@ -102,6 +102,12 @@ pub extern "CoreFoundation" fn CFStringCompare(
 
 // #405 — CFString 을 UTF-8 로 꺼낸다. 폰트 검증이 "요청한 이름이 실제로 어떤 family 로
 // 해석됐는지" 를 사용자 메시지에 실을 때 쓴다 (`CTFontCopyFamilyName` 결과가 CFString 이다).
+// #406 — 설치된 font family 이름 목록. `CTFontCreateWithName` 이 **없는 이름에도 실패하지 않고
+// 시스템 기본 폰트를 돌려주기 때문에**, 그것만으로는 "오타 · 미설치" 와 "설치돼 있는데 family 가
+// 다름 (PostScript 이름을 적은 경우 등)" 을 가를 수 없다. 이 목록에 있는지로 가른다 — Linux 의
+// `FontconfigNoMatch` 에 해당하는 판정이다.
+pub extern "CoreText" fn CTFontManagerCopyAvailableFontFamilyNames() ?CFArrayRef;
+
 pub extern "CoreText" fn CFStringGetLength(theString: CFStringRef) CFIndex;
 pub extern "CoreText" fn CFStringGetBytes(
     theString: CFStringRef,

--- a/src/font/macos/coretext.zig
+++ b/src/font/macos/coretext.zig
@@ -108,6 +108,16 @@ pub extern "CoreFoundation" fn CFStringCompare(
 // `FontconfigNoMatch` 에 해당하는 판정이다.
 pub extern "CoreText" fn CTFontManagerCopyAvailableFontFamilyNames() ?CFArrayRef;
 
+// #406 — 설치된 폰트의 **PostScript 이름** 목록을 얻는 경로. family 목록에는 `Menlo-Regular`
+// 같은 이름이 아예 없어서, 사용자가 그것을 적으면 미설치로 오판했다. 실측으로 family 256 개
+// 옆에 PostScript 699 개가 더 있다.
+pub const CTFontCollectionRef = *anyopaque;
+pub const CTFontDescriptorRef = *anyopaque;
+pub extern "CoreText" fn CTFontCollectionCreateFromAvailableFonts(options: ?CFDictionaryRef) ?CTFontCollectionRef;
+pub extern "CoreText" fn CTFontCollectionCreateMatchingFontDescriptors(collection: CTFontCollectionRef) ?CFArrayRef;
+pub extern "CoreText" fn CTFontDescriptorCopyAttribute(descriptor: CTFontDescriptorRef, attribute: CFStringRef) ?CFStringRef;
+pub extern "CoreText" const kCTFontNameAttribute: CFStringRef;
+
 pub extern "CoreText" fn CFStringGetLength(theString: CFStringRef) CFIndex;
 pub extern "CoreText" fn CFStringGetBytes(
     theString: CFStringRef,

--- a/src/font/macos/coretext.zig
+++ b/src/font/macos/coretext.zig
@@ -100,6 +100,20 @@ pub extern "CoreFoundation" fn CFStringCompare(
     compareOptions: u32,
 ) i32;
 
+// #405 — CFString 을 UTF-8 로 꺼낸다. 폰트 검증이 "요청한 이름이 실제로 어떤 family 로
+// 해석됐는지" 를 사용자 메시지에 실을 때 쓴다 (`CTFontCopyFamilyName` 결과가 CFString 이다).
+pub extern "CoreText" fn CFStringGetLength(theString: CFStringRef) CFIndex;
+pub extern "CoreText" fn CFStringGetBytes(
+    theString: CFStringRef,
+    range: CFRange,
+    encoding: CFStringEncoding,
+    lossByte: u8,
+    isExternalRepresentation: bool,
+    buffer: ?[*]u8,
+    maxBufLen: CFIndex,
+    usedBufLen: ?*CFIndex,
+) CFIndex;
+
 pub extern "CoreText" fn CTFontCreateForString(
     currentFont: CTFontRef,
     string: CFStringRef,

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -126,11 +126,25 @@ pub const CoreTextFontContext = struct {
             };
             const actual_family = ct.CTFontCopyFamilyName(candidate);
             const matched = ct.CFStringCompare(actual_family, family_str, 0) == 0;
-            ct.CFRelease(actual_family);
             if (!matched) {
+                // #405 — **무엇으로 대체됐는지 알린다.** 이 이름을 버리면 사용자는 설치된
+                // 폰트가 왜 "not found" 인지 알 수 없다. macOS 에서 흔한 원인은 config 에
+                // PostScript 이름 (`.SF NS Mono` 등) 을 적은 경우다 — 폰트는 찾아지는데
+                // family 이름이 달라 여기 걸린다.
+                var sub_buf: [256]u8 = undefined;
+                const sub: ?[]const u8 = blk: {
+                    const n = ct.CFStringGetLength(actual_family);
+                    if (n <= 0) break :blk null;
+                    var used: ct.CFIndex = 0;
+                    _ = ct.CFStringGetBytes(actual_family, ct.CFRange{ .location = 0, .length = n }, ct.kCFStringEncodingUTF8, 0, false, &sub_buf, @intCast(sub_buf.len), &used);
+                    if (used <= 0) break :blk null;
+                    break :blk sub_buf[0..@intCast(used)];
+                };
+                ct.CFRelease(actual_family);
                 ct.CFRelease(candidate);
-                @import("../validate.zig").showNotFoundFatal(family, font_families);
+                @import("../validate.zig").showNotFoundFatalSub(family, font_families, sub);
             }
+            ct.CFRelease(actual_family);
             fallback_fonts[fallback_count] = candidate;
             if (fallback_count == 0) {
                 font = candidate;

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -37,26 +37,38 @@ pub const LigatureGlyph = ligature.LigatureGlyph;
 pub const LigatureSpacer = ligature.LigatureSpacer;
 pub const LigatureMatch = ligature.LigatureMatch;
 
-/// #406 — `family` 가 시스템에 **설치된 family 이름**인지. Linux 의 `FontconfigNoMatch` 판정에
-/// 해당한다.
+/// #406 — 사용자가 적은 `family` 에 맞는 **설치된 이름의 정식 표기**를 찾아 `out` 에 담아
+/// 돌려준다. Linux 의 `FontconfigNoMatch` 판정에 해당한다.
 ///
 /// `CTFontCreateWithName` 은 없는 이름에도 실패하지 않고 시스템 기본 폰트를 돌려주기 때문에,
-/// 그 반환값만으로는 "오타 · 미설치" 와 "설치돼 있는데 family 가 다름" 을 가를 수 없다. 후자는
-/// config 에 PostScript 이름 (`.SF NS Mono`) 을 적었을 때 생긴다 — 폰트는 실재하므로 띄워야 하고,
-/// 전자는 조용히 넘어가면 안 되므로 막아야 한다.
+/// 그 반환값만으로는 "오타 · 미설치" 와 "설치돼 있는데 표기가 다름" 을 가를 수 없다. 그래서
+/// 설치 목록을 직접 본다. family 이름과 PostScript 이름 두 곳을 보며, 비교는 정규화
+/// (`normalizeFamily`) 후에 한다.
 ///
-/// ⚠️ **판정하지 못하면 `true` 를 돌려준다** (fail-open). 목록 조회가 실패했을 때 `false` 를
-/// 주면 정상 폰트까지 전부 미설치로 몰려 **앱이 아예 안 뜬다.** Linux 의 `FamilyAvailability`
-/// 가 `.unknown` 을 두고 *"미설치로 오판해 Font not found 를 내지 않는다"* 고 한 것과 같은
-/// 이유다 — 판정 불가는 거절 사유가 아니다. 폰트가 정말 못 쓰는 것이면 그 뒤 로드 경로가
-/// 자기 에러로 알린다.
-fn familyIsInstalled(family: []const u8) bool {
-    const names = ct.CTFontManagerCopyAvailableFontFamilyNames() orelse return true;
+/// **bool 이 아니라 이름을 돌려주는 이유** — `CTFontCreateWithName` 은 정규화를 모른다.
+/// `menloregular` 를 그대로 주면 Helvetica 가 오므로 (실측: cell_w 19 → 25), 매칭된 정식 이름
+/// (`Menlo-Regular`) 으로 **폰트를 다시 만들어야** 의도한 폰트가 나온다. 통과만 시키고 원래
+/// 문자열을 쓰면 엉뚱한 폰트로 조용히 그려진다.
+///
+/// `null` 이면 그런 이름이 없다 — 오타 · 미설치이고 호출부가 fatal 로 간다.
+///
+/// ⚠️ **판정하지 못하면 원래 이름을 그대로 돌려준다** (fail-open). 목록 조회가 실패했을 때
+/// `null` 을 주면 정상 폰트까지 전부 미설치로 몰려 **앱이 아예 안 뜬다.** Linux 의
+/// `FamilyAvailability` 가 `.unknown` 을 두고 *"미설치로 오판해 Font not found 를 내지 않는다"*
+/// 고 한 것과 같은 이유다 — 판정 불가는 거절 사유가 아니다. 폰트가 정말 못 쓰는 것이면 그 뒤
+/// 로드 경로가 자기 에러로 알린다.
+fn resolveInstalledName(family: []const u8, out: []u8) ?[]const u8 {
+    var want_buf: [256]u8 = undefined;
+    const want = normalizeFamily(family, &want_buf);
+    if (want.len == 0) return family;
+
+    const names = ct.CTFontManagerCopyAvailableFontFamilyNames() orelse return family;
     defer ct.CFRelease(names);
-    if (ct.CFArrayGetCount(names) <= 0) return true;
+    const count = ct.CFArrayGetCount(names);
+    if (count <= 0) return family;
 
     var buf: [256]u8 = undefined;
-    const count = ct.CFArrayGetCount(names);
+    var norm_buf: [256]u8 = undefined;
     var i: ct.CFIndex = 0;
     while (i < count) : (i += 1) {
         const name_ptr = ct.CFArrayGetValueAtIndex(names, i) orelse continue;
@@ -66,9 +78,71 @@ fn familyIsInstalled(family: []const u8) bool {
         var used: ct.CFIndex = 0;
         _ = ct.CFStringGetBytes(name, ct.CFRange{ .location = 0, .length = n }, ct.kCFStringEncodingUTF8, 0, false, &buf, @intCast(buf.len), &used);
         if (used <= 0) continue;
-        if (std.ascii.eqlIgnoreCase(family, buf[0..@intCast(used)])) return true;
+        const got = buf[0..@intCast(used)];
+        if (std.mem.eql(u8, want, normalizeFamily(got, &norm_buf))) {
+            if (got.len > out.len) return family;
+            @memcpy(out[0..got.len], got);
+            return out[0..got.len];
+        }
     }
-    return false;
+    return postScriptNameFor(want, out);
+}
+
+/// PostScript 이름 (`Menlo-Regular`) 쪽에서 찾는다. `resolveInstalledName` 의 두 번째 경로다.
+///
+/// **family 목록에는 이 이름이 아예 없다** — 실측으로 family 256 개 옆에 PostScript 이름이
+/// 699 개 더 있었다. 그래서 사용자가 `Menlo-Regular` 를 적으면 폰트가 실재하는데도 미설치로
+/// 오판했다.
+///
+/// `want` 는 **이미 정규화된** 문자열이라 `menloregular` 처럼 하이픈 없이 적어도 맞는다.
+///
+/// ⚠️ **정규화가 family 이름과 겹치는 것은 문제가 아니다.** 실측에서 73 쌍이 겹쳤는데 전부
+/// *같은 폰트의 두 이름* 이었다 (`"Al Bayan"` ↔ `"AlBayan"` · `"Arial Black"` ↔ `"Arial-Black"`).
+/// 서로 다른 폰트가 뭉치는 경우는 없어서 어느 쪽에 맞아도 결과가 같다.
+fn postScriptNameFor(want: []const u8, out: []u8) ?[]const u8 {
+    const collection = ct.CTFontCollectionCreateFromAvailableFonts(null) orelse return null;
+    defer ct.CFRelease(collection);
+    const descs = ct.CTFontCollectionCreateMatchingFontDescriptors(collection) orelse return null;
+    defer ct.CFRelease(descs);
+
+    const count = ct.CFArrayGetCount(descs);
+    var buf: [256]u8 = undefined;
+    var norm_buf: [256]u8 = undefined;
+    var i: ct.CFIndex = 0;
+    while (i < count) : (i += 1) {
+        const d_ptr = ct.CFArrayGetValueAtIndex(descs, i) orelse continue;
+        const desc: ct.CTFontDescriptorRef = @constCast(d_ptr);
+        const ps = ct.CTFontDescriptorCopyAttribute(desc, ct.kCTFontNameAttribute) orelse continue;
+        defer ct.CFRelease(ps);
+        const n = ct.CFStringGetLength(ps);
+        if (n <= 0) continue;
+        var used: ct.CFIndex = 0;
+        _ = ct.CFStringGetBytes(ps, ct.CFRange{ .location = 0, .length = n }, ct.kCFStringEncodingUTF8, 0, false, &buf, @intCast(buf.len), &used);
+        if (used <= 0) continue;
+        const got = buf[0..@intCast(used)];
+        if (std.mem.eql(u8, want, normalizeFamily(got, &norm_buf))) {
+            if (got.len > out.len) return null;
+            @memcpy(out[0..got.len], got);
+            return out[0..got.len];
+        }
+    }
+    return null;
+}
+
+/// 폰트 이름 비교용 정규화 — 소문자로 낮추고 공백 · 하이픈 · 밑줄을 뺀다.
+///
+/// 사용자가 `"apple color emoji"` · `"AppleColorEmoji"` 처럼 적는 것을 받아 주기 위한 것이다.
+/// **설치된 family 256 개를 전부 정규화해도 충돌이 0 건**이라 (macOS 실측, #406) 다른 폰트로
+/// 오인될 위험이 없다. 버퍼가 차면 거기서 끊는다 — 그만큼 긴 이름은 어차피 위 비교에서 갈린다.
+fn normalizeFamily(name: []const u8, buf: []u8) []const u8 {
+    var n: usize = 0;
+    for (name) |c| {
+        if (c == ' ' or c == '-' or c == '_') continue;
+        if (n >= buf.len) break;
+        buf[n] = std.ascii.toLower(c);
+        n += 1;
+    }
+    return buf[0..n];
 }
 
 pub const CoreTextFontContext = struct {
@@ -155,14 +229,13 @@ pub const CoreTextFontContext = struct {
                 @import("../validate.zig").showNotFoundFatal(family, font_families);
             };
             defer ct.CFRelease(family_str);
-            const candidate = ct.CTFontCreateWithName(family_str, @floatCast(spec.size_logical), null) orelse {
+            var candidate = ct.CTFontCreateWithName(family_str, @floatCast(spec.size_logical), null) orelse {
                 @import("../validate.zig").showNotFoundFatal(family, font_families);
             };
             const actual_family = ct.CTFontCopyFamilyName(candidate);
             const matched = ct.CFStringCompare(actual_family, family_str, 0) == 0;
             if (!matched) {
-                // #405 — **무엇으로 대체됐는지** 알린다. 이 이름을 버리면 사용자는 설치된
-                // 폰트가 왜 "not found" 인지 알 수 없다.
+                // 무엇으로 해석됐는지 — **로그에만** 쓴다. 아래 fatal 에는 넘기지 않는다.
                 var sub_buf: [256]u8 = undefined;
                 const sub: ?[]const u8 = blk: {
                     const n = ct.CFStringGetLength(actual_family);
@@ -174,18 +247,58 @@ pub const CoreTextFontContext = struct {
                 };
                 ct.CFRelease(actual_family);
 
-                // #406 — **설치돼 있는데 이름만 갈린 것이면 그 폰트로 띄운다.** 시작을 막는
-                // 것은 이름이 아예 없을 때 (오타 · 미설치) 뿐이다. Linux 가
-                // `FontconfigNoMatch` 로 가르는 것과 같은 정책인데, 여기서는
-                // `CTFontCreateWithName` 이 없는 이름에도 시스템 기본을 돌려주므로 설치 목록을
-                // 직접 봐야 가를 수 있다.
-                if (!familyIsInstalled(family)) {
+                // #406 — **찾을 수 있는 이름이면 그 폰트로 띄운다.** 시작을 막는 것은 이름이
+                // 아예 없을 때 (오타 · 미설치) 뿐이다. Linux 가 `FontconfigNoMatch` 로 가르는
+                // 것과 같은 정책인데, 여기서는 `CTFontCreateWithName` 이 없는 이름에도 시스템
+                // 기본을 돌려주므로 설치 목록을 직접 봐야 가를 수 있다.
+                var canon_buf: [256]u8 = undefined;
+                const canonical = resolveInstalledName(family, &canon_buf) orelse {
                     ct.CFRelease(candidate);
-                    @import("../validate.zig").showNotFoundFatalSub(family, font_families, sub);
+                    // ⚠️ **대체 이름을 넘기지 않는다** (`Sub` 아닌 쪽을 부른다). macOS 는
+                    // **어떤 오타에도** 대체본을 주므로 (`Menloo` → `Helvetica`) 그 이름이
+                    // 정보가 아니라 노이즈다 — "Helvetica 가 있으니 그걸 쓰나?" 로 읽힌다.
+                    // Linux 는 fontconfig 가 실제로 별칭을 주입했을 때만 값이 나와서 유용하다.
+                    @import("../validate.zig").showNotFoundFatal(family, font_families);
+                };
+
+                if (std.mem.eql(u8, canonical, family)) {
+                    // 사용자가 적은 그대로 설치된 이름이다. family 이름이 다르게 나오는 것은
+                    // PostScript 이름을 적었을 때 정상이다 (`Menlo-Regular` → family `Menlo`).
+                    log.appendLine("font", "chain[{d}] \"{s}\" is an installed font name (family \"{s}\") — using it", .{
+                        fallback_count, family, sub orelse "?",
+                    });
+                } else {
+                    // **정식 표기로 폰트를 다시 만든다.** `CTFontCreateWithName` 은 정규화를
+                    // 모르기 때문에, 검사만 통과시키고 사용자가 적은 문자열을 그대로 쓰면 엉뚱한
+                    // 폰트가 그려진다 — `menloregular` 를 그대로 주면 Helvetica 가 온다
+                    // (실측: cell_w 19 → 25). `Menlo-Regular` 로 다시 만들면 의도대로 나온다.
+                    var remade_ok = false;
+                    if (ct.CFStringCreateWithBytes(
+                        null,
+                        canonical.ptr,
+                        @intCast(canonical.len),
+                        ct.kCFStringEncodingUTF8,
+                        0,
+                    )) |canon_str| {
+                        defer ct.CFRelease(canon_str);
+                        if (ct.CTFontCreateWithName(canon_str, @floatCast(spec.size_logical), null)) |remade| {
+                            ct.CFRelease(candidate);
+                            candidate = remade;
+                            remade_ok = true;
+                        }
+                    }
+                    if (remade_ok) {
+                        log.appendLine("font", "chain[{d}] \"{s}\" matched installed \"{s}\" — using it", .{
+                            fallback_count, family, canonical,
+                        });
+                    } else {
+                        // 여기 오면 **엉뚱한 폰트로 그린다** (`sub`). 조용히 넘어가면 나중에
+                        // "글자 폭이 왜 다르지" 로만 보이므로 원인을 로그에 남긴다.
+                        log.appendLine("font", "chain[{d}] \"{s}\" matched installed \"{s}\" but re-create failed — falling back to \"{s}\"", .{
+                            fallback_count, family, canonical, sub orelse "?",
+                        });
+                    }
                 }
-                log.appendLine("font", "chain[{d}] \"{s}\" resolved to \"{s}\" (system alias) — using it", .{
-                    fallback_count, family, sub orelse "?",
-                });
             } else {
                 ct.CFRelease(actual_family);
             }

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -44,9 +44,16 @@ pub const LigatureMatch = ligature.LigatureMatch;
 /// 그 반환값만으로는 "오타 · 미설치" 와 "설치돼 있는데 family 가 다름" 을 가를 수 없다. 후자는
 /// config 에 PostScript 이름 (`.SF NS Mono`) 을 적었을 때 생긴다 — 폰트는 실재하므로 띄워야 하고,
 /// 전자는 조용히 넘어가면 안 되므로 막아야 한다.
+///
+/// ⚠️ **판정하지 못하면 `true` 를 돌려준다** (fail-open). 목록 조회가 실패했을 때 `false` 를
+/// 주면 정상 폰트까지 전부 미설치로 몰려 **앱이 아예 안 뜬다.** Linux 의 `FamilyAvailability`
+/// 가 `.unknown` 을 두고 *"미설치로 오판해 Font not found 를 내지 않는다"* 고 한 것과 같은
+/// 이유다 — 판정 불가는 거절 사유가 아니다. 폰트가 정말 못 쓰는 것이면 그 뒤 로드 경로가
+/// 자기 에러로 알린다.
 fn familyIsInstalled(family: []const u8) bool {
-    const names = ct.CTFontManagerCopyAvailableFontFamilyNames() orelse return false;
+    const names = ct.CTFontManagerCopyAvailableFontFamilyNames() orelse return true;
     defer ct.CFRelease(names);
+    if (ct.CFArrayGetCount(names) <= 0) return true;
 
     var buf: [256]u8 = undefined;
     const count = ct.CFArrayGetCount(names);

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -37,6 +37,33 @@ pub const LigatureGlyph = ligature.LigatureGlyph;
 pub const LigatureSpacer = ligature.LigatureSpacer;
 pub const LigatureMatch = ligature.LigatureMatch;
 
+/// #406 — `family` 가 시스템에 **설치된 family 이름**인지. Linux 의 `FontconfigNoMatch` 판정에
+/// 해당한다.
+///
+/// `CTFontCreateWithName` 은 없는 이름에도 실패하지 않고 시스템 기본 폰트를 돌려주기 때문에,
+/// 그 반환값만으로는 "오타 · 미설치" 와 "설치돼 있는데 family 가 다름" 을 가를 수 없다. 후자는
+/// config 에 PostScript 이름 (`.SF NS Mono`) 을 적었을 때 생긴다 — 폰트는 실재하므로 띄워야 하고,
+/// 전자는 조용히 넘어가면 안 되므로 막아야 한다.
+fn familyIsInstalled(family: []const u8) bool {
+    const names = ct.CTFontManagerCopyAvailableFontFamilyNames() orelse return false;
+    defer ct.CFRelease(names);
+
+    var buf: [256]u8 = undefined;
+    const count = ct.CFArrayGetCount(names);
+    var i: ct.CFIndex = 0;
+    while (i < count) : (i += 1) {
+        const name_ptr = ct.CFArrayGetValueAtIndex(names, i) orelse continue;
+        const name: ct.CFStringRef = @constCast(name_ptr);
+        const n = ct.CFStringGetLength(name);
+        if (n <= 0) continue;
+        var used: ct.CFIndex = 0;
+        _ = ct.CFStringGetBytes(name, ct.CFRange{ .location = 0, .length = n }, ct.kCFStringEncodingUTF8, 0, false, &buf, @intCast(buf.len), &used);
+        if (used <= 0) continue;
+        if (std.ascii.eqlIgnoreCase(family, buf[0..@intCast(used)])) return true;
+    }
+    return false;
+}
+
 pub const CoreTextFontContext = struct {
     primary_font: ct.CTFontRef,
     font_em_size: f32,
@@ -127,10 +154,8 @@ pub const CoreTextFontContext = struct {
             const actual_family = ct.CTFontCopyFamilyName(candidate);
             const matched = ct.CFStringCompare(actual_family, family_str, 0) == 0;
             if (!matched) {
-                // #405 — **무엇으로 대체됐는지 알린다.** 이 이름을 버리면 사용자는 설치된
-                // 폰트가 왜 "not found" 인지 알 수 없다. macOS 에서 흔한 원인은 config 에
-                // PostScript 이름 (`.SF NS Mono` 등) 을 적은 경우다 — 폰트는 찾아지는데
-                // family 이름이 달라 여기 걸린다.
+                // #405 — **무엇으로 대체됐는지** 알린다. 이 이름을 버리면 사용자는 설치된
+                // 폰트가 왜 "not found" 인지 알 수 없다.
                 var sub_buf: [256]u8 = undefined;
                 const sub: ?[]const u8 = blk: {
                     const n = ct.CFStringGetLength(actual_family);
@@ -141,10 +166,22 @@ pub const CoreTextFontContext = struct {
                     break :blk sub_buf[0..@intCast(used)];
                 };
                 ct.CFRelease(actual_family);
-                ct.CFRelease(candidate);
-                @import("../validate.zig").showNotFoundFatalSub(family, font_families, sub);
+
+                // #406 — **설치돼 있는데 이름만 갈린 것이면 그 폰트로 띄운다.** 시작을 막는
+                // 것은 이름이 아예 없을 때 (오타 · 미설치) 뿐이다. Linux 가
+                // `FontconfigNoMatch` 로 가르는 것과 같은 정책인데, 여기서는
+                // `CTFontCreateWithName` 이 없는 이름에도 시스템 기본을 돌려주므로 설치 목록을
+                // 직접 봐야 가를 수 있다.
+                if (!familyIsInstalled(family)) {
+                    ct.CFRelease(candidate);
+                    @import("../validate.zig").showNotFoundFatalSub(family, font_families, sub);
+                }
+                log.appendLine("font", "chain[{d}] \"{s}\" resolved to \"{s}\" (system alias) — using it", .{
+                    fallback_count, family, sub orelse "?",
+                });
+            } else {
+                ct.CFRelease(actual_family);
             }
-            ct.CFRelease(actual_family);
             fallback_fonts[fallback_count] = candidate;
             if (fallback_count == 0) {
                 font = candidate;

--- a/src/font/validate.zig
+++ b/src/font/validate.zig
@@ -52,24 +52,42 @@ fn schemaErrorMessage(msg_buf: []u8, line: []const u8, cfg_path: []const u8) []c
 /// config 의 font.family 전체 (UTF-8 raw). 본 함수는 dialog.showFatal 로
 /// process 종료.
 pub fn showNotFoundFatal(missing: []const u8, chain: []const []const u8) noreturn {
+    showNotFoundFatalSub(missing, chain, null);
+}
+
+/// #405 — `substitute` 는 **그 이름이 실제로 어떤 폰트로 해석됐는지**다. 있으면 "설치는 됐는데
+/// 다른 것으로 바뀐다" 를 함께 알린다.
+///
+/// 세 platform 중 **Linux · macOS 만** 이 값을 채운다. 둘은 요청 이름으로 조회한 뒤 *돌아온
+/// family 를 비교*하는 구조라 (Linux 는 fontconfig substitution, macOS 는
+/// `CTFontCreateWithName` 이 실패 대신 대체 폰트를 주는 성질) 대체가 실제로 일어난다. Windows 는
+/// `IDWriteFontCollection.FindFamilyName` 이 시스템 컬렉션에서 exact match 만 보므로 대체가
+/// 개입할 여지가 없어 `null` 이다.
+pub fn showNotFoundFatalSub(missing: []const u8, chain: []const []const u8, substitute: ?[]const u8) noreturn {
     var msg_buf: [2048]u8 = undefined;
-    dialog.showFatal(messages.config_error_title, notFoundMessage(&msg_buf, missing, chain));
+    dialog.showFatal(messages.config_error_title, notFoundMessageSub(&msg_buf, missing, chain, substitute));
 }
 
 /// `showNotFoundFatal` 의 메시지 조립부 — 세 OS 공통 형식의 단일 정의.
 /// Linux host 는 boot 단계에서 자체 blocking overlay 로 표시해야 해서 dialog
 /// 호출과 분리해 이 함수만 쓴다 (#289 B6).
 pub fn notFoundMessage(msg_buf: []u8, missing: []const u8, chain: []const []const u8) []const u8 {
+    return notFoundMessageSub(msg_buf, missing, chain, null);
+}
+
+/// #405 — `substitute` 가 있으면 "설치는 됐는데 fontconfig 가 다른 폰트로 바꿨다" 를 함께
+/// 알린다. Linux host 만 채우고 (fontconfig 특유), 나머지 platform 은 `null` 로 기존 형식이다.
+pub fn notFoundMessageSub(msg_buf: []u8, missing: []const u8, chain: []const []const u8, substitute: ?[]const u8) []const u8 {
     var alloc_buf: [4096]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&alloc_buf);
     const cfg_path: []const u8 = paths.configPath(fba.allocator()) catch messages.unknown_path_msg;
 
-    return notFoundMessageForPath(msg_buf, missing, chain, cfg_path);
+    return notFoundMessageForPath(msg_buf, missing, chain, cfg_path, substitute);
 }
 
 /// 경로 조회와 분리한 순수 formatter. dialog layout 같은 사용자 메시지 경계
 /// 테스트도 이 함수를 사용해 실제 producer와 다른 문구를 복제하지 않는다.
-pub fn notFoundMessageForPath(msg_buf: []u8, missing: []const u8, chain: []const []const u8, cfg_path: []const u8) []const u8 {
+pub fn notFoundMessageForPath(msg_buf: []u8, missing: []const u8, chain: []const []const u8, cfg_path: []const u8, substitute: ?[]const u8) []const u8 {
     var fbs = std.io.fixedBufferStream(msg_buf);
     const w = fbs.writer();
     w.print(messages.font_not_found_format, .{missing}) catch {};
@@ -78,6 +96,13 @@ pub fn notFoundMessageForPath(msg_buf: []u8, missing: []const u8, chain: []const
         if (fam.len == 0) continue;
         const marker = if (std.mem.eql(u8, fam, missing)) messages.font_not_installed_marker else "";
         w.print(messages.font_chain_entry_format, .{ fam, marker }) catch {};
+    }
+    // #405 — 설치는 됐는데 대체된 경우, 그 사실과 확인 방법을 알린다. 이게 없으면 사용자는
+    // 파일도 있고 목록에도 나오는 폰트가 왜 "not found" 인지 알 수 없다.
+    if (substitute) |sub| {
+        if (sub.len > 0 and !std.mem.eql(u8, sub, missing)) {
+            w.print(messages.font_substituted_format, .{ sub, missing }) catch {};
+        }
     }
     w.print(messages.font_chain_footer_format, .{cfg_path}) catch {};
     return fbs.getWritten();
@@ -104,6 +129,6 @@ test "font validation messages preserve runtime values and final newline" {
             "  - \"Noto Color Emoji\"\n" ++
             "\nAll families listed in font.family must be installed on the system.\n\n" ++
             "Config path:\n/tmp/config_3.json\n",
-        notFoundMessageForPath(&missing_buf, "Missing Font", &chain, "/tmp/config_3.json"),
+        notFoundMessageForPath(&missing_buf, "Missing Font", &chain, "/tmp/config_3.json", null),
     );
 }

--- a/src/host/linux/dialog_layout.zig
+++ b/src/host/linux/dialog_layout.zig
@@ -407,6 +407,7 @@ test "current Linux dialog messages fit the 640x480 logical minimum" {
         font_families[0],
         &font_families,
         "/home/example/.config/tildaz/config_98.json",
+        null,
     );
 
     var takeover_buf: [512]u8 = undefined;

--- a/src/host/linux/software_terminal.zig
+++ b/src/host/linux/software_terminal.zig
@@ -336,6 +336,11 @@ pub const Renderer = struct {
     dialog_title_font_ctx: ?font.Context = null,
     /// 지연 생성에 필요한 것 — `Renderer.init` 이 받은 그대로 보관한다.
     font_chain: []const []const u8 = &.{},
+    /// #406 — dialog 를 **시스템 기본 고정폭**으로 그린다. 폰트 설정이 잘못됐다고 알리는
+    /// 화면이 바로 그 잘못된 설정으로 그려지면 안 되기 때문이다 — 실제로 `font.family` 에
+    /// 오타를 냈을 때 fallback 인 비례폭 폰트로 그려져 자간이 벌어졌다. 폰트 검증 실패
+    /// 경로가 dialog 를 띄우기 전에 세운다.
+    dialog_use_system_font: bool = false,
     scale_num: u32 = 120,
     scale_den: u32 = 120,
     /// L10-β — IME 조합 중 (preedit) 텍스트. host (wayland_minimal) 가 매
@@ -487,7 +492,11 @@ pub const Renderer = struct {
     /// 아예 못 뜨지만, 이 시점의 실패는 dialog 하나의 문제여야 한다.
     pub fn ensureDialogFonts(self: *Renderer, allocator: std.mem.Allocator) void {
         if (self.dialog_font_ctx != null and self.dialog_title_font_ctx != null) return;
-        const chain = self.font_chain;
+        // `monospace` 는 generic family 라 fontconfig 가 시스템 기본 고정폭으로 해석하는 것이
+        // **의도된 동작**이다 (`isGenericFamily`). 사용자 chain 을 못 믿는 상황에서 쓸 수 있는
+        // 유일한 이름이다.
+        const system_chain = [_][]const u8{"monospace"};
+        const chain: []const []const u8 = if (self.dialog_use_system_font) &system_chain else self.font_chain;
         if (self.dialog_font_ctx == null) {
             const spec = ui_metrics.dialogBodyFontSpec();
             self.dialog_font_ctx = font.Context.init(

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1517,6 +1517,9 @@ const Client = struct {
                 // 그 폰트로 chain 을 만들고 로그를 남긴다. 시작을 막는 것은 이름이 아예
                 // 없을 때 (`.missing`) 뿐이다.
                 if (avail.availability != .missing) continue;
+                // #406 — 이 dialog 는 **폰트 설정이 잘못됐다고 알리는 화면**이다. 그것을
+                // 그 설정으로 그리면 읽기 어려워진다 (실측: 비례폭 폰트로 자간이 벌어졌다).
+                self.renderer.dialog_use_system_font = true;
                 var font_msg_buf: [2048]u8 = undefined;
                 const msg = font_validate.notFoundMessageSub(&font_msg_buf, family, chain, avail.substitute);
                 log.userFacing("fatal", msg);

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1508,9 +1508,14 @@ const Client = struct {
             const chain = self.config.font_families[0..self.config.font_family_count];
             for (chain) |family| {
                 if (family.len == 0) continue;
-                if (font_linux.familyInstalled(self.allocator, family) != .missing) continue;
+                // #405 — 대체된 폰트 이름을 함께 받아 메시지에 싣는다. 설치는 됐는데
+                // fontconfig 규칙이 다른 폰트로 바꿔치기한 경우 (`ttf-twemoji` 등) 사용자가
+                // 원인을 찾을 수 있게 한다.
+                var sub_buf: [256]u8 = undefined;
+                const avail = font_linux.familyInstalledDetail(self.allocator, family, &sub_buf);
+                if (avail.availability != .missing) continue;
                 var font_msg_buf: [2048]u8 = undefined;
-                const msg = font_validate.notFoundMessage(&font_msg_buf, family, chain);
+                const msg = font_validate.notFoundMessageSub(&font_msg_buf, family, chain, avail.substitute);
                 log.userFacing("fatal", msg);
                 self.runFatalDialog(messages.config_error_title, msg);
                 std.process.exit(1);

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1513,6 +1513,9 @@ const Client = struct {
                 // 원인을 찾을 수 있게 한다.
                 var sub_buf: [256]u8 = undefined;
                 const avail = font_linux.familyInstalledDetail(self.allocator, family, &sub_buf);
+                // #406 — 대체된 것 (`.substituted`) 은 폰트가 실재하므로 막지 않는다. 로더가
+                // 그 폰트로 chain 을 만들고 로그를 남긴다. 시작을 막는 것은 이름이 아예
+                // 없을 때 (`.missing`) 뿐이다.
                 if (avail.availability != .missing) continue;
                 var font_msg_buf: [2048]u8 = undefined;
                 const msg = font_validate.notFoundMessageSub(&font_msg_buf, family, chain, avail.substitute);

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -185,15 +185,23 @@ pub const font_chain_header_msg = "config \"font.family\" chain (in order):\n";
 pub const font_chain_entry_format = "  - \"{s}\"{s}\n";
 pub const font_not_installed_marker = " ← not installed";
 
-/// #405 — 폰트가 **설치돼 있는데** fontconfig 가 다른 폰트로 바꿔치기해서 못 쓰는 경우.
-/// 이 줄이 없으면 사용자는 파일도 있고 `fc-list` 에도 나오는 폰트가 왜 "not found" 인지
-/// 알 수 없다 (실제로 `ttf-twemoji` 가 `Noto Color Emoji` 요청을 가로채 부팅이 막혔다).
-/// Linux 전용 — fontconfig 의 시스템 전역 별칭 주입이 원인이라 다른 platform 에는 없다.
+/// #405 — 요청한 이름이 **다른 폰트로 해석되는** 경우. 이 줄이 없으면 사용자는 파일도 있고
+/// 목록에도 나오는 폰트가 왜 "not found" 인지 알 수 없다 (Linux 실기: `ttf-twemoji` 가
+/// `Noto Color Emoji` 요청을 가로채 부팅이 막혔다).
+///
+/// **Linux 전용이 아니다** — macOS 도 PostScript 이름 (`Menlo-Regular`) · 시스템 UI 폰트
+/// (`.SF NS Mono`) 를 적으면 같은 자리에 온다 (#406 실기).
+///
+/// **세 platform 이 같은 문구를 쓴다.** 원인은 OS 마다 다르지만 (Linux 는 fontconfig 별칭,
+/// macOS 는 PostScript · 시스템 UI 이름) 사용자가 할 일은 *"정확한 family 이름을 쓰는 것"* 하나로
+/// 같다. OS 별 확인 명령은 `CONFIG.md` 의 "Font names" 절에 있으므로 여기서 반복하지 않는다.
+///
+/// 예전에는 Linux 문구 (`fc-match` · `/etc/fonts/conf.d/`) 가 하드코딩돼 있어서 **macOS 에서
+/// 없는 명령을 안내했다** ([#406](https://github.com/ensky0/tildaz/issues/406) 실기).
 pub const font_substituted_format =
-    "\nThis family IS installed, but fontconfig resolves it to \"{s}\".\n" ++
-    "A font package may have installed a system-wide alias rule.\n" ++
-    "  check:  fc-match \"{s}\"\n" ++
-    "  rules:  /etc/fonts/conf.d/\n";
+    "\nThis name resolves to \"{s}\" instead of \"{s}\".\n" ++
+    "Use the exact family name as installed on this system.\n" ++
+    "See CONFIG.md \"Font names\" for how to list them.\n";
 pub const font_chain_footer_format =
     "\nAll families listed in font.family must be installed on the system.\n\nConfig path:\n{s}\n";
 

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -184,6 +184,16 @@ pub const font_not_found_format = "Font not found: \"{s}\"\n\n";
 pub const font_chain_header_msg = "config \"font.family\" chain (in order):\n";
 pub const font_chain_entry_format = "  - \"{s}\"{s}\n";
 pub const font_not_installed_marker = " ← not installed";
+
+/// #405 — 폰트가 **설치돼 있는데** fontconfig 가 다른 폰트로 바꿔치기해서 못 쓰는 경우.
+/// 이 줄이 없으면 사용자는 파일도 있고 `fc-list` 에도 나오는 폰트가 왜 "not found" 인지
+/// 알 수 없다 (실제로 `ttf-twemoji` 가 `Noto Color Emoji` 요청을 가로채 부팅이 막혔다).
+/// Linux 전용 — fontconfig 의 시스템 전역 별칭 주입이 원인이라 다른 platform 에는 없다.
+pub const font_substituted_format =
+    "\nThis family IS installed, but fontconfig resolves it to \"{s}\".\n" ++
+    "A font package may have installed a system-wide alias rule.\n" ++
+    "  check:  fc-match \"{s}\"\n" ++
+    "  rules:  /etc/fonts/conf.d/\n";
 pub const font_chain_footer_format =
     "\nAll families listed in font.family must be installed on the system.\n\nConfig path:\n{s}\n";
 


### PR DESCRIPTION
`ttf-twemoji` 를 설치했더니 config 가 그대로인데 **"Font not found" 로 부팅이 막히던** 문제입니다.
파일도 `fc-list` 도 멀쩡한데 시작이 안 돼 원인을 찾기 어려웠습니다.

## 원인

fontconfig 의 substitution 입니다. `ttf-twemoji` 가 `/etc/fonts/conf.d/75-twemoji.conf` 를
활성화해서 정확한 이름을 줘도 다른 폰트가 옵니다.

```sh
$ fc-match "Noto Color Emoji"
twemoji.ttf: "Twemoji" "Regular"
```

우리 판정 (요청 family 와 반환 family 가 다르면 거부) **자체는 옳습니다** — 안 그러면 오타를 낸
폰트가 조용히 다른 것으로 그려집니다. 문제는 **결과만 버리고 이유를 안 남긴 것**, 그리고 **실제로
설치돼 있는데도 시작을 막은 것**이었습니다.

## 무엇을 바꿨나

| 커밋 | 내용 | platform |
|---|---|---|
| [a9a6af7](https://github.com/ensky0/tildaz/commit/a9a6af7) | 대체된 폰트 이름을 진단 메시지에 (#405) | 공통 + Linux · macOS |
| [40d4f42](https://github.com/ensky0/tildaz/commit/40d4f42) | 대체된 폰트로 그냥 띄운다 | Linux · macOS |
| [5d9f0c3](https://github.com/ensky0/tildaz/commit/5d9f0c3) | macOS 판정 fail-open | macOS |
| [ac8c3ed](https://github.com/ensky0/tildaz/commit/ac8c3ed) | 대소문자 · 띄어쓰기 · PostScript 이름 수용 | macOS |
| [43f7a1c](https://github.com/ensky0/tildaz/commit/43f7a1c) | 오타 · 없는 이름을 fatal 로 + dialog 시스템 폰트 | Linux |

핵심은 **두 경우를 가른 것**입니다.

| 상황 | 전 | 후 |
|---|---|---|
| 이름이 아예 없다 (오타 · 미설치) | fatal | **fatal 유지** |
| 설치돼 있는데 대체됐다 | fatal | **경고 로그 + 그 폰트로 진행** |

## 세 platform 동작 (실측)

| `font.family` 에 적은 이름 | macOS | Linux | Windows |
|---|---|---|---|
| 정확한 family 이름 | ✅ 기동 | ✅ 기동 | ✅ 기동 |
| 대소문자 다름 | ✅ | ✅ | ✅ |
| 붙여쓰기 | ✅ | ✅ | ❌ fatal |
| PostScript 이름 | ✅ | ❌ fatal | ❌ fatal |
| 설치돼 있는데 별칭이 가로챔 | ✅ 기동 + 안내 | ✅ 기동 + 안내 | — 해당 없음 |
| **오타 · 없는 이름** | ✅ fatal | ✅ fatal | ✅ fatal |

**오타를 fatal 로 잡는 것이 세 platform 에서 같아졌습니다** — 이 작업의 목표였습니다.
붙여쓰기 · PostScript 이름 수용은 platform 마다 다른데, 이 PR 의 범위 밖이라 별도 이슈로 뗐습니다.

## Windows 검증 — 회귀 없음

Windows 전용 코드는 한 줄도 바뀌지 않았고 공통 파일 둘 (`validate.zig` · `messages.zig`) 만
바뀌었습니다. `showNotFoundFatal` · `notFoundMessage` 를 `null` 을 넘기는 wrapper 로 남겨
Windows 문구는 이전과 같아야 하는데, [실측으로 확인했습니다](https://github.com/ensky0/tildaz/issues/406#issuecomment-5225108208)
(노트북 Intel i5-1240P · Windows 11 26200).

- 정상 폰트 → 기동 ✅
- 없는 폰트 → `Font not found` fatal ✅
- **그 메시지에 `This family IS installed…` 줄이 없음** ✅ ← 유일하게 Windows 를 건드릴 수 있던 지점
- `zig build check` 6 타겟 통과 ✅

## 문서

`CONFIG.md` 에 폰트 이름을 **어떻게 알아내는지**를 추가했습니다 — `fc-list` 에 있다고 쓸 수 있는
것이 아니라 `fc-match` 가 같은 폰트를 돌려줘야 한다는 것이 요점입니다.

Closes #405
Closes #406