### PR TITLE
fix(renderer): Windows Present 가 UI 스레드를 잡지 않게 waitable swapchain 으로 (#435)

### DIFF
--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -445,7 +445,27 @@ pub const App = struct {
             if (!self.tab_drag.active and !self.tab_scroll_user_override)
                 self.ensureActiveTabVisible();
 
-            if (should_render or force_render or blink_tick) {
+            // #435 — swap chain 이 다음 프레임을 받을 준비가 됐나. 논블로킹 확인이라
+            // UI 스레드를 잡지 않는다. 준비가 안 됐으면 이번 tick 은 그리지 않고 넘겨,
+            // 곧장 `messageLoop` 으로 돌아가 유휴 드레인 (#387 사양 A) 을 계속한다.
+            //
+            // ⚠️ **순서가 중요하다 — 그릴 게 있을 때만 묻는다.** frame-latency waitable 은
+            // 세마포어라 **기다려서 통과하면 카운트를 소비**하고, 그 카운트는 `Present` 한
+            // 프레임이 물러날 때 돌아온다 (그래서 정석이 "기다린다 → 반드시 present 한다"
+            // 1:1 이다). 그릴지 정하기 전에 물으면 유휴 프레임이 카운트만 먹고 present 를
+            // 안 해서 카운트가 영영 안 돌아오고, 몇 프레임 뒤부터 화면이 멈춘다.
+            //
+            // **`needs_render` 를 지우지 않는 것도 핵심이다** — 아래 게이트를 통과했을
+            // 때만 닫는다. 여기서 닫으면 "그릴 이유가 있었는데 안 그린" 프레임의 이유가
+            // 사라져, 다음 출력이 올 때까지 화면이 멈춘다.
+            //
+            // waitable 이 없는 경로 (legacy DISCARD · DirectComposition) 는 `frameReady`
+            // 가 항상 true 라 동작이 이 이슈 이전과 완전히 같다.
+            const want_render = should_render or force_render or blink_tick;
+            const swap_ready = want_render and r.frameReady();
+            if (want_render and !swap_ready) perf.incExtra(&perf.swapwait);
+
+            if (swap_ready) {
                 // 그리기로 했으니 게이트를 닫는다. 렌더 중에 도착한 메시지는 큐에 있다가
                 // 이 프레임 뒤에 처리되면서 다시 열므로 변화를 놓치지 않는다.
                 self.window.needs_render = false;
@@ -512,7 +532,9 @@ pub const App = struct {
                 // 조합 중이 아니거나 위치가 안 바뀐 프레임은 건너뛸 수 있다. 폭포 중 프레임당
                 // 비용은 측정하지 않았다 — 하려면 조합 여부 · 좌표 변화로 가드를 두면 된다.
                 self.window.imeSetCompositionPos(r.last_cursor_px_x, r.last_cursor_px_y);
-            } else {
+            } else if (!want_render) {
+                // #386 ② 게이트가 닫힌 경우만 여기서 센다. swap chain 대기로 넘긴 tick 은
+                // 위에서 `perf.swapwait` 로 따로 세므로 두 이유가 한 칸에 섞이지 않는다.
                 perf.incExtra(&perf.onrender);
             }
         }

--- a/src/perf.zig
+++ b/src/perf.zig
@@ -50,6 +50,10 @@ pub var render: Counter = .{}; // renderTerminal excluding Present
 pub var shape: Counter = .{}; // grapheme cluster shaping — subset of render, extra = chain miss
 pub var present: Counter = .{}; // swap_chain.Present
 pub var onrender: Counter = .{}; // onRender total — extra = skip_swap count
+/// #435 — swap chain 이 아직 다음 프레임을 못 받아서 건너뛴 frame tick 수 (extra).
+/// `onrender` 의 `skip` 과 **섞지 않는다** — 그쪽은 *"화면이 안 바뀌어서 안 그렸다"*
+/// (#386 ②) 라 뜻이 다르고, 한 칸에 합치면 그 게이트를 못 본다.
+pub var swapwait: Counter = .{};
 
 /// Cross-platform working-state timestamp(ns). Linux = CLOCK_MONOTONIC,
 /// macOS = CLOCK_UPTIME_RAW, Windows = QueryUnbiasedInterruptTimePrecise.
@@ -129,6 +133,7 @@ pub fn dumpAndReset(label: []const u8) void {
     const sh = snapshot(&shape);
     const pr = snapshot(&present);
     const on = snapshot(&onrender);
+    const sw = snapshot(&swapwait);
 
     var buf: [4096]u8 = undefined;
     const text = std.fmt.bufPrint(
@@ -143,6 +148,9 @@ pub fn dumpAndReset(label: []const u8) void {
             // 가르려고 뽑는다. miss = chain 전체 미스 (base codepoint fallback).
             "shape    calls={d} ms={d:.3} miss={d}\n" ++
             "present  calls={d} ms={d:.3}\n" ++
+            // #435 — swap chain 이 안 받아서 건너뛴 tick. waitable 이 없는 경로 (legacy
+            // DISCARD · DirectComposition) 에서는 항상 0 이다.
+            "swapwait ticks={d}\n" ++
             "onrender calls={d} ms={d:.3} skip={d}\n",
         .{
             label,
@@ -165,6 +173,7 @@ pub fn dumpAndReset(label: []const u8) void {
             sh[3],
             pr[0],
             @as(f64, @floatFromInt(pr[1])) / 1_000_000.0,
+            sw[3],
             on[0],
             @as(f64, @floatFromInt(on[1])) / 1_000_000.0,
             on[3],

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -35,6 +35,11 @@ const ligature_mod = @import("../font/ligature.zig");
 const isLigatureCandidate = ligature_mod.isLigatureCandidate;
 
 const MAX_INSTANCES: u32 = 32768;
+/// #435 — frame-latency waitable 을 논블로킹으로 확인 (`frameReady`) 하고, 다 쓰면 닫는다.
+extern "kernel32" fn WaitForSingleObject(?*anyopaque, u32) callconv(.c) u32;
+extern "kernel32" fn CloseHandle(?*anyopaque) callconv(.c) i32;
+const WAIT_OBJECT_0: u32 = 0;
+
 extern "user32" fn GetDpiForWindow(?*anyopaque) callconv(.c) c_uint;
 extern "user32" fn GetWindowLongPtrW(?*anyopaque, c_int) callconv(.c) isize;
 extern "user32" fn GetClientRect(?*anyopaque, *dw.RECT) callconv(.c) i32;
@@ -221,6 +226,17 @@ pub const D3d11Renderer = struct {
     device: *d3d.ID3D11Device,
     ctx: *d3d.ID3D11DeviceContext,
     swap_chain: *d3d.IDXGISwapChain,
+    /// #435 — frame-latency waitable. **flip-model + `CreateSwapChainForHwnd`
+    /// 경로에서만** 잡힌다 (layered / BitBlt 폴백 · DirectComposition 경로는 null).
+    /// null 이면 이 renderer 는 이 이슈 이전과 완전히 같게 동작한다.
+    frame_waitable: ?*anyopaque = null,
+    /// `Present` 의 sync interval. waitable 이 있으면 0 (vblank 대기를 `Present` 가
+    /// 하지 않는다 — 박자는 #386 프레임 클럭이 잡고, 백프레셔는 `frame_waitable` 이
+    /// 논블로킹으로 알려 준다). 없으면 1 로 기존 동작 유지.
+    present_sync: u32 = 1,
+    /// `ResizeBuffers` 가 되살려야 하는 생성 시 플래그. 0 을 넘기면 waitable 이
+    /// 떨어져 나가 `frame_waitable` 이 영영 신호되지 않는다.
+    swap_chain_flags: u32 = 0,
     /// #89 2단계 — 반투명(opacity<255) composition 경로의 DComp 객체.
     /// opacity 100% (hwnd flip-model) 또는 composition 실패 fallback 시 null.
     dcomp_device: ?*d3d.IDCompositionDesktopDevice = null,
@@ -463,6 +479,105 @@ pub const D3d11Renderer = struct {
         };
     }
 
+    /// #435 — 큐에 허용하는 프레임 수. **1 이면 안 된다** — 우리 frame tick 은 vblank 와
+    /// 위상이 독립이라 (드레인 4 ms → 렌더 → present 순서라 present 가 tick 후반부에 난다)
+    /// 직전 프레임이 아직 안 물러난 채로 다음 tick 이 온다. 예전 `Present(1, 0)` 은 vblank
+    /// 까지 블록하면서 루프 위상을 vblank 에 재정렬해 줬는데 sync 0 은 그게 없다.
+    ///
+    /// 1 로 뒀을 때 실측: 60 Hz `ansi` 에서 **tick 12 개 중 4 개 (33 %) 를 게이트가 버렸다**
+    /// (`swapwait ticks=4` · 그린 프레임 7 / onrender 12).
+    const MAX_FRAME_LATENCY: u32 = 2;
+    /// flip model 은 `BufferCount >= MaximumFrameLatency + 1` 이라야 실제로 그만큼 큐에 든다.
+    const WAITABLE_BUFFER_COUNT: u32 = MAX_FRAME_LATENCY + 1;
+
+    /// #435 — flip-model swap chain 을 `IDXGIFactory2::CreateSwapChainForHwnd` 로 만든다.
+    /// `D3D11CreateDeviceAndSwapChain` 과 갈리는 점은 하나다 — 이쪽만 `DESC1.Flags` 를
+    /// 받아서 `FRAME_LATENCY_WAITABLE_OBJECT` 를 걸 수 있다. 그 이벤트가 있어야
+    /// *"swap chain 이 다음 프레임을 받을 준비가 됐나"* 를 **블로킹 없이** 물어볼 수 있고,
+    /// 그래야 `Present` 를 sync 0 으로 두고도 큐가 차서 막히는 것을 앞에서 피한다.
+    ///
+    /// 성공하면 `device` · `ctx` · `swap_chain` · `waitable` · `flags_out` 을 채운다.
+    /// 실패는 HRESULT 로 반환하고, 정리는 **호출자의 폴백 루프**가 한다 (그쪽이 legacy
+    /// 경로 실패와 같은 자리에서 풀어야 재시도 순서가 어긋나지 않는다).
+    ///
+    /// `Width` / `Height` 를 0 으로 두면 DXGI 가 대상 창의 client 영역에서 가져온다 —
+    /// 기존 `DXGI_SWAP_CHAIN_DESC.BufferDesc` 가 0 이던 것과 같은 동작이다.
+    fn createWaitableHwndChain(
+        hwnd: ?*anyopaque,
+        driver_value: u32,
+        swap_effect: u32,
+        buffer_count: u32,
+        device: *?*d3d.ID3D11Device,
+        ctx: *?*d3d.ID3D11DeviceContext,
+        swap_chain: *?*d3d.IDXGISwapChain,
+        waitable: *?*anyopaque,
+        flags_out: *u32,
+    ) d3d.HRESULT {
+        const dev_hr = d3d.D3D11CreateDevice(
+            null,
+            driver_value,
+            null,
+            d3d.D3D11_CREATE_DEVICE_BGRA_SUPPORT, // D2D interop 필요 (#136)
+            null,
+            0,
+            d3d.D3D11_SDK_VERSION,
+            device,
+            null,
+            ctx,
+        );
+        if (dev_hr < 0) return dev_hr;
+        const dev = device.* orelse return -1;
+
+        var factory_any: ?*anyopaque = null;
+        const fac_hr = d3d.CreateDXGIFactory1(&d3d.IID_IDXGIFactory2, &factory_any);
+        if (fac_hr < 0) return fac_hr;
+        const factory2: *d3d.IDXGIFactory2 = @ptrCast(@alignCast(factory_any orelse return -1));
+        defer _ = factory2.Release();
+
+        const flags = d3d.DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+        const desc1 = d3d.DXGI_SWAP_CHAIN_DESC1{
+            .Width = 0,
+            .Height = 0,
+            .Format = d3d.DXGI_FORMAT_B8G8R8A8_UNORM,
+            .SampleDesc = .{ .Count = 1 },
+            .BufferUsage = d3d.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            .BufferCount = buffer_count,
+            .Scaling = d3d.DXGI_SCALING_STRETCH,
+            .SwapEffect = swap_effect,
+            // hwnd swap chain 은 per-pixel 알파를 쓰지 않는다 (반투명은 opacity<255 의
+            // DirectComposition 경로 담당 — #89 2단계).
+            .AlphaMode = d3d.DXGI_ALPHA_MODE_IGNORE,
+            .Flags = flags,
+        };
+        const sc_hr = factory2.CreateSwapChainForHwnd(@ptrCast(dev), hwnd, &desc1, null, null, swap_chain);
+        if (sc_hr < 0) return sc_hr;
+        if (swap_chain.* == null) return -1;
+        flags_out.* = flags;
+
+        // #89 — DXGI 내장 Alt+Enter 감시 차단. 이 경로는 factory 를 이미 들고 있어
+        // swap chain 의 `GetParent` 로 되찾을 필요가 없다.
+        const mwa_hr = factory2.MakeWindowAssociation(hwnd, d3d.DXGI_MWA_NO_WINDOW_CHANGES | d3d.DXGI_MWA_NO_ALT_ENTER);
+        log.appendLineVerbose("d3d", "MakeWindowAssociation(NO_WINDOW_CHANGES|NO_ALT_ENTER) hr=0x{x}", .{@as(u32, @bitCast(mwa_hr))});
+
+        // 큐 깊이는 `MAX_FRAME_LATENCY` 주석 참고 — 위상 어긋남을 흡수할 만큼만 두고
+        // 그 이상은 waitable 이 막는다. 더 키우면 입력 → 화면 지연이 그만큼 늘어난다.
+        var sc2_any: ?*anyopaque = null;
+        if (swap_chain.*.?.QueryInterface(&d3d.IID_IDXGISwapChain2, &sc2_any) >= 0) {
+            if (sc2_any) |p| {
+                const sc2: *d3d.IDXGISwapChain2 = @ptrCast(@alignCast(p));
+                defer _ = sc2.Release();
+                _ = sc2.SetMaximumFrameLatency(MAX_FRAME_LATENCY);
+                waitable.* = sc2.GetFrameLatencyWaitableObject();
+            }
+        }
+        // 여기서 실패해도 swap chain 자체는 쓸 수 있다. 다만 논블로킹 확인 수단이 없으니
+        // 호출자가 `present_sync` 를 1 로 남겨 예전(vsync present) 동작으로 돈다.
+        if (waitable.* == null) {
+            log.appendLine("d3d", "frame latency waitable unavailable — keeping vsync present", .{});
+        }
+        return sc_hr;
+    }
+
     /// 주어진 driver type 하나로 renderer 전체를 만든다. 하드웨어 → WARP 재시도는
     /// `init` 이 담당한다.
     ///
@@ -512,28 +627,57 @@ pub const D3d11Renderer = struct {
         const swap_effects: []const u32 = if (layered_window) &layered_swap_effects else &standard_swap_effects;
         var create_hr: d3d.HRESULT = if (composition_active) 0 else -1;
         var selected_swap_effect: u32 = if (composition_active) d3d.DXGI_SWAP_EFFECT_FLIP_DISCARD else d3d.DXGI_SWAP_EFFECT_DISCARD;
+        // #435 — flip-model 은 `CreateSwapChainForHwnd` 로 만들어 frame-latency waitable 을
+        // 건다. `D3D11CreateDeviceAndSwapChain` 은 `DESC1.Flags` 를 못 받아 이 플래그를
+        // 걸 방법이 없다. legacy `DISCARD` (layered 창 · flip 둘 다 실패한 폴백) 는 애초에
+        // waitable 이 없는 swap effect 라 예전 경로를 그대로 쓴다 — 그 경우 `frame_waitable`
+        // 이 null 로 남고 `present_sync` 가 1 이라 이 이슈 이전과 동작이 완전히 같다.
+        var frame_waitable: ?*anyopaque = null;
+        var swap_chain_flags: u32 = 0;
         if (composition_active) sc_desc.BufferCount = 2;
         for (if (composition_active) swap_effects[0..0] else swap_effects) |swap_effect| {
-            sc_desc.BufferCount = if (swap_effect == d3d.DXGI_SWAP_EFFECT_DISCARD) 1 else 2;
+            const buffer_count: u32 = if (swap_effect == d3d.DXGI_SWAP_EFFECT_DISCARD) 1 else WAITABLE_BUFFER_COUNT;
+            // 아래 생성 로그가 이 값을 읽는다. flip 경로는 `sc_desc` 를 쓰지 않지만
+            // 여기서 함께 맞춰 두지 않으면 로그의 `buffers=` 가 틀린 값을 찍는다.
+            sc_desc.BufferCount = buffer_count;
             sc_desc.SwapEffect = swap_effect;
-            create_hr = d3d.D3D11CreateDeviceAndSwapChain(
-                null,
-                driver_value,
-                null,
-                d3d.D3D11_CREATE_DEVICE_BGRA_SUPPORT, // D2D interop 필요 (#136)
-                null,
-                0,
-                d3d.D3D11_SDK_VERSION,
-                &sc_desc,
-                &swap_chain,
-                &device,
-                null,
-                &ctx,
-            );
+            if (swap_effect == d3d.DXGI_SWAP_EFFECT_DISCARD) {
+                create_hr = d3d.D3D11CreateDeviceAndSwapChain(
+                    null,
+                    driver_value,
+                    null,
+                    d3d.D3D11_CREATE_DEVICE_BGRA_SUPPORT, // D2D interop 필요 (#136)
+                    null,
+                    0,
+                    d3d.D3D11_SDK_VERSION,
+                    &sc_desc,
+                    &swap_chain,
+                    &device,
+                    null,
+                    &ctx,
+                );
+            } else {
+                create_hr = createWaitableHwndChain(
+                    hwnd,
+                    driver_value,
+                    swap_effect,
+                    buffer_count,
+                    &device,
+                    &ctx,
+                    &swap_chain,
+                    &frame_waitable,
+                    &swap_chain_flags,
+                );
+            }
             if (create_hr >= 0) {
                 selected_swap_effect = swap_effect;
                 break;
             }
+            if (frame_waitable) |h| {
+                _ = CloseHandle(h);
+                frame_waitable = null;
+            }
+            swap_chain_flags = 0;
             if (ctx) |c| {
                 _ = c.Release();
                 ctx = null;
@@ -555,12 +699,16 @@ pub const D3d11Renderer = struct {
             });
             return error.D3D11CreateFailed;
         }
-        log.appendLineVerbose("d3d", "swap chain created: driver={s} layered={} composition={} effect={s} buffers={d}", .{
+        // #435 — `waitable` 이 이 빌드가 어느 경로로 떴는지 가르는 값이다. 회귀 판정에서
+        // *"waitable 이 안 걸린 채 sync 0 으로 도는"* 조합을 배제하는 근거라 로그로 남긴다.
+        log.appendLine("d3d", "swap chain created: driver={s} layered={} composition={} effect={s} buffers={d} waitable={} present_sync={d}", .{
             @tagName(driver_type),
             layered_window,
             composition_active,
             swapEffectName(selected_swap_effect),
             sc_desc.BufferCount,
+            frame_waitable != null,
+            @as(u32, if (frame_waitable != null) 0 else 1),
         });
 
         // #89 — DXGI 의 내장 Alt+Enter 감시 차단. DXGI 는 swap chain 이 붙은
@@ -572,7 +720,10 @@ pub const D3d11Renderer = struct {
         // 는 정상인데 taskbar 영역만 검정 + 클릭은 통과 — DXGI FS 전환의
         // 전형). NO_WINDOW_CHANGES 로 감시 자체를 끈다. (composition swap
         // chain 은 hwnd 연동 자체가 없어 해당 없음.)
-        if (!composition_active) {
+        // #435 — `createWaitableHwndChain` 을 지난 경우 (`swap_chain_flags != 0`) 는 그
+        // 안에서 이미 걸었다. 남는 것은 legacy `DISCARD` (layered · flip 전멸 폴백) 뿐이라
+        // 예전처럼 `GetParent` 로 factory 를 되찾는다.
+        if (!composition_active and swap_chain_flags == 0) {
             var factory_ptr: ?*anyopaque = null;
             if (swap_chain.?.GetParent(&d3d.IID_IDXGIFactory, &factory_ptr) >= 0) {
                 if (factory_ptr) |fp| {
@@ -592,6 +743,8 @@ pub const D3d11Renderer = struct {
             if (dcomp_visual) |v| _ = v.Release();
             if (dcomp_target) |t| _ = t.Release();
             if (dcomp_device) |dd| _ = dd.Release();
+            // #435 — waitable HANDLE 의 소유권은 우리에게 있다 (`GetFrameLatencyWaitableObject`).
+            if (frame_waitable) |h| _ = CloseHandle(h);
             _ = ctx.?.Release();
             _ = swap_chain.?.Release();
             _ = device.?.Release();
@@ -755,6 +908,11 @@ pub const D3d11Renderer = struct {
             .device = device.?,
             .ctx = ctx.?,
             .swap_chain = swap_chain.?,
+            .frame_waitable = frame_waitable,
+            // waitable 이 없으면 (legacy DISCARD · composition · QI 실패) sync 1 을 유지해
+            // 이 이슈 이전과 완전히 같게 둔다.
+            .present_sync = if (frame_waitable != null) 0 else 1,
+            .swap_chain_flags = swap_chain_flags,
             .dcomp_device = dcomp_device,
             .dcomp_target = dcomp_target,
             .dcomp_visual = dcomp_visual,
@@ -807,9 +965,25 @@ pub const D3d11Renderer = struct {
         if (self.dcomp_visual) |v| _ = v.Release();
         if (self.dcomp_target) |t| _ = t.Release();
         if (self.dcomp_device) |dd| _ = dd.Release();
+        // #435 — `GetFrameLatencyWaitableObject` 가 준 HANDLE 은 호출자 소유다.
+        if (self.frame_waitable) |h| {
+            _ = CloseHandle(h);
+            self.frame_waitable = null;
+        }
         _ = self.swap_chain.Release();
         _ = self.ctx.Release();
         _ = self.device.Release();
+    }
+
+    /// #435 — swap chain 이 다음 프레임을 받을 준비가 됐나. **블로킹하지 않는다**
+    /// (timeout 0). `false` 면 이번 프레임 tick 은 그리지 않고 넘긴다 — UI 스레드는
+    /// 곧장 메시지 루프로 돌아가 유휴 드레인 (#387 사양 A) 을 계속한다.
+    ///
+    /// waitable 이 없는 경로 (legacy `DISCARD` · DirectComposition · QI 실패) 는 항상
+    /// `true` 다. 그쪽은 `present_sync` 가 1 이라 `Present` 가 예전처럼 페이싱한다.
+    pub fn frameReady(self: *const D3d11Renderer) bool {
+        const h = self.frame_waitable orelse return true;
+        return WaitForSingleObject(h, 0) == WAIT_OBJECT_0;
     }
 
     pub fn invalidate(self: *D3d11Renderer) void {
@@ -869,7 +1043,10 @@ pub const D3d11Renderer = struct {
         }
         // Unbind render target before resize
         self.ctx.OMSetRenderTargets(0, null, null);
-        _ = self.swap_chain.ResizeBuffers(0, width, height, 0, 0);
+        // #435 — 생성 시 플래그를 그대로 돌려줘야 한다. 0 을 넘기면 waitable 이 떨어져
+        // 나가 `frame_waitable` 이 영영 신호되지 않고, 그러면 `frameReady` 가 계속 false
+        // 라 창 크기를 바꾼 뒤로 화면이 멈춘다.
+        _ = self.swap_chain.ResizeBuffers(0, width, height, 0, self.swap_chain_flags);
         self.createRTV();
         self.vp_width = width;
         self.vp_height = height;
@@ -1719,8 +1896,13 @@ pub const D3d11Renderer = struct {
         perf.addTimed(&perf.render, render_t0);
 
         // Present
+        //
+        // #435 — waitable 경로는 sync 0 이다. vblank 대기를 여기서 하면 그동안 UI 스레드가
+        // 묶여 유휴 드레인 (#387 사양 A) 이 통째로 굶는다 — 그게 이 이슈의 상태 A 다.
+        // 박자는 #386 프레임 클럭이 잡고, 큐 포화는 `frameReady` 가 앞에서 막는다.
+        // waitable 이 없는 경로는 `present_sync` 가 1 이라 예전 그대로다.
         const present_t0 = perf.now();
-        _ = self.swap_chain.Present(1, 0);
+        _ = self.swap_chain.Present(self.present_sync, 0);
         perf.addTimed(&perf.present, present_t0);
     }
 

--- a/src/renderer/windows/d3d11.zig
+++ b/src/renderer/windows/d3d11.zig
@@ -379,7 +379,7 @@ pub const IDXGISwapChain = extern struct {
 
     const VTable = extern struct {
         // IUnknown (0-2)
-        QueryInterface: *const anyopaque,
+        QueryInterface: *const fn (*IDXGISwapChain, *const GUID, *?*anyopaque) callconv(.c) HRESULT,
         AddRef: *const anyopaque,
         Release: *const fn (*IDXGISwapChain) callconv(.c) u32,
         // IDXGIObject (3-6)
@@ -398,6 +398,9 @@ pub const IDXGISwapChain = extern struct {
         ResizeBuffers: *const fn (*IDXGISwapChain, u32, u32, u32, u32, u32) callconv(.c) HRESULT,
     };
 
+    pub fn QueryInterface(self: *IDXGISwapChain, riid: *const GUID, out: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, out);
+    }
     pub fn Release(self: *IDXGISwapChain) u32 {
         return self.vtable.Release(self);
     }
@@ -805,6 +808,14 @@ pub const DXGI_SWAP_CHAIN_DESC1 = extern struct {
     Flags: u32 = 0,
 };
 
+/// #435 — swap chain 이 다음 프레임을 받을 준비가 됐는지 **논블로킹으로 물어볼 수 있는**
+/// 이벤트를 달아 준다. `IDXGIFactory2::CreateSwapChainFor*` 로 만들 때만 걸 수 있고
+/// `D3D11CreateDeviceAndSwapChain` 으로는 못 건다.
+///
+/// ⚠️ **`0x800` 과 헷갈리기 쉽다** — 그쪽은 `ALLOW_TEARING` 이다. 값은 zig 가 번들한
+/// MinGW-w64 `dxgi.h` 의 `DXGI_SWAP_CHAIN_FLAG` 로 확인했다.
+pub const DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT: u32 = 0x40;
+
 pub const IID_IDXGIFactory2 = GUID{
     .Data1 = 0x50c83a1c,
     .Data2 = 0xe072,
@@ -834,7 +845,7 @@ pub const IDXGIFactory2 = extern struct {
         GetParent: *const anyopaque,
         // IDXGIFactory (7-11)
         EnumAdapters: *const anyopaque,
-        MakeWindowAssociation: *const anyopaque,
+        MakeWindowAssociation: *const fn (*IDXGIFactory2, ?*anyopaque, u32) callconv(.c) HRESULT,
         GetWindowAssociation: *const anyopaque,
         CreateSwapChain: *const anyopaque,
         CreateSoftwareAdapter: *const anyopaque,
@@ -843,7 +854,7 @@ pub const IDXGIFactory2 = extern struct {
         IsCurrent: *const anyopaque,
         // IDXGIFactory2 (14-24)
         IsWindowedStereoEnabled: *const anyopaque,
-        CreateSwapChainForHwnd: *const anyopaque,
+        CreateSwapChainForHwnd: *const fn (*IDXGIFactory2, *anyopaque, ?*anyopaque, *const DXGI_SWAP_CHAIN_DESC1, ?*const anyopaque, ?*anyopaque, *?*IDXGISwapChain) callconv(.c) HRESULT,
         CreateSwapChainForCoreWindow: *const anyopaque,
         GetSharedResourceAdapterLuid: *const anyopaque,
         RegisterStereoStatusWindow: *const anyopaque,
@@ -862,6 +873,100 @@ pub const IDXGIFactory2 = extern struct {
     /// 상위 호환(선두 18 slot 동일)이라 기존 wrapper 로 그대로 사용.
     pub fn CreateSwapChainForComposition(self: *IDXGIFactory2, device: *anyopaque, desc: *const DXGI_SWAP_CHAIN_DESC1, restrict_out: ?*anyopaque, out: *?*IDXGISwapChain) HRESULT {
         return self.vtable.CreateSwapChainForComposition(self, device, desc, restrict_out, out);
+    }
+    /// #435 — hwnd 용. `D3D11CreateDeviceAndSwapChain` 과 달리 `DESC1.Flags` 를 받아서
+    /// frame-latency waitable 을 걸 수 있다. `fullscreen_desc` 는 null 이면 windowed.
+    /// 반환은 `CreateSwapChainForComposition` 과 같은 이유로 `IDXGISwapChain` 으로 받는다.
+    pub fn CreateSwapChainForHwnd(self: *IDXGIFactory2, device: *anyopaque, hwnd: ?*anyopaque, desc: *const DXGI_SWAP_CHAIN_DESC1, fullscreen_desc: ?*const anyopaque, restrict_out: ?*anyopaque, out: *?*IDXGISwapChain) HRESULT {
+        return self.vtable.CreateSwapChainForHwnd(self, device, hwnd, desc, fullscreen_desc, restrict_out, out);
+    }
+    /// #89 — DXGI 내장 Alt+Enter 감시 차단. 지금까지는 swap chain 의 `GetParent` 로
+    /// `IDXGIFactory` 를 다시 얻어 불렀는데, hwnd 경로는 factory 를 이미 들고 있다.
+    pub fn MakeWindowAssociation(self: *IDXGIFactory2, hwnd: ?*anyopaque, flags: u32) HRESULT {
+        return self.vtable.MakeWindowAssociation(self, hwnd, flags);
+    }
+};
+
+// --- IDXGISwapChain2 (#435) ---
+// IDXGISwapChain (0-17) + IDXGISwapChain1 (18-28) + IDXGISwapChain2 (29-35).
+// 선두 18 slot 이 IDXGISwapChain 과 같아 같은 포인터를 두 타입으로 볼 수 있지만,
+// 아래 두 메서드는 QueryInterface 로 얻은 IDXGISwapChain2 에서만 부른다.
+//
+// Slots (zig 번들 MinGW-w64 `dxgi1_3.h` 의 IDXGISwapChain2Vtbl 로 확인):
+// 18-28: IDXGISwapChain1 (GetDesc1, GetFullscreenDesc, GetHwnd, GetCoreWindow, Present1,
+//        IsTemporaryMonoSupported, GetRestrictToOutput, SetBackgroundColor,
+//        GetBackgroundColor, SetRotation, GetRotation)
+// 29:    SetSourceSize
+// 30:    GetSourceSize
+// 31:    SetMaximumFrameLatency
+// 32:    GetMaximumFrameLatency
+// 33:    GetFrameLatencyWaitableObject
+// 34-35: SetMatrixTransform, GetMatrixTransform
+
+pub const IID_IDXGISwapChain2 = GUID{
+    .Data1 = 0xa8be2ac4,
+    .Data2 = 0x199f,
+    .Data3 = 0x4946,
+    .Data4 = .{ 0xb3, 0x31, 0x79, 0x59, 0x9f, 0xb9, 0x8d, 0xe7 },
+};
+
+pub const IDXGISwapChain2 = extern struct {
+    vtable: *const VTable,
+
+    const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: *const anyopaque,
+        AddRef: *const anyopaque,
+        Release: *const fn (*IDXGISwapChain2) callconv(.c) u32,
+        // IDXGIObject (3-6)
+        SetPrivateData: *const anyopaque,
+        SetPrivateDataInterface: *const anyopaque,
+        GetPrivateData: *const anyopaque,
+        GetParent: *const anyopaque,
+        // IDXGIDeviceSubObject (7)
+        GetDevice: *const anyopaque,
+        // IDXGISwapChain (8-17)
+        Present: *const anyopaque,
+        GetBuffer: *const anyopaque,
+        SetFullscreenState: *const anyopaque,
+        GetFullscreenState: *const anyopaque,
+        GetDesc: *const anyopaque,
+        ResizeBuffers: *const anyopaque,
+        ResizeTarget: *const anyopaque,
+        GetContainingOutput: *const anyopaque,
+        GetFrameStatistics: *const anyopaque,
+        GetLastPresentCount: *const anyopaque,
+        // IDXGISwapChain1 (18-28)
+        GetDesc1: *const anyopaque,
+        GetFullscreenDesc: *const anyopaque,
+        GetHwnd: *const anyopaque,
+        GetCoreWindow: *const anyopaque,
+        Present1: *const anyopaque,
+        IsTemporaryMonoSupported: *const anyopaque,
+        GetRestrictToOutput: *const anyopaque,
+        SetBackgroundColor: *const anyopaque,
+        GetBackgroundColor: *const anyopaque,
+        SetRotation: *const anyopaque,
+        GetRotation: *const anyopaque,
+        // IDXGISwapChain2 (29-35)
+        SetSourceSize: *const anyopaque,
+        GetSourceSize: *const anyopaque,
+        SetMaximumFrameLatency: *const fn (*IDXGISwapChain2, u32) callconv(.c) HRESULT,
+        GetMaximumFrameLatency: *const anyopaque,
+        GetFrameLatencyWaitableObject: *const fn (*IDXGISwapChain2) callconv(.c) ?*anyopaque,
+        SetMatrixTransform: *const anyopaque,
+        GetMatrixTransform: *const anyopaque,
+    };
+
+    pub fn Release(self: *IDXGISwapChain2) u32 {
+        return self.vtable.Release(self);
+    }
+    pub fn SetMaximumFrameLatency(self: *IDXGISwapChain2, max_latency: u32) HRESULT {
+        return self.vtable.SetMaximumFrameLatency(self, max_latency);
+    }
+    /// 반환 HANDLE 의 소유권은 **호출자**에게 있다 — 다 쓰면 `CloseHandle`.
+    pub fn GetFrameLatencyWaitableObject(self: *IDXGISwapChain2) ?*anyopaque {
+        return self.vtable.GetFrameLatencyWaitableObject(self);
     }
 };
 


### PR DESCRIPTION
Windows 에서 `Present(1, 0)` 이 프레임 tick 핸들러 안에서 UI 스레드를 vblank 까지 붙잡는 바람에,
[#387](https://github.com/ensky0/tildaz/issues/387) 이 넣은 **유휴 드레인이 쓰라고 만든 시간이
사라지고 있었다.** 그래서 프레임당 드레인이 1 회(4.8 ms)로 묶이는 상태와 3~4 회(15.3 ms)로 포화되는
상태 사이에서 회차마다 굳어, 같은 빌드가 `ansi` 를 **20 ↔ 79 MiB/s** 로 냈다 ([#435](https://github.com/ensky0/tildaz/issues/435)).

flip-model swapchain 을 `IDXGIFactory2::CreateSwapChainForHwnd` 로 만들어 frame-latency waitable 을
걸고 `Present` 를 sync 0 으로 뒀다. 큐 포화는 렌더 직전의 **논블로킹** 확인(`frameReady`)이 막으므로
**UI 스레드가 어디서도 잠들지 않는다.** 박자는 [#386](https://github.com/ensky0/tildaz/issues/386)
프레임 클럭이 그대로 잡는다 — `window.zig` · SPEC §13 무변경. waitable 을 못 얻는 경로(layered ·
BitBlt 폴백 · composition)는 `present_sync = 1` 로 남아 **이전과 동작이 완전히 같다.**

설계 근거와 구현 중 걸린 결함 둘(세마포어 소비 순서 · 큐 깊이 1 의 위상 손실)은
[#435 코멘트 ⑧](https://github.com/ensky0/tildaz/issues/435#issuecomment-5235895057) ·
[⑨](https://github.com/ensky0/tildaz/issues/435#issuecomment-5236151805) 에 있다.

## 검증 — 세 기기

`ansi` 64 MiB · 120x40 · scrollback 32,767 · `ReleaseFast -Dsimd=true` · producer 고정
([#397](https://github.com/ensky0/tildaz/issues/397) 방식) · before/after **교대** 실행.
판정은 **`present ms / 프레임`** 이다 (드레인 임계는 주사율 종속이라 못 쓴다).

| 기기 | 조건 | before | after | 기운 회차 |
|---|---|--:|--:|---|
| AMD Ryzen AI 7 350 · Radeon 860M · 60 Hz | 하네스 위생 | — | — | 2/30 → **0/300** |
| **Intel i5-1240P · Iris Xe · 59 Hz** | **배경 부하** | **20.7** | **69.7** (+237 %) | **15/15 → 0/15** |
| Intel i5-1240P · Iris Xe · 59 Hz | 배경 최소화 | 73.6 | 72.8 (−1.1 %) | 2/15 → **0/15** |

- **i5 의 배경 부하 조건이 이 fix 의 성공 기준이었다** — 그 기기에서 깊은 상태를 확실히 부르는
  조건이고, before 15 회차가 전부 `present/f` 10.78~10.91 로 갇혔는데 after 는 0.17~0.22 로
  한 번도 빠지지 않았다 ([코멘트 ⑩](https://github.com/ensky0/tildaz/issues/435#issuecomment-5250333860)).
- **회귀 없음** — 조용한 조건에서 −1.1 %, 드레인 duty 동일.
- **새 경로가 실제로 잡힌 것**을 회차마다 로그로 확인했다 —
  `effect=flip_discard buffers=3 waitable=true present_sync=0`.
- **세마포어 누수 없음** — `swapwait` 가 회차를 거듭해도 평평하다 (i5 회차당 0.87 / 0.33 ·
  AMD 300 회차 구간별 0.80~1.02).
- **티어링 없음** — 1 GiB 폭포(15 초 연속 스크롤) 육안. Radeon 860M · **Iris Xe** 양쪽
  ([코멘트 ⑪](https://github.com/ensky0/tildaz/issues/435#issuecomment-5250363339)).
  그 회차 덤프의 `render : present` = 873 : 873 (1:1).

`zig build` (ReleaseFast · SIMD) · `zig build check` (6 타겟) · `zig build test` — 두 기기 모두 통과.

## 딸린 것

사이트에 실린 Windows `ansi` **37.3** ([#434](https://github.com/ensky0/tildaz/issues/434)) 은
상태 A 가 섞인 표본이라 다시 떠야 한다. 기댓값은 위 조용한 조건의 **72.8** 이다. 별도 작업으로 둔다.

Closes #435
