### PR TITLE
fix(config): 인스턴스 간 핫키 중복을 기동 시 잡고 겹친 상대를 알려준다 (#431)

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,9 @@ const themes = @import("themes.zig");
 const dialog = @import("dialog.zig");
 const messages = @import("messages.zig");
 const instance_context = @import("instance_context.zig");
+// #431 — 기동 시 인스턴스 간 핫키 중복 검사. `instances.zig` 도 이 모듈을 import 하지만
+// (`config.Hotkey`), 서로의 *값*에 의존하지 않아 순환 참조가 성립한다.
+const instances = @import("instances.zig");
 const paths = @import("paths.zig");
 const font_validate = @import("font/validate.zig");
 const font_constants = @import("font/constants.zig");
@@ -904,26 +907,60 @@ pub const Config = struct {
         };
         defer allocator.free(path);
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch {
-            // #382 — 측정 인스턴스는 **사용자 설정을 만들지 않는다.** config 는 worker 와
-            // 공유하지만 (같은 폰트 · 테마로 재야 다른 터미널과의 비교가 성립한다) 그것은
-            // *읽기* 까지다. 파일이 없는 기계에서 하네스를 먼저 돌리면 측정 프로세스가
-            // 사용자 config 를 만드는 주체가 되는데, 그것은 launcher 의 일이다
-            // (`instances.createDefaultConfig` — auto_start · 단축키 동기화까지 함께 한다).
-            // 측정은 기본값을 메모리에서만 쓰고 지나간다.
-            if (!instance_context.isStress()) createDefault(allocator, path, shell_resolved);
-            return defaultOwned(allocator, shell_resolved);
-        };
-        defer file.close();
+        const loaded = blk: {
+            const file = std.fs.openFileAbsolute(path, .{}) catch {
+                // #382 — 측정 인스턴스는 **사용자 설정을 만들지 않는다.** config 는 worker 와
+                // 공유하지만 (같은 폰트 · 테마로 재야 다른 터미널과의 비교가 성립한다) 그것은
+                // *읽기* 까지다. 파일이 없는 기계에서 하네스를 먼저 돌리면 측정 프로세스가
+                // 사용자 config 를 만드는 주체가 되는데, 그것은 launcher 의 일이다
+                // (`instances.createDefaultConfig` — auto_start · 단축키 동기화까지 함께 한다).
+                // 측정은 기본값을 메모리에서만 쓰고 지나간다.
+                if (!instance_context.isStress()) createDefault(allocator, path, shell_resolved);
+                break :blk defaultOwned(allocator, shell_resolved);
+            };
+            defer file.close();
 
-        const content = file.readToEndAlloc(allocator, 64 * 1024) catch {
-            return defaultOwned(allocator, shell_resolved);
-        };
-        defer allocator.free(content);
+            const content = file.readToEndAlloc(allocator, 64 * 1024) catch {
+                break :blk defaultOwned(allocator, shell_resolved);
+            };
+            defer allocator.free(content);
 
-        // disk 정상 — parse 가 JSON 의 shell 을 dupe 하므로 인자는 미사용. 누수 방지 free.
-        allocator.free(shell_resolved);
-        return parse(allocator, content, path);
+            // disk 정상 — parse 가 JSON 의 shell 을 dupe 하므로 인자는 미사용. 누수 방지 free.
+            allocator.free(shell_resolved);
+            break :blk parse(allocator, content, path);
+        };
+
+        // #431 — 핫키 중복 검사는 **여기 한 곳**이다. `parse` 안에 두면 위의 두 fallback
+        // (파일 없음 · 못 읽음) 이 구멍으로 남는데, 그 경로가 쓰는 `Defaults.hotkey` 는
+        // config_0 의 기본값과 **같은 키**라 오히려 겹치기 쉽다 (`tildaz --instance 9` 처럼
+        // config 없는 index 로 직접 띄우는 경우).
+        fatalIfHotkeyTakenByLowerIndex(allocator, loaded.hotkey, path);
+        return loaded;
+    }
+
+    /// **뒤에 있는 것이 양보한다** ([#431](https://github.com/ensky0/tildaz/issues/431)) —
+    /// 자기보다 낮은 index 가 같은 전역 핫키를 쓰면 이 인스턴스가 멈춘다. 겹친 두 인스턴스는
+    /// 양쪽 다 중복을 감지하므로, 규칙이 없으면 둘 다 안 뜬다.
+    ///
+    /// 세 platform 이 여기서 함께 덮인다. 전에는 Windows 만 `RegisterHotKey` 실패로 뒤늦게
+    /// 걸렸고 (원인이 자기 다른 인스턴스인지 알 수 없는 안내였다), macOS 는 `CGEventTap` 이
+    /// 배타 등록이 아니라 **두 인스턴스가 같은 키에 함께 반응**했다.
+    fn fatalIfHotkeyTakenByLowerIndex(allocator: std.mem.Allocator, hotkey: Hotkey, config_path: []const u8) void {
+        // 측정 인스턴스는 전역 핫키를 등록하지 않는다 (#382). worker index 가 없으면
+        // (단위 테스트 등) 비교할 자기 자신이 없다.
+        if (instance_context.isStress()) return;
+        const self_index = instance_context.workerIndex() orelse return;
+        const owner = instances.lowerIndexHotkeyConflict(allocator, self_index, hotkey) orelse return;
+
+        // 사용자가 적은 원문 대신 canonical 표기를 쓴다 — fallback 경로에는 원문 자체가 없다.
+        var key_buf: [64]u8 = undefined;
+        var msg_buf: [384]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &msg_buf,
+            messages.config_hotkey_duplicate_format,
+            .{ hotkeyDisplay(&key_buf, hotkey), owner },
+        ) catch messages.config_hotkey_duplicate_fallback_msg;
+        showConfigFatalMsg(config_path, msg);
     }
 
     /// #218 — fail 경로 공통: shell 은 인수한 `shell_resolved`(owned) 보관, static

--- a/src/instances.zig
+++ b/src/instances.zig
@@ -490,6 +490,84 @@ pub fn hotkeyOwner(allocator: std.mem.Allocator, indices: []const u32, candidate
     return null;
 }
 
+/// 기동 시 핫키 중복 판정에 쓰는 한 인스턴스의 상태. `hotkey` 가 `null` 이면 그 config 를
+/// 읽거나 파싱하지 못했다는 뜻이다.
+pub const HotkeyEntry = struct { index: u32, hotkey: ?config.Hotkey };
+
+/// **뒤에 있는 것이 양보한다** ([#431](https://github.com/ensky0/tildaz/issues/431)) —
+/// `self_index` 보다 **낮은** index 중 같은 핫키를 쓰는 가장 작은 index 를 돌려준다.
+///
+/// 이 방향이 필요한 이유: 겹친 두 인스턴스는 *양쪽 다* 중복을 감지한다. 규칙 없이 둘 다
+/// 멈추면 사용자는 아무 인스턴스도 못 쓴다. 낮은 쪽을 살려 두면 항상 정확히 한 쪽만 멈춘다.
+///
+/// `hotkey == null` 인 항목은 건너뛴다 — *남의* config 가 깨져서 내가 못 뜨는 일을 만들지
+/// 않는다. 같은 파일을 읽는 `hotkeyOwner` 가 `error.InvalidConfig` 를 전파하는 것과 정책이
+/// 반대인데, 그쪽은 사용자가 키를 **고르는 중**이라 "검사하지 못했다" 를 알려야 해서다
+/// (`dialog.HotkeyValidation.check_failed`).
+///
+/// I/O 가 없어 단위 테스트가 그대로 태울 수 있다 — 디스크를 읽는 부분은
+/// `lowerIndexHotkeyConflict` 가 맡는다.
+pub fn conflictingLowerIndex(entries: []const HotkeyEntry, self_index: u32, candidate: config.Hotkey) ?u32 {
+    var winner: ?u32 = null;
+    for (entries) |entry| {
+        if (entry.index >= self_index) continue;
+        const existing = entry.hotkey orelse continue;
+        if (!std.meta.eql(existing, candidate)) continue;
+        if (winner == null or entry.index < winner.?) winner = entry.index;
+    }
+    return winner;
+}
+
+/// 디스크의 다른 config 를 읽어 `conflictingLowerIndex` 에 넘긴다. 목록 자체를 못 얻거나
+/// 메모리가 없으면 `null` — **검사를 못 했다고 기동을 막지는 않는다** (전역 핫키 등록 실패는
+/// 그 뒤 단계에서 여전히 잡힌다).
+pub fn lowerIndexHotkeyConflict(allocator: std.mem.Allocator, self_index: u32, candidate: config.Hotkey) ?u32 {
+    const indices = listConfigIndices(allocator) catch return null;
+    defer allocator.free(indices);
+
+    const entries = allocator.alloc(HotkeyEntry, indices.len) catch return null;
+    defer allocator.free(entries);
+    for (indices, 0..) |index, i| {
+        const parsed: ?config.Hotkey = blk: {
+            const text = configHotkeyText(allocator, index) catch break :blk null;
+            defer allocator.free(text);
+            break :blk config.Hotkey.fromString(text);
+        };
+        entries[i] = .{ .index = index, .hotkey = parsed };
+    }
+    return conflictingLowerIndex(entries, self_index, candidate);
+}
+
+test "핫키 중복은 뒤에 있는 인스턴스가 양보한다 (#431)" {
+    const f1 = config.Hotkey.fromString("F1").?;
+    const f2 = config.Hotkey.fromString("F2").?;
+    const entries = [_]HotkeyEntry{
+        .{ .index = 0, .hotkey = f1 },
+        .{ .index = 3, .hotkey = f1 },
+        .{ .index = 5, .hotkey = f2 },
+        .{ .index = 7, .hotkey = null }, // 읽기·파싱 실패 — 건너뛴다
+        .{ .index = 9, .hotkey = f1 },
+    };
+
+    // 낮은 index 가 이미 쓰고 있으면 그 index. 여럿이면 가장 작은 것.
+    try std.testing.expectEqual(@as(?u32, 0), conflictingLowerIndex(&entries, 9, f1));
+    try std.testing.expectEqual(@as(?u32, 0), conflictingLowerIndex(&entries, 3, f1));
+
+    // 자기보다 높은 index 는 보지 않는다 — 양보는 뒤에 있는 쪽 몫이다.
+    try std.testing.expectEqual(@as(?u32, null), conflictingLowerIndex(&entries, 0, f1));
+    try std.testing.expectEqual(@as(?u32, null), conflictingLowerIndex(&entries, 5, f2));
+
+    // 같은 index (자기 자신) 도 충돌이 아니다.
+    try std.testing.expectEqual(@as(?u32, null), conflictingLowerIndex(entries[0..1], 0, f1));
+
+    // 겹치는 키가 없으면 null.
+    try std.testing.expectEqual(@as(?u32, null), conflictingLowerIndex(&entries, 9, config.Hotkey.fromString("F4").?));
+
+    // hotkey == null 인 항목은 어떤 후보와도 안 겹친다.
+    const only_null = [_]HotkeyEntry{.{ .index = 1, .hotkey = null }};
+    try std.testing.expectEqual(@as(?u32, null), conflictingLowerIndex(&only_null, 2, f1));
+}
+
 test "only canonical numbered config names are accepted" {
     try std.testing.expectEqual(@as(?u32, 0), parseConfigFileName("config_0.json"));
     try std.testing.expectEqual(@as(?u32, 42), parseConfigFileName("config_42.json"));

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -308,6 +308,15 @@ pub const config_field_integer_range_required_format = "Configuration: \"{s}\" m
 pub const config_unknown_theme_header_format = "Configuration: unknown theme \"{s}\"\n\nAvailable themes:\n";
 pub const config_hotkey_invalid_format = "Configuration: failed to parse \"hotkey\" value \"{s}\".\n\nOnly F1-F12 may be used without modifiers. Other keys require Ctrl, Alt, Super, or Cmd.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_invalid_fallback_msg = "Configuration: hotkey invalid";
+/// #431 — 다른 TildaZ 인스턴스가 이미 쓰는 전역 핫키. 뒤에 있는 (index 가 큰) 쪽이 양보하므로
+/// 이 메시지는 그 인스턴스에만 나온다. **겹친 상대를 번호로 짚어 주는 것이 핵심이다** — 예전엔
+/// Windows 의 `RegisterHotKey` 실패 안내가 "Another app already registered the same combination"
+/// 이라고만 해서, 원인이 자기 다른 인스턴스라는 것도 몇 번인지도 알 수 없었다.
+pub const config_hotkey_duplicate_format =
+    "The hotkey \"{s}\" is already used by TildaZ {d}.\n\n" ++
+    "Each TildaZ instance needs its own global hotkey. Change \"hotkey\" in this instance's config and start it again.";
+pub const config_hotkey_duplicate_fallback_msg =
+    "This hotkey is already used by another TildaZ instance. Change \"hotkey\" in this instance's config and start it again.";
 pub const config_font_family_empty_msg = "Configuration: \"font.family\" must not be empty.";
 pub const config_font_chain_too_long_format = "Configuration: font.family + glyph_fallback total exceeds {d} entries.";
 pub const config_font_chain_too_long_fallback_msg = "Configuration: font chain too long";


### PR DESCRIPTION
핫키 중복 검사가 **새 인스턴스 프롬프트에만** 있었다 (#431). `config_N.json` 을 직접 고쳐 같은
핫키를 만들면 **세 platform 어디에서도 검사하지 않았고**, 그 뒤 벌어지는 일만 갈렸다.

| platform | 겹친 채로 띄우면 (전) |
|---|---|
| **Windows** | `RegisterHotKey` 실패 → *"Another app already registered the same combination"* — 원인이 자기 다른 인스턴스인지, 몇 번인지 알 수 없다 |
| **macOS** | `CGEventTap` 은 배타 등록이 아니라 **두 인스턴스가 같은 키에 함께 반응** — 실패 안내조차 없다 |
| **Linux** | 등록 주체가 DE 라 또 다르다 |

## 무엇을 했나

`Config.load` 끝에서 **한 번** 검사한다 (`showConfigFatalMsg` — 다른 config 검증 fatal 과 같은
방식). cross-platform 경로라 세 host 가 함께 덮인다.

**`parse` 가 아니라 `load` 인 이유가 있다.** `load` 는 config 파일이 없거나 못 읽으면 `parse` 를
아예 거치지 않고 기본값을 돌려주는데, 그 경로가 쓰는 `Defaults.hotkey` 는 config_0 의 기본값과
**같은 키**라 오히려 겹치기 쉽다 — `tildaz --instance 9` 처럼 config 없는 index 로 직접 띄우면
F1 짜리 config 가 새로 만들어지며 config_0 과 부딪힌다. 검사를 `parse` 안에 두면 이 경로가 그대로
구멍으로 남는다. 두 경로가 합류하는 `load` 끝이 단일 확인 지점이다. 원문 문자열이 없는 경로가
있으므로 표시는 `hotkeyDisplay` 의 canonical 표기를 쓴다.

**규칙 — 뒤에 있는 것이 양보한다.** 자기보다 **낮은** index 가 같은 핫키를 쓰면 그 쪽이
멈춘다. 겹친 두 인스턴스는 *양쪽 다* 중복을 감지하므로 규칙이 없으면 둘 다 안 뜬다. 낮은 쪽을
살려 두면 **항상 정확히 한 쪽만** 멈춘다.

```
The hotkey "Ctrl+Alt+F9" is already used by TildaZ 2.

Each TildaZ instance needs its own global hotkey. Change "hotkey" in this
instance's config and start it again.

Config path:
  C:\Users\ensky0\AppData\Roaming\tildaz\config_8.json
```

### 설계 선택 두 가지

**① 판정부를 순수 함수로 분리했다.** `conflictingLowerIndex` 는 I/O 가 없어 단위 테스트가
그대로 태운다 (낮은 index 충돌 / 높은 index 무시 / 자기 자신 무시 / `null` 건너뛰기 / 충돌
없음). 디스크를 읽는 `lowerIndexHotkeyConflict` 는 그 위의 얇은 wrapper 다.

**② 다른 인스턴스의 config 가 깨졌으면 그 항목만 건너뛴다.** *남의* config 때문에 내가 못 뜨는
일을 만들지 않는다. 같은 파일을 읽는 `hotkeyOwner` 는 `error.InvalidConfig` 를 전파하는데 **그
쪽은 그대로 두었다** — 프롬프트는 사용자가 키를 *고르는 중*이라 "검사하지 못했다"
(`HotkeyValidation.check_failed`) 를 알리는 것이 의도된 동작이다. 정책이 반대라 함수를 나눴다.

측정 인스턴스는 전역 핫키를 등록하지 않으므로 (#382) 검사 대상이 아니다.

## 검증

`zig build test` · `zig build check` (6 타겟) 통과.

**Windows 실기** (Intel i5-1240P · 1920x1080 · Windows 11) — `config_2` 와 `config_8` 을 같은
`Ctrl+Alt+F9` 로 두고 확인했다. `config_0` (daily) 은 `F1` 이라 어느 쪽과도 겹치지 않는다.

| 확인 | 결과 |
|---|---|
| instance **8** 기동 | **막힘** — 위 문구가 `TildaZ 2` 를 지목 |
| instance **2** 기동 | **정상** — 자기보다 낮은 index 중 겹치는 것이 없다 |
| **config 없는 index 9** 로 직접 기동 | **막힘** — 기본 `F1` 이 config_0 과 겹쳐 *"The hotkey "F1" is already used by TildaZ 0."* (`parse` 를 안 거치는 fallback 경로) |
| 프롬프트 경로 회귀 | 기존 안내 *"Already used by TildaZ 0."* + `Create` 비활성 **그대로** |

**Linux · macOS 는 실기를 하지 않았다.** 감지 코드가 `Config.parse` 한 곳이고 판정부가 순수
함수라 단위 테스트가 platform 무관하게 같은 것을 검증한다. 갈리는 것은 *fatal 을 무엇으로
보여 주는가* 하나뿐인데 — Linux 는 config 파싱이 Wayland backend 등록 *전*이라 overlay 가 아니라
**stderr + log** 로 나간다 — 그건 이 변경이 만든 동작이 아니라 **기존 모든 config fatal 이 이미
그렇다.**

Closes #431
