### PR TITLE
fix(config): 기본 scrollback 을 100,000 → 10,000 (#425)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -44,7 +44,7 @@ user's `$SHELL` env (or
   "hotkey": "F1",
   "auto_start": true,
   "hidden_start": false,
-  "max_scroll_lines": 100000
+  "max_scroll_lines": 10000
 }
 ```
 
@@ -71,7 +71,7 @@ user's `$SHELL` env (or
   "hotkey": "F1",
   "auto_start": true,
   "hidden_start": false,
-  "max_scroll_lines": 100000
+  "max_scroll_lines": 10000
 }
 ```
 
@@ -98,7 +98,7 @@ user's `$SHELL` env (or
   "hotkey": "F1",
   "auto_start": true,
   "hidden_start": false,
-  "max_scroll_lines": 100000
+  "max_scroll_lines": 10000
 }
 ```
 
@@ -123,7 +123,7 @@ Every numeric field name carries its unit (`_percent`, `_point`, `_ratio`). Stri
 | `hotkey` | string | "F1", "Ctrl+Space", "Shift+Cmd+T", … | "F1" | "F1" | "F1" | Global toggle hotkey. `cmd` token = Win key on Windows / Cmd on macOS / Super on Linux |
 | `auto_start` | bool | — | true | true | true | Start on login (Registry Run on Windows, LaunchAgent on macOS, XDG autostart `.desktop` on Linux) |
 | `hidden_start` | bool | — | false | false | false | Start hidden (first toggle reveals) |
-| `max_scroll_lines` | int | 100–10,000,000 | 100,000 | 100,000 | 100,000 | Scrollback buffer (lines) |
+| `max_scroll_lines` | int | 100–10,000,000 | 10,000 | 10,000 | 10,000 | Scrollback buffer (lines) |
 
 ### Font names
 

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -88,7 +88,7 @@
   "hotkey": "F1",
   "auto_start": true,
   "hidden_start": false,
-  "max_scroll_lines": 100000
+  "max_scroll_lines": 10000
 }</code></pre>
           <p class="code-note">Every key is required (strict schema). <code>shell</code>, <code>font.family</code>, and the fallback fonts must exist on the system; on macOS/Windows use that platform's shell (e.g. <code>cmd.exe</code>) and installed fonts. See <a href="https://github.com/ensky0/tildaz/blob/main/CONFIG.md">CONFIG.md</a> for every field and the built-in theme names.</p>
         </article>

--- a/src/config.zig
+++ b/src/config.zig
@@ -707,7 +707,13 @@ pub const Defaults = struct {
     pub const hotkey: []const u8 = "F1";
     pub const auto_start: bool = true;
     pub const hidden_start: bool = false;
-    pub const max_scroll_lines: u32 = 100_000;
+    /// 100,000 은 다른 터미널의 10~100 배였다 (#425 조사 — 2 위 alacritty · GNOME Terminal
+    /// 이 10,000 이고 중앙값은 1,000~2,000, 우리가 자리를 물려받은 Tilda 는 5,000). 그 값이
+    /// `cols=120` 에서 130.5 MiB 라 앱의 `parse` 시간이 1.82 배 · `yields` 가 0 → 86 만이
+    /// 됐다 (실측). 활성 작업집합이 캐시를 넘어서 생기는 비용이고 (`instructions` 는 같은데
+    /// `cache-misses` 4,341 배) 로직 최적화로는 줄지 않는다. 최상위권 (ghostty 10 MB ·
+    /// Windows Terminal 9,001 · GNOME Terminal · alacritty 10,000) 에 맞춘다.
+    pub const max_scroll_lines: u32 = 10_000;
 
     /// Primary font — 단일 string. 시스템에 반드시 설치돼 있어야 함 (없으면
     /// startup 시 fatal). Windows: Cascadia Code (Win10 22H2+ / Win11 기본).


### PR DESCRIPTION
[#425](https://github.com/ensky0/tildaz/issues/425) 의 조사와 실측에 따라 기본값을 낮춰요.

## 왜

**조사한 터미널 열여섯 중 우리가 압도적 1 위였어요.** 2 위 (alacritty · GNOME Terminal) 가 10,000 이고 중앙값은 1,000~2,000 이며, 우리가 자리를 물려받은 **Tilda 가 5,000** · Guake 가 1,000 이에요. alacritty 는 100,000 을 *상한* 으로 두고, Windows Terminal 은 설정으로도 32,767 을 못 넘어요. ([전체 표](https://github.com/ensky0/tildaz/issues/425#issuecomment-5231193682))

**그 값의 대가를 실측했어요** (64 MiB · `plain` · 5 회 절사평균 · i5-1240P · CachyOS).

| 지표 | sb=500 | sb=100,000 |
|---|---:|---:|
| `parse` | 125.166 ms | **227.585 ms (1.82 배)** |
| `yields` | 0 | **861,237** |
| peak RSS | 15.9 MiB | **113.9 MiB** |

원인은 **활성 작업집합이 캐시를 넘는 것**이에요 — `perf stat` 에서 `instructions` 는 **1.00 배로 같은데** `cycles` 1.54 배 · `cache-misses` **4,341 배** · `dTLB-load-misses` 86 배이고 IPC 가 4.06 → 2.62 로 떨어져요. 코드가 더 많은 일을 하는 게 아니라 메모리를 기다리는 것이라 **로직 최적화로는 줄지 않아요.**

10,000 줄은 `cols=120` 에서 **13.0 MiB** 로, 최상위권과 같은 자리예요 (ghostty 10 MB · WT 11.7 MiB · GNOME · alacritty 13.0 MiB).

## 기존 사용자 영향 — 없어요

config 파일에 `max_scroll_lines` 가 이미 있으면 **그 값이 그대로** 쓰여요 (schema 상 required key 라 항상 있어요). 바뀌는 건 **새로 만들어지는 config 와 문서의 기본값**이에요. 설정 가능 범위 (100~10,000,000) 도 그대로예요.

## 변경

| 파일 | 내용 |
|---|---|
| `src/config.zig` | `Defaults.max_scroll_lines` 100_000 → 10_000 (+ 근거 주석) |
| `CONFIG.md` | 예시 config 3 곳 · 기본값 표 |
| `docs/config/index.html` | 사이트 예시 config |

## 검증

- `zig build -Doptimize=ReleaseFast -Dsimd=true` ✅
- `zig build test` ✅
- `zig build check` (Linux · macOS · Windows × x86_64/aarch64 6 타겟) ✅
- 하네스 헤더가 `scrollback 10000 lines` 로 바뀌는 것으로 실제 반영 확인 ✅