### PR TITLE
fix(system_open): xdg-open 자식을 pid 지목으로 거둔다 — 좀비 누적 (#457)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -967,8 +967,16 @@ onrender 진단 수치에만 적용한다. instance timeout이나 Linux startup/
 
 **메커니즘:**
 - Windows: `ShellExecuteW(NULL, "open", path, ...)` — 사용자 default editor (`.json` / `.log` 의 file association).
-- macOS: `[NSWorkspace openURL:]` 또는 `system("open <path>")` — Finder 가 file extension 따라 default app.
-- Linux: `xdg-open <path>` — XDG MIME database.
+- macOS: `/usr/bin/open <path>` 를 자식 process 로 — Finder 가 file extension 따라 default app.
+- Linux: `xdg-open <path>` 를 자식 process 로 — XDG MIME database.
+
+**자식 process 회수 (macOS · Linux)** — spawn 한 자식은 **그 pid 를 지목한 thread 가 `waitpid` 로
+거둔다** ([#457](https://github.com/ensky0/tildaz/issues/457)). 안 거두면 `[xdg-open] <defunct>` 가
+worker 수명 동안 상한 없이 쌓인다. 거둘 때 `SIGCHLD = SIG_IGN` 이나 `waitpid(-1)` 를 쓰지 않는
+이유는 §7 의 PTY 자식 관리와 충돌하기 때문이다 — 그 둘은 `processWaitLoop` 의
+`waitpid(child_pid, ...)` 를 자식이 죽기도 전에 `ECHILD` 로 반환시켜, 탭이 열리자마자 닫히고
+[#129](https://github.com/ensky0/tildaz/issues/129) 의 SIGHUP grace · SIGKILL fallback 이 무력화된다.
+Windows 는 `ShellExecuteW` 라 우리가 자식을 만들지 않아 이 문제가 없다.
 
 ### 11.3 About 다이얼로그 — 경로 표시 (모두 절대 경로) + Tip 라인
 

--- a/src/system_open.zig
+++ b/src/system_open.zig
@@ -11,6 +11,8 @@
 const std = @import("std");
 const Runtime = @import("runtime.zig").Runtime;
 const builtin = @import("builtin");
+const posix = std.posix;
+const log = @import("log.zig");
 
 pub fn openInDefaultApp(rt: Runtime, allocator: std.mem.Allocator, path: []const u8) void {
     switch (builtin.os.tag) {
@@ -32,13 +34,35 @@ fn openWindows(allocator: std.mem.Allocator, path: []const u8) void {
 fn openSpawn(rt: Runtime, cmd: []const u8, path: []const u8) void {
     // #451 — `Child.init` + 필드 설정 + `spawn` ➡️ `std.process.spawn(io, options)`
     // (릴리즈 노트 *Process*). stdio 는 `.Ignore` → `.ignore` 로 이름만 바뀌었다.
-    _ = std.process.spawn(rt.io, .{
+    const child = std.process.spawn(rt.io, .{
         .argv = &.{ cmd, path },
         .stdin = .ignore,
         .stdout = .ignore,
         .stderr = .ignore,
     }) catch return;
-    // detached — 자식 process 종료 안 기다림. open / xdg-open 은 즉시 fork.
+
+    // #457 — 자식을 거두지 않으면 `[xdg-open] <defunct>` 가 worker 수명 동안 상한
+    // 없이 쌓인다. `open` / `xdg-open` 은 편집기를 띄우고 곧 끝나므로 이 thread 도
+    // 금방 사라진다.
+    //
+    // 거두는 대상을 **이 pid 하나로 지목**하는 것이 핵심이다. PTY 는 자식마다
+    // `processWaitLoop` 에서 `waitpid(child_pid, ...)` 로 블로킹하고 그 반환을 신호로
+    // `child_exited` 를 세운 뒤 `exit_cb` 를 부르는데 (`terminal/posix/pty.zig`),
+    // `SIGCHLD = SIG_IGN` 이나 `waitpid(-1)` 로 거두면 그 `waitpid` 가 자식이 죽기도
+    // 전에 `ECHILD` 로 반환한다 — 탭이 열리자마자 닫히고 #129 의 SIGHUP grace 와
+    // SIGKILL fallback 이 무력화된다. pid 를 지목하면 대상이 겹치지 않는다.
+    const pid = child.id orelse return;
+    const thread = std.Thread.spawn(.{}, reapChild, .{pid}) catch |err| {
+        // 좀비가 하나 남을 뿐 열기 자체는 이미 성공했다. 조용히 넘기지 않고 남긴다.
+        log.appendLine("open", "reap thread spawn failed: {s} (pid={d})", .{ @errorName(err), pid });
+        return;
+    };
+    thread.detach();
+}
+
+/// spawn 한 자식 하나만 거둔다. 다른 자식 (PTY) 을 건드리지 않으려고 pid 를 지목한다.
+fn reapChild(pid: posix.pid_t) void {
+    _ = posix.system.waitpid(pid, null, 0);
 }
 
 // Windows-only — `extern` 은 platform 분기와 무관하게 syntactic 으로 항상


### PR DESCRIPTION
## 무엇

`Ctrl+Shift+P` / `Ctrl+Shift+L` 을 누를 때마다 `[xdg-open] <defunct>` 가 worker 수명 동안 **상한 없이** 쌓였다 ([#457](https://github.com/ensky0/tildaz/issues/457)). `openSpawn` 이 자식을 띄우고 회수하지 않아서다.

## 어떻게 — spawn 한 **그 pid 하나만** 지목해 거둔다

이슈 본문의 A~D 가 아니라 다섯 번째 안이다. B·C 를 소스로 배제한 근거가 핵심이다.

| 안 | 판정 |
|---|---|
| **B** `SIGCHLD = SIG_IGN` | ❌ **사용자 가시 버그.** PTY 의 `processWaitLoop` 이 `waitpid(child_pid, ...)` 로 블로킹하고 그 반환을 신호로 `exit_cb` 를 부르는데, 커널 자동 회수가 이 `waitpid` 를 **자식이 죽기도 전에 `ECHILD` 로** 반환시킨다 → 탭이 열리자마자 닫히고 [#129](https://github.com/ensky0/tildaz/issues/129) 의 SIGHUP grace · SIGKILL fallback 이 무력화된다 |
| **C** `waitpid(-1, WNOHANG)` | ❌ `-1` 이 PTY 자식의 종료를 가로채 같은 자리를 건드린다. 이득 없이 race 만 는다 |
| **A** double fork | ⭕ 되지만 `std.process.spawn` 을 버리고 `fork` × 2 + `execve` 를 직접 써야 해 POSIX 전용 경로가 새로 생긴다. 얻는 것은 thread 하나뿐 |
| **E (채택)** pid 지목 회수 thread | ✅ 대상이 겹치지 않아 PTY 경로를 원리적으로 안 건드린다. macOS 도 같은 코드로 무해하게 지나가 platform 분기가 없다 |

## 영향 범위 — detached spawn 전수 확인

문제는 이 경로 하나다.

| 경로 | 자식을 거두나 | 판정 |
|---|---|---|
| `system_open.zig` `openSpawn` | ❌ | **당사자** |
| `instances.zig` `spawnWorker` | ❌ | 문제 없음 — worker 는 계속 살아 있고 launcher 가 먼저 끝나 좀비가 될 틈이 없다 |
| `shortcut_sync/linux.zig` (hyprctl) | ✅ | 정상 |
| `dialog/macos.zig` (osascript) | ✅ | 정상 |

Windows 는 `ShellExecuteW` 라 우리가 자식을 만들지 않는다.

## 검증

미니PC · AMD Ryzen 7 8845HS · CachyOS · KDE Plasma Wayland · Zig 0.16.0

| 방법 | 결과 |
|---|---|
| 독립 드라이버 5 회 호출 | fix 전 자식 5 · **좀비 5** → fix 후 자식 0 · **좀비 0** |
| 실기 `Ctrl+Shift+P`/`L` 각 6 회 | 호출 기록형 `xdg-open` 을 그 인스턴스 PATH 앞에 두어 **호출 12 회 확인**, 그 worker 밑 자식은 탭 셸 하나뿐 **좀비 0** |
| 대조군 | 같은 시각 fix 없는 설치본 v0.8.1 (instance 0) 에는 `[xdg-open] <defunct>` 가 **회수되지 않은 채 남아** 있었다 |
| `zig build check` | 6 타겟 통과 |
| `zig build test` | 4/4 통과 |

## 문서

`SPEC.md` §11.2 에 자식 회수 정책을 적고, **사실과 어긋나 있던 macOS 서술**을 바로잡았다 — `[NSWorkspace openURL:]` / `system("open <path>")` 로 적혀 있었지만 실제 코드는 `/usr/bin/open` 을 자식 process 로 spawn 한다.

Closes #457