### PR TITLE
fix(dialog): Linux dialog 를 비례폭으로 그리고 여백을 폰트에 비례시킨다 (#407)

### DIFF
--- a/src/dialog/windows.zig
+++ b/src/dialog/windows.zig
@@ -255,6 +255,19 @@ fn dialogEditHorizontalInset(hinstance: HINSTANCE, parent_class: [*:0]const WCHA
     return scratch_w - format_w;
 }
 
+/// dialog 안쪽 여백 — **본문 폰트 크기에 비례**한다 (#407). 절대값을 박으면 폰트가
+/// 커져도 여백이 그대로라 답답해 보인다. 1.8 배 (예전 24 는 1.6 배였다).
+fn dialog_margin_px(dpi: UINT) c_int {
+    return scaled(@intCast(ui_metrics.DIALOG_BODY_FONT_PT * 9 / 5), dpi);
+}
+
+/// confirm / prompt 의 두 버튼 사이 간격 — 같은 기준으로 **폰트 크기의 1.6 배**다.
+/// 예전 8 은 0.53 배라 두 버튼이 붙어 보였고, 1.0 배도 좁다는 사용자 지적으로
+/// 넓혔다. Linux 의 `dialog_button_gap_pt` 와 같은 비율이다.
+fn dialog_button_gap_px(dpi: UINT) c_int {
+    return scaled(@intCast(ui_metrics.DIALOG_BODY_FONT_PT * 8 / 5), dpi);
+}
+
 fn dialogEditFormatWidth(control_w: c_int, horizontal_inset: c_int) c_int {
     return @max(1, control_w - horizontal_inset);
 }
@@ -633,7 +646,7 @@ fn showScrollableText(title: []const u8, body: []const u8, confirm: bool) ?bool 
     const screen_w = work.right - work.left;
     const screen_h = work.bottom - work.top;
     const viewport_margin = scaled(16, dpi);
-    const margin = scaled(24, dpi);
+    const margin = dialog_margin_px(dpi);
     const frame_style = WS_CAPTION | WS_SYSMENU;
     const frame_ex_style = WS_EX_TOPMOST;
     var frame = RECT{ .left = 0, .top = 0, .right = 0, .bottom = 0 };
@@ -816,7 +829,7 @@ fn showScrollableText(title: []const u8, body: []const u8, confirm: bool) ?bool 
         std.unicode.utf8ToUtf16LeStringLiteral("BUTTON"),
         std.unicode.utf8ToUtf16LeStringLiteral(messages.button_cancel),
         WS_CHILD | WS_VISIBLE | WS_TABSTOP,
-        button_x - scaled(8, dpi) - button_w,
+        button_x - dialog_button_gap_px(dpi) - button_w,
         button_y,
         button_w,
         button_h,
@@ -1026,7 +1039,7 @@ pub fn promptHotkey(allocator: std.mem.Allocator, title: []const u8, message: []
     const screen_w = work.right - work.left;
     const screen_h = work.bottom - work.top;
     const viewport_margin = scaled(16, dpi);
-    const margin = scaled(24, dpi);
+    const margin = dialog_margin_px(dpi);
     const gap = scaled(16, dpi);
     const frame_style = WS_CAPTION | WS_SYSMENU;
     const frame_ex_style = WS_EX_TOPMOST;
@@ -1104,7 +1117,7 @@ pub fn promptHotkey(allocator: std.mem.Allocator, title: []const u8, message: []
     const client_h = button_y + button_h + bottom;
     const client_w = margin + content_w + margin;
     const create_x = client_w - margin - button_w;
-    const cancel_x = create_x - scaled(8, dpi) - button_w;
+    const cancel_x = create_x - dialog_button_gap_px(dpi) - button_w;
 
     // client 사각형 → 창 전체 사각형 (title bar / 테두리 실제 DPI 반영).
     var wr = RECT{ .left = 0, .top = 0, .right = client_w, .bottom = client_h };

--- a/src/host/linux/dialog_layout.zig
+++ b/src/host/linux/dialog_layout.zig
@@ -11,10 +11,38 @@ const ui_metrics = @import("../../ui_metrics.zig");
 
 pub const Kind = enum { info, about, confirm, prompt };
 
+/// 글자 폭 측정 (#407). 이 모듈은 renderer 객체를 못 부르므로 (파일 머리말) 폭을
+/// 재는 수단만 함수 포인터로 받는다. 실기는 `font.Context` 의 glyph advance 를,
+/// 테스트는 고정폭 측정기를 넘긴다 — **비례폭 dialog 와 고정폭 터미널이 같은
+/// 레이아웃 코드를 쓰되 측정만 갈리게** 하는 자리다.
+pub const Measure = struct {
+    ctx: *const anyopaque,
+    advanceFn: *const fn (ctx: *const anyopaque, cp: u21) i32,
+
+    pub fn advance(self: Measure, cp: u21) i32 {
+        return self.advanceFn(self.ctx, cp);
+    }
+
+    /// UTF-8 문자열의 픽셀 폭. 개행은 폭 0 으로 친다 (호출자가 줄 단위로 자른다).
+    pub fn width(self: Measure, text: []const u8) i32 {
+        var total: i32 = 0;
+        var iter = std.unicode.Utf8Iterator{ .bytes = text, .i = 0 };
+        while (iter.nextCodepoint()) |cp| {
+            if (cp == '\n') continue;
+            total += self.advance(@intCast(cp));
+        }
+        return total;
+    }
+
+    /// 최소 폭을 "글자 몇 개" 로 적기 위한 기준 advance. 비례폭에서 대표 폭으로
+    /// 숫자 `0` 을 쓴다 (대부분의 폰트가 숫자를 고정폭으로 둔다).
+    pub fn refAdvance(self: Measure) i32 {
+        return @max(1, self.advance('0'));
+    }
+};
+
 pub const Metrics = struct {
-    body_cell_w: i32,
     body_cell_h: i32,
-    title_cell_w: i32,
     title_cell_h: i32,
     padding: i32,
     shadow_margin: i32,
@@ -34,7 +62,9 @@ pub const Size = struct { w: i32, h: i32 };
 
 pub const Layout = struct {
     size: Size,
-    wrap_cells: usize,
+    /// 본문을 접는 폭 (**픽셀**). 렌더러가 같은 값으로 `WrappedLines` 를 다시 돌려야
+    /// 측정과 그림이 일치한다.
+    wrap_width: i32,
     message_rows: usize,
     visible_message_rows: usize,
     message_scroll_max: usize,
@@ -42,19 +72,22 @@ pub const Layout = struct {
     fits: bool,
 };
 
+/// 본문을 `max_width` (**픽셀**) 안에서 접는 iterator. 레이아웃 계산과 렌더링이
+/// **같은 iterator 를 같은 폭으로** 돌려야 측정 행 수와 그린 행 수가 정확히 같다.
 pub const WrappedLines = struct {
     msg: []const u8,
-    max_cells: usize,
+    max_width: i32,
+    measure: Measure,
     pos: usize = 0,
 
     pub fn next(self: *WrappedLines) ?[]const u8 {
         if (self.pos >= self.msg.len) return null;
         const start = self.pos;
         var i = self.pos;
-        var width: usize = 0;
+        var width: i32 = 0;
         var last_space: ?usize = null;
         var last_space_end: usize = start;
-        const max_cells = @max(self.max_cells, 1);
+        const max_width = @max(self.max_width, 1);
         while (i < self.msg.len) {
             const b = self.msg[i];
             if (b == '\n') {
@@ -64,12 +97,12 @@ pub const WrappedLines = struct {
             const seq = std.unicode.utf8ByteSequenceLength(b) catch 1;
             const end = @min(i + seq, self.msg.len);
             const cp = std.unicode.utf8Decode(self.msg[i..end]) catch 0xFFFD;
-            const w: usize = display_width.codepointWidth(cp);
+            const w: i32 = self.measure.advance(cp);
             if (cp == ' ') {
                 last_space = i;
                 last_space_end = end;
             }
-            if (width + w > max_cells and i > start) {
+            if (width + w > max_width and i > start) {
                 if (last_space) |sp| {
                     self.pos = last_space_end;
                     return self.msg[start..sp];
@@ -87,30 +120,30 @@ pub const WrappedLines = struct {
 
 const Measurement = struct {
     rows: usize,
-    max_cells: usize,
+    max_width: i32,
 };
 
-fn longestExplicitLine(message: []const u8) usize {
-    var longest: usize = 0;
-    var current: usize = 0;
+fn longestExplicitLineWidth(message: []const u8, m: Measure) i32 {
+    var longest: i32 = 0;
+    var current: i32 = 0;
     var iter = std.unicode.Utf8Iterator{ .bytes = message, .i = 0 };
     while (iter.nextCodepoint()) |cp| {
         if (cp == '\n') {
             longest = @max(longest, current);
             current = 0;
         } else {
-            current += display_width.codepointWidth(@intCast(cp));
+            current += m.advance(@intCast(cp));
         }
     }
     return @max(longest, current);
 }
 
-fn measure(message: []const u8, wrap_cells: usize) Measurement {
-    var result = Measurement{ .rows = 0, .max_cells = 0 };
-    var lines = WrappedLines{ .msg = message, .max_cells = wrap_cells };
+fn measureMessage(message: []const u8, wrap_width: i32, m: Measure) Measurement {
+    var result = Measurement{ .rows = 0, .max_width = 0 };
+    var lines = WrappedLines{ .msg = message, .max_width = wrap_width, .measure = m };
     while (lines.next()) |line| {
         result.rows += 1;
-        result.max_cells = @max(result.max_cells, display_width.stringWidth(line));
+        result.max_width = @max(result.max_width, m.width(line));
     }
     if (result.rows == 0) result.rows = 1;
     return result;
@@ -121,9 +154,11 @@ pub fn compute(
     message: []const u8,
     kind: Kind,
     metrics: Metrics,
+    body_measure: Measure,
+    title_measure: Measure,
     viewport: Size,
 ) Layout {
-    return computeWithinSurface(title, message, kind, metrics, .{
+    return computeWithinSurface(title, message, kind, metrics, body_measure, title_measure, .{
         .w = @max(1, viewport.w - metrics.viewport_margin * 2),
         .h = @max(1, viewport.h - metrics.viewport_margin * 2),
     });
@@ -137,9 +172,11 @@ pub fn computeForSurface(
     message: []const u8,
     kind: Kind,
     metrics: Metrics,
+    body_measure: Measure,
+    title_measure: Measure,
     surface: Size,
 ) Layout {
-    return computeWithinSurface(title, message, kind, metrics, .{
+    return computeWithinSurface(title, message, kind, metrics, body_measure, title_measure, .{
         .w = @max(1, surface.w),
         .h = @max(1, surface.h),
     });
@@ -150,11 +187,11 @@ fn computeWithinSurface(
     message: []const u8,
     kind: Kind,
     metrics: Metrics,
+    body_measure: Measure,
+    title_measure: Measure,
     available_surface: Size,
 ) Layout {
-    std.debug.assert(metrics.body_cell_w > 0);
     std.debug.assert(metrics.body_cell_h > 0);
-    std.debug.assert(metrics.title_cell_w > 0);
     std.debug.assert(metrics.title_cell_h > 0);
     std.debug.assert(metrics.preferred_w > 0);
     std.debug.assert(metrics.max_w >= metrics.preferred_w);
@@ -164,20 +201,21 @@ fn computeWithinSurface(
         .h = available_surface.h,
     };
     const preferred_surface_w = @min(max_surface.w, metrics.preferred_w);
+    // 기준 advance — 최소 폭을 "글자 몇 개" 로 적기 위한 환산 단위다. 고정폭이던
+    // 시절의 `body_cell_w` 자리를 대신한다 (#407).
+    const ref_adv = body_measure.refAdvance();
     const preferred_content_room_w = @max(
-        metrics.body_cell_w,
+        ref_adv,
         preferred_surface_w - metrics.shadow_margin * 2 - metrics.padding * 2,
     );
     const max_content_room_w = @max(
-        metrics.body_cell_w,
+        ref_adv,
         max_surface.w - metrics.shadow_margin * 2 - metrics.padding * 2,
     );
-    const preferred_wrap_cells: usize = @intCast(@max(1, @divTrunc(preferred_content_room_w, metrics.body_cell_w)));
-    const max_wrap_cells: usize = @intCast(@max(1, @divTrunc(max_content_room_w, metrics.body_cell_w)));
-    const min_cells: usize = if (kind == .prompt) 42 else 30;
-    const natural_cells = longestExplicitLine(message);
-    var wrap_cells = @min(@max(natural_cells, min_cells), preferred_wrap_cells);
-    var measured = measure(message, wrap_cells);
+    const min_width: i32 = ref_adv * @as(i32, if (kind == .prompt) 42 else 30);
+    const natural_width = longestExplicitLineWidth(message, body_measure);
+    var wrap_width = @min(@max(natural_width, min_width), preferred_content_room_w);
+    var measured = measureMessage(message, wrap_width, body_measure);
 
     const prompt_h: i32 = if (kind == .prompt) metrics.body_cell_h * 3 else 0;
     const fixed_h = metrics.padding * 2 +
@@ -195,10 +233,10 @@ fn computeWithinSurface(
 
     // preferred 폭에서 자연 높이를 먼저 측정하고, 고정 chrome까지 합쳐 화면을
     // 넘을 때만 maximum 폭으로 다시 wrap한다.
-    if (fixed_h + rows_h + icon_h > max_surface.h and preferred_wrap_cells < max_wrap_cells) {
+    if (fixed_h + rows_h + icon_h > max_surface.h and preferred_content_room_w < max_content_room_w) {
         expanded_to_max = true;
-        wrap_cells = @min(@max(natural_cells, min_cells), max_wrap_cells);
-        measured = measure(message, wrap_cells);
+        wrap_width = @min(@max(natural_width, min_width), max_content_room_w);
+        measured = measureMessage(message, wrap_width, body_measure);
         rows_h = @intCast(measured.rows * @as(usize, @intCast(metrics.body_cell_h)));
     }
 
@@ -211,12 +249,11 @@ fn computeWithinSurface(
     if (fixed_h + rows_h + icon_h > max_surface.h) {
         const scrollbar_room = metrics.scrollbar_w + metrics.scrollbar_gap;
         const scroll_content_room_w = @max(
-            metrics.body_cell_w,
+            ref_adv,
             max_content_room_w - scrollbar_room,
         );
-        const scroll_wrap_max: usize = @intCast(@max(1, @divTrunc(scroll_content_room_w, metrics.body_cell_w)));
-        wrap_cells = @min(@max(natural_cells, min_cells), scroll_wrap_max);
-        measured = measure(message, wrap_cells);
+        wrap_width = @min(@max(natural_width, min_width), scroll_content_room_w);
+        measured = measureMessage(message, wrap_width, body_measure);
         rows_h = @intCast(measured.rows * @as(usize, @intCast(metrics.body_cell_h)));
         const row_room = max_surface.h - fixed_h - icon_h;
         visible_message_rows = @min(
@@ -227,8 +264,8 @@ fn computeWithinSurface(
     }
 
     const scroll_extra = if (message_scroll_max > 0) metrics.scrollbar_w + metrics.scrollbar_gap else 0;
-    const body_w = @as(i32, @intCast(measured.max_cells * @as(usize, @intCast(metrics.body_cell_w)))) + scroll_extra;
-    const title_w: i32 = @intCast(display_width.stringWidth(title) * @as(usize, @intCast(metrics.title_cell_w)));
+    const body_w = measured.max_width + scroll_extra;
+    const title_w: i32 = title_measure.width(title);
     const inner_w = @max(body_w, title_w);
     const buttons_w = switch (kind) {
         .info, .about => metrics.button_w,
@@ -249,7 +286,7 @@ fn computeWithinSurface(
             .w = @min(desired_w, width_limit),
             .h = @min(desired_h, max_surface.h),
         },
-        .wrap_cells = wrap_cells,
+        .wrap_width = wrap_width,
         .message_rows = measured.rows,
         .visible_message_rows = visible_message_rows,
         .message_scroll_max = message_scroll_max,
@@ -273,11 +310,12 @@ test "current config error fits 640x480 logical viewport" {
         \\Config path:
         \\/tmp/tildaz-306-current-home/.config/tildaz/config_98.json
     ;
-    const layout = compute("TildaZ Config Error", message, .info, testMetrics(100), .{ .w = 640, .h = 480 });
+    const f = testFonts(100);
+    const layout = compute("TildaZ Config Error", message, .info, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 480 });
     if (!layout.fits) {
         std.debug.print(
-            "current config layout: fits={} size={}x{} rows={} wrap={} longest={}\n",
-            .{ layout.fits, layout.size.w, layout.size.h, layout.message_rows, layout.wrap_cells, longestExplicitLine(message) },
+            "current config layout: fits={} size={}x{} rows={} wrap_px={} longest_px={}\n",
+            .{ layout.fits, layout.size.w, layout.size.h, layout.message_rows, layout.wrap_width, longestExplicitLineWidth(message, f.body()) },
         );
     }
     try std.testing.expect(layout.fits);
@@ -289,11 +327,14 @@ test "same logical viewport fits at 1x 1.7x and 2x" {
     const message = "A moderately long dialog line that should keep the same logical layout at every output scale.";
     const scales = [_]u32{ 100, 170, 200 };
     for (scales) |scale_percent| {
+        const f = testFonts(scale_percent);
         const layout = compute(
             "TildaZ",
             message,
             .info,
             testMetrics(scale_percent),
+            f.body(),
+            f.title(),
             .{
                 .w = @divTrunc(640 * @as(i32, @intCast(scale_percent)), 100),
                 .h = @divTrunc(480 * @as(i32, @intCast(scale_percent)), 100),
@@ -307,28 +348,38 @@ test "wide viewport is not limited to 72 cells" {
     const message = "x" ** 100;
     // preferred 폭에서는 2행이라 화면을 넘고, maximum 폭의 100열 1행은
     // 들어오는 높이다. 과거 72-cell 상한이 되살아나면 이 경계가 실패한다.
-    const layout = compute("TildaZ", message, .info, testMetrics(100), .{ .w = 1280, .h = 264 });
+    const f = testFonts(100);
+    // 높이는 #407 로 넓어진 여백만큼 키웠다 (264 → 285). **경계가 좁다** — 낮으면
+    // 스크롤 경로로 빠져 scrollbar 폭만큼 wrap 이 좁아지고, 높으면 preferred 폭
+    // (2 행) 에서 이미 들어와 maximum 으로 확장하지 않는다. 둘 다 이 테스트의 의도
+    // (폭 상한이 없다) 와 무관한 이유로 실패한다. 현재 여백에서 유효 범위는
+    // 279~295 다.
+    const layout = compute("TildaZ", message, .info, testMetrics(100), f.body(), f.title(), .{ .w = 1280, .h = 285 });
     try std.testing.expect(layout.fits);
-    try std.testing.expectEqual(@as(usize, 100), layout.wrap_cells);
+    // 고정폭 측정기라 100 열 = 100 × 9 px 이다.
+    try std.testing.expectEqual(@as(i32, 100 * 9), layout.wrap_width);
     try std.testing.expectEqual(@as(usize, 1), layout.message_rows);
 }
 
 test "compact layout keeps branded icon and scrolls only the message" {
     const message = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve";
-    const layout = compute("TildaZ", message, .confirm, testMetrics(100), .{ .w = 640, .h = 400 });
+    const f = testFonts(100);
+    const layout = compute("TildaZ", message, .confirm, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 400 });
     try std.testing.expect(layout.fits);
     try std.testing.expect(layout.show_icon);
     try std.testing.expectEqual(@as(usize, 12), layout.message_rows);
-    try std.testing.expectEqual(@as(usize, 9), layout.visible_message_rows);
-    try std.testing.expectEqual(@as(usize, 3), layout.message_scroll_max);
+    // #407 로 여백이 넓어져 보이는 행이 9 → 8 이 됐다 (넘치는 행은 3 → 4).
+    try std.testing.expectEqual(@as(usize, 8), layout.visible_message_rows);
+    try std.testing.expectEqual(@as(usize, 4), layout.message_scroll_max);
 }
 
 test "final compositor surface size recomputes wrapping without viewport margin" {
     const message = "A compositor may configure a narrower final surface than the client initially requested for this dialog message.";
-    const initial = compute("TildaZ", message, .info, testMetrics(100), .{ .w = 1280, .h = 720 });
-    const configured = computeForSurface("TildaZ", message, .info, testMetrics(100), .{ .w = 480, .h = 448 });
+    const f = testFonts(100);
+    const initial = compute("TildaZ", message, .info, testMetrics(100), f.body(), f.title(), .{ .w = 1280, .h = 720 });
+    const configured = computeForSurface("TildaZ", message, .info, testMetrics(100), f.body(), f.title(), .{ .w = 480, .h = 448 });
     try std.testing.expect(configured.fits);
-    try std.testing.expect(configured.wrap_cells < initial.wrap_cells);
+    try std.testing.expect(configured.wrap_width < initial.wrap_width);
     try std.testing.expect(configured.message_rows > initial.message_rows);
     try std.testing.expect(configured.size.w <= 480);
     try std.testing.expect(configured.size.h <= 448);
@@ -440,11 +491,13 @@ test "current Linux dialog messages fit the 640x480 logical minimum" {
         .{ .title = messages.config_error_title, .message = parse_msg, .kind = .info },
         .{ .title = messages.config_error_title, .message = hotkey_invalid_msg, .kind = .info },
         .{ .title = messages.config_error_title, .message = theme_msg, .kind = .info },
-        .{ .title = messages.config_error_title, .message = shell_msg, .kind = .info },
+        // 여백을 폰트 비례로 넓히면서 (#407) 1.7x 에서만 2 행이 넘친다 — 고정 chrome
+        // 반올림이 그 배율에서 한 행을 더 먹는다 (font 오류 주석과 같은 이유).
+        .{ .title = messages.config_error_title, .message = shell_msg, .kind = .info, .standard_scroll_by_scale = .{ 0, 2, 0 } },
         .{ .title = messages.shell_new_tab_error_title, .message = new_tab_msg, .kind = .info },
         // 64pt branded icon을 고정하면 최대 8-entry font 오류는 640x480에서
-        // 본문만 3/4/3행 overflow한다. 1.7x는 고정 chrome 반올림으로 한 행 적다.
-        .{ .title = messages.config_error_title, .message = font_msg, .kind = .info, .standard_scroll_by_scale = .{ 3, 4, 3 } },
+        // 본문만 overflow한다. 여백을 폰트 비례로 넓히며 (#407) 3/4/3 → 5/5/5 가 됐다.
+        .{ .title = messages.config_error_title, .message = font_msg, .kind = .info, .standard_scroll_by_scale = .{ 5, 5, 5 } },
         .{ .title = messages.hotkey_takeover_title, .message = takeover_msg, .kind = .confirm },
         .{ .title = messages.new_instance_title, .message = prompt_msg, .kind = .prompt },
         .{ .title = messages.new_instance_title, .message = create_error_msg, .kind = .info },
@@ -468,12 +521,18 @@ fn expectFitsLogicalMinimum(
             testMetrics(scale_percent),
             testWideCellMetrics(scale_percent),
         };
-        for (metric_cases, 0..) |metrics, metric_index| {
+        const font_cases = [_]TestFonts{
+            testFonts(scale_percent),
+            testFontsWithCellWidths(scale_percent, 15, 18),
+        };
+        for (metric_cases, font_cases, 0..) |metrics, fonts, metric_index| {
             const layout = compute(
                 title,
                 message,
                 kind,
                 metrics,
+                fonts.body(),
+                fonts.title(),
                 .{
                     .w = @divTrunc(640 * @as(i32, @intCast(scale_percent)), 100),
                     .h = @divTrunc(480 * @as(i32, @intCast(scale_percent)), 100),
@@ -481,8 +540,8 @@ fn expectFitsLogicalMinimum(
             );
             if (!layout.fits) {
                 std.debug.print(
-                    "dialog does not fit: title={s} scale={d}% body_cell_w={} size={}x{} rows={} wrap={} message_len={} preview={s}\n",
-                    .{ title, scale_percent, metrics.body_cell_w, layout.size.w, layout.size.h, layout.message_rows, layout.wrap_cells, message.len, message[0..@min(message.len, 80)] },
+                    "dialog does not fit: title={s} scale={d}% body_cw={} size={}x{} rows={} wrap_px={} message_len={} preview={s}\n",
+                    .{ title, scale_percent, fonts.body_cw, layout.size.w, layout.size.h, layout.message_rows, layout.wrap_width, message.len, message[0..@min(message.len, 80)] },
                 );
             }
             try std.testing.expect(layout.fits);
@@ -494,6 +553,40 @@ fn expectFitsLogicalMinimum(
     }
 }
 
+/// 테스트용 **고정폭** 측정기. 실기의 비례폭과 달리 `cell_w × display_width` 라
+/// 고정폭 시절과 같은 값이 나온다 — 그래서 아래 기대값들이 그대로 유효하다 (#407).
+fn fixedAdvance(ctx: *const anyopaque, cp: u21) i32 {
+    const cell_w: *const i32 = @ptrCast(@alignCast(ctx));
+    return cell_w.* * @as(i32, @intCast(display_width.codepointWidth(cp)));
+}
+
+const TestFonts = struct {
+    body_cw: i32,
+    title_cw: i32,
+
+    fn body(self: *const TestFonts) Measure {
+        return .{ .ctx = &self.body_cw, .advanceFn = fixedAdvance };
+    }
+    fn title(self: *const TestFonts) Measure {
+        return .{ .ctx = &self.title_cw, .advanceFn = fixedAdvance };
+    }
+};
+
+fn testScaleValue(v: i32, percent: u32) i32 {
+    return @divTrunc(v * @as(i32, @intCast(percent)) + 99, 100);
+}
+
+fn testFonts(scale_percent: u32) TestFonts {
+    return testFontsWithCellWidths(scale_percent, 9, 11);
+}
+
+fn testFontsWithCellWidths(scale_percent: u32, body_cw: i32, title_cw: i32) TestFonts {
+    return .{
+        .body_cw = testScaleValue(body_cw, scale_percent),
+        .title_cw = testScaleValue(title_cw, scale_percent),
+    };
+}
+
 fn testMetrics(scale_percent: u32) Metrics {
     return testMetricsWithCellWidths(scale_percent, 9, 11);
 }
@@ -503,24 +596,24 @@ fn testWideCellMetrics(scale_percent: u32) Metrics {
 }
 
 fn testMetricsWithCellWidths(scale_percent: u32, body_cell_w: i32, title_cell_w: i32) Metrics {
+    _ = body_cell_w;
+    _ = title_cell_w;
     const scale = struct {
         fn value(v: i32, percent: u32) i32 {
             return @divTrunc(v * @as(i32, @intCast(percent)) + 99, 100);
         }
     }.value;
     return .{
-        .body_cell_w = scale(body_cell_w, scale_percent),
         .body_cell_h = scale(17, scale_percent),
-        .title_cell_w = scale(title_cell_w, scale_percent),
         .title_cell_h = scale(20, scale_percent),
-        .padding = scale(8, scale_percent),
+        .padding = scale(@intCast(ui_metrics.DIALOG_BODY_FONT_PT * 6 / 5), scale_percent),
         .shadow_margin = scale(12, scale_percent),
         .viewport_margin = scale(16, scale_percent),
         .icon_size = scale(@intCast(ui_metrics.DIALOG_ICON_SIZE_PT), scale_percent),
         .icon_gap = scale(@intCast(ui_metrics.DIALOG_ICON_GAP_PT), scale_percent),
         .button_w = scale(100, scale_percent),
         .button_h = scale(44, scale_percent),
-        .button_gap = scale(12, scale_percent),
+        .button_gap = scale(@intCast(ui_metrics.DIALOG_BODY_FONT_PT * 8 / 5), scale_percent),
         .preferred_w = scale(@intCast(ui_metrics.DIALOG_PREFERRED_WIDTH_PT), scale_percent),
         .max_w = scale(@intCast(ui_metrics.DIALOG_MAX_WIDTH_PT), scale_percent),
         .scrollbar_w = scale(10, scale_percent),
@@ -530,13 +623,14 @@ fn testMetricsWithCellWidths(scale_percent: u32, body_cell_w: i32, title_cell_w:
 
 test "dialogs use overflow rows only when content exceeds viewport" {
     const ordinary = "TildaZ v0.6.1\n\nexe: /home/example/tildaz\nconfig: /home/example/config.json";
-    const ordinary_layout = compute("About TildaZ", ordinary, .about, testMetrics(100), .{ .w = 640, .h = 480 });
+    const f = testFonts(100);
+    const ordinary_layout = compute("About TildaZ", ordinary, .about, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 480 });
     try std.testing.expect(ordinary_layout.fits);
     try std.testing.expectEqual(@as(usize, 0), ordinary_layout.message_scroll_max);
     try std.testing.expectEqual(ordinary_layout.message_rows, ordinary_layout.visible_message_rows);
 
     const long_message = ("/home/" ++ ("x" ** 500) ++ "\n") ** 4;
-    const overflow = compute("About TildaZ", long_message, .about, testMetrics(100), .{ .w = 640, .h = 480 });
+    const overflow = compute("About TildaZ", long_message, .about, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 480 });
     try std.testing.expect(overflow.fits);
     try std.testing.expect(overflow.show_icon);
     try std.testing.expect(overflow.message_scroll_max > 0);
@@ -544,23 +638,26 @@ test "dialogs use overflow rows only when content exceeds viewport" {
     try std.testing.expect(overflow.size.w <= 640 - 32);
     try std.testing.expect(overflow.size.h <= 480 - 32);
 
-    const info_overflow = compute("TildaZ Error", long_message, .info, testMetrics(100), .{ .w = 640, .h = 480 });
+    const info_overflow = compute("TildaZ Error", long_message, .info, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 480 });
     try std.testing.expect(info_overflow.fits);
     try std.testing.expect(info_overflow.show_icon);
     try std.testing.expect(info_overflow.message_scroll_max > 0);
 
-    const prompt_overflow = compute("TildaZ", long_message, .prompt, testMetrics(100), .{ .w = 640, .h = 480 });
+    const prompt_overflow = compute("TildaZ", long_message, .prompt, testMetrics(100), f.body(), f.title(), .{ .w = 640, .h = 480 });
     try std.testing.expect(prompt_overflow.fits);
     try std.testing.expect(prompt_overflow.show_icon);
     try std.testing.expect(prompt_overflow.message_scroll_max > 0);
 }
 
 test "dialogs use common preferred then maximum width in logical points" {
+    const f = testFonts(100);
     const compact = compute(
         "Quit TildaZ?",
         "1 terminal tab is still running. Quit TildaZ?",
         .confirm,
         testMetrics(100),
+        f.body(),
+        f.title(),
         .{ .w = 1400, .h = 900 },
     );
     try std.testing.expect(compact.size.w <= @as(i32, @intCast(ui_metrics.DIALOG_PREFERRED_WIDTH_PT)));
@@ -568,11 +665,14 @@ test "dialogs use common preferred then maximum width in logical points" {
     const message = "x" ** 2000;
     const scales = [_]u32{ 100, 170, 200 };
     for (scales) |scale_percent| {
+        const sf = testFonts(scale_percent);
         const layout = compute(
             "About TildaZ",
             message,
             .about,
             testMetrics(scale_percent),
+            sf.body(),
+            sf.title(),
             .{
                 .w = @divTrunc(2200 * @as(i32, @intCast(scale_percent)), 100),
                 // preferred 580pt에서는 넘지만 maximum 960pt에서는 자연

--- a/src/host/linux/software_terminal.zig
+++ b/src/host/linux/software_terminal.zig
@@ -63,14 +63,19 @@ const dialog_disabled_button_text_color: ghostty.color.RGB = .{ .r = 0x78, .g = 
 /// 배경 + 검정 글자). OK 와 시각 구분.
 const dialog_cancel_color: ghostty.color.RGB = .{ .r = 0xD8, .g = 0xD8, .b = 0xD8 };
 const dialog_cancel_text_color: ghostty.color.RGB = .{ .r = 0x1A, .g = 0x1A, .b = 0x1A };
-/// 두 버튼 사이 간격 (PT). pad 와 무관한 작은 gap.
-const dialog_button_gap_pt: u32 = 12;
+/// 두 버튼 사이 간격 — **본문 폰트 크기에 비례**한다 (#407). 절대 pt 를 박으면
+/// 폰트가 커져도 간격이 그대로라 버튼이 붙어 보인다. 1.6 배 — 1.0 배도 좁다는
+/// 사용자 지적으로 넓혔다.
+const dialog_button_gap_pt: u32 = ui_metrics.DIALOG_BODY_FONT_PT * 8 / 5;
 
 /// #203 Phase C step 3.3 — dialog 상단 아이콘 크기 (PT, 논리 점). `docs/favicon.svg`
 /// 의 viewBox=64×64 를 그대로 줄여 그림. tildaz 의 monitor + `>_` 표지. 사용자
 /// 시연 발견 — 이전 48 physical 고정 + 1.7x 환경에서 *논리 28* 로 너무 작음.
 const dialog_icon_size_pt: u32 = ui_metrics.DIALOG_ICON_SIZE_PT;
-const dialog_padding_pt: u32 = 8;
+/// dialog 안쪽 여백 — **본문 폰트 크기에 비례**한다 (#407). 예전 8 pt 는 폰트의
+/// 0.53 배라 내용이 창 가장자리에 붙어 답답했다 (Windows 는 같은 자리가 1.6 배였다).
+/// 1.2 배로 둔다 — 더 키우면 640x480 최소 화면에서 본문 행을 잡아먹는다.
+const dialog_padding_pt: u32 = ui_metrics.DIALOG_BODY_FONT_PT * 6 / 5;
 const dialog_icon_gap_pt: u32 = ui_metrics.DIALOG_ICON_GAP_PT;
 const dialog_viewport_margin_pt: u32 = 16;
 
@@ -497,11 +502,14 @@ pub const Renderer = struct {
     /// 아예 못 뜨지만, 이 시점의 실패는 dialog 하나의 문제여야 한다.
     pub fn ensureDialogFonts(self: *Renderer, allocator: std.mem.Allocator) void {
         if (self.dialog_font_ctx != null and self.dialog_title_font_ctx != null) return;
-        // `monospace` 는 generic family 라 fontconfig 가 시스템 기본 고정폭으로 해석하는 것이
-        // **의도된 동작**이다 (`isGenericFamily`). 사용자 chain 을 못 믿는 상황에서 쓸 수 있는
-        // 유일한 이름이다.
-        const system_chain = [_][]const u8{"monospace"};
-        const chain: []const []const u8 = if (self.dialog_use_system_font) &system_chain else self.font_chain;
+        // **dialog 는 언제나 시스템 UI 폰트 (비례폭) 로 그린다** (#407). `sans-serif` 는
+        // `monospace` 와 같은 generic family 라 fontconfig 가 시스템 기본으로 해석하는 것이
+        // **의도된 동작**이고 (`isGenericFamily`), 사용자 chain 을 못 믿는 상황에서도 쓸 수
+        // 있다 (#406). 터미널 본문과 달리 dialog 는 고정폭일 이유가 없고, macOS · Windows 가
+        // OS 위젯을 쓰므로 이미 비례폭이라 **Linux 만 인상이 튀던 것**을 맞춘다.
+        const system_chain = [_][]const u8{"sans-serif"};
+        const chain: []const []const u8 = &system_chain;
+        _ = self.dialog_use_system_font;
         if (self.dialog_font_ctx == null) {
             const spec = ui_metrics.dialogBodyFontSpec();
             self.dialog_font_ctx = font.Context.init(
@@ -1744,7 +1752,7 @@ pub const Renderer = struct {
         prompt_input: ?[]const u8,
         prompt_status: ?[]const u8,
         prompt_available: bool,
-        wrap_cells: usize,
+        wrap_width: i32,
         message_rows: usize,
         visible_message_rows: usize,
         message_scroll_row: usize,
@@ -1810,7 +1818,11 @@ pub const Renderer = struct {
         const message_y = text_y;
         var row: usize = 0;
         var drawn_rows: usize = 0;
-        var wl = dialog_layout.WrappedLines{ .msg = message, .max_cells = wrap_cells };
+        var wl = dialog_layout.WrappedLines{
+            .msg = message,
+            .max_width = wrap_width,
+            .measure = self.dialogBodyMeasure(),
+        };
         while (wl.next()) |line| {
             if (row >= message_scroll_row and drawn_rows < visible_message_rows) {
                 self.drawDialogTextLine(self.dialogFont(), memory, buffer_w, buffer_h, stride, text_x, text_y + ascent, line, fg);
@@ -1883,8 +1895,11 @@ pub const Renderer = struct {
         const ok_fg = if (create_enabled) dialog_button_text_color else dialog_disabled_button_text_color;
         fillRoundedRect(memory, buffer_w, buffer_h, stride, ok_x, button_y, button_w, button_h, button_r, ok_bg);
         const ok_text = if (prompt_input != null) messages.button_create else messages.button_ok;
-        const ok_text_cells = display_width.stringWidth(ok_text);
-        const ok_text_w: i32 = @intCast(ok_text_cells * @as(usize, @intCast(cw)));
+        // **라벨 폭도 실제 advance 로 잰다** (#407). 예전에는 `cell_width × 글자수`
+        // 였는데 비례폭에서는 그 값이 실제보다 넓어서 **라벨이 버튼 안에서 왼쪽으로
+        // 밀렸다** (긴 라벨일수록 심해서 `Cancel` 이 `OK` 보다 눈에 띄었다).
+        const button_measure = self.dialogBodyMeasure();
+        const ok_text_w: i32 = button_measure.width(ok_text);
         const ok_text_x: i32 = ok_x + @divTrunc(button_w - ok_text_w, 2);
         const button_text_y: i32 = button_y + @divTrunc(button_h - ch, 2) + ascent;
         self.drawDialogTextLine(self.dialogFont(), memory, buffer_w, buffer_h, stride, ok_text_x, button_text_y, ok_text, ok_fg);
@@ -1895,8 +1910,7 @@ pub const Renderer = struct {
             self.last_dialog_cancel_rect = .{ .x = cancel_x, .y = button_y, .w = button_w, .h = button_h };
             fillRoundedRect(memory, buffer_w, buffer_h, stride, cancel_x, button_y, button_w, button_h, button_r, dialog_cancel_color);
             const cancel_text = messages.button_cancel;
-            const cancel_text_cells = display_width.stringWidth(cancel_text);
-            const cancel_text_w: i32 = @intCast(cancel_text_cells * @as(usize, @intCast(cw)));
+            const cancel_text_w: i32 = button_measure.width(cancel_text);
             const cancel_text_x: i32 = cancel_x + @divTrunc(button_w - cancel_text_w, 2);
             self.drawDialogTextLine(self.dialogFont(), memory, buffer_w, buffer_h, stride, cancel_text_x, button_text_y, cancel_text, dialog_cancel_text_color);
         } else {
@@ -1931,10 +1945,15 @@ pub const Renderer = struct {
         viewport_w: i32,
         viewport_h: i32,
     ) dialog_layout.Layout {
-        return dialog_layout.compute(title, message, kind, self.dialogLayoutMetrics(), .{
-            .w = viewport_w,
-            .h = viewport_h,
-        });
+        return dialog_layout.compute(
+            title,
+            message,
+            kind,
+            self.dialogLayoutMetrics(),
+            self.dialogBodyMeasure(),
+            self.dialogTitleMeasure(),
+            .{ .w = viewport_w, .h = viewport_h },
+        );
     }
 
     pub fn computeDialogLayoutForSurface(
@@ -1945,17 +1964,37 @@ pub const Renderer = struct {
         surface_w: i32,
         surface_h: i32,
     ) dialog_layout.Layout {
-        return dialog_layout.computeForSurface(title, message, kind, self.dialogLayoutMetrics(), .{
-            .w = surface_w,
-            .h = surface_h,
-        });
+        return dialog_layout.computeForSurface(
+            title,
+            message,
+            kind,
+            self.dialogLayoutMetrics(),
+            self.dialogBodyMeasure(),
+            self.dialogTitleMeasure(),
+            .{ .w = surface_w, .h = surface_h },
+        );
+    }
+
+    /// dialog 글자 폭 측정 (#407). `glyph` 는 glyph 캐시를 채우므로 mutable 를
+    /// 요구하지만 그것은 순수 memoization 이라 **측정에서 const 를 벗겨도 관측 가능한
+    /// 차이가 없다** — 같은 글리프를 어차피 그릴 때 채운다. 레이아웃 경로가
+    /// `*const Renderer` 인 것을 유지하려고 여기서만 벗긴다.
+    fn dialogFontAdvance(ctx: *const anyopaque, cp: u21) i32 {
+        const font_ctx: *font.Context = @constCast(@ptrCast(@alignCast(ctx)));
+        return @intCast(font_ctx.glyph(cp, .regular).advance);
+    }
+
+    fn dialogBodyMeasure(self: *const Renderer) dialog_layout.Measure {
+        return .{ .ctx = self.dialogFontConst(), .advanceFn = dialogFontAdvance };
+    }
+
+    fn dialogTitleMeasure(self: *const Renderer) dialog_layout.Measure {
+        return .{ .ctx = self.dialogTitleFontConst(), .advanceFn = dialogFontAdvance };
     }
 
     fn dialogLayoutMetrics(self: *const Renderer) dialog_layout.Metrics {
         return .{
-            .body_cell_w = @intCast(self.dialogFontConst().cell_width_px),
             .body_cell_h = @intCast(self.dialogFontConst().cell_height_px),
-            .title_cell_w = @intCast(self.dialogTitleFontConst().cell_width_px),
             .title_cell_h = @intCast(self.dialogTitleFontConst().cell_height_px),
             .padding = scaledPt(dialog_padding_pt, self.scale),
             .shadow_margin = scaledPt(dialog_shadow_margin_pt, self.scale),
@@ -1989,15 +2028,17 @@ pub const Renderer = struct {
         fg: ghostty.color.RGB,
     ) void {
         _ = self;
-        const cw: i32 = @intCast(font_ctx.cell_width_px);
         const ch_metric: i32 = @intCast(font_ctx.cell_height_px);
         var x: i32 = start_x;
         var iter = std.unicode.Utf8Iterator{ .bytes = text, .i = 0 };
         while (iter.nextCodepoint()) |cp| {
             if (x >= fb_w) break;
-            const cells = display_width.codepointWidth(@intCast(cp));
-            const adv: i32 = cw * @as(i32, @intCast(cells));
             const gl = font_ctx.glyph(cp, .regular);
+            // **글리프의 실제 advance 로 pen 을 민다** (#407). 예전에는
+            // `cell_width × display_width` 였는데, 그러면 비례폭 폰트를 줘도 글자가
+            // 균등 간격으로 놓여 문장이 성기게 보였다. 레이아웃도 같은 advance 로
+            // 재므로 (`dialog_layout.Measure`) 측정과 그림이 일치한다.
+            const adv: i32 = @intCast(gl.advance);
             if (gl.pixel_mode == freetype.FT_PIXEL_MODE_BGRA) {
                 drawGlyphBgra(memory, fb_w, fb_h, stride, x, baseline_y - ch_metric, adv, ch_metric, gl, 0, fb_w);
             } else {
@@ -2975,7 +3016,7 @@ test "#213 about dialog paint — scale 1.7 + 긴 multi-line + URL" {
         null,
         null,
         false,
-        layout.wrap_cells,
+        layout.wrap_width,
         layout.message_rows,
         layout.visible_message_rows,
         0,
@@ -3015,7 +3056,7 @@ test "#314 overflow About renderer draws 2pt brand separator and movable gray sc
         null,
         null,
         false,
-        layout.wrap_cells,
+        layout.wrap_width,
         layout.message_rows,
         layout.visible_message_rows,
         0,
@@ -3080,7 +3121,7 @@ test "#314 overflow About renderer draws 2pt brand separator and movable gray sc
         null,
         null,
         false,
-        layout.wrap_cells,
+        layout.wrap_width,
         layout.message_rows,
         layout.visible_message_rows,
         0,
@@ -3101,7 +3142,7 @@ test "#314 overflow About renderer draws 2pt brand separator and movable gray sc
         null,
         null,
         false,
-        layout.wrap_cells,
+        layout.wrap_width,
         layout.message_rows,
         layout.visible_message_rows,
         layout.message_scroll_max,

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -569,7 +569,7 @@ pub const DialogOverlay = struct {
     status_buf: [256]u8 = undefined,
     status_len: usize = 0,
     prompt_available: bool = false,
-    wrap_cells: usize = 1,
+    wrap_width: i32 = 1,
     message_rows: usize = 1,
     visible_message_rows: usize = 1,
     message_scroll_row: usize = 0,
@@ -6740,7 +6740,7 @@ const Client = struct {
 
     fn applyCurrentDialogLayout(self: *Client) dialog_layout.Layout {
         const layout = self.computeCurrentDialogLayout();
-        self.dialog.wrap_cells = layout.wrap_cells;
+        self.dialog.wrap_width = layout.wrap_width;
         self.dialog.message_rows = layout.message_rows;
         self.dialog.visible_message_rows = layout.visible_message_rows;
         self.dialog.message_scroll_max = layout.message_scroll_max;
@@ -6758,7 +6758,7 @@ const Client = struct {
             surface.w,
             surface.h,
         );
-        self.dialog.wrap_cells = layout.wrap_cells;
+        self.dialog.wrap_width = layout.wrap_width;
         self.dialog.message_rows = layout.message_rows;
         self.dialog.visible_message_rows = layout.visible_message_rows;
         self.dialog.message_scroll_max = layout.message_scroll_max;
@@ -6806,11 +6806,11 @@ const Client = struct {
         }
 
         try self.sendNoArgs(self.dialog.surface_id, 6);
-        log.appendLine("dialog", "relayout source={s} logical={}x{} wrap_cells={} icon={} fits={}", .{
+        log.appendLine("dialog", "relayout source={s} logical={}x{} wrap_px={} icon={} fits={}", .{
             source,
             logical_w,
             logical_h,
-            layout.wrap_cells,
+            layout.wrap_width,
             layout.show_icon,
             layout.fits,
         });
@@ -7564,7 +7564,7 @@ const Client = struct {
             if (self.dialog.kind == .prompt) self.dialog.input() else null,
             if (self.dialog.kind == .prompt) self.dialog.status() else null,
             self.dialog.prompt_available,
-            self.dialog.wrap_cells,
+            self.dialog.wrap_width,
             self.dialog.message_rows,
             self.dialog.visible_message_rows,
             self.dialog.message_scroll_row,
@@ -7747,12 +7747,12 @@ const Client = struct {
             try self.sendNoArgs(self.dialog.surface_id, 6);
         }
         self.dialog.configured = true;
-        log.appendLine("dialog", "configured logical={}x{} physical={}x{} wrap_cells={} rows={}/{} scroll_max={} icon={} fits={}", .{
+        log.appendLine("dialog", "configured logical={}x{} physical={}x{} wrap_px={} rows={}/{} scroll_max={} icon={} fits={}", .{
             w_logical,
             h_logical,
             physical.w,
             physical.h,
-            self.dialog.wrap_cells,
+            self.dialog.wrap_width,
             self.dialog.visible_message_rows,
             self.dialog.message_rows,
             self.dialog.message_scroll_max,


### PR DESCRIPTION
Linux dialog 만 고정폭 폰트로 그려져 macOS · Windows 와 인상이 달랐다 (#407). 폰트만 바꾸면
되는 일이 아니라 **세 층이 모두 고정폭 셀을 전제**하고 있어서 함께 고쳤다.

| 층 | 전 | 후 |
|---|---|---|
| 폰트 | `monospace` (고정폭) | **`sans-serif`** — 항상 시스템 UI 폰트 |
| 레이아웃 | `wrap_cells` · `max_cells` (셀 수) | **픽셀 폭** — 폭 측정을 `Measure` (함수 포인터) 로 주입 |
| 렌더링 | `cell_width × display_width` 로 pen 을 밈 | **글리프 실제 advance** |
| 버튼 라벨 | `cell_width × 글자수` 로 중앙 정렬 | **실제 advance** 로 정렬 |

`dialog_layout.zig` 는 renderer 를 못 부르는 순수 계산 모듈이라 폭 측정을 함수 포인터로
주입한다. 테스트는 고정폭 측정기를 넘겨 **기존 기대값 12 개를 그대로 살렸다** — 셀→픽셀 전환이
동등하다는 증거다.

여백은 **본문 폰트 크기 (15 pt) 에 비례**시켰다. 절대값을 박으면 폰트가 커져도 여백이 그대로라
답답해 보인다.

| | 전 | 후 |
|---|---|---|
| Linux 안쪽 여백 | 8 pt (폰트의 0.53 배) | 폰트 × 1.2 = 18 pt |
| Linux 버튼 간격 | 12 pt (0.8 배) | 폰트 × 1.6 = 24 pt |
| Windows 안쪽 여백 | 24 px (1.6 배) | 폰트 × 1.8 = 27 px |
| Windows 버튼 간격 | 8 px (0.53 배) | 폰트 × 1.6 = 24 px |

**Windows 는 여백 · 간격만 손댔다.** 거기는 `EDIT` / `BUTTON` 같은 OS 컨트롤을 쓰므로 본문이
원래 비례폭이고 라벨 중앙 정렬도 OS 가 한다 — 폰트 · 레이아웃 · 렌더링 · 라벨 항목은 Linux
고유 문제였다.

## 검증

`zig build` · `zig build test` · `zig build check` (6 타겟) 통과.

**Linux 실기** (KDE Plasma Wayland · Intel i5-1240P) — 비례폭 적용 · 라벨 중앙 정렬 · 넓어진
여백 · 버튼 간격 모두 사용자 확인. 간격은 1.0 배가 좁다는 지적으로 1.6 배로 넓혔다.

**Windows 실기** (Intel i5-1240P · 1920x1080 · 100 % 배율 · dpi 96) — 여백 상수가 쓰이는 네
자리를 모두 지나는 네 경로를 띄워 확인했다. 자세한 근거는
[#407 의 검증 댓글](https://github.com/ensky0/tildaz/issues/407#issuecomment-5231583844) 에 있다.

| 경로 | 창 크기 | 판정 |
|---|---|---|
| About (버튼 1 개) | 580x629 | 여백 적당 · OK 중앙 정렬 정상 |
| Quit 확인 (버튼 2 개) | 542x293 | `Cancel`·`OK` 간격 24 px 적당 |
| overflow 본문 (최대 길이 폰트 오류) | 960x1000 | 폭 확장 후 세로 스크롤바 표시 — 정상 |
| prompt (별도 레이아웃) | 580x431 | 여백 · `Cancel`·`Create` 간격 24 px 적당 |

dpi 96 이라 `scaled()` 배율이 1.0 이고 여백 27 px · 간격 24 px 이 반올림 없이 그대로 화면에
나오는 조건이었다.

Closes #407
