### PR TITLE
feat(cli): --version · --help 추가, 버전에 빌드 커밋 표시 (#383)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,41 @@ Common fields:
 Font fallback is capped at 8 families total: 1 primary `font.family` plus up to
 7 entries in `font.glyph_fallback`.
 
+## Command line
+
+TildaZ needs no arguments to start. These options are available:
+
+```bash
+tildaz --instance 1     # run instance 1, with its own window, config, and log
+tildaz --toggle         # show or hide the running instance, then exit (Linux only)
+tildaz --autostart      # start the way the desktop session starts TildaZ
+tildaz --version        # print the version, then exit
+tildaz --help           # print the option list, then exit
+```
+
+`--version` prints the release version, plus the commit it was built from when
+TildaZ was built from a git checkout:
+
+```
+$ tildaz --version
+tildaz 0.7.0 (d1ad1ff)
+```
+
+A `-dirty` suffix on the commit — `tildaz 0.7.0 (d1ad1ff-dirty)` — means the
+build had uncommitted local changes. Builds from a source archive with no git
+metadata print the version alone. The same string appears in the About dialog
+(`Ctrl+Shift+I`, or `Shift+Cmd+I` on macOS) and on the first line of the log
+file, so any of the three identifies a build exactly.
+
+`--toggle` is meant for a desktop shortcut: bind `tildaz --toggle` to a key in
+your desktop's keyboard settings, and it shows or hides the running instance.
+
+On macOS the executable lives inside the app bundle, so call it by path:
+
+```bash
+/Applications/TildaZ.app/Contents/MacOS/tildaz --version
+```
+
 ## Build
 
 Requirements:

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const manifest = @import("build.zig.zon");
 const versioning = @import("build/version.zig");
+const git_version = @import("build/git_version.zig");
 
 // Ghostty는 Windows target query의 ABI가 null이면 내부 target만 MSVC로
 // 바꾼다. TildaZ root는 Zig가 이미 resolve한 GNU ABI를 계속 써서 두 module의
@@ -56,9 +57,15 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // 컴파일 타임 상수 — About 다이얼로그 / tildaz.log 의 boot 엔트리에서 사용.
+    // 컴파일 타임 상수 — About 다이얼로그 / `--version` / tildaz.log 의 boot 엔트리에서
+    // 사용. 세 값을 사람이 읽는 한 줄로 합치는 규칙은 `src/version.zig` 한 곳에 있다.
     const build_opts = b.addOptions();
     build_opts.addOption([]const u8, "version", app_version.full);
+    // #383 — 어느 커밋에서 빌드했나. git 이 없거나 `.git` 이 없는 소스 tarball 이면
+    // 빈 문자열이고 버전 문자열에서 통째로 빠진다 (`build/git_version.zig`).
+    const git = git_version.detect(b);
+    build_opts.addOption([]const u8, "commit", git.commit);
+    build_opts.addOption(bool, "commit_dirty", git.dirty);
     exe_mod.addOptions("build_options", build_opts);
 
     // #19 — 현재 Ghostty pin + Zig 0.15.2에서 Linux · macOS · Windows native

--- a/build/git_version.zig
+++ b/build/git_version.zig
@@ -1,0 +1,62 @@
+//! 빌드 시점 git 상태 조회 — About / `--version` / 로그에 찍히는 commit 정보 ([#383](https://github.com/ensky0/tildaz/issues/383)).
+//!
+//! release version 의 단일 원본은 `build.zig.zon` 의 `.version` 이고 그 파생은
+//! `build/version.zig` 가 담당한다. 이 모듈은 그 위에 얹는 **어느 커밋에서 빌드했나**
+//! 하나만 본다. 둘을 사람이 읽는 한 줄로 합치는 규칙은 runtime 쪽 `src/version.zig`
+//! 한 곳에 있다 — 규칙이 두 군데면 About 과 `--version` 이 갈린다.
+//!
+//! ## 조회에 실패해도 빌드는 계속된다
+//!
+//! git 이 PATH 에 없거나 `.git` 이 없는 소스 tarball (배포판 패키지 빌드가 그렇다) 이면
+//! `commit` 이 빈 문자열이 되고 버전 문자열은 `0.7.0` 처럼 커밋 없이 나온다. 여기서
+//! 빌드를 세우지 않는 이유는 commit 이 *진단 편의* 값이지 동작에 필요한 값이 아니라서다.
+//!
+//! ## 이 조회는 `zig build` 를 부를 때마다 다시 돈다
+//!
+//! `runAllowFail` 은 build graph 를 만드는 시점 (= configure) 에 실행된다. 그래서 커밋을
+//! 하거나 작업 트리를 더럽히면 다음 `zig build` 에서 값이 갱신되고, 값이 그대로면
+//! `addOptions` 가 만드는 파일 내용도 같아서 캐시가 그대로 맞는다.
+
+const std = @import("std");
+
+pub const Info = struct {
+    /// short commit hash (git 이 정하는 길이, 최소 7자). 조회 실패면 빈 문자열.
+    commit: []const u8 = "",
+
+    /// 작업 트리에 커밋되지 않은 변경이 있는가. `commit` 이 비면 항상 false —
+    /// 커밋을 모르는데 "그 커밋에서 바뀌었다" 고 말할 수 없다.
+    dirty: bool = false,
+};
+
+pub fn detect(b: *std.Build) Info {
+    // build root 를 명시한다. `zig build` 를 어느 cwd 에서 부르든 같은 저장소를 본다.
+    const root = b.build_root.path orelse ".";
+    var code: u8 = 0;
+
+    const hash_raw = b.runAllowFail(
+        &.{ "git", "-C", root, "rev-parse", "--short", "HEAD" },
+        &code,
+        .Ignore,
+    ) catch return .{};
+    const commit = std.mem.trim(u8, hash_raw, " \t\r\n");
+    // 커밋이 하나도 없는 저장소 (`git init` 직후) 는 위에서 실패하지만, 방어적으로 본다.
+    if (commit.len == 0) return .{};
+
+    // `--untracked-files=no` 는 `git describe --dirty` 와 같은 판정이다. 추적되지 않는
+    // 새 파일 (빌드 산출물 · 스크래치 파일) 은 dirty 로 치지 않고 **추적 중인 파일의
+    // staged + unstaged 변경**만 본다.
+    //
+    // `git diff --quiet` 를 쓰지 않는 이유: staged 변경을 못 본다 (`git add` 만 한 상태가
+    // clean 으로 읽힌다). `status` 는 그것까지 보고, 덤으로 index 를 refresh 해서 내용은
+    // 같은데 mtime 만 바뀐 파일이 dirty 로 오탐되는 것도 막는다.
+    const status = b.runAllowFail(
+        &.{ "git", "-C", root, "status", "--porcelain", "--untracked-files=no" },
+        &code,
+        .Ignore,
+    ) catch return .{ .commit = commit };
+
+    return .{
+        .commit = commit,
+        .dirty = std.mem.trim(u8, status, " \t\r\n").len != 0,
+    };
+}

--- a/src/about.zig
+++ b/src/about.zig
@@ -13,11 +13,11 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const build_options = @import("build_options");
 const dialog = @import("dialog.zig");
 const log = @import("log.zig");
 const messages = @import("messages.zig");
 const paths = @import("paths.zig");
+const version = @import("version.zig");
 
 pub const Details = struct {
     version: []const u8,
@@ -79,7 +79,10 @@ pub fn showAboutDialog() void {
     };
 
     const msg = formatMessageAlloc(allocator, .{
-        .version = build_options.version,
+        // #383 — semver 뿐 아니라 빌드한 커밋까지 (`0.7.0 (d1ad1ff-dirty)`). 사용자가
+        // 이 다이얼로그를 그대로 복사해 이슈에 붙이므로, 어느 커밋인지가 여기 있어야
+        // 릴리즈 사이의 빌드를 되묻지 않는다. `--version` · 로그와 같은 문자열이다.
+        .version = version.string,
         .exe_path = exe_path,
         .pid = pid,
         .config_path = config_path,
@@ -101,6 +104,25 @@ extern "kernel32" fn GetCurrentProcessId() callconv(.c) u32;
 fn getCurrentProcessIdWindows() u32 {
     if (builtin.os.tag != .windows) return 0;
     return GetCurrentProcessId();
+}
+
+test "#383 About 첫 줄은 `--version` · 로그와 같은 버전 문자열이다" {
+    // 세 표시 지점이 갈리지 않게 묶는다. About 만 `build_options.version` 을 그대로 쓰던
+    // 시절로 되돌아가면 (= 커밋이 빠지면) 여기서 잡힌다.
+    const msg = try formatMessageAlloc(std.testing.allocator, .{
+        .version = version.string,
+        .exe_path = "/usr/bin/tildaz",
+        .pid = 42,
+        .config_path = "/tmp/config_0.json",
+        .log_path = "/tmp/tildaz_0.log",
+        .open_config_key = "Ctrl+Shift+P",
+        .open_log_key = "Ctrl+Shift+L",
+    });
+    defer std.testing.allocator.free(msg);
+
+    var expected_buf: [256]u8 = undefined;
+    const expected_first_line = try std.fmt.bufPrint(&expected_buf, "TildaZ v{s}", .{version.string});
+    try std.testing.expect(std.mem.startsWith(u8, msg, expected_first_line));
 }
 
 test "#314 About formatter preserves content beyond the old 2048-byte limit" {

--- a/src/console.zig
+++ b/src/console.zig
@@ -1,0 +1,130 @@
+//! CLI 텍스트 출력 — `--version` · `--help` · 인자 오류가 콘솔로 나가는 유일한 경로
+//! ([#383](https://github.com/ensky0/tildaz/issues/383)).
+//!
+//! 창을 띄우기 **전에** 끝나는 명령들이라 `dialog.zig` 를 거치지 않는다. 다이얼로그는
+//! 창 · 렌더러 · (Linux 는) Wayland 연결이 선 뒤에야 뜨는데, 여기서는 그 앞에서 한 줄
+//! 찍고 종료하는 게 목적이다.
+//!
+//! ## Windows 가 이 모듈이 존재하는 이유
+//!
+//! `tildaz.exe` 는 `subsystem = .Windows` 다 (`build.zig` 의 `exe.subsystem`) — 콘솔에
+//! 붙어 있지 않아서 `std.fs.File.stdout()` 이 PEB 의 빈 핸들을 돌려주고, 거기 쓴 글은
+//! **아무 데도 나타나지 않는다.** 그래서 Windows 만 (1) 상속받은 std handle 을 먼저 보고
+//! (2) 없으면 부모 콘솔에 붙어 `CONOUT$` 를 직접 연다.
+//!
+//! **남아 있는 Windows 한계 (미검증).** GUI subsystem 프로세스는 셸이 종료를 기다리지
+//! 않는다. 그래서 `tildaz --version` 의 출력이 다음 프롬프트 *뒤에* 찍혀 보일 수 있다.
+//! vim · ghostty 가 콘솔 subsystem 런처 (`.com`) 를 따로 두는 이유가 이것이다. 이 세션은
+//! Linux 머신이라 실기 확인을 못 했다 — 실기에서 문제가 되면 런처 분리는 별도 이슈로 뗀다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+
+const Stream = enum { standard, diagnostic };
+
+/// stdout. `--version` · `--help` 처럼 **요청한 결과**를 낸다.
+pub fn out(text: []const u8) void {
+    write(.standard, text);
+}
+
+/// stderr. 인자 오류처럼 **요청이 실패한 이유**를 낸다. 리다이렉트로 결과만 갈무리하는
+/// 스크립트가 오류에 오염되지 않게 stdout 과 나눈다.
+pub fn err(text: []const u8) void {
+    write(.diagnostic, text);
+}
+
+/// 줄바꿈까지 붙여 한 번에 쓴다. 두 번 나눠 쓰면 다른 프로세스의 출력이 사이에 끼어든다.
+pub fn outLine(text: []const u8) void {
+    writeLine(.standard, text);
+}
+
+pub fn errLine(text: []const u8) void {
+    writeLine(.diagnostic, text);
+}
+
+fn writeLine(stream: Stream, text: []const u8) void {
+    var buf: [2048]u8 = undefined;
+    const joined = std.fmt.bufPrint(&buf, "{s}\n", .{text}) catch {
+        // 버퍼를 넘기는 긴 텍스트는 두 번에 나눠 쓴다. 줄이 갈릴 수 있지만 내용을
+        // 버리지는 않는다.
+        write(stream, text);
+        write(stream, "\n");
+        return;
+    };
+    write(stream, joined);
+}
+
+fn write(stream: Stream, text: []const u8) void {
+    switch (builtin.os.tag) {
+        .windows => writeWindows(stream, text),
+        else => {
+            const file: std.fs.File = switch (stream) {
+                .standard => .stdout(),
+                .diagnostic => .stderr(),
+            };
+            // 파이프가 닫혔거나 (`tildaz --version | head`) 콘솔이 없으면 쓸 곳이 없다.
+            // 버전을 못 찍었다고 종료 코드를 바꾸지는 않는다.
+            file.writeAll(text) catch {};
+        },
+    }
+}
+
+// ── Windows ────────────────────────────────────────────────────────────────
+
+const STD_OUTPUT_HANDLE: windows.DWORD = 0xFFFF_FFF5; // (DWORD)-11
+const STD_ERROR_HANDLE: windows.DWORD = 0xFFFF_FFF4; // (DWORD)-12
+const ATTACH_PARENT_PROCESS: windows.DWORD = 0xFFFF_FFFF; // (DWORD)-1
+
+extern "kernel32" fn AttachConsole(dwProcessId: windows.DWORD) callconv(.winapi) windows.BOOL;
+
+fn writeWindows(stream: Stream, text: []const u8) void {
+    const handle = windowsHandle(stream) orelse return;
+
+    // 콘솔 핸들에 대한 WriteFile 은 바이트를 **콘솔 출력 코드페이지**로 해석한다.
+    // 여기 나가는 텍스트 (`messages.zig` 의 CLI 문자열 + 버전) 는 전부 ASCII 라
+    // 코드페이지가 무엇이든 같게 보인다. 비 ASCII 를 넣게 되면 `WriteConsoleW` 로
+    // 바꿔야 한다.
+    var remaining = text;
+    while (remaining.len != 0) {
+        var written: windows.DWORD = 0;
+        const chunk: windows.DWORD = @intCast(@min(remaining.len, std.math.maxInt(u32)));
+        if (windows.kernel32.WriteFile(handle, remaining.ptr, chunk, &written, null) == 0) return;
+        if (written == 0) return; // 더 이상 진행되지 않는다 — 무한 루프 방지.
+        remaining = remaining[written..];
+    }
+}
+
+fn windowsHandle(stream: Stream) ?windows.HANDLE {
+    // ① 상속받은 std handle 이 먼저다. `tildaz --version > out.txt` 처럼 셸이
+    //    리다이렉트를 걸어 두면 GUI subsystem 이라도 그 핸들이 상속된다. 이걸 건너뛰고
+    //    바로 CONOUT$ 를 열면 리다이렉트가 무시되고 콘솔로 새어 나간다.
+    const id: windows.DWORD = switch (stream) {
+        .standard => STD_OUTPUT_HANDLE,
+        .diagnostic => STD_ERROR_HANDLE,
+    };
+    if (windows.kernel32.GetStdHandle(id)) |handle| {
+        if (handle != windows.INVALID_HANDLE_VALUE) return handle;
+    }
+
+    // ② 콘솔에서 띄웠지만 GUI subsystem 이라 핸들이 없는 평범한 경우. 부모 콘솔에
+    //    붙는다. 이미 콘솔이 있으면 ERROR_ACCESS_DENIED 로 실패하는데, 그때도 아래
+    //    CONOUT$ 는 열리므로 결과를 보지 않는다.
+    _ = AttachConsole(ATTACH_PARENT_PROCESS);
+
+    // ③ 콘솔의 활성 출력 버퍼. stdout · stderr 모두 같은 이름을 쓴다 (`CONERR$` 는
+    //    없다) — 콘솔로 떨어지는 시점에서 둘의 구분은 의미를 잃는다.
+    const handle = windows.kernel32.CreateFileW(
+        std.unicode.utf8ToUtf16LeStringLiteral("CONOUT$"),
+        windows.GENERIC_READ | windows.GENERIC_WRITE,
+        windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE,
+        null,
+        windows.OPEN_EXISTING,
+        0,
+        null,
+    );
+    // 부모가 콘솔이 아니면 (탐색기 · 작업 스케줄러 · 자동 시작) 여기서 실패한다.
+    // 쓸 곳이 없다는 뜻이라 조용히 포기한다.
+    if (handle == windows.INVALID_HANDLE_VALUE) return null;
+    return handle;
+}

--- a/src/host/linux_wayland.zig
+++ b/src/host/linux_wayland.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const run_options = @import("../run_options.zig");
-const build_options = @import("build_options");
+const version = @import("../version.zig");
 const log = @import("../log.zig");
 const perf = @import("../perf.zig");
 const messages = @import("../messages.zig");
@@ -66,8 +66,8 @@ pub fn showFatalRunError(err: anyerror) void {
 }
 
 pub fn run(opts: run_options.RunOptions) !void {
-    log.logStart(build_options.version);
-    defer log.logStop(build_options.version);
+    log.logStart(version.string);
+    defer log.logStop(version.string);
     // #396 — 측정 인스턴스면 종료 직전에 perf 스냅숏을 남긴다. `defer` 는 LIFO 라
     // 위의 `logStop` **보다 먼저** 돈다 — 로그 파일이 닫히기 전이어야 한다.
     // worker 는 no-op (게이트는 `instance_context.isStress`).

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -17,7 +17,7 @@
 
 const std = @import("std");
 const run_options = @import("../run_options.zig");
-const build_options = @import("build_options");
+const version = @import("../version.zig");
 const objc = @import("../macos_objc.zig");
 const config = @import("../config.zig");
 const ghostty = @import("ghostty-vt");
@@ -216,7 +216,7 @@ fn atExitLogStop() callconv(.c) void {
     // defer 가 안 불려서 이 핸들러 안에 둔다 — 이 함수가 존재하는 이유와 같다.
     // 로그 파일이 닫히기 전이어야 하므로 `logStop` 앞이다. worker 는 no-op.
     perf.dumpOnExit();
-    log.logStop(build_options.version);
+    log.logStop(version.string);
 }
 
 // NSApplication delegate — `applicationShouldTerminate:` 한 메서드만 구현.
@@ -2793,7 +2793,7 @@ pub fn run(opts: run_options.RunOptions) !void {
     // 통합 로그 파일에 boot/exit 라인을 남긴다 (`log.zig`). macOS 는
     // `~/Library/Logs/tildaz_N.log` — Console.app 이 자동 인덱싱해 GUI 에서
     // 바로 열람 가능.
-    log.logStart(build_options.version);
+    log.logStart(version.string);
     // #197 — env TILDAZ_VERBOSE 면 protocol/timing/detail 로그까지 (기본은 lifecycle).
     log.setVerbose(std.process.hasEnvVarConstant("TILDAZ_VERBOSE"));
     // Cmd+Q (NSApp terminate:) 는 `exit()` 직행 — defer 안 불림. atexit 등록.

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -17,7 +17,7 @@ const themes = @import("../themes.zig");
 const instance_context = @import("../instance_context.zig");
 const instances = @import("../instances.zig");
 const ui_metrics = @import("../ui_metrics.zig");
-const build_options = @import("build_options");
+const version = @import("../version.zig");
 
 const WCHAR = u16;
 extern "kernel32" fn GetEnvironmentVariableW([*:0]const WCHAR, ?[*]WCHAR, u32) callconv(.c) u32;
@@ -49,8 +49,8 @@ pub fn run(opts: run_options.RunOptions) !void {
 
     // %APPDATA%\tildaz\tildaz_N.log 에 부팅 / 종료 라인을 남긴다.
     // stale exe 가 자동 실행되는 케이스를 사후 추적하기 위한 감사 로그.
-    log.logStart(build_options.version);
-    defer log.logStop(build_options.version);
+    log.logStart(version.string);
+    defer log.logStop(version.string);
     // #396 — 측정 인스턴스면 종료 직전에 perf 스냅숏을 남긴다. `defer` 는 LIFO 라
     // 위의 `logStop` **보다 먼저** 돈다 — 로그 파일이 닫히기 전이어야 한다.
     // worker 는 no-op (게이트는 `instance_context.isStress`).

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,12 +8,14 @@ const host = switch (builtin.os.tag) {
 };
 const autostart = @import("autostart.zig");
 const config = @import("config.zig");
+const console = @import("console.zig");
 const instance_context = @import("instance_context.zig");
 const instance_request = @import("instance_request.zig");
 const instances = @import("instances.zig");
 const messages = @import("messages.zig");
 const run_options = @import("run_options.zig");
 const shortcut_sync = @import("shortcut_sync.zig");
+const version = @import("version.zig");
 
 /// `std.log` 호출 (ghostty-vt 의 `unimplemented mode` 등) 을 우리 통합 로그로
 /// redirect — stdout/stderr 안 찍힘. macOS 는 `~/Library/Logs/tildaz_N.log`,
@@ -44,6 +46,28 @@ pub fn panic(msg: []const u8, st: ?*std.builtin.StackTrace, ret_addr: ?usize) no
     host.showPanic(msg, addr, st);
 }
 
+/// #383 — 인자 오류는 셋 다 stderr + `exit(2)` 이고, 다음 행동 (`--help`) 을 같이
+/// 안내한다. 종료 코드 2 는 기존 동작 그대로다 (bash 의 "잘못된 사용법" 관례).
+fn exitUnknownOption(arg: []const u8) noreturn {
+    printOptionError(messages.unknown_option_format, .{arg});
+}
+
+fn exitOptionNeedsValue(option: []const u8) noreturn {
+    printOptionError(messages.option_needs_value_format, .{option});
+}
+
+fn exitInvalidValue(option: []const u8, value: []const u8) noreturn {
+    printOptionError(messages.option_invalid_value_format, .{ value, option });
+}
+
+fn printOptionError(comptime fmt: []const u8, args: anytype) noreturn {
+    // 인자는 사용자가 준 문자열이라 길이 상한이 없다. 버퍼를 넘기면 (예: 아주 긴 경로를
+    // 옵션 자리에 넣은 경우) 값을 뺀 일반 안내로 떨어뜨린다 — 안내가 사라지는 것보다 낫다.
+    var buf: [1024]u8 = undefined;
+    console.errLine(std.fmt.bufPrint(&buf, fmt, args) catch messages.option_error_fallback_msg);
+    std.process.exit(2);
+}
+
 pub fn main() void {
     const args = std.process.argsAlloc(std.heap.page_allocator) catch std.process.exit(2);
     defer std.process.argsFree(std.heap.page_allocator, args);
@@ -52,25 +76,54 @@ pub fn main() void {
     var toggle_index: ?u32 = null;
     // #382 — 측정용 내부 옵션. 문서화하지 않는다 (`run_options.zig` 참고).
     var run_opts: run_options.RunOptions = .{};
+
+    // #383 — `--version` / `--help` 는 다른 인자보다 **먼저** 본다. 두 가지 이유다.
+    //
+    //  1. 창 · 전역 핫키 · worker lock 어느 것도 건드리지 않고 끝나야 한다. 버전만
+    //     보려는데 핫키가 등록되거나 lock 을 잡으면 평소 쓰는 인스턴스를 방해한다.
+    //  2. `tildaz --instance 1 --help` 처럼 다른 옵션과 섞여 와도 사용자의 의도는
+    //     "설명을 보여 달라" 이다. 위치와 무관하게 이긴다.
+    //
+    // 둘 다 있으면 `--help` 가 이긴다 — 옵션 목록 쪽이 더 많은 것을 알려 준다.
+    var show_help = false;
+    var show_version = false;
+    for (args[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) show_help = true;
+        if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-v")) show_version = true;
+    }
+    if (show_help) {
+        console.outLine(messages.help_text);
+        std.process.exit(0);
+    }
+    if (show_version) {
+        var buf: [256]u8 = undefined;
+        // 버전 문자열은 `version.string` 하나에서 온다 — About 다이얼로그 · 로그의
+        // `[boot]` 줄과 같은 값이라야 사용자가 어디서 읽어 오든 같은 것을 말한다.
+        const line = std.fmt.bufPrint(&buf, messages.version_line_format, .{version.string}) catch
+            version.string;
+        console.outLine(line);
+        std.process.exit(0);
+    }
+
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
         if (std.mem.eql(u8, arg, "--instance")) {
-            if (i + 1 >= args.len) std.process.exit(2);
+            if (i + 1 >= args.len) exitOptionNeedsValue(arg);
             i += 1;
-            worker_index = std.fmt.parseInt(u32, args[i], 10) catch std.process.exit(2);
+            worker_index = std.fmt.parseInt(u32, args[i], 10) catch exitInvalidValue(arg, args[i]);
         } else if (std.mem.eql(u8, arg, "-e")) {
-            if (i + 1 >= args.len) std.process.exit(2);
+            if (i + 1 >= args.len) exitOptionNeedsValue(arg);
             i += 1;
             run_opts.command = args[i];
         } else if (std.mem.eql(u8, arg, "-size")) {
-            if (i + 1 >= args.len) std.process.exit(2);
+            if (i + 1 >= args.len) exitOptionNeedsValue(arg);
             i += 1;
-            run_opts.grid = run_options.parseGrid(args[i]) orelse std.process.exit(2);
+            run_opts.grid = run_options.parseGrid(args[i]) orelse exitInvalidValue(arg, args[i]);
         } else if (std.mem.eql(u8, arg, "-scrollback")) {
-            if (i + 1 >= args.len) std.process.exit(2);
+            if (i + 1 >= args.len) exitOptionNeedsValue(arg);
             i += 1;
-            run_opts.scrollback = std.fmt.parseInt(usize, args[i], 10) catch std.process.exit(2);
+            run_opts.scrollback = std.fmt.parseInt(usize, args[i], 10) catch exitInvalidValue(arg, args[i]);
         } else if (std.mem.eql(u8, arg, "--autostart")) {
             autostart_launch = true;
         } else if (std.mem.eql(u8, arg, "--toggle")) {
@@ -81,6 +134,16 @@ pub fn main() void {
                     i += 1;
                 } else |_| {}
             }
+        } else if (builtin.os.tag == .macos and std.mem.startsWith(u8, arg, "-psn_")) {
+            // macOS LaunchServices 가 앱을 띄우며 붙일 수 있는 process serial number.
+            // 우리가 준 인자가 아니라서 아래 unknown 처리에 걸리면 `open TildaZ.app` 이
+            // 통째로 실패한다. Qt (`QCoreApplication`) · Chromium 도 같은 접두사로
+            // 걸러 낸다. 값은 쓰지 않고 버린다.
+        } else {
+            // #383 이전에는 여기가 없어서 **모르는 인자가 조용히 무시**됐다. `tildaz
+            // --versoin` 같은 오타가 아무 말 없이 평소처럼 창을 띄워서, 사용자가 뭘
+            // 잘못 쳤는지 알 방법이 없었다.
+            exitUnknownOption(arg);
         }
     }
 
@@ -102,7 +165,10 @@ pub fn main() void {
             @import("log.zig").appendLine("toggle-ipc", "--toggle sent to running instance", .{});
             std.process.exit(0);
         } else {
-            std.debug.print("{s}\n", .{messages.toggle_unsupported_msg});
+            // #383 — `std.debug.print` 는 Windows GUI subsystem 에서 아무 데도 나가지
+            // 않는다. 다른 CLI 출력과 같은 경로 (`console.zig`) 로 보내 부모 콘솔에
+            // 붙어서 찍는다.
+            console.errLine(messages.toggle_unsupported_msg);
             std.process.exit(2);
         }
     }

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -116,6 +116,50 @@ pub const request_endpoint_ready_timeout_msg =
 pub const toggle_unsupported_msg =
     "The --toggle option is only supported on Linux.";
 
+/// #383 — CLI 출력. 창을 띄우기 전에 콘솔로 나가는 유일한 텍스트 묶음이라 dialog 를
+/// 거치지 않고 `console.zig` 가 직접 쓴다.
+///
+/// `--help` 는 **사용자 옵션만** 싣는다. 측정용 `-e` · `-size` · `-scrollback` (#381 ·
+/// #382) 은 `run_options.zig` 의 문서 주석대로 내부용이라 여기 없다 — 사용자에게 노출하면
+/// "이미 떠 있는 인스턴스와의 관계" 같은 미정 사양을 전부 정해야 한다.
+///
+/// 이름은 `tildaz` (실행 파일 이름) 로 쓴다. About 다이얼로그의 `TildaZ` 는 제품 이름이고,
+/// 여기는 사용자가 방금 친 명령어와 같은 토큰이어야 복붙이 성립한다.
+pub const version_line_format = "tildaz {s}";
+
+pub const help_text =
+    \\TildaZ — drop-down terminal for Linux, macOS, and Windows.
+    \\
+    \\Usage:
+    \\  tildaz [options]
+    \\
+    \\Options:
+    \\  --instance <N>   Run instance N (default: 0). Each instance keeps its own
+    \\                   window, config file, and log file.
+    \\  --toggle [N]     Show or hide the running instance N (default: 0), then
+    \\                   exit. Linux only.
+    \\  --autostart      Start the way the desktop session starts TildaZ.
+    \\  -v, --version    Print the version, then exit.
+    \\  -h, --help       Print this help, then exit.
+    \\
+    \\Documentation: https://github.com/ensky0/tildaz
+;
+
+/// 인자 오류 세 갈래. 셋 다 `--help` 로 안내해 다음 행동이 한 줄로 이어지게 한다.
+/// #383 이전에는 세 경우 모두 아무 말 없이 `exit(2)` 였다 (모르는 옵션은 무시되어
+/// 창이 그냥 떴다) — 사용자가 오타를 알아챌 방법이 없었다.
+pub const unknown_option_format =
+    "tildaz: unknown option \"{s}\"\nRun \"tildaz --help\" to see the available options.";
+pub const option_needs_value_format =
+    "tildaz: \"{s}\" needs a value.\nRun \"tildaz --help\" to see the available options.";
+pub const option_invalid_value_format =
+    "tildaz: \"{s}\" is not a valid value for \"{s}\".\nRun \"tildaz --help\" to see the available options.";
+
+/// 위 세 format 의 bufPrint 가 실패할 때 (사용자가 준 인자가 버퍼보다 길 때) 쓴다.
+/// 값을 못 넣더라도 다음 행동은 알려 준다.
+pub const option_error_fallback_msg =
+    "tildaz: invalid command line.\nRun \"tildaz --help\" to see the available options.";
+
 /// run/launcher 오류를 세 platform에서 같은 사용자 문구로 변환한다.
 pub fn runFailureMessage(buf: []u8, err: anyerror) []const u8 {
     return switch (err) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,7 +10,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 test "aggregate root imports every common and native-host test module" {
-    // Cross-platform modules (35 files).
+    // Cross-platform modules (36 files).
     _ = @import("about.zig");
     _ = @import("box_drawing.zig");
     _ = @import("chrome_palette.zig");
@@ -45,6 +45,7 @@ test "aggregate root imports every common and native-host test module" {
     _ = @import("tab_layout.zig");
     _ = @import("terminal_interaction.zig");
     _ = @import("ui_metrics.zig");
+    _ = @import("version.zig");
     _ = @import("windows_input_adapter.zig");
 
     switch (builtin.os.tag) {

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,0 +1,87 @@
+//! 사용자에게 보이는 버전 문자열의 **단일 조립 지점** ([#383](https://github.com/ensky0/tildaz/issues/383)).
+//!
+//! `--version` · About 다이얼로그 · `tildaz_N.log` 의 `[boot]` / `[exit]` 세 곳이 모두
+//! 이 문자열 하나를 쓴다. 규칙을 호출처마다 두면 사용자가 이슈에 붙여 온 버전과 로그의
+//! 버전이 갈려서, 어느 쪽이 맞는지 되묻는 비용이 생긴다.
+//!
+//! ## 형식
+//!
+//! ```text
+//! 0.7.0                   .git 이 없는 소스 tarball 빌드 (배포판 패키지 등)
+//! 0.7.0 (d1ad1ff)         그 커밋 그대로 빌드
+//! 0.7.0 (d1ad1ff-dirty)   그 커밋 + 커밋되지 않은 로컬 변경
+//! ```
+//!
+//! `-dirty` 는 `git describe --dirty` 의 기본 접미사다. Linux 커널의
+//! `scripts/setlocalversion` 도 같은 단어를 쓴다 — 설명 없이 "로컬 수정본" 으로 읽히는
+//! 표기라서 골랐다. 후보였던 `modified` (Go 의 `vcs.modified`) 와 `+` (커널이 태그 아닌
+//! 커밋에 붙이는 표시) 는 뜻은 통하지만 관례 인지도가 낮다.
+//!
+//! ## 값의 출처
+//!
+//! 셋 다 `build_options` 의 comptime 상수다 — `version` 은 `build.zig.zon` 의 `.version`
+//! 에서 (`build/version.zig`), `commit` / `commit_dirty` 는 빌드 시점 git 조회에서
+//! (`build/git_version.zig`) 온다. 그래서 이 문자열도 comptime 에 완성되고 runtime 에
+//! 조립도 할당도 없다.
+
+const std = @import("std");
+const build_options = @import("build_options");
+
+/// 이 빌드의 버전 문자열. 위 문서 주석의 형식을 따른다.
+pub const string: []const u8 = compose(
+    build_options.version,
+    build_options.commit,
+    build_options.commit_dirty,
+);
+
+/// 조립 규칙 그 자체. `string` 이 comptime 에 한 번 부르고, 테스트가 같은 함수로 규칙을
+/// 검증한다 — 규칙과 검증이 같은 코드를 보게 하려고 상수 안에 인라인하지 않았다.
+pub fn compose(
+    comptime version: []const u8,
+    comptime commit: []const u8,
+    comptime dirty: bool,
+) []const u8 {
+    // 커밋을 모르면 괄호 자체를 쓰지 않는다. `0.7.0 ()` 나 `0.7.0 (unknown)` 은 값이
+    // 없다는 사실만 시끄럽게 알릴 뿐, 읽는 사람이 할 수 있는 일이 없다.
+    if (commit.len == 0) return version;
+    return version ++ " (" ++ commit ++ (if (dirty) "-dirty" else "") ++ ")";
+}
+
+test "compose 는 커밋을 괄호에 넣는다" {
+    try std.testing.expectEqualStrings("0.7.0 (d1ad1ff)", compose("0.7.0", "d1ad1ff", false));
+}
+
+test "compose 는 커밋되지 않은 변경에 -dirty 를 붙인다" {
+    try std.testing.expectEqualStrings("0.7.0 (d1ad1ff-dirty)", compose("0.7.0", "d1ad1ff", true));
+}
+
+test "compose 는 커밋이 없으면 버전만 낸다" {
+    // `.git` 이 없는 소스 tarball 빌드. dirty 는 커밋을 모르면 의미가 없어서 무시된다.
+    try std.testing.expectEqualStrings("0.7.0", compose("0.7.0", "", false));
+    try std.testing.expectEqualStrings("0.7.0", compose("0.7.0", "", true));
+}
+
+test "compose 는 prerelease 버전과 긴 hash 도 그대로 보존한다" {
+    // `build.zig.zon` 이 허용하는 prerelease 형식 (`build/version.zig`) 과, 저장소가
+    // 커져서 git 이 abbreviation 을 늘렸을 때를 같이 본다.
+    try std.testing.expectEqualStrings(
+        "0.7.1-rc.2 (d1ad1ff4ecee-dirty)",
+        compose("0.7.1-rc.2", "d1ad1ff4ecee", true),
+    );
+}
+
+test "string 은 이 빌드의 실제 값으로 조립된다" {
+    // 값 자체는 빌드마다 다르므로 형식만 본다. 커밋을 아는 빌드면 버전 뒤에 괄호가 붙고,
+    // 모르는 빌드면 버전과 정확히 같다.
+    try std.testing.expect(std.mem.startsWith(u8, string, build_options.version));
+    if (build_options.commit.len == 0) {
+        try std.testing.expectEqualStrings(build_options.version, string);
+    } else {
+        try std.testing.expect(std.mem.endsWith(u8, string, ")"));
+        try std.testing.expect(std.mem.indexOf(u8, string, build_options.commit) != null);
+        try std.testing.expectEqual(
+            build_options.commit_dirty,
+            std.mem.endsWith(u8, string, "-dirty)"),
+        );
+    }
+}


### PR DESCRIPTION
Closes #383

버전을 확인할 방법이 About 다이얼로그뿐이었다. 창을 띄우고 단축키를 눌러야 해서, 이슈를 받을 때 "어느 버전인가" 를 되묻는 비용이 있었다.

```
$ tildaz --version
tildaz 0.7.0 (60995b9)
```

## 버전 문자열에 빌드 커밋을 넣는다

릴리즈 사이의 빌드는 semver 만으로 구분되지 않는다. [`build/git_version.zig`](https://github.com/ensky0/tildaz/blob/feat/383-version-option/build/git_version.zig) 가 빌드 시점에 `git rev-parse --short HEAD` 로 커밋을, `git status --porcelain -uno` 로 작업 트리의 변경 여부를 읽어 `build_options` 로 넘긴다.

| 상황 | 출력 |
|---|---|
| `.git` 이 없는 소스 tarball 빌드 (배포판 패키지 등) | `0.7.0` |
| 그 커밋 그대로 빌드 | `0.7.0 (60995b9)` |
| 그 커밋 + 커밋되지 않은 로컬 변경 | `0.7.0 (60995b9-dirty)` |

`-dirty` 는 [`git describe --dirty`](https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---dirtymark) 의 기본 접미사이고 Linux 커널의 `scripts/setlocalversion` 도 같은 단어를 쓴다. 후보였던 `modified` (Go 의 `vcs.modified`) 와 `+` 기호는 뜻은 통하지만 관례 인지도가 낮아 쓰지 않았다.

dirty 판정에 `git diff --quiet` 가 아니라 `status` 를 쓴 이유는 **전자가 staged 변경을 못 보기 때문**이다 (`git add` 만 한 상태가 clean 으로 읽힌다). `--untracked-files=no` 로 추적되지 않는 파일을 빼는 것은 `git describe --dirty` 와 같은 판정이다.

git 이 없거나 `.git` 이 없으면 커밋이 빈 문자열이 되고 괄호가 통째로 빠진다. 빌드를 세우지 않는 이유는 커밋이 *진단 편의* 값이지 동작에 필요한 값이 아니라서다.

참고로 ghostty 는 태그 빌드면 `1.3.2`, 아니면 `1.3.2-<branch>+<short hash>` 로 조립하고 dirty 는 감지만 하고 문자열에 안 넣는다 ([`GitVersion.zig`](https://github.com/ghostty-org/ghostty/blob/91f66da24527fa02d92b5fd0b41cd020f553a64c/src/build/GitVersion.zig)). 우리는 dirty 를 표시한다 — 로컬 빌드를 쓰는 사람이 이슈를 낼 때 그 구분이 진단 비용을 줄인다.

## 표시 지점 세 곳을 하나로 모은다

새 [`src/version.zig`](https://github.com/ensky0/tildaz/blob/feat/383-version-option/src/version.zig) 의 `version.string` 하나를 `--version` · About 다이얼로그 · 로그의 `[boot]` / `[exit]` 줄이 함께 쓴다. 규칙을 호출처마다 두면 사용자가 이슈에 붙여 온 버전과 로그의 버전이 갈려 어느 쪽이 맞는지 되묻게 된다. 세 값이 모두 comptime 상수라 문자열도 comptime 에 완성되고 runtime 조립·할당이 없다.

About 첫 줄이 `TildaZ v0.7.0 (…)` 이 되는 것은 `about.zig` 의 새 테스트가 `version.string` 과 묶어 고정한다.

## 모르는 인자를 더 이상 조용히 무시하지 않는다

**이슈 본문의 "잘못된 인자는 조용히 `exit(2)`" 는 사실과 달랐다.** 파싱 loop 에 `else` 분기가 없어서 `exit(2)` 는 아는 옵션의 값이 빠졌을 때만이었고, 모르는 인자는 아무 반응 없이 무시됐다. `tildaz --versoin` 같은 오타가 평소처럼 창을 띄워서 사용자가 무엇을 잘못 쳤는지 알 방법이 없었다.

이제 세 갈래 모두 stderr 로 이유를 말하고 `exit(2)` 한다 (종료 코드는 기존 그대로).

```
$ tildaz --versoin
tildaz: unknown option "--versoin"
Run "tildaz --help" to see the available options.

$ tildaz --instance
tildaz: "--instance" needs a value.
Run "tildaz --help" to see the available options.

$ tildaz --instance abc
tildaz: "abc" is not a valid value for "--instance".
Run "tildaz --help" to see the available options.
```

macOS LaunchServices 가 붙일 수 있는 `-psn_*` 는 예외로 걸러 낸다 — 오류로 처리하면 `open TildaZ.app` 이 통째로 실패한다. Qt (`QCoreApplication`) · Chromium 도 같은 접두사로 걸러 낸다.

`--version` / `--help` 는 다른 인자보다 **먼저** 보고 즉시 끝낸다. 창 · 전역 핫키 · worker lock 어느 것도 건드리지 않는다 (이슈의 "세 platform 모두 초기화 앞에서 끝나야 한다" 조건).

`--help` 는 사용자 옵션만 싣는다. 측정용 `-e` · `-size` · `-scrollback` (#381 · #382) 은 [`run_options.zig`](https://github.com/ensky0/tildaz/blob/main/src/run_options.zig) 의 문서 주석대로 내부용이라 넣지 않았다.

## Windows 는 콘솔에 직접 붙는다 (⚠️ 실기 미검증)

`tildaz.exe` 는 `subsystem = .Windows` 라 stdout 이 없어서, 그냥 쓰면 출력이 **아무 데도 나타나지 않는다**. 새 [`src/console.zig`](https://github.com/ensky0/tildaz/blob/feat/383-version-option/src/console.zig) 가

1. 상속받은 std handle 을 **먼저** 본다 — `tildaz --version > out.txt` 리다이렉트를 보존하기 위해서다. 이걸 건너뛰고 바로 `CONOUT$` 를 열면 리다이렉트가 무시되고 콘솔로 새어 나간다.
2. 없으면 `AttachConsole(ATTACH_PARENT_PROCESS)` 후 `CONOUT$` 를 직접 연다.

같은 경로로 `--toggle` 의 "Linux only" 안내도 보낸다 — 기존 `std.debug.print` 는 Windows GUI subsystem 에서 아무 데도 나가지 않았다.

**이 Windows 경로는 실기 미검증이다** (작업 머신이 Linux). 컴파일은 `zig build check` 의 6 타겟으로 확인했다. GUI subsystem 은 셸이 프로세스 종료를 기다리지 않아 출력이 프롬프트 뒤에 찍혀 보일 수 있다 — vim · ghostty 가 콘솔 subsystem 런처를 따로 두는 이유다. 실기에서 문제가 되면 런처 분리는 별도 이슈로 뗀다. **macOS 도 실기 미검증이다.**

## 검증

| 항목 | 결과 |
|---|---|
| `zig build test` | 통과 (`version.zig` 5 · `about.zig` About 회귀 1 신규) |
| `zig build check` | 통과 — Linux · macOS · Windows × x86_64 / aarch64 6 타겟 |
| Linux 실기 | `--version` · `-v` · `--help` · 인자 오류 3 종 · stdout/stderr 분리 |
| 버전 문자열 3 경우 | clean `0.7.0 (60995b9)` / dirty `0.7.0 (d1ad1ff-dirty)` / git 없음 `0.7.0` |
| About 다이얼로그 | 첫 줄 `TildaZ v0.7.0 (d1ad1ff-dirty)` 확인 |
| 로그 `[boot]` | `tildaz v0.7.0 (d1ad1ff-dirty)  pid=41894  exe=…` 확인 |

실기 환경: 노트북 · Intel Core i5-1240P, CachyOS · KDE Plasma · Wayland, 1920x1080 · 59.997 Hz (100 %).

git 없는 빌드는 `zig` 만 있는 `PATH` 로 실제 빌드해서 확인했다 (`0.7.0`, 빌드 exit 0).
