### PR TITLE
fix(renderer): cluster 가 글리프 여러 개면 합성해 그린다 — macOS (#401)

### DIFF
--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -13,11 +13,28 @@ const font_spec = @import("../spec.zig");
 const log = @import("../../log.zig");
 const perf = @import("../../perf.zig");
 
+/// 한 cluster 가 낼 수 있는 글리프 수 상한. Windows `MAX_CLUSTER_GLYPHS` 와 같은 값이다.
+pub const MAX_CLUSTER_GLYPHS: usize = 16;
+
 pub const GlyphResult = struct {
     font: ct.CTFontRef,
+    /// 첫 글리프. `count == 1` 인 흔한 경우의 빠른 길이고, multi-glyph 여도 여기는 채워진다.
     index: ct.CGGlyph,
     /// true 면 caller 가 CFRelease 책임. fallback font 생성 후 cache 안 할 때.
     owned: bool,
+
+    /// #401 — **cluster 가 글리프 하나로 합성되지 않는 경우**를 위한 것이다.
+    ///
+    /// Apple Color Emoji 는 `👨‍❤️‍👨` 같은 `❤️` 조합을 **글리프 2 개**로 준다 (`👨‍👩‍👧` 는
+    /// 1 개다). 예전에는 첫 글리프만 쓰고 나머지를 버려서 `👨` 만 그려졌다. Windows 는 같은
+    /// 상황을 `advances` · `offsets` 로 겹쳐 그려 해결하고 있었고 (#139), 여기도 같은 구조다.
+    ///
+    /// `positions` 는 `CTRun` 이 준 값 그대로다 — GPOS 가 적용된 위치라 이대로 그려야 모양이
+    /// 맞는다. 첫 글리프 기준 상대 좌표다.
+    glyphs: [MAX_CLUSTER_GLYPHS]ct.CGGlyph = undefined,
+    positions: [MAX_CLUSTER_GLYPHS]ct.CGPoint = undefined,
+    /// 유효한 글리프 수. 1 이면 `index` 만 쓰면 된다.
+    count: u8 = 1,
 };
 
 /// #399 (B) — cluster 캐시가 값을 버릴 때 (퇴출 · 무효화 · 덮어쓰기) 부르는 해제다.
@@ -741,20 +758,36 @@ pub const CoreTextFontContext = struct {
         const run_count = ct.CFArrayGetCount(runs);
         if (run_count == 0) return null;
 
-        // 첫 run — 대부분 grapheme cluster 가 1 run + 1 glyph 으로 shape 됨.
+        // 첫 run 을 쓴다. cluster 하나를 넘겼으므로 CT 가 run 을 나눌 일이 거의 없다 —
+        // 실측으로도 `❤️` 가 든 조합까지 전부 run 1 개였다 (#401).
         const run_ptr = ct.CFArrayGetValueAtIndex(runs, 0) orelse return null;
         const run: ct.CTRunRef = @constCast(run_ptr);
 
         const glyph_count = ct.CTRunGetGlyphCount(run);
-        if (glyph_count == 0) return null;
+        if (glyph_count <= 0) return null;
 
-        var glyph: ct.CGGlyph = 0;
+        // #401 — **글리프를 전부 가져온다.** 예전에는 첫 개만 쓰고 버렸는데, Apple Color Emoji
+        // 가 `👨‍❤️‍👨` 같은 `❤️` 조합을 글리프 2 개로 줘서 `👨` 만 그려졌다. 폰트가 1 개로
+        // 합성해 주는 cluster (`👨‍👩‍👧` 등) 는 아래 경로가 그대로 `count == 1` 이 된다.
+        const take: usize = @min(@as(usize, @intCast(glyph_count)), MAX_CLUSTER_GLYPHS);
+        var glyphs: [MAX_CLUSTER_GLYPHS]ct.CGGlyph = undefined;
+        var positions: [MAX_CLUSTER_GLYPHS]ct.CGPoint = undefined;
+
         if (ct.CTRunGetGlyphsPtr(run)) |ptr| {
-            glyph = ptr[0];
+            @memcpy(glyphs[0..take], ptr[0..take]);
         } else {
-            ct.CTRunGetGlyphs(run, ct.CFRange{ .location = 0, .length = 1 }, @ptrCast(&glyph));
+            ct.CTRunGetGlyphs(run, ct.CFRange{ .location = 0, .length = @intCast(take) }, &glyphs);
         }
-        if (glyph == 0) return null;
+        // 위치는 GPOS 가 적용된 값이라 이대로 그려야 모양이 맞는다. Windows 가 `advances` ·
+        // `offsets` 를 함께 넘기는 것과 같은 이유다 (#139).
+        if (ct.CTRunGetPositionsPtr(run)) |ptr| {
+            @memcpy(positions[0..take], ptr[0..take]);
+        } else {
+            ct.CTRunGetPositions(run, ct.CFRange{ .location = 0, .length = @intCast(take) }, &positions);
+        }
+
+        // `.notdef` 는 실패로 본다 — caller 가 base codepoint 로 fallback 한다.
+        if (glyphs[0] == 0) return null;
 
         // run 의 실제 사용 폰트 — CT 가 fallback 으로 골라준 것 (Apple Color Emoji 등).
         // GetAttributes 와 GetValue 는 non-owning reference 라 line 이 release 되면
@@ -766,7 +799,14 @@ pub const CoreTextFontContext = struct {
         const run_font: ct.CTFontRef = @constCast(font_val);
         _ = ct.CFRetain(run_font);
 
-        return .{ .font = run_font, .index = glyph, .owned = true };
+        return .{
+            .font = run_font,
+            .index = glyphs[0],
+            .owned = true,
+            .glyphs = glyphs,
+            .positions = positions,
+            .count = @intCast(take),
+        };
     }
 
     /// 2-char ligature lookup (SPEC § 12.2). `cp0` + `cp1` 을 primary font 로

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -982,7 +982,9 @@ pub const MetalRenderer = struct {
                                 self.drawTextInstances(encoder, text_buf[0..text_count]);
                                 text_count = 0;
                             }
-                            const entry_opt = self.atlas.getOrInsert(result.font, @intCast(result.index));
+                            // #401 — cluster 가 글리프 여러 개면 한 비트맵으로 합성한다.
+                            // 하나면 `getOrInsertCluster` 가 기존 경로로 넘긴다.
+                            const entry_opt = self.atlas.getOrInsertCluster(result.font, result.glyphs[0..result.count], result.positions[0..result.count]);
                             if (result.owned) ct.CFRelease(result.font);
                             if (entry_opt) |entry| {
                                 if (entry.w > 0 and entry.h > 0) {
@@ -1006,7 +1008,8 @@ pub const MetalRenderer = struct {
                     @memcpy(cluster[1..][0..take], extras[0..take]);
                     const r_opt = self.font.resolveGrapheme(cluster[0 .. 1 + take]);
                     if (r_opt) |result| {
-                        const entry_opt = self.atlas.getOrInsert(result.font, @intCast(result.index));
+                        // #401 — 위 배칭 경로와 같은 이유로 multi-glyph 를 합성해 그린다.
+                        const entry_opt = self.atlas.getOrInsertCluster(result.font, result.glyphs[0..result.count], result.positions[0..result.count]);
                         if (result.owned) ct.CFRelease(result.font);
                         if (entry_opt) |entry| {
                             if (entry.w > 0 and entry.h > 0) {

--- a/src/renderer/macos/glyph_atlas.zig
+++ b/src/renderer/macos/glyph_atlas.zig
@@ -85,6 +85,35 @@ pub const GlyphAtlas = struct {
         return entry;
     }
 
+    /// #401 — **cluster 가 글리프 여러 개일 때 하나의 비트맵으로 합성**한다.
+    ///
+    /// Apple Color Emoji 는 `👨‍❤️‍👨` 같은 `❤️` 조합을 글리프 2 개로 준다 (`👨‍👩‍👧` 는 1 개다).
+    /// 예전에는 첫 글리프만 그려서 `👨` 만 보였다. Windows 의 `getOrInsertCluster` 와 같은
+    /// 자리이고, 거기서 `advances` · `offsets` 를 넘기는 것이 여기서는 `positions` 다 — `CTRun`
+    /// 이 준 GPOS 적용 위치라 이대로 그려야 모양이 맞는다.
+    ///
+    /// 글리프가 하나면 기존 경로로 넘긴다 — 키가 `(font, index)` 라 캐시 적중률이 그쪽이 높다.
+    pub fn getOrInsertCluster(
+        self: *GlyphAtlas,
+        font: ct.CTFontRef,
+        glyphs: []const ct.CGGlyph,
+        positions: []const ct.CGPoint,
+    ) ?AtlasEntry {
+        if (glyphs.len == 0) return null;
+        if (glyphs.len == 1) return self.getOrInsert(font, glyphs[0]);
+
+        // 키는 글리프 인덱스들의 해시다. 같은 폰트 안에서 인덱스 조합이 같으면 결과가 같다
+        // (positions 는 그 조합에서 결정되므로 키에 안 넣는다).
+        var h = std.hash.Wyhash.init(0xC1_05_7E_47);
+        for (glyphs) |g| h.update(std.mem.asBytes(&g));
+        const key = GlyphKey{ .font_ptr = @intFromPtr(font), .index = @truncate(h.final()) };
+        if (self.cache.get(key)) |entry| return entry;
+
+        const entry = self.rasterizeCluster(font, glyphs, positions) orelse return null;
+        self.cache.put(key, entry) catch return null;
+        return entry;
+    }
+
     /// 탭바 컨트롤 아이콘 (`< > × +`) 을 `tab_icons` 로 rasterize 해 atlas 에
     /// 캐시 (#268). 폰트 글리프가 아니라 우리가 만든 알파 커버리지라 codepoint
     /// 대신 아이콘 enum 을 key 로 씀 (font=0 은 유효한 CTFontRef 아님). 커버리지
@@ -152,6 +181,125 @@ pub const GlyphAtlas = struct {
         self.dirty = true;
         self.dirty_min_y = 0;
         self.dirty_max_y = ATLAS_SIZE;
+    }
+
+    /// #401 — 여러 글리프를 `positions` 대로 한 비트맵에 그린다. `rasterize` 의 multi-glyph 판이라
+    /// 주석은 그쪽을 참고한다 (색 · smoothing · CTM scale · baseline 정렬 이유가 모두 같다).
+    ///
+    /// **다른 것은 bounding box 하나다.** 글리프마다 rect 를 받아 각자의 position 만큼 옮긴 뒤
+    /// 합집합을 낸다 — 그래야 겹쳐 쌓이는 글리프 (Apple Color Emoji 의 `❤️` 조합) 가 안 잘린다.
+    fn rasterizeCluster(
+        self: *GlyphAtlas,
+        font: ct.CTFontRef,
+        glyphs: []const ct.CGGlyph,
+        positions: []const ct.CGPoint,
+    ) ?AtlasEntry {
+        const n = glyphs.len;
+        if (n == 0 or n > 16 or positions.len < n) return null;
+
+        var rects: [16]ct.CGRect = undefined;
+        _ = ct.CTFontGetBoundingRectsForGlyphs(
+            font,
+            ct.kCTFontOrientationDefault,
+            glyphs.ptr,
+            @ptrCast(&rects),
+            @intCast(n),
+        );
+
+        // 각 글리프 rect 를 자기 position 만큼 옮겨 합집합. 여기가 단일 글리프판과 갈리는 곳이다.
+        var min_x = rects[0].origin.x + positions[0].x;
+        var min_y = rects[0].origin.y + positions[0].y;
+        var max_x = min_x + rects[0].size.width;
+        var max_y = min_y + rects[0].size.height;
+        for (1..n) |i| {
+            const rx = rects[i].origin.x + positions[i].x;
+            const ry = rects[i].origin.y + positions[i].y;
+            if (rx < min_x) min_x = rx;
+            if (ry < min_y) min_y = ry;
+            if (rx + rects[i].size.width > max_x) max_x = rx + rects[i].size.width;
+            if (ry + rects[i].size.height > max_y) max_y = ry + rects[i].size.height;
+        }
+
+        const traits = ct.CTFontGetSymbolicTraits(font);
+        const is_color = (traits & ct.kCTFontTraitColorGlyphs) != 0;
+
+        // advance 는 첫 글리프 것을 쓴다. cluster 는 셀 격자에 맞춰 그리므로 (renderer 가
+        // `glyphCenterDx` 로 가운데 정렬) 합계를 쓰면 오히려 어긋난다.
+        var adv = [1]ct.CGSize{.{ .width = 0, .height = 0 }};
+        var first = [1]ct.CGGlyph{glyphs[0]};
+        _ = ct.CTFontGetAdvancesForGlyphs(font, ct.kCTFontOrientationDefault, &first, &adv, 1);
+        const advance_px: f32 = @floatCast(adv[0].width * self.scale);
+
+        const s = self.scale;
+        const x0 = @floor(min_x * s);
+        const y0 = @floor(min_y * s);
+        const x1 = @ceil(max_x * s);
+        const y1 = @ceil(max_y * s);
+        const gw_f = x1 - x0;
+        const gh_f = y1 - y0;
+        if (gw_f <= 0 or gh_f <= 0) return null;
+
+        const gw: u32 = @intFromFloat(gw_f);
+        const gh: u32 = @intFromFloat(gh_f);
+        if (gw > 256 or gh > 256) return null; // temp_buf 한계.
+
+        const bytes_per_row = gw * 4;
+        const colorspace = ct.CGColorSpaceCreateDeviceRGB() orelse return null;
+        defer ct.CGColorSpaceRelease(colorspace);
+        const ctx = ct.CGBitmapContextCreate(
+            self.temp_buf.ptr,
+            gw,
+            gh,
+            8,
+            bytes_per_row,
+            colorspace,
+            ct.kCGImageAlphaPremultipliedFirst | ct.kCGBitmapByteOrder32Little,
+        ) orelse return null;
+        defer ct.CGContextRelease(ctx);
+
+        @memset(self.temp_buf[0 .. gw * gh * 4], 0);
+        ct.CGContextSetAllowsFontSmoothing(ctx, true);
+        ct.CGContextSetShouldSmoothFonts(ctx, true);
+        ct.CGContextSetShouldAntialias(ctx, true);
+        ct.CGContextSetRGBFillColor(ctx, 1, 1, 1, 1);
+        ct.CGContextScaleCTM(ctx, @floatCast(s), @floatCast(s));
+
+        // 합집합 원점을 비트맵 (0,0) 에 맞추고, 각 글리프는 자기 position 을 더해 그린다.
+        // 원점 보정이 `floor(·*s)/s` 인 이유는 단일 글리프판과 같다 (#156 baseline jitter).
+        const base_x = -@floor(min_x * s) / s;
+        const base_y = -@floor(min_y * s) / s;
+        var draw_pos: [16]ct.CGPoint = undefined;
+        for (0..n) |i| {
+            draw_pos[i] = .{ .x = base_x + positions[i].x, .y = base_y + positions[i].y };
+        }
+        ct.CTFontDrawGlyphs(font, glyphs.ptr, &draw_pos, n, ctx);
+
+        const pos = self.packGlyph(gw, gh) orelse blk: {
+            self.reset();
+            break :blk self.packGlyph(gw, gh) orelse return null;
+        };
+        const atlas_x = pos[0];
+        const atlas_y = pos[1];
+        const atlas_row_bytes = ATLAS_SIZE * 4;
+        for (0..gh) |row| {
+            const src_off = row * bytes_per_row;
+            const dst_off = (atlas_y + @as(u32, @intCast(row))) * atlas_row_bytes + atlas_x * 4;
+            @memcpy(self.pixels[dst_off..][0..bytes_per_row], self.temp_buf[src_off..][0..bytes_per_row]);
+        }
+        self.dirty = true;
+        if (atlas_y < self.dirty_min_y) self.dirty_min_y = atlas_y;
+        if (atlas_y + gh > self.dirty_max_y) self.dirty_max_y = atlas_y + gh;
+
+        return AtlasEntry{
+            .x = @intCast(atlas_x),
+            .y = @intCast(atlas_y),
+            .w = @intCast(gw),
+            .h = @intCast(gh),
+            .bearing_x = @intFromFloat(x0),
+            .bearing_y = @intFromFloat(y0),
+            .is_color = is_color,
+            .advance = advance_px,
+        };
     }
 
     fn rasterize(self: *GlyphAtlas, font: ct.CTFontRef, glyph_index: ct.CGGlyph) ?AtlasEntry {


### PR DESCRIPTION
`❤️` 가 든 ZWJ cluster 가 **첫 emoji 만 보이던** 문제입니다 (`👨‍❤️‍👨` → `👨`).

## 원인

**폰트가 그 조합을 1 글리프로 못 줄입니다.** CoreText 로 직접 재 보니 어느 폰트를 지정해도
run 은 1 개 (Apple Color Emoji) 인데 **글리프가 2 개**입니다. 우리는 cluster 하나를 글리프
하나로 가정하고 **첫 글리프만** 썼기 때문에 뒤가 사라졌습니다.

| cluster | run | glyph |
|---|---:|---:|
| `👨‍❤️‍👨` | 1 | **2** |
| `👨‍👩‍👧` (대조군) | 1 | 1 |

길이 문제가 아닙니다 — 5 codepoint 인 `👨‍👩‍👧` 는 멀쩡한데 6 codepoint 인 `👨‍❤️‍👨` 가 깨졌습니다.
[VS-16 도 변수가 아니었습니다](https://github.com/ensky0/tildaz/issues/401#issuecomment-5224511567) —
VS-16 을 뺀 4 codepoint 도 같이 깨집니다. 원인은 `❤️` 자체입니다.

## 무엇을 바꿨나

**Windows 가 이미 하던 것을 macOS 에 만들었습니다.** 글리프를 버리지 않고 여러 개를 한 비트맵에
합성해 그립니다.

- `GlyphResult` 를 multi-glyph 로 확장
- atlas 에 cluster 래스터 경로 추가 — `CTFontDrawGlyphs` 가 원래 `count` 인자를 받는
  multi-glyph API 라, `count = 1` 로 부르던 것을 넓히고 `CTRunGetPositions` 로 위치를 받습니다
- 셀 루프와 #399 의 캐시가 새 타입을 다루도록

## 세 platform 상태

| platform | 이 이슈의 증상 | 비고 |
|---|---|---|
| **Windows** | ✅ **원래 없음** | `getOrInsertCluster` 로 multi-glyph 를 합성해 그림 — 참조 구현이 됐습니다 ([실기 확인](https://github.com/ensky0/tildaz/issues/401#issuecomment-5223916750)) |
| **macOS** | ❌ → ✅ **이 PR** | |
| **Linux** | ✅ 증상 없음 | Noto Color Emoji 가 1 글리프로 줍니다. 다만 `n != 1` 거부가 그대로라 **잠재 위험은 남습니다** |

## Linux 는 이 PR 에 없습니다

[조사 결과](https://github.com/ensky0/tildaz/issues/401#issuecomment-5224540934) 이 환경에서
글리프를 실제로 버리는 cluster 를 **하나도 찾지 못했습니다.** 재현 케이스 없이 atlas 합성을
건드리면 검증할 대상이 없어서 분리했습니다 — 재현 케이스 탐색은
[#401 에 계획](https://github.com/ensky0/tildaz/issues/401#issuecomment-5225161780)이 있습니다.

**그래서 이 PR 은 #401 을 닫지 않습니다.**

## 검증

- macOS 실기 — 여섯 조합 전부 합성 확인
- `zig build check` 6 타겟 · `zig build test` 통과 (최신 main 위로 rebase 한 뒤 재실행)