### PR TITLE
fix(autostart/macos): plist 가 `open -a` 로 앱을 띄운다 — launchd job 종료에 worker 가 끌려갔다 (#442)

### DIFF
--- a/src/autostart/macos.zig
+++ b/src/autostart/macos.zig
@@ -1,19 +1,46 @@
 // macOS auto-start: `~/Library/LaunchAgents/com.tildaz.app.plist`
 //
-// 사용자 로그인 시 launchd 가 plist 따라 우리 .app 의 main 바이너리를 실행.
-// Windows 의 `autostart/windows.zig` (HKCU\...\Run) 와 동등.
+// 사용자 로그인 시 launchd 가 plist 따라 `open -a TildaZ.app --args --autostart`
+// 을 실행 — LaunchServices 가 우리 앱을 띄운다. Windows 의
+// `autostart/windows.zig` (HKCU\...\Run) 와 동등.
 //
-// LaunchAgent 위치는 Apple 표준 — `man launchd.plist` 참고. plist 자체는
-// 로그인 시 자동 load 라 file drop 만으로 충분 (`launchctl load` 호출 불필요).
-// disable 시 file 삭제만 — 다음 로그인부터 효과. 현재 세션 즉시 bootout 이
-// 필요하면 수동 (`disable` 의 doc comment 참조).
+// plist 가 우리 바이너리를 **직접** 지목하면 안 된다. launchd 는 plist 에 적힌
+// 프로세스를 그 LaunchAgent job 의 본체로 보는데, `--autostart` launcher 는
+// worker 를 spawn 한 뒤 곧바로 `exit(0)` 하는 설계다 (`main.zig` 의
+// `runLauncher`). launcher 가 끝나면 launchd 가 job 을 닫으면서
+// (`service inactive` → `shutting down` → `cleaning up` → `removing child`)
+// 같은 job 의 worker 도 함께 사라진다. 실측 (재부팅 1회 + `launchctl kickstart`
+// 재현 1회, 증상 동일): worker 가 AppKit 초기화를 마치고 Input Monitoring 권한을
+// 요청하던 중 launcher 의 `exit(0)` 과 **같은 밀리초**에 끊겼고, 로그에는
+// `[boot]` 만 남고 `config loaded` 도 `[exit]` 도 없었다. 종료 시그널의 종류는
+// macOS 가 로그로 남기지 않아 확인하지 못했다.
 //
-// 라벨 (`com.tildaz.app`) 은 reverse-DNS — 다른 사용자 LaunchAgent 와 충돌 방지.
+// `open` 을 거치면 앱이 LaunchServices 의 별개 job
+// (`application.me.ensky0.tildaz.…`) 으로 떠서 launcher 종료와 무관하게
+// 살아남는다 — 같은 로그의 사용자 수동 실행 경로에서 대조 확인했다.
 
 const std = @import("std");
 const paths = @import("../paths.zig");
 
 const LABEL = "com.tildaz.app";
+
+/// `.app` 번들 안에서 실행 중일 때 쓰는 `ProgramArguments` 항목 — 정상 경로.
+/// `open` 이 LaunchServices 에 요청을 넘겨 앱을 별개 job 으로 띄운다.
+const PROGRAM_ARGS_VIA_OPEN =
+    \\        <string>/usr/bin/open</string>
+    \\        <string>-a</string>
+    \\        <string>{s}</string>
+    \\        <string>--args</string>
+    \\        <string>--autostart</string>
+;
+
+/// 번들 밖에서 실행 중일 때의 fallback (`zig-out/bin` 의 bare 바이너리 등).
+/// `open` 으로 지목할 번들이 없어 바이너리를 직접 적는다 — 이 경로에는 위
+/// 주석의 worker 동반 종료 문제가 그대로 남는다.
+const PROGRAM_ARGS_DIRECT =
+    \\        <string>{s}</string>
+    \\        <string>--autostart</string>
+;
 
 /// `~/Library/LaunchAgents/com.tildaz.app.plist` 경로 (allocator-based).
 fn plistPath(allocator: std.mem.Allocator) ![]u8 {
@@ -36,6 +63,47 @@ fn currentExePath(allocator: std.mem.Allocator) ![]u8 {
     return allocator.dupe(u8, slice);
 }
 
+/// exe 경로에서 `.app` 번들 root 를 뽑는다 — `open -a` 가 지목할 대상.
+/// `.../TildaZ.app/Contents/MacOS/tildaz` → `.../TildaZ.app`.
+/// 번들 구조가 아니면 null (호출자가 직접 실행 fallback 을 쓴다).
+fn appBundlePath(exe: []const u8) ?[]const u8 {
+    const macos_dir = std.fs.path.dirname(exe) orelse return null;
+    if (!std.mem.endsWith(u8, macos_dir, "/Contents/MacOS")) return null;
+    const contents_dir = std.fs.path.dirname(macos_dir) orelse return null;
+    const bundle = std.fs.path.dirname(contents_dir) orelse return null;
+    if (!std.mem.endsWith(u8, bundle, ".app")) return null;
+    return bundle;
+}
+
+/// plist 본문 생성. 파일 쓰기와 분리해 두어 단위 테스트가 결과 XML 을 그대로
+/// 고정한다 — plist 는 손으로 확인하기 어렵고 한 글자만 틀려도 launchd 가
+/// 조용히 무시한다.
+fn renderPlist(allocator: std.mem.Allocator, exe: []const u8) ![]u8 {
+    const program_args = if (appBundlePath(exe)) |bundle|
+        try std.fmt.allocPrint(allocator, PROGRAM_ARGS_VIA_OPEN, .{bundle})
+    else
+        try std.fmt.allocPrint(allocator, PROGRAM_ARGS_DIRECT, .{exe});
+    defer allocator.free(program_args);
+
+    return std.fmt.allocPrint(allocator,
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>{s}</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\{s}
+        \\    </array>
+        \\    <key>RunAtLoad</key>
+        \\    <true/>
+        \\</dict>
+        \\</plist>
+        \\
+    , .{ LABEL, program_args });
+}
+
 /// auto-start 활성화 — LaunchAgent plist 작성. 이미 같은 내용이면 건드리지
 /// 않는다. macOS 가 LaunchAgent 변경을 "background activity" 알림으로 보여줄
 /// 수 있어서, 실제 변경이 있을 때만 파일 timestamp 를 바꾼다.
@@ -46,24 +114,7 @@ pub fn enable(allocator: std.mem.Allocator) !void {
     const path = try plistPath(allocator);
     defer allocator.free(path);
 
-    const plist = try std.fmt.allocPrint(allocator,
-        \\<?xml version="1.0" encoding="UTF-8"?>
-        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        \\<plist version="1.0">
-        \\<dict>
-        \\    <key>Label</key>
-        \\    <string>{s}</string>
-        \\    <key>ProgramArguments</key>
-        \\    <array>
-        \\        <string>{s}</string>
-        \\        <string>--autostart</string>
-        \\    </array>
-        \\    <key>RunAtLoad</key>
-        \\    <true/>
-        \\</dict>
-        \\</plist>
-        \\
-    , .{ LABEL, exe });
+    const plist = try renderPlist(allocator, exe);
     defer allocator.free(plist);
 
     _ = try paths.writeFileIfChanged(allocator, path, plist);
@@ -76,4 +127,68 @@ pub fn disable(allocator: std.mem.Allocator) void {
     const path = plistPath(allocator) catch return;
     defer allocator.free(path);
     std.fs.deleteFileAbsolute(path) catch {};
+}
+
+test "appBundlePath 는 .app 번들 root 만 인정한다" {
+    try std.testing.expectEqualStrings(
+        "/Applications/TildaZ.app",
+        appBundlePath("/Applications/TildaZ.app/Contents/MacOS/tildaz").?,
+    );
+    // 번들 밖 bare 바이너리 — 직접 실행 fallback 이 필요한 경우.
+    try std.testing.expect(appBundlePath("/usr/local/bin/tildaz") == null);
+    // `Contents/MacOS` 아래가 아니면 번들 main 바이너리가 아니다.
+    try std.testing.expect(appBundlePath("/tmp/TildaZ.app/Contents/tildaz") == null);
+    // 두 단계 위가 `.app` 으로 끝나지 않으면 번들이 아니다.
+    try std.testing.expect(appBundlePath("/tmp/Foo/Contents/MacOS/tildaz") == null);
+}
+
+test "renderPlist 는 번들 실행을 open 경유로 적는다" {
+    const allocator = std.testing.allocator;
+    const plist = try renderPlist(allocator, "/Applications/TildaZ.app/Contents/MacOS/tildaz");
+    defer allocator.free(plist);
+    try std.testing.expectEqualStrings(
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>com.tildaz.app</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>/usr/bin/open</string>
+        \\        <string>-a</string>
+        \\        <string>/Applications/TildaZ.app</string>
+        \\        <string>--args</string>
+        \\        <string>--autostart</string>
+        \\    </array>
+        \\    <key>RunAtLoad</key>
+        \\    <true/>
+        \\</dict>
+        \\</plist>
+        \\
+    , plist);
+}
+
+test "renderPlist 는 번들 밖 실행이면 바이너리를 직접 적는다" {
+    const allocator = std.testing.allocator;
+    const plist = try renderPlist(allocator, "/usr/local/bin/tildaz");
+    defer allocator.free(plist);
+    try std.testing.expectEqualStrings(
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>com.tildaz.app</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>/usr/local/bin/tildaz</string>
+        \\        <string>--autostart</string>
+        \\    </array>
+        \\    <key>RunAtLoad</key>
+        \\    <true/>
+        \\</dict>
+        \\</plist>
+        \\
+    , plist);
 }


### PR DESCRIPTION
## 무엇을 고쳤나

`auto_start=true` 인데 mac 을 재시동하면 TildaZ 가 뜨지 않고 F1 도 반응하지 않던 문제다.

plist 가 우리 바이너리를 직접 지목하면 launchd 는 `--autostart` launcher 를 `com.tildaz.app` job 의 본체로 본다. launcher 는 worker 를 spawn 한 뒤 곧바로 `exit(0)` 하는 설계라, 본체가 끝나는 순간 launchd 가 job 을 닫으면서 (`service inactive` → `shutting down` → `cleaning up` → `removing child`) 같은 묶음의 worker 도 함께 사라졌다.

`open -a` 를 거치면 앱이 LaunchServices 의 별개 job (`application.me.ensky0.tildaz.…`) 으로 떠서 launcher 종료와 무관하게 남는다. AGENTS.md 가 수동 실행에 이미 요구하던 방식이고, 자동 시작만 그 규칙에서 빠져 있었다.

```diff
  <key>ProgramArguments</key>
  <array>
-     <string>/Applications/TildaZ.app/Contents/MacOS/tildaz</string>
+     <string>/usr/bin/open</string>
+     <string>-a</string>
+     <string>/Applications/TildaZ.app</string>
+     <string>--args</string>
      <string>--autostart</string>
  </array>
```

## 함께 들어간 것

- `appBundlePath` / `renderPlist` 를 파일 쓰기와 분리했다. plist 는 한 글자만 틀려도 launchd 가 조용히 무시하므로 **결과 XML 전체를 문자열로 고정하는 테스트 3개**를 넣었다.
- 번들 밖에서 실행 중일 때 (`zig-out/bin` 의 bare 바이너리 등) 는 지목할 `.app` 이 없어 기존 방식으로 fallback 한다. 그 경로에는 같은 문제가 남는다는 것을 주석에 명시했다.
- 원인 · 실측 로그를 파일 상단 주석에 남겼다. 미확인으로 남은 부분 (종료 시그널의 종류) 도 그대로 적었다.

## 검증

| 단계 | 결과 |
|---|---|
| `zig build test` | 통과 (새 테스트 3개 포함) |
| `zig build check` — Linux · macOS · Windows × x86_64 / aarch64 6 타겟 compile-only | 통과 |
| 실험용 label 로 launchd 실동작 | 통과 — worker 30초 관측 내내 생존, `enter NSApp run loop` 완주 |
| **실제 재시동** | **통과** — job 이 닫힌 뒤에도 worker 가 살아남고 F1 로 창이 떴다 (MacBook Pro M5 Pro, macOS) |

## 다른 platform 영향

없다. Windows 의 Registry Run 과 Linux 의 XDG autostart 는 실행한 프로세스를 서비스 본체로 관리하는 job 묶음이 없다. 자세한 근거는 [#442](https://github.com/ensky0/tildaz/issues/442) 본문의 표 (Linux 의 systemd scope 환경은 미검증으로 표기).

Closes #442
