### PR TITLE
feat(stress): Terminal.app 을 비교 대상에 넣는다 (#414)

### DIFF
--- a/dist/macos/color-capture.m
+++ b/dist/macos/color-capture.m
@@ -57,17 +57,33 @@ static SCShareableContent *shareableContentOrDie(void) {
     return result;
 }
 
+/// `app` 열 옆에 **bundle identifier** 를 함께 낸다 (#414).
+///
+/// `applicationName` 은 **시스템 로케일로 번역된 표시 이름**이다. 한국어 macOS 에서
+/// Terminal.app 은 `터미널` 로 나오고 (`제어 센터` · `알림 센터` 도 마찬가지다), 이걸
+/// 영문 이름으로 찾으면 조용히 빗나간다 — `compare-terminals.sh --capture` 가 실제로
+/// Terminal.app 창을 못 찾아 전체 화면으로 물러섰다. bundle identifier 는 언어에 따라
+/// 바뀌지 않아 스크립트가 찾는 기준으로 쓸 수 있다.
+///
+/// 사람이 눈으로 읽을 때는 `app` 이 여전히 편하므로 **두 열을 같이 둔다.**
 static void listWindows(void) {
     SCShareableContent *content = shareableContentOrDie();
-    printf("%-8s %-24s %-12s %s\n", "id", "app", "크기(pt)", "제목");
+    printf("%-8s %-28s %-24s %-12s %s\n", "id", "bundle", "app", "크기(pt)", "제목");
     for (SCWindow *w in content.windows) {
         if (!w.onScreen) continue;
         char size[32];
         snprintf(size, sizeof(size), "%.0fx%.0f", w.frame.size.width,
                  w.frame.size.height);
-        printf("%-8u %-24s %-12s %s\n", (unsigned)w.windowID,
-               w.owningApplication.applicationName.UTF8String ?: "(?)", size,
-               w.title.UTF8String ?: "");
+        // **빈 문자열도 `-` 로 채운다.** `?:` 는 nil 만 걸러서, bundle identifier 가 빈
+        // 문자열인 앱은 그대로 통과해 **공백만 찍힌다.** 그러면 이 줄을 공백으로 쪼개 읽는
+        // 쪽 (`compare-terminals.sh` 의 awk) 에서 **열이 하나 통째로 밀려** 엉뚱한 값을 본다.
+        // CLI 로 띄운 alacritty 가 실제로 그랬다 (실측 — LaunchServices 를 안 거쳐서 그렇다).
+        const char *bundle = w.owningApplication.bundleIdentifier.UTF8String;
+        if (!bundle || !*bundle) bundle = "-";
+        const char *app = w.owningApplication.applicationName.UTF8String;
+        if (!app || !*app) app = "(?)";
+        printf("%-8u %-28s %-24s %-12s %s\n", (unsigned)w.windowID, bundle, app,
+               size, w.title.UTF8String ?: "");
     }
 }
 

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -1014,6 +1014,7 @@ Windows 만의 주의점이에요.
 | **kitty · ghostty · foot 은 없어요** | Windows 판이 없고 (foot 은 Wayland 전용) `command -v` 로 자동으로 빠져요 |
 | **창이 다른 창 뒤에 뜰 수 있어요** | Win32 는 *foreground 프로세스가 **직접** 시작한 프로세스* 에만 창을 앞으로 낼 권한을 줘요 ([SetForegroundWindow](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow)). `wt` 는 실행 별칭이라 부모 관계가 끊기고, wezterm 은 GUI 를 손자 프로세스로 띄웠어요. **`wt` 는 Windows Terminal 자체의 버그** ([#18324](https://github.com/microsoft/terminal/issues/18324), Priority-1) 로 **1.23.10353.0 에서 고쳐졌어요** — `wt --version` 이 그보다 낮으면 업데이트하세요. wezterm 은 아래처럼 실행 방법을 바꿔서 해결했어요. 상태를 봐야 하면 `--capture` 를 쓰세요 |
 | **alacritty 는 `zwj` 계열을 소화하지 못해요 — 스크립트가 자동으로 빼요** | 바로 아래 절 참고. Windows + `zwj` / `zwj_varied` 조합만 해당해요 |
+| **alacritty 는 큰 출력 뒤에 안 닫혀요 — 스크립트가 상한을 두고 정리해요** | 아래 두 번째 절 참고. 워크로드를 안 가리고 (`plain` 에서도 나요) `--capture` 를 켠 실행에서만 드러나요 |
 
 #### alacritty 는 Windows 에서 `zwj` 계열을 못 돌려요 (자동 제외)
 
@@ -1070,6 +1071,40 @@ PATH="$FP" dist/stress/compare-terminals.sh --mb 64 --workload zwj --repeat 3 --
 처음에 둘을 한 묶음으로 빼서 wezterm 값을 통째로 잃은 적이 있어요 ([#381](https://github.com/ensky0/tildaz/issues/381)) —
 그리고 그 값이 중요했어요. grapheme 워크로드에서 **wezterm 이 우리보다 2.7~2.9 배 빨라서**, 빼 버리면
 "우리가 꼴찌" 라는 사실이 표에서 사라져요.
+
+#### alacritty 는 큰 출력을 끝낸 뒤 스스로 안 닫혀요 (상한을 두고 정리)
+
+위 `zwj` 절과 **다른 증상이에요.** 저건 출력 *도중* 진행이 막히는 것이고, 이건 **출력이 다 끝나고
+producer 가 정상 종료한 뒤** `alacritty.exe` 만 남는 거예요. 그래서 워크로드를 안 가려요 — `plain`
+에서 났어요 ([#414](https://github.com/ensky0/tildaz/issues/414), alacritty 0.17.0 (94e7c88) ·
+노트북 AMD Ryzen AI 7 350 · Windows 11 Pro 26200).
+
+**우리 스크립트 없이도 나요.** `alacritty -e <producer>` 만으로 재현돼요.
+
+| 출력량 | 결과 | | 출력량 | 결과 |
+|---|---|---|---|---|
+| 1 MiB | 3/3 스스로 종료 | | **16 MiB** | **2/3 멈춤** |
+| 8 MiB | 3/3 스스로 종료 | | **32 MiB** | **3/3 멈춤** |
+| | | | **64 MiB** | **3/3 멈춤** |
+
+**영구 멈춤이에요.** 64 MiB 를 180 초 기다려도 안 닫히고, 그동안 **CPU 시간이 늘지 않아요**
+(5.6 초에서 고정 · `Responding=True` · 자식 프로세스 없음) — 오래 걸리는 일을 하는 중이 아니라
+멈춘 거예요. producer 쪽은 매번 멀쩡해요 (timing 파일이 완전하고 프로세스가 안 남아요).
+
+**측정값은 유효해요.** 멈춤이 측정과 캡처가 **모두 끝난 뒤**에 일어나고, 값은 producer 가 쓴
+timing 파일에서 나와요. 그래서 `zwj` 처럼 대상에서 빼지 않아요.
+
+**스크립트는 그 시도의 hold 만큼만 기다리고 정리해요.** 기다림의 목적이 *producer 의 hold 가 끝나는
+것* 하나뿐이라 상한도 거기에 맞춘 거예요 — 재시도 회차는 hold 가 `CAPTURE_RETRY_HOLD_MS` 로
+늘어나므로 상한도 같이 늘어나요. 상한에 걸리면 표에 이렇게 남아요.
+
+```
+alacritty      @ ok  120x40
+               ⚠ alacritty — producer 가 끝난 뒤에도 안 닫혀서 1 회차를 강제로 정리했어요 (측정값은 유효해요).
+```
+
+**`--capture` 를 끄면 이 경로를 아예 안 타요** — 기다림 자체가 캡처 전용이고, 캡처가 없으면 곧바로
+정리해요. 기록용 실행 (`--capture` 없이 `--repeat 5`) 은 처음부터 영향이 없었어요.
 
 **wezterm 은 `wezterm-gui start --always-new-process` 로 띄워요** (Windows). 두 가지를 함께
 해결해요.

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -279,6 +279,7 @@ dist/stress/compare-terminals.sh --mb 64 --workload plain --repeat 5
 | 측정 중 창을 클릭하거나 포커스를 바꾸지 않아요 | 실측 중 키보드 · 마우스가 눌려 그 회차를 버렸어요 |
 | 이전 실행의 잔여 터미널 프로세스를 먼저 정리해요 | `kitty --detach` 와 ghostty 는 스크립트가 끝나도 남아서 다음 회차와 CPU 를 나눠요 |
 | **평소 쓰는 TildaZ worker 를 종료해요** — **이제 스크립트가 자동으로 해요** | 다른 터미널은 백그라운드 인스턴스가 없는데 TildaZ 만 worker 가 떠 있으면 렌더 · CPU 를 나눠 써요. 터미널 비교에서는 **공정성**이 깨지고 배분 측정에서는 **값이 눌려요** — 형태가 다를 뿐 결론이 같아서 `hygiene.sh` 가 두 도구 모두에서 내려요. 규칙으로만 적어 뒀더니 실제로 잊고 여러 회차를 돌린 적이 있어요 ([#381](https://github.com/ensky0/tildaz/issues/381)). **끝나도 다시 안 띄워요** — 필요하면 직접 띄우세요 |
+| **비교 대상 터미널을 종료해요** — **스크립트가 검사해서 걸리면 멈춰요** | 떠 있으면 그 앱이 사용자 창을 그리며 CPU 를 나눠 써요. **숨기는 것으로는 부족해요** — 터미널은 빌드 · 로그를 띄워 둔 채 두는 앱이라, 숨겨도 그 안의 프로그램은 계속 돌아요. 게다가 **Terminal.app · iTerm2 는 hide 로 아예 못 막아요**: 둘 다 *이미 떠 있는 앱 프로세스에 창을 붙이는* 방식이라 우리 측정 창이 사용자 창과 **같은 프로세스** 안에서 그려지고, 창을 만드는 순간 그 앱의 hide 가 풀려요. 같은 함정을 wezterm 이 먼저 만나 `--always-new-process` 로 피했는데 그 둘에는 그런 통로가 없어요 ([#414](https://github.com/ensky0/tildaz/issues/414)). **자동으로 닫지는 않아요** — 사용자의 작업 창이라서요. 그래서 **이 스크립트는 대상이 아닌 터미널에서 돌려요** (VS Code 터미널 · SSH 등) |
 | AC 전원에 연결하고 절전 · **화면 잠금을 꺼요** — **잠금 차단은 스크립트가 해요** | 노트북은 배터리 · 열로 스로틀링이 걸려요. 그리고 잠금 화면이 뜨면 **`render` 만 무너지고 `parse` 는 정상이라 결과만 봐서는 티가 안 나요** — 아래 참고. AC 연결 자체는 사람이 해야 하고, 스크립트는 **검사해서 걸리면 멈춰요** |
 | **CPU 를 최고 성능으로 둬요** — **이제 스크립트가 해요** | AC 만 확인하고 전원 프로파일은 안 봤더니 `balanced` (EPP `balance_performance`) 인 채로 여러 세션을 쟀어요. Linux 는 `powerprofilesctl set performance` 로 **sudo 없이** 되고, Windows 는 **전원 모드(overlay)** 를 최고 성능으로 둬요 — 둘 다 끝나면 되돌려요. **Windows 는 전원 *구성표* 가 아니에요** — 아래 참고 |
 | **Windows 노트북은 동적 새로 고침 빈도(DRR)를 꺼요** | 켜져 있으면 주사율이 측정 중에 바뀌어 **회차가 두 무리로 갈려요** — 아래 참고. `hygiene.sh` 가 시작 전에 이걸 직접 검사하고 걸리면 멈춰요 |
@@ -628,11 +629,13 @@ dist/stress/compare-terminals.sh --mb 64 --workload plain --cols 120 --rows 40
 | platform | 자동으로 도는 대상 |
 |---|---|
 | Linux | TildaZ · alacritty · kitty · wezterm · ghostty · **foot** |
-| macOS | TildaZ · alacritty · kitty · wezterm · ghostty · **iTerm2** |
-| Windows | TildaZ · alacritty · wezterm · **Windows Terminal (`wt`)** |
+| macOS | TildaZ · alacritty · kitty · wezterm · ghostty · **iTerm2** · **Terminal.app** |
+| Windows | TildaZ · alacritty · wezterm · **Windows Terminal (`wt`)** · **conhost** |
 
 Windows 에 kitty · ghostty 판이 없고 foot 은 Wayland 전용이라, Windows 는 그 자리를
 Windows Terminal 이 채워요.
+
+**OS 기본 터미널 둘 (Terminal.app · conhost) 만 설치 여부를 안 봐요** — 그 OS 에 항상 있으니까요.
 
 **굵은 자리는 "그 OS 사용자가 실제로 쓰는 것" 이에요.** 나머지 넷 (alacritty · kitty ·
 wezterm · ghostty) 은 개발자 취향의 선택지라 그것만 놓고 보면 그림이 왜곡돼요 — macOS
@@ -654,24 +657,82 @@ fragment 도 같은 구조예요 (아래 Windows 절).
 | CLI (`open -na iTerm.app --args`) | 격자 옵션이 없어요 |
 | AppleScript 로 창을 만든 뒤 크기 변경 | **명령이 먼저 시작돼서** 그 시점 격자로 출력해요 |
 
-#### Terminal.app 은 넣지 못했어요 — 세 방법이 다 막혔어요
+**측정 창은 스크립트가 닫아요** ([#414](https://github.com/ensky0/tildaz/issues/414)). 프로파일의
+`Close Sessions On End` 는 **세션만** 닫아서 **빈 창이 남거든요** — 회차마다 쌓이고, 다음 실행의
+위생 검사에도 계속 걸려요. 창 이름이 곧 프로파일 이름 (`tildaz-stress`) 이라 그걸로 우리 창만
+골라요. 사용자가 열어 둔 창은 이름이 달라서 후보에 안 들어가요.
 
-macOS 의 OS 기본 터미널이라 Windows 의 conhost 와 같은 자리인데, 넣으려다 접었어요.
-**다시 시도하는 분이 같은 길을 헤매지 않도록** 실패 셋을 남겨요 (전부 실측이에요).
+#### Terminal.app 은 escape sequence 로 넣어요
 
-| 방법 | 결과 |
+macOS 의 OS 기본 터미널이라 **Windows 의 conhost 와 같은 자리**예요 — 하한 기준선이자,
+시스템 기본 터미널이 어느 정도인지 보여 주는 대조군이에요.
+
+**격자는 `CSI 8 ; rows ; cols t` 로 줘요.** 셸이 자기 손으로 창을 리사이즈하니까 프로파일이
+필요 없고, 사용자 설정에 흔적이 남을 일도 없어요.
+
+```sh
+printf '\033[8;40;120t'      # 셸이 자기 창을 120 열 × 40 행으로 바꿔요
+```
+
+한동안 *"Terminal.app 은 격자를 프로파일로만 받는다"* 고 정리돼 있었어요
+([#381](https://github.com/ensky0/tildaz/issues/381#issuecomment-5220061290)). 그건 시도한 세
+방법이 **셋 다 같은 길**이었기 때문이에요 — 전부 *Terminal.app 에게 격자를 알려 주는* 통로를
+찾고 있었어요. escape sequence 는 방향이 반대라 그 구조에 아예 걸리지 않아요
+([#414](https://github.com/ensky0/tildaz/issues/414) 에서 실측 3/3 이 목표 격자와 일치).
+
+| 예전 방법 | 왜 막혔나 |
 |---|---|
-| AppleScript `do script` + 격자 설정 | ❌ 명령이 먼저 뜨고 격자가 나중이라 **셸이 30×120 을 봐요** — AppleScript 는 120×40 이라고 보고하는데도요 |
-| `defaults` 로 임시 프로파일 추가 | ❌ **실행 중인 앱이 안 읽어요** (`-1728`). 게다가 앱이 종료하며 자기 설정으로 덮어써서 **사용자 설정 손상 위험**이 있어요 |
-| `.terminal` 파일 + `open` | ❌ 프로파일은 추가되는데 **`CommandString` 이 실행되지 않아요** |
+| AppleScript `do script` + 격자 설정 | 창을 만든 **뒤** 격자를 바꿔요 |
+| `defaults` 로 임시 프로파일 | **프로파일**로 줘요 — 실행 중인 앱이 안 읽어요 (`-1728`) |
+| `.terminal` 파일 + `open` | **프로파일**로 줘요 — `CommandString` 이 실행되지 않아요 |
 
-근본 원인은 **Terminal.app 이 격자 · scrollback 을 오직 프로파일로만 받고, 그 프로파일이
-실행 중인 앱과 충돌한다**는 구조예요. 세 번 다 사용자 설정에 흔적이 남아서 매번 지워야
-했어요 (전부 원복 확인했어요).
+그때 기록된 *"셸이 30×120 을 봐요"* 는 뒤바뀐 격자가 아니었어요. **그 머신 기본 프로파일의
+120 열 × 30 행**이에요 — `stty size` 가 `rows cols` 순서로 찍은 값을 `cols×rows` 로 읽은
+거예요. 격자를 못 준 게 아니라 **애초에 안 바뀐 상태의 값**이었어요.
 
-남은 길은 *"Terminal.app 을 완전히 종료한 상태에서 프로파일을 심고 → 실행 → 측정 → 종료 →
-제거"* 인데, 회차마다 앱 재시작이 필요하고 사용자가 Terminal 을 쓰고 있으면 방해돼요.
-**그래서 넣지 않아요.**
+**명령은 `exec` 로 띄워요.** 이게 창 정리까지 함께 풀어요.
+
+```applescript
+do script "exec sh <wrapper>"     -- 로그인 셸 자체를 wrapper 로 대체해요
+```
+
+로그인 셸을 대체하니까 producer 가 끝나는 순간 그 창에 **실행 중인 프로세스가 없어요.**
+왜 그게 중요한지는 아래 함정에 적어요.
+
+##### ⚠ 실행 중인 셸이 있는 창은 닫히지 않아요 — 확인 시트
+
+`close` 를 불러도 **아무 반응 없이 창이 그대로**인 것처럼 보이는 때가 있어요. 인덱스로 바꿔도,
+네 번을 반복해도 그대로였어요 (실측). `System Events` 로 들여다보고서야 원인이 나왔어요.
+
+```
+[… TildaZ-stress-9999 … sheets=1] [… TildaZ-stress-terminal … sheets=1]
+```
+
+실행 중인 셸이 있는 창을 닫으려 하면 Terminal.app 이 **확인 시트 (`취소` / `종료`) 를 띄워요.**
+시트가 응답을 기다리는 동안 창은 안 닫히고, **그 뒤의 close 는 전부 무시돼요.** 시트를
+승인하려면 Accessibility 권한이 필요하고 버튼 이름이 로케일 의존이라 (`종료` / `Terminate`)
+자동화로 쓸 수 없어요.
+
+그래서 **순서가 정해져 있어요** — `cleanup_terminals` 가 프로세스를 먼저 죽이고, **그 뒤에**
+창을 닫아요. `exec` 로 로그인 셸까지 대체해 두면 남는 프로세스가 없어서 시트가 아예 안 떠요
+(실측: 닫기 전후 시트 0, 창이 깨끗이 닫혀요).
+
+##### 창은 태그로 찾아요
+
+`do script` 가 돌려주는 **tab** 에 `custom title` 로 태그 (`TildaZ-stress-<pid>`) 를 달고, 그
+태그로만 창을 닫아요. `front window` 로 잡지 않는 이유는 그 찰나에 사용자가 다른 창을 앞으로
+가져오면 **사용자 창에 태그가 붙어 나중에 닫히기 때문**이에요. pid 를 넣어서 앞선 실행이 남긴
+창도 안 건드려요.
+
+##### ❌ scrollback 은 못 맞춰요
+
+AppleScript 사전에 크기 속성이 아예 없어요 (있는 `history` 는 **내용 읽기 전용**이에요).
+그래서 사용자 프로파일 값이 그대로 쓰이고, **이 대상만 조건이 달라요.** 스크립트가 매 실행에서
+경고해요.
+
+conhost 와 같은 처지이긴 한데 **성격이 조금 달라요** — conhost 는 "스크롤백 없음" 으로 고정이라
+적어도 재현은 되는데, Terminal.app 은 **머신마다 값이 달라요.** 조건이 다를 뿐 아니라 재현성도
+떨어진다는 뜻이라, 이 대상의 숫자는 그 점을 알고 읽어야 해요.
 
 **전부 자동이에요.** TildaZ 도 스크립트가 직접 띄워요 — 측정용 실행 옵션 `-e <실행파일>` ·
 `-size <COLS>x<ROWS>` 를 [#382](https://github.com/ensky0/tildaz/issues/382) 에서 만들었어요.
@@ -752,6 +813,11 @@ dist/stress/compare-terminals.sh --mb 8 --workload zwj --repeat 1 --timeout 30 -
 이 구분이 없던 때 **창을 한 번도 못 잡던 conhost 가 계속 `@` 로 성공처럼 보였어요**
 ([#381](https://github.com/ensky0/tildaz/issues/381)).
 
+**macOS 도 이제 이 구분을 해요** ([#414](https://github.com/ensky0/tildaz/issues/414)). 예전에는
+`~` · `?` 를 Windows 만 갈라내고 macOS 는 전부 `@` 로 찍혀서, **전체 화면으로 물러선 회차를
+사람이 PNG 을 열어 봐야만** 알 수 있었어요. 실제로 Terminal.app · iTerm2 두 대상이 전체 화면으로
+찍혔는데 표에는 `@` 로 나왔고, 파일을 열어 보고서야 발견했어요.
+
 **`_` 도 같은 사유로 나중에 갈라낸 거예요.** `@` 는 *"캡처 API 가 성공을 돌려줬다"* 는 뜻이었을
 뿐이라, 창 단위로 찍었는데 **단색 이미지**가 나와도 성공으로 보였어요 — 실측으로 alacritty 가
 **550 byte** 였고 같은 실행의 정상 캡처는 65~134 KB 였어요. 판정은 **파일 크기** (2 KiB 미만) 로
@@ -774,7 +840,7 @@ producer 가 창을 **4 초** 더 붙들고 있어요 (그래야 찍을 창이 �
 
 | platform | 쓰는 도구 | 범위 | 알아 둘 것 |
 |---|---|---|---|
-| **macOS** | [`dist/macos/color-capture.m`](../macos/color-capture.m) (ScreenCaptureKit) | **창 단위** | **완전히 가려진 창도 찍혀요** (실측: 같은 자리에 창 둘을 겹치고 아래 창을 찍으니 아래 창 내용이 나왔어요). 스크립트가 `clang` 으로 빌드해서 써요. **화면 기록 권한**이 필요하고 잠금 화면이면 실패해요. 창을 못 찾으면 `screencapture -x` 전체 화면으로 물러서요 |
+| **macOS** | [`dist/macos/color-capture.m`](../macos/color-capture.m) (ScreenCaptureKit) | **창 단위** | **완전히 가려진 창도 찍혀요** (실측: 같은 자리에 창 둘을 겹치고 아래 창을 찍으니 아래 창 내용이 나왔어요). 스크립트가 `clang` 으로 빌드해서 써요. **화면 기록 권한**이 필요하고 잠금 화면이면 실패해요. 찾는 기준은 **bundle identifier** 예요 (`com.apple.Terminal` 등) — 앱 이름은 **시스템 언어로 번역**돼서 기준이 될 수 없어요 (아래 참고). 창을 못 찾으면 `screencapture -x` 전체 화면으로 물러서고 `?` 를 찍어요 |
 | **Windows** | PowerShell (`PrintWindow` → 실패 시 `CopyFromScreen`) | **창 단위** | 창을 띄우자마자 **(0,0) 으로 옮기고 맨 앞으로** 올려요 (`SWP_NOACTIVATE` 라 포커스는 안 뺏어요). `PrintWindow` 가 실패하는 흔한 원인은 **hold 가 모자라 창이 이미 닫힌 것**이라, 그 회차는 hold 를 늘려 다시 찍어요 (아래 참고). **DPI 함정도 있어요 — 아래 참고** |
 | **Linux (sway · Hyprland)** | `grim` | 전체 화면 | wlroots 계열의 `zwlr_screencopy` 를 써요. **가려진 창은 못 찍어요** — Wayland 는 client 가 다른 창 내용을 읽을 수 없어요. 타일링이라 보통 안 가려져요 |
 | **Linux (KDE Plasma)** | `spectacle -b -n -a` | **활성 창** | KWin 은 `zwlr_screencopy` 를 client 에게 노출하지 않아 grim 이 안 돼요. `org.kde.KWin.ScreenShot2` 는 호출자를 검증해서 직접 부를 수 없고, **Spectacle 이 정상 통로**예요 (KDE 기본 설치). `-a` 라 **창 단위로 찍히고 가려짐 문제도 없어요** (활성 창은 맨 앞이니까요). 다만 방금 뜬 창이 활성이 아니면 엉뚱한 창이 찍혀요 — 확실히 하려면 KWin 스크립팅으로 대상을 활성화해야 하는데, 필요한지 확인되기 전엔 안 넣었어요 |
@@ -782,6 +848,37 @@ producer 가 창을 **4 초** 더 붙들고 있어요 (그래야 찍을 창이 �
 
 리눅스에 **하나로 다 되는 방법은 없어요** — Wayland 는 client 가 화면을 읽을 수 없고 통로가
 compositor 마다 달라요. 위 순서대로 시도하고, 하나도 없으면 시작할 때 그 사실을 알려요.
+
+#### macOS 에서 창을 못 찾는 두 가지 이유 ([#414](https://github.com/ensky0/tildaz/issues/414))
+
+둘 다 실측으로 만났고, **증상이 똑같아요** — 그 회차만 전체 화면으로 찍혀요.
+
+**① 앱 이름이 시스템 언어로 번역돼요.** `color-capture --list` 의 `app` 열은
+`SCWindow.owningApplication.applicationName` 인데, 이건 **표시 이름**이라 한국어 macOS 에서는
+`Terminal` 이 `터미널` 로 나와요 (`제어 센터` · `알림 센터` 도 마찬가지예요).
+
+```
+91       com.apple.Terminal           터미널                757x479      tildaz — … — 80×24
+```
+
+그래서 찾는 기준을 **bundle identifier** 로 바꿨어요. 언어에 따라 바뀌지 않거든요. **언어별
+이름 표는 두지 않아요** — 언어가 늘 때마다 표를 늘려야 하고, 같은 언어라도 OS 판이 바뀌면
+표기가 달라져 조용히 빗나가요. 현지화되지 않는 대상들 (kitty · alacritty · wezterm · ghostty) 만
+우연히 멀쩡했던 것이라, OS 기본 앱을 대상에 넣자마자 드러났어요.
+
+**② hide 된 앱의 창은 목록에 아예 없어요.** `--list` 는 `onScreen` 인 창만 내요. 그런데 위생
+절차가 배경 앱을 hide 하는데 (`hygiene_minimize_macos`), **이미 떠 있던 Terminal.app · iTerm2 는
+그 hide 를 겪은 앱에 창을 붙이는** 방식이라 창이 `onScreen` 이 아니에요. 실측에서 iTerm2 가
+`visible=false` 인 채로 `--list` 에 없었고, 사용자가 다시 띄우자 바로 나타났어요.
+
+그래서 **스크립트가 측정 창을 만든 뒤 그 앱의 hide 를 풀어요** (`set visible to true`). hide 만
+풀고 **앞으로 가져오지는 않아서 포커스를 뺏지 않아요** (실측). 가려져 있어도 ScreenCaptureKit 은
+창 내용을 주니까 그걸로 충분해요.
+
+**이건 캡처만의 이야기가 아니에요.** hide 된 앱은 화면을 그리지 않으니, 그대로 두면 **그 회차만
+렌더 부하가 빠진 채** 측정돼요 — 새 프로세스로 떠서 화면에 올라오는 다른 대상들과 조건이 달라져
+그 대상에게 유리해져요. 위의 [측정 위생](#측정-위생)대로 **대상 터미널을 미리 종료**하면 애초에
+hide 를 겪지 않으니, 둘은 같은 문제의 앞뒤 대비책이에요.
 `xdg-desktop-portal` 은 표준이지만 **권한 대화상자가 떠서** 손 안 대고 도는 측정과 안 맞아요.
 
 #### 찍기 전에 2 초 기다려요
@@ -1019,6 +1116,7 @@ macOS · Linux 는 `wezterm` 을 그대로 쓰되 `--always-new-process` 는 똑
 | ghostty | 임시 config 의 `scrollback-limit = N` |
 | **wt** | **CLI 로 못 줘요** — profile 설정이에요. 스크립트가 **JSON fragment** 로 측정용 프로필을 더해서 거기에 담아요 (아래) |
 | **conhost** | **불가** — `mode con: lines` 가 창=버퍼예요. **이 대상만 조건이 달라요** (스크립트가 매 실행에 경고해요) |
+| **Terminal.app** | **불가** — AppleScript 에 크기 속성이 없어요 (`history` 는 내용 읽기 전용). **사용자 프로파일 값이 쓰여요** — conhost 와 달리 머신마다 값이 달라서 재현성도 떨어져요 (스크립트가 매 실행에 경고해요) |
 
 **wt 는 JSON fragment 로 프로필을 더해요 — 사용자 `settings.json` 을 교체하지 않아요.**
 

--- a/dist/stress/compare-terminals.sh
+++ b/dist/stress/compare-terminals.sh
@@ -223,11 +223,85 @@ WORK_DIR=$(mktemp -d)
 #   사용자 프로필이 `never` 면 남을 수 있다.
 # - alacritty · wezterm 은 macOS 실측에서 정상적으로 닫혔다 (같은 코드베이스).
 # 남는다고 확인되면 그때 Windows 전용 정리를 붙인다 — 확인 전에 추측으로 코드를 넣지 않는다.
+# Terminal.app 측정 창에 붙이는 태그 (#414). 값은 아래 Terminal.app 절에서 채운다.
+# **비어 있으면 이 실행에서 Terminal.app 을 안 띄웠다는 뜻**이라 창을 닫으러 가지 않는다 —
+# 떠 있지도 않은 Terminal.app 을 osascript 가 깨우면 측정 도중에 앱 하나가 새로 뜬다.
+TERMINAL_APP_TAG=""
+
+# 우리가 태그를 붙인 Terminal.app 창만 닫는다.
+#
+# **닫기 전에 그 창의 프로세스가 죽어 있어야 한다.** 실행 중인 셸이 있는 창을 닫으려 하면
+# Terminal.app 이 확인 시트 (`취소` / `종료`) 를 띄우는데, 시트가 응답을 기다리는 동안 창은
+# 안 닫히고 **뒤따르는 close 가 전부 무시된다** (macOS 실측, #414 — 네 번을 반복해도 창이
+# 그대로였고 `System Events` 로 보고서야 시트가 원인인 것을 알았다). 시트를 승인하려면
+# Accessibility 권한이 필요하고 버튼 이름이 로케일 의존이라 자동화로 쓸 수 없다.
+#
+# 그래서 호출부인 `cleanup_terminals` 는 `ps` 로 프로세스를 먼저 죽인 **뒤에** 이걸 부른다.
+# 측정 창 자체도 `exec` 로 로그인 셸을 대체해 (아래 Terminal.app 절) producer 가 끝나면
+# 남는 프로세스가 없다.
+#
+# 태그로만 찾으므로 **사용자가 따로 열어 둔 창은 후보에 들어가지 않는다.**
+terminal_app_close() {
+    [ -n "$TERMINAL_APP_TAG" ] || return 0
+    osascript -e "tell application \"Terminal\" to close (every window whose custom title is \"$TERMINAL_APP_TAG\")" \
+        >/dev/null 2>&1 || true
+}
+
+# iTerm2 측정 창도 우리가 닫는다 (#414).
+#
+# 프로파일의 `Close Sessions On End` 는 **세션만** 닫아서 **빈 창이 남는다.** 회차마다 쌓이고,
+# 다음 실행의 위생 검사 (`hygiene_running_terminals`) 에도 계속 걸린다.
+#
+# 창 이름이 곧 프로파일 이름이라 그것으로 우리 창만 고른다 — 사용자가 열어 둔 창은 이름이
+# 달라서 후보에 안 들어간다 (실측: `[tildaz-stress]` 와 `[-bash]` 가 이름으로 갈렸다).
+#
+# **AppleScript 의 `windows` 목록에는 닫은 뒤에도 항목이 남을 수 있다.** 실제로 닫혔는지는
+# ScreenCaptureKit 의 창 목록으로 확인했다 (화면에서 사라진다). Terminal.app 도 같다.
+ITERM_WINDOW_OPENED=0
+# 프로파일 이름이자 **창 이름**이다 (iTerm2 가 프로파일 이름을 창 제목으로 쓴다). wt 의
+# `WT_PROFILE_NAME` 과 같은 자리이고, 아래 프로파일 JSON · 창 생성 · 창 정리가 모두 이 값을 쓴다.
+ITERM_PROFILE_NAME="tildaz-stress"
+iterm2_window_close() {
+    [ "$ITERM_WINDOW_OPENED" = 1 ] || return 0
+    osascript -e "tell application \"iTerm\" to close (every window whose name is \"$ITERM_PROFILE_NAME\")" \
+        >/dev/null 2>&1 || true
+}
+
+# 측정 창을 만든 **뒤** 그 앱의 hide 를 푼다 (#414). macOS 전용이다.
+#
+# 위생 절차가 배경 앱을 hide 하는데 (`hygiene.sh` 의 `hygiene_minimize_macos`), **이미 떠
+# 있던 앱에 창을 붙이는 두 대상 (Terminal.app · iTerm2) 은 그 hide 를 그대로 물려받는다.**
+# hide 된 앱의 창은 화면에 올라오지 않아서 두 가지가 깨진다.
+#
+#   - **캡처** — `--list` 는 `onScreen` 인 창만 낸다. 목록에 없으니 전체 화면으로 물러선다.
+#   - **측정 자체** — 그리지 않는 창은 렌더 부하가 빠진다. 새 프로세스로 떠서 화면에 올라오는
+#     다른 대상들과 조건이 달라지므로, 이 대상만 유리해진다.
+#
+# `set visible to true` 는 **hide 만 풀고 앞으로 가져오지는 않는다** — 포커스를 뺏지 않는다
+# (실측으로 확인). 가려져 있어도 ScreenCaptureKit 은 창 내용을 준다.
+#
+# Automation 권한이 없으면 조용히 실패하고 지금까지와 똑같이 동작한다.
+mac_app_unhide() {
+    osascript -e "tell application \"System Events\" to set visible of process \"$1\" to true" \
+        >/dev/null 2>&1 || true
+}
+
 cleanup_terminals() {
+    # 회차 정리는 그 대상 이름을 준다. EXIT trap 은 안 준다 (아래 참고).
+    _ct_name="${1:-}"
     [ "$IS_WINDOWS" = 1 ] && return 0
     ps -eo pid,args 2>/dev/null | grep "$WORK_DIR" | grep -v grep | while read -r _p _rest; do
         kill "$_p" 2>/dev/null || true
     done
+    # 이름이 없으면 (EXIT trap) 항상 시도한다 — 중단된 실행이 창을 남기지 않게 하는 안전망이다.
+    # 이름이 있으면 그 대상의 회차 정리이므로 Terminal.app 회차에서만 닫는다. 다른 대상의
+    # 회차마다 osascript 를 부르면 측정 사이에 쓸데없는 프로세스가 돈다.
+    if [ -z "$_ct_name" ] || [ "$_ct_name" = terminal ]; then
+        terminal_app_close
+    fi
+    if [ -z "$_ct_name" ] || [ "$_ct_name" = iterm2 ]; then
+        iterm2_window_close
+    fi
 }
 # --- wt 의 scrollback 을 맞추기 위한 fragment 프로필 (#381, Windows 전용) ---------------
 #
@@ -361,7 +435,7 @@ wt_stub_remove() {
 # 사용자 설정 파일은 전혀 건드리지 않는다. `wt` 가 `settings.json` 을 통째로 갈아끼우고
 # 복원해야 하는 것과 대비되는 자리라, 여기서는 **우리가 만든 파일 하나만 지우면 끝**이다.
 ITERM_PROFILE_DIR="$HOME/Library/Application Support/iTerm2/DynamicProfiles"
-ITERM_PROFILE_FILE="$ITERM_PROFILE_DIR/tildaz-stress.json"
+ITERM_PROFILE_FILE="$ITERM_PROFILE_DIR/$ITERM_PROFILE_NAME.json"
 iterm2_profile_remove() {
     [ -f "$ITERM_PROFILE_FILE" ] || return 0
     rm -f "$ITERM_PROFILE_FILE"
@@ -422,6 +496,14 @@ if [ "$IS_WINDOWS" = 1 ]; then
     if [ "$SCROLLBACK" -gt 32767 ]; then
         echo "⚠ --scrollback $SCROLLBACK 은 wt 의 최대값 32767 을 넘어요 — wt 는 32767 로 잘려요."
     fi
+fi
+if [ "$IS_MACOS" = 1 ]; then
+    # #414 — conhost 와 같은 이유로 매 실행에서 알린다. 다만 **성격이 다르다**: conhost 는
+    # "스크롤백 없음" 으로 고정이라 적어도 재현은 되는데, Terminal.app 은 사용자 프로파일
+    # 값이라 머신마다 다르다. 조건이 다를 뿐 아니라 재현성도 떨어진다는 뜻이다.
+    echo ""
+    echo "⚠ terminal (Terminal.app) 은 scrollback 을 못 맞춰요 — 사용자 프로파일 값이 쓰여요."
+    echo "  AppleScript 에 크기 속성이 없어서 통로가 없어요 (격자는 escape sequence 로 줘요)."
 fi
 echo ""
 # #381 — **배경에서 그리는 앱이 우리 수치만 누른다.** 같은 조건에서 VS Code · Edge 를 최소화하는
@@ -574,6 +656,28 @@ win_proc_name() {
         alacritty) printf 'alacritty' ;;
         wezterm) printf 'wezterm-gui' ;;
         wt) printf 'WindowsTerminal' ;;
+        *) printf '' ;;
+    esac
+}
+
+# macOS 에서 그 대상의 창을 찾을 **bundle identifier**. 위 `win_proc_name` 과 같은 자리다.
+#
+# **로케일과 무관한 유일한 식별자라서 쓴다** (#414). 앱 이름 (`applicationName`) 은 시스템
+# 언어로 번역돼서 (`Terminal` → `터미널`) 찾는 기준이 될 수 없다. 언어별 이름 표를 두는
+# 방법은 쓰지 않는다 — 언어가 늘 때마다 표를 늘려야 하고, 같은 언어에서도 OS 판이 바뀌면
+# 표기가 달라져 조용히 빗나간다.
+#
+# 값은 각 앱의 `Info.plist` 에서 직접 읽었다 (macOS, 2026-08-10). tildaz 는
+# [`dist/macos/Info.plist.in`](../macos/Info.plist.in) 이 원본이다.
+mac_bundle_id() {
+    case "$1" in
+        terminal) printf 'com.apple.Terminal' ;;
+        iterm2) printf 'com.googlecode.iterm2' ;;
+        kitty) printf 'net.kovidgoyal.kitty' ;;
+        alacritty) printf 'org.alacritty' ;;
+        wezterm) printf 'com.github.wez.wezterm' ;;
+        ghostty) printf 'com.mitchellh.ghostty' ;;
+        tildaz) printf 'me.ensky0.tildaz' ;;
         *) printf '' ;;
     esac
 }
@@ -838,15 +942,32 @@ capture_screen() {
         Darwin)
             # 창 목록에서 그 앱의 **가장 큰 windowID** 를 고른다 — windowID 는 단조 증가하므로
             # 방금 뜬 창이다. 사용자가 따로 열어 둔 같은 앱의 창을 찍지 않기 위해서다.
-            # 앱 이름은 대상 이름과 대소문자만 다르다 (`WezTerm` · `Ghostty` · `TildaZ`).
+            #
+            # **찾는 기준은 bundle identifier 다** (#414). 예전에는 앱 이름으로 찾았는데,
+            # `applicationName` 이 **시스템 로케일로 번역된 이름**이라 한국어 macOS 에서
+            # Terminal.app 이 `터미널` 로 나와 매칭이 통째로 빗나갔다 (실측 — 그 회차가 조용히
+            # 전체 화면으로 찍혔다). 현지화되지 않는 대상들 (kitty · alacritty · wezterm ·
+            # ghostty) 만 우연히 멀쩡했던 것이라, OS 기본 앱을 넣자마자 드러났다.
+            #
+            # **이름 매칭도 남겨 둔다.** bundle identifier 가 없는 창이 있고 (`-` 로 나온다),
+            # 번들 안 바이너리를 직접 띄우는 tildaz 가 그럴 수 있다. 둘 중 하나만 맞아도 고른다.
             _wid=""
             if [ -n "$MAC_CAPTURE" ]; then
                 _wid=$("$MAC_CAPTURE" --list 2>/dev/null |
-                    awk -v t="$_ctarget" 'index(tolower($2), t) == 1 { print $1 }' |
+                    awk -v b="$(mac_bundle_id "$_ctarget")" -v t="$_ctarget" \
+                        '(b != "" && $2 == b) || index(tolower($3), t) == 1 { print $1 }' |
                     sort -n | tail -1)
             fi
-            [ -n "$_wid" ] && { "$MAC_CAPTURE" --window "$_wid" "$_png" >/dev/null 2>&1 || true; }
-            # 창을 못 찾았으면 전체 화면으로 물러선다 — 가려져 있으면 안 보이지만 없는 것보다 낫다.
+            # 창을 못 찾았거나 창 단위 캡처가 실패하면 전체 화면으로 물러선다 — 가려져 있으면
+            # 안 보이지만 없는 것보다 낫다. **어느 쪽이었는지 표시를 남긴다** — 예전에는 macOS 가
+            # 이 구분 없이 전부 `@` 로 찍혀서, 전체 화면으로 물러선 회차를 **사람이 PNG 을 열어
+            # 봐야만** 알 수 있었다 (#414 에서 실제로 그렇게 발견됐다).
+            if [ -z "$_wid" ]; then
+                CAPTURE_NOWIN=1
+            else
+                "$MAC_CAPTURE" --window "$_wid" "$_png" >/dev/null 2>&1 || true
+                [ -s "$_png" ] || CAPTURE_FELLBACK=1
+            fi
             # `-x` 는 셔터음을 끈다. **화면 기록 권한**이 필요하고 잠금 화면이면 실패한다.
             [ -s "$_png" ] || screencapture -x "$_png" >/dev/null 2>&1 || true
             ;;
@@ -1067,7 +1188,7 @@ run_terminal() {
         # 그 pid 가 즉시 끝나는 부모이고, ghostty 는 실행 실패 화면을 띄운 채 기다린다.
         # `cleanup_terminals` 가 이 실행의 `WORK_DIR` 패턴으로 실제 창을 정리한다.
         [ -n "$_pid" ] && kill "$_pid" 2>/dev/null || true
-        cleanup_terminals
+        cleanup_terminals "$_name"
 
         # #413 — **hold 가 끝날 때까지 기다린 뒤에 다음으로 넘어간다.**
         #
@@ -1295,8 +1416,8 @@ if [ "$IS_MACOS" = 1 ] && [ -d /Applications/iTerm.app ]; then
     cat > "$ITERM_PROFILE_FILE" << EOF
 {
   "Profiles": [{
-    "Name": "tildaz-stress",
-    "Guid": "tildaz-stress",
+    "Name": "$ITERM_PROFILE_NAME",
+    "Guid": "$ITERM_PROFILE_NAME",
     "Columns": $COLS,
     "Rows": $ROWS,
     "Scrollback Lines": $SCROLLBACK,
@@ -1309,8 +1430,58 @@ if [ "$IS_MACOS" = 1 ] && [ -d /Applications/iTerm.app ]; then
 EOF
     # 파일 감시로 읽으므로 반영을 기다린다. 바로 창을 만들면 프로파일이 없어서 실패한다.
     sleep 2
-    run_terminal iterm2 osascript -e \
-        'tell application "iTerm" to create window with profile "tildaz-stress"'
+    # 회차 정리가 이 실행의 창을 닫도록 표시한다 (`iterm2_window_close`).
+    ITERM_WINDOW_OPENED=1
+    # 창을 만든 **뒤** hide 를 푼다 — 이유는 `mac_app_unhide` 주석에 있다. 순서가 중요하다:
+    # 창이 생기기 전에 풀면 그 뒤에 만들어진 창이 다시 안 보이는 상태로 남을 수 있다.
+    run_terminal iterm2 osascript \
+        -e "tell application \"iTerm\" to create window with profile \"$ITERM_PROFILE_NAME\"" \
+        -e 'tell application "System Events" to set visible of process "iTerm2" to true'
+fi
+
+# Terminal.app — macOS 의 OS 기본 터미널이라 **Windows 의 conhost 와 같은 자리**다 (#414).
+# 하한 기준선이자, 시스템 기본 터미널이 어느 정도인지 보여 주는 대조군이다.
+#
+# **격자는 escape sequence 로 준다** — `CSI 8 ; rows ; cols t` 로 **셸이 자기 손으로 창을
+# 리사이즈**한다. 프로파일이 필요 없고 사용자 설정에 흔적이 안 남는다.
+#
+# [#381](https://github.com/ensky0/tildaz/issues/381#issuecomment-5220061290) 에서 막혔던 세
+# 방법 (AppleScript 로 창을 만든 뒤 격자 변경 · `defaults` 임시 프로파일 · `.terminal` 파일)
+# 은 셋 다 *Terminal.app 에게 격자를 알려 주는* 통로를 찾고 있었다. 이건 방향이 반대라 그
+# 구조에 아예 걸리지 않는다 — macOS 실측 3/3 에서 `stty size` 가 목표 격자와 일치했다.
+#
+# **`exec` 가 중요하다.** 로그인 셸을 wrapper 로 대체하므로 producer 가 끝나는 순간 그 창에
+# 실행 중인 프로세스가 없다. 그래야 회차 정리가 확인 시트 없이 창을 닫는다
+# (`terminal_app_close` 주석). `exec` 없이 닫으려다 시트에 막히는 것을 실측했다.
+#
+# **scrollback 은 못 맞춘다** — AppleScript 사전에 크기 속성이 아예 없다 (있는 `history` 는
+# 내용 읽기 전용이다). 사용자 프로파일 값이 그대로 쓰이므로 **이 대상만 조건이 다르고**,
+# 위의 scrollback 경고가 매 실행에서 그 사실을 알린다.
+#
+# 앱은 `/System/Applications/Utilities/Terminal.app` 에 항상 있어서 존재 검사를 두지 않는다
+# (iTerm2 · ghostty 처럼 설치 여부가 갈리는 대상과 다르다).
+if [ "$IS_MACOS" = 1 ]; then
+    T="$WORK_DIR/terminal.timing"
+    # 태그에 pid 를 넣어 **이 실행이 만든 창만** 고른다. 앞선 실행이 남긴 창이 있어도 안 건드린다.
+    TERMINAL_APP_TAG="TildaZ-stress-$$"
+    TERMINAL_WRAPPER="$WORK_DIR/terminal-app.sh"
+    # heredoc 이 `\033` 은 리터럴로 두고 `${ROWS}` 만 확장한다 (unquoted heredoc 의 백슬래시는
+    # `$` · 백틱 · `\` · 개행 앞에서만 특수하다).
+    cat > "$TERMINAL_WRAPPER" << EOF
+#!/bin/sh
+printf '\033[8;${ROWS};${COLS}t'
+$(producer_cmd "$T")
+EOF
+    chmod +x "$TERMINAL_WRAPPER"
+    # `do script` 가 돌려주는 **tab** 에 태그를 단다. `front window` 로 잡으면 그 찰나에
+    # 사용자가 다른 창을 앞으로 가져왔을 때 **사용자 창에 태그가 붙어 나중에 닫히므로**
+    # 그렇게 하지 않는다.
+    run_terminal terminal osascript \
+        -e 'tell application "Terminal"' \
+        -e "set t to do script \"exec sh '$TERMINAL_WRAPPER'\"" \
+        -e "set custom title of t to \"$TERMINAL_APP_TAG\"" \
+        -e 'end tell' \
+        -e 'tell application "System Events" to set visible of process "Terminal" to true'
 fi
 
 # TildaZ — `-e` · `-size` 로 자동 측정한다 (#382). 그 두 옵션은 **측정 내부용**이라

--- a/dist/stress/compare-terminals.sh
+++ b/dist/stress/compare-terminals.sh
@@ -1060,6 +1060,16 @@ capture_count() {
 RESULTS="$WORK_DIR/results"
 : > "$RESULTS"
 
+# producer 가 끝난 뒤에도 안 닫혀 상한에 걸린 회차를 적는다 (#414). **없으면 아무것도 안 찍는다** —
+# 정상 실행의 표를 어지럽히지 않으려는 것이다.
+#
+# ⚠️ 진행 줄 (`printf '%-14s '` 로 시작해 `@` · `~` 를 이어 찍는 그 줄) 이 **개행으로 끝난 뒤에**
+# 불러야 한다. 중간에 부르면 표가 깨진다. 들여쓰기는 그 줄의 이름 칸 (14 자 + 공백) 에 맞춘 것이다.
+stuck_note() {
+    [ "$_stuck" -gt 0 ] || return 0
+    echo "               ⚠ $_name — producer 가 끝난 뒤에도 안 닫혀서 ${_stuck} 회차를 강제로 정리했어요 (측정값은 유효해요)."
+}
+
 # 한 터미널을 `REPEAT` 회 돌리고, 회차별 경과 시간을 한 줄에 모아 적는다.
 #
 # 형식: 이름 <TAB> "ns ns ns …" <TAB> cols <TAB> rows <TAB> cols_start <TAB> rows_start
@@ -1080,6 +1090,8 @@ run_terminal() {
     _wait_max=0
     # 이 대상에서 hold 를 늘려 다시 찍은 회차 수. 표 아래 요약에 적는다.
     _retried=0
+    # producer 가 끝난 뒤에도 터미널이 안 닫혀 상한에 걸린 회차 수 (#414). `stuck_note` 참고.
+    _stuck=0
     _run=1
     while [ "$_run" -le "$REPEAT" ]; do
         # #413 — 한 회차를 최대 두 번 시도한다. **창 단위로 못 찍었으면** (`~` · `_` · `?`)
@@ -1181,8 +1193,34 @@ run_terminal() {
         # 캡처를 켜면 producer 가 `HOLD_MS` 만큼 더 살아 있다. 그걸 중간에 죽이면 셸이
         # `Terminated: 15` 를 표 위에 찍어 결과를 읽기 어렵게 만든다 (macOS 실측). 스스로
         # 끝나기를 기다렸다가 정리한다 — 어차피 그때까지 창이 살아 있어야 캡처가 된다.
+        #
+        # **기다림에는 상한이 있다** (#414 Windows 실기). 기다리는 목적이 *producer 의 hold 가
+        # 끝나는 것* 하나뿐이라 상한도 **그 시도의 hold** (`_hold_this`) 다 — 그보다 오래
+        # 기다려서 얻는 것이 없다. 재시도 회차는 hold 가 `CAPTURE_RETRY_HOLD_MS` 로 늘어나므로
+        # (#413) 상한도 같이 늘어난다. 아래 settle 이 쓰는 값과 같은 변수를 쓴다.
+        # 상한이 없던 동안 alacritty 회차가 **영영 끝나지 않았다.** producer 는 정상 종료했는데
+        # (프로세스가 남지 않고 timing 도 완전하다) `alacritty.exe` 만 남았다. 우리 스크립트
+        # 없이 `alacritty -e <producer>` 만으로도 나고, 180 초를 기다려도 안 닫히며 그동안
+        # **CPU 시간이 늘지 않는다** — 오래 걸리는 일을 하는 중이 아니라 멈춘 것이다. 출력량
+        # 의존이라 8 MiB 이하는 멀쩡하다 (README 의 Windows 절에 실측 표가 있다).
+        #
+        # 상한이 지나면 **아래 `kill` 이 정리한다** (멈춘 alacritty 가 그 `kill` 하나로 창까지
+        # 사라지는 것을 실측했다). **그 회차의 값은 버리지 않는다** — 멈춤은 측정과 캡처가 모두
+        # 끝난 뒤에 일어나고, 값은 producer 가 쓴 timing 파일에서 나오기 때문이다.
         if [ -n "$CAPTURE_DIR" ] && [ -n "$_pid" ]; then
-            wait "$_pid" 2>/dev/null || true
+            # 0.2 초씩 센다 — 매 바퀴 `date` 를 부르지 않으려는 것이다. 그래서 이 값은 **하한**
+            # 이다: 한 바퀴가 `sleep` 이 자는 시간보다 길 수 있어서 (Git Bash 실측 316 ms — MSYS
+            # 는 프로세스 생성이 비싸다) 실제로는 조금 더 기다린다. 우리에게 필요한 보장이
+            # *"producer 의 hold 가 끝날 때까지는 기다린다"* 라 넉넉한 쪽이 안전하다.
+            _left=$(( ((_hold_this + 999) / 1000 + 3) * 5 ))
+            while [ "$_left" -gt 0 ] && kill -0 "$_pid" 2>/dev/null; do
+                sleep 0.2
+                _left=$((_left - 1))
+            done
+            # 상한에 걸렸으면 **조용히 넘기지 않는다** — 대상 줄 아래에 회차 수를 적는다.
+            if kill -0 "$_pid" 2>/dev/null; then
+                _stuck=$((_stuck + 1))
+            fi
         fi
         # 창이 남아 있으면 정리한다. `kill $_pid` 만으로는 부족하다 — kitty 는 `--detach` 라
         # 그 pid 가 즉시 끝나는 부모이고, ghostty 는 실행 실패 화면을 띄운 채 기다린다.
@@ -1232,10 +1270,12 @@ run_terminal() {
 
     if [ -z "$_samples" ]; then
         printf ' timeout / 실행 안 됨\n'
+        stuck_note
         printf '%s\tskipped\t0\t0\t0\t0\n' "$_name" >> "$RESULTS"
         return
     fi
     printf ' ok  %sx%s\n' "$_cols" "$_rows"
+    stuck_note
     # 앞의 공백을 없애 awk 가 필드를 세기 쉽게 한다.
     _samples=$(printf '%s' "$_samples" | sed 's/^ *//')
     printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$_name" "$_samples" "$_cols" "$_rows" "$_cols0" "$_rows0" "$_wait_max" >> "$RESULTS"

--- a/dist/stress/hygiene.sh
+++ b/dist/stress/hygiene.sh
@@ -140,6 +140,46 @@ hygiene_minimize_macos() {
     osascript -e 'tell application "System Events" to set visible of (every process whose visible is true and name is not "Finder") to false' >/dev/null 2>&1
 }
 
+# 비교 대상 터미널 중 **지금 떠 있는 것**의 이름을 낸다 (#414). 없으면 빈 문자열이다.
+#
+# **왜 hide 로는 부족한가.** 배경 앱 최소화 (`hygiene_minimize_*`) 는 *그리기* 를 멈추는
+# 수단이지 프로세스를 없애는 게 아니다. 터미널은 사용자가 빌드 · 로그 같은 것을 띄워 둔 채
+# 두는 앱이라, 숨겨도 그 안의 프로그램은 계속 CPU 를 쓴다.
+#
+# **그리고 둘은 hide 로 아예 못 막는다.** `Terminal.app` (`do script`) 과 `iTerm2`
+# (`create window`) 는 **이미 떠 있는 앱 프로세스에 창을 붙이는** 방식이라, 우리 측정 창이
+# 사용자 창과 *같은 프로세스* 안에서 그려진다. 게다가 창을 만드는 순간 그 앱의 hide 가
+# 풀린다. 같은 함정을 wezterm 이 먼저 만났고 `--always-new-process` 로 피했다
+# (`compare-terminals.sh` 의 wezterm 절) — 그 플래그에 해당하는 것이 이 둘에는 없다.
+#
+# **이름은 각 앱의 실행 파일 이름이다.** 이 머신에서 `Terminal` · `iTerm2` 는 `pgrep -x` 로
+# 잡히는 것을 확인했고 (macOS, 2026-08-10), 나머지 넷은 각 앱의 표준 이름이라 **미검증**이다.
+# 틀리면 검사가 조용히 통과하므로, 대상을 늘릴 때는 실기에서 한 번 찍어 본다.
+#
+# **conhost 는 목록에 없다** — Windows 에서 이 스크립트를 돌리는 Git Bash 자신이 conhost
+# 안에서 돌아 **항상 걸린다.** conhost 측정은 회차마다 새 콘솔을 띄우므로 기존 창과 프로세스가
+# 갈린다.
+hygiene_running_terminals() {
+    case "$HYG_PLATFORM" in
+        macos)   _hyg_terms="Terminal iTerm2 kitty alacritty wezterm-gui ghostty" ;;
+        linux)   _hyg_terms="alacritty kitty wezterm-gui ghostty foot" ;;
+        windows) _hyg_terms="alacritty wezterm-gui WindowsTerminal" ;;
+        *)       return 0 ;;
+    esac
+    if [ "$HYG_PLATFORM" = windows ]; then
+        # 한 번에 묻는다 — 이름마다 powershell 을 띄우면 그것만으로 몇 초가 든다.
+        powershell -NoProfile -Command \
+            "(Get-Process $(echo "$_hyg_terms" | tr ' ' ',') -ErrorAction SilentlyContinue | Select-Object -ExpandProperty ProcessName -Unique) -join ' '" \
+            2>/dev/null | tr -d '\r'
+    else
+        _hyg_found=""
+        for _hyg_t in $_hyg_terms; do
+            pgrep -x "$_hyg_t" >/dev/null 2>&1 && _hyg_found="$_hyg_found $_hyg_t"
+        done
+        printf '%s' "${_hyg_found# }"
+    fi
+}
+
 # --- 검사 -----------------------------------------------------------------
 #
 # 값을 `HYG_*` 에 채우고, 측정을 망칠 것이 있으면 경고를 stderr 로 내고 1 을 돌려준다.
@@ -221,6 +261,17 @@ AC 미연결 (BatteryStatus=1) — 배터리에서는 스로틀링이 걸리고 
     if ! hygiene_can_minimize; then
         _warn="$_warn
 배경 앱을 자동으로 못 내려요 (KDE · macOS · Windows 에서만 해요) — 브라우저 · 에디터를 직접 최소화해요 (우리 수치만 최대 64 % 눌려요)"
+    fi
+
+    # 비교 대상 터미널은 **떠 있으면 안 된다** (#414). 이유는 `hygiene_running_terminals`
+    # 주석에 있다. 자동으로 닫지 않는다 — worker 와 달리 **사용자의 작업 창**이라 없애면
+    # 안 된다 (배경 앱을 최소화만 하고 닫지 않는 것과 같은 이유다).
+    _terms=$(hygiene_running_terminals)
+    if [ -n "$_terms" ]; then
+        _warn="$_warn
+비교 대상 터미널이 떠 있어요: $_terms — 측정 전에 종료해요 (숨기는 것으로는 부족해요)"
+        _warn="$_warn
+  이 스크립트는 대상이 아닌 터미널에서 돌려요 (VS Code 터미널 · SSH 등)"
     fi
 
     if [ -n "$_warn" ]; then


### PR DESCRIPTION
## 무엇

`compare-terminals.sh` 의 macOS 비교 대상에 **Terminal.app** 을 넣는다. macOS 의 OS 기본
터미널이라 **Windows 의 conhost 와 같은 자리**다 — 하한 기준선이자, 시스템 기본 터미널이 어느
정도인지 보여 주는 대조군이다.

[#414](https://github.com/ensky0/tildaz/issues/414) 는 원래 *"세 방법이 다 막혔다"* 로 열렸는데,
**네 번째 통로**가 있었다. 앞의 셋은 전부 *Terminal.app 에게 격자를 알려 주는* 통로를 찾고
있었고, 이건 방향이 반대다 — **셸이 자기 손으로 창을 리사이즈한다.**

| 커밋 | 무엇 |
|---|---|
| d24bfdd | Terminal.app 대상 추가 + 그 과정에서 드러난 캡처 버그 둘 |
| a603b40 | producer 가 끝난 뒤 안 닫히는 터미널을 무한정 기다리지 않는다 (Windows 검증 중 발견) |

### 어떻게 넣었나 (d24bfdd)

| 요소 | 방법 |
|---|---|
| 격자 | wrapper 첫 줄의 `printf '\033[8;<rows>;<cols>t'` — 프로파일이 필요 없어 **사용자 설정에 흔적이 구조적으로 안 남는다** |
| 실행 | `do script "exec sh <wrapper>"` — `exec` 가 핵심이다 |
| 창 특정 | `do script` 가 돌려주는 tab 에 `custom title` 태그 (`TildaZ-stress-<pid>`). front window 를 추측하지 않아 **사용자 창을 건드릴 위험이 없다** |
| 창 정리 | 프로세스를 먼저 죽이고 **그 뒤에** 태그 창을 닫는다 |
| scrollback | ❌ 못 맞춘다 — AppleScript 사전에 크기 속성이 없다. 매 실행 경고 + README 각주로 **명시**한다 |

**`exec` 가 두 가지를 동시에 푼다.** 로그인 셸을 wrapper 로 대체하니 producer 가 끝난 창에
실행 중인 프로세스가 없고, 그래야 `close` 가 **확인 시트 없이** 통과한다. 시트가 뜨면 창이 안
닫힐 뿐 아니라 **뒤따르는 close 가 전부 무시된다.**

함께 고친 **캡처 버그 둘** — 둘 다 증상이 같다. 그 회차만 조용히 전체 화면으로 찍힌다.

- **앱 이름이 로케일로 번역된다.** `applicationName` 은 표시 이름이라 한국어 macOS 에서
  `Terminal` 이 `터미널` 로 나온다. 현지화되지 않는 대상들만 우연히 멀쩡했던 것이라 OS 기본 앱을
  넣자마자 드러났다. **bundle identifier** 로 바꿨다 (언어별 이름 표는 두지 않는다).
- **hide 된 앱의 창은 화면에 안 올라온다.** 위생 절차가 배경 앱을 hide 하는데, 이미 떠 있는 앱에
  창을 붙이는 두 대상(Terminal.app · iTerm2)이 그것을 물려받는다. 캡처만의 문제가 아니라
  **그리지 않는 창은 렌더 부하가 빠져 그 대상만 유리해진다.** 창을 만든 뒤 hide 를 푼다.

그 밖에 iTerm2 측정 창 정리, macOS 도 창 단위 실패를 `?` / `~` 로 표시, 위생 검사에 *"비교 대상
터미널이 떠 있으면 안 된다"* 를 넣었다.

### 왜 두 번째 커밋이 붙었나 (a603b40)

Windows 검증에서 `--capture` 실행이 **영영 끝나지 않았다.** 측정 · 캡처가 다 끝나고 producer 도
정상 종료했는데 `alacritty.exe` 만 남아, 상한이 없는 `wait "$_pid"` 가 무한정 기다렸다.

**원인은 alacritty 쪽이다.** 우리 스크립트 없이 `alacritty -e <producer>` 만으로 재현된다
(1 · 8 MiB 0/6 · 16 MiB 2/3 · 32 MiB 3/3 · 64 MiB 3/3). 180 초를 기다려도 안 닫히고 그동안
**CPU 시간이 늘지 않는다** — 오래 걸리는 일을 하는 중이 아니라 멈춘 것이다. 기존에 적혀 있던
`zwj` 멈춤([#381](https://github.com/ensky0/tildaz/issues/381))과는 **출력 도중이냐 끝난 뒤냐**로
성격이 다르고, 그래서 워크로드도 가리지 않는다 (`plain` 에서 났다).

우리 쪽 결함은 *"그것을 무한정 기다리는 것"* 이라 **기다림에 상한을 뒀다.** 그 `wait` 이 있는
이유가 *producer 의 hold 가 끝나기를* 기다리는 것 하나뿐이므로 **상한도 거기에 맞춘 것**이지
증상을 가리는 우회가 아니다. 상한은 **그 시도의 hold** (`_hold_this`) 라 재시도 회차에서는
`CAPTURE_RETRY_HOLD_MS` 만큼 같이 늘어난다 (#413). 지나면 이미 있던 `kill` 이 정리한다.

**측정값은 버리지 않고 대상에서도 빼지 않는다** — 멈춤이 측정과 캡처가 모두 끝난 뒤에 일어나고,
값은 producer 가 쓴 timing 파일에서 나온다. 대신 상한에 걸린 회차를 표에 남긴다.

```
alacritty      @ ok  120x40
               ⚠ alacritty — producer 가 끝난 뒤에도 안 닫혀서 1 회차를 강제로 정리했어요 (측정값은 유효해요).
```

### [#413](https://github.com/ensky0/tildaz/issues/413) 위로 rebase 했다

작업 도중 main 에 `8503d41` (#413) 이 들어왔고 **같은 파일의 같은 구역**이었다. 충돌은 두
군데였고 이렇게 풀었다.

| 충돌 | 해결 |
|---|---|
| 회차 정리 뒤 블록 (`compare-terminals.sh`) | #413 의 새 구조 (settle · 재시도 판정) 를 살리고, 그 안의 `cleanup_terminals` 만 `cleanup_terminals "$_name"` 으로 |
| 캡처 도구 표의 두 행 (`README.md`) | macOS 행은 이 브랜치 것 (bundle identifier 는 그대로 사실), **Windows 행은 main 것** — #413 이 `ddagrab` 2 차 경로를 지웠으므로 |
| 대상별 카운터 초기화 | `_retried` (#413) 와 `_stuck` (#414) 둘 다 유지 |

그리고 상한이 쓰던 값을 고정 `HOLD_MS` 에서 **`_hold_this`** 로 바꿨다. #413 이 hold 를 시도마다
바꾸므로, 바로 아래 settle 과 **같은 변수를 봐야** 재시도 회차에서 상한이 어긋나지 않는다.
`ddagrab` 잔재가 남지 않은 것도 확인했다 (남은 언급은 전부 #413 이 적은 이력 서술이다).

## 검증

| 항목 | 환경 | 결과 |
|---|---|---|
| 여섯 대상 격자 · **창 단위 캡처** | macOS · MacBook Pro (M5 Pro) | 통과 — 전체 화면으로 물러선 회차 0, 측정 창 · 프로세스 잔여 0. Terminal.app · iTerm2 가 이미 떠 있는 최악 조건에서 쟀다 |
| 위생 검사의 **Windows 프로세스 이름** | Windows | 통과 — `[alacritty wezterm-gui WindowsTerminal]` 로 기대값과 일치. 실제 창 목록과도 대조했다 |
| 검사가 실제로 막는지 | Windows | 통과 — `exit=1` + 경고. `hygiene_check` 가 `hygiene_begin` 앞이라 **환경을 바꾸지 않고** 끝난다 |
| **상한 코드** (a603b40) | Windows | 통과 — 실제 코드 블록을 `sed` 로 떼어 안 끝나는 프로세스에 물렸다. `_hold_this=4000` → 9 초, `=15000` → 23 초로 **hold 를 따라간다.** 카운터 · 정리 · 경고 줄 정렬 · `set -eu` 안전 모두 확인 |
| **rebase 후 전체 실행** | Windows | 통과 — **손대지 않고 `exit=0` 완주.** 다섯 대상 전부 `@ ok 120x40` (창 단위 캡처, 내용 있음). **3 회차가 #413 재시도 (hold 15000 ms) 를 탔다** — 두 변경이 함께 도는 것을 확인한 셈이다 |
| `sh -n` (rebase 후) | Windows | 통과 — `compare-terminals.sh` · `hygiene.sh` |
| 위생 검사의 **Linux 프로세스 이름** | Linux | **미실행** — 아래 참고 |

Windows 환경은 노트북 AMD Ryzen AI 7 350 (8C/16T) · 2880x1800 120 Hz · Windows 11 Pro 26200 ·
Git Bash · alacritty 0.17.0 (94e7c88) 이다.

> **정직하게 적어 둔다** — 전체 실행 회차에서는 alacritty 가 안 멈췄다 (경고 줄이 안 나왔다).
> 그래서 그 실행만으로는 상한 코드가 밟혔다는 증거가 못 되고, 그 판정은 떼어낸 블록 검증이 한다.
> 스크립트 경로에서의 발생률은 아직 모른다.

## 남은 것 — 이 PR 은 #414 를 닫지 않는다

`hygiene_running_terminals` 의 **Linux 이름** (`alacritty kitty wezterm-gui ghostty foot`) 이 아직
미검증이다. 틀리면 검사가 조용히 통과하므로 Windows 와 같은 ① · ② 로 한 번 봐야 한다. 그래서
`Closes` 를 쓰지 않고 이슈를 열어 둔다.

Terminal.app 의 scrollback 은 구조적으로 못 맞춘다 — 해결이 아니라 **명시**했다 (conhost 와 같은
자리이되, 사용자 프로파일 값이라 **재현성도 떨어진다**는 점을 함께 적었다).

관련: #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
