### PR TITLE
chore(zig): 부동소수점 → 정수 변환을 반올림 함수 하나로 (#452)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -80,7 +80,7 @@ PT 값 → 같은 *visual* 결과 보장 (DPI / scale 환경 무관).
 | `TAB_ARROW_W_PT` | 24 | `App.TAB_ARROW_W` | `arrow_w_px` | `Renderer.tabArrowWPx()` |
 | `TAB_PLUS_W_PT` | 24 | `App.TAB_PLUS_W` | `plus_w_px` | `Renderer.tabPlusWPx()` |
 
-**`pt → px` 변환은 반올림이고 공통 함수만 쓴다** ([#350](https://github.com/ensky0/tildaz/issues/350) 2026-07-30 확정). 위 표의 각 `*_PT` 를 physical pixel 로 바꿀 때 세 platform 이 **같은 규칙**을 쓰고, 계산은 [`src/ui_metrics.zig`](src/ui_metrics.zig) 의 세 함수에만 있다. host / renderer 가 `@intFromFloat(@as(f32, @floatFromInt(X_PT)) * scale)` 을 직접 적지 않는다.
+**`pt → px` 변환은 반올림이고 공통 함수만 쓴다** ([#350](https://github.com/ensky0/tildaz/issues/350) 2026-07-30 확정). 위 표의 각 `*_PT` 를 physical pixel 로 바꿀 때 세 platform 이 **같은 규칙**을 쓰고, 계산은 [`src/ui_metrics.zig`](src/ui_metrics.zig) 의 세 함수에만 있다. host / renderer 가 `@round(@as(f32, @floatFromInt(X_PT)) * scale)` 을 직접 적지 않는다.
 
 | 함수 | 결과 | 쓰는 자리 |
 |---|---|---|

--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -239,7 +239,7 @@ pub const App = struct {
         const inputs = self.tabBarLayoutInputs();
         const layout = tab_layout.compute(inputs);
         const new_sx = tab_layout.ensureActiveVisible(inputs, layout, @intCast(self.session.activeIndex()));
-        self.tab_scroll_x = @intFromFloat(new_sx);
+        self.tab_scroll_x = @trunc(new_sx);
     }
 
     /// 화살표 클릭으로 viewport 한 step (= 1 탭 너비) 이동 (#117). 양 끝 clamp.
@@ -249,7 +249,7 @@ pub const App = struct {
         const inputs = self.tabBarLayoutInputs();
         const layout = tab_layout.compute(inputs);
         if (tab_layout.scrollByArrow(inputs, layout, dir)) |sx| {
-            self.tab_scroll_x = @intFromFloat(sx);
+            self.tab_scroll_x = @trunc(sx);
             self.tab_scroll_user_override = true;
             self.invalidateRenderer();
         }
@@ -822,7 +822,7 @@ pub const App = struct {
         // #117 — tab_area 안에서 mouse_x → world 좌표. 탭 viewport 시작 x 가
         // tab_area_x (화살표 있을 때 ARROW_W) 에 오프셋. world_x = (mouse_x -
         // tab_area_x) + scroll_x.
-        const local_x = mouse_x - @as(c_int, @intFromFloat(layout.tab_area_x));
+        const local_x = mouse_x - @as(c_int, @trunc(layout.tab_area_x));
         const world_x = local_x + self.tab_scroll_x;
         const tab_index_raw = @divTrunc(world_x, self.TAB_WIDTH);
         if (tab_index_raw < 0) return;
@@ -843,7 +843,7 @@ pub const App = struct {
         // #117 — DragState 는 world 좌표. 탭 영역 좌표계: world_x = (mouse_x -
         // tab_area_x) + scroll_x. tab_area_x = 화살표 있으면 ARROW_W, 없으면 0.
         const layout = self.tabBarLayout();
-        const world_x = (mouse_x - @as(c_int, @intFromFloat(layout.tab_area_x))) + self.tab_scroll_x;
+        const world_x = (mouse_x - @as(c_int, @trunc(layout.tab_area_x))) + self.tab_scroll_x;
         _ = self.tab_drag.begin(world_x, self.TAB_WIDTH, self.session.count());
     }
 
@@ -852,8 +852,8 @@ pub const App = struct {
         // scroll 한 step 이동 후 drag.move 에 *갱신된* world 좌표 전달.
         const layout = self.tabBarLayout();
         const total = self.tabBarTotalWidth();
-        const tab_area_x_int: c_int = @intFromFloat(layout.tab_area_x);
-        const vp: c_int = @intFromFloat(layout.tab_area_w);
+        const tab_area_x_int: c_int = @trunc(layout.tab_area_x);
+        const vp: c_int = @trunc(layout.tab_area_w);
         if (vp > 0 and total > vp) {
             const max_sx = total - vp;
             const edge: c_int = 32;

--- a/src/chrome_palette.zig
+++ b/src/chrome_palette.zig
@@ -146,7 +146,7 @@ fn linearToSrgb(v: f64) f64 {
 }
 
 fn quant(v: f32) u8 {
-    return @intFromFloat(std.math.clamp(@round(v * 255.0), 0.0, 255.0));
+    return @round(std.math.clamp(v * 255.0, 0.0, 255.0));
 }
 
 fn toColor(l: [3]f64) [4]f32 {

--- a/src/config.zig
+++ b/src/config.zig
@@ -837,7 +837,7 @@ pub fn defaultConfigJsonWithHotkey(
 // 변환 (DockPosition enum / Hotkey struct / Theme pointer / alpha u8).
 const default_dock_position: DockPosition = DockPosition.fromString(Defaults.dock_position) orelse unreachable;
 /// JSON 은 percent (0..100, f32), 메모리는 alpha (0..255 u8). `100.0` percent → `255` alpha.
-const default_opacity_alpha: u8 = @intFromFloat(@round(Defaults.opacity_percent * 255.0 / 100.0));
+const default_opacity_alpha: u8 = @round(Defaults.opacity_percent * 255.0 / 100.0);
 const default_theme: ?*const themes.Theme = themes.findTheme(Defaults.theme);
 const default_hotkey: Hotkey = Hotkey.fromString(Defaults.hotkey) orelse unreachable;
 const default_font_size_point: u8 = Defaults.font_size_point;
@@ -1054,7 +1054,7 @@ pub const Config = struct {
             if (wv.object.get("opacity_percent")) |v| {
                 const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.opacity_percent"});
                 if (f < 0.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.opacity_percent", "0..100" });
-                config.opacity_alpha = @intFromFloat(@round(f * 255.0 / 100.0));
+                config.opacity_alpha = @round(f * 255.0 / 100.0);
             }
         }
 

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -429,8 +429,8 @@ pub const CoreTextFontContext = struct {
             font_family,
             cell_w_px,
             cell_h_px,
-            @as(u32, @intFromFloat(@round(ascent * retina_scale))),
-            @as(u32, @intFromFloat(@round(descent * retina_scale))),
+            @as(u32, @round(ascent * retina_scale)),
+            @as(u32, @round(descent * retina_scale)),
         });
 
         // #375 — 변종 chain. `CTFontCreateCopyWithSymbolicTraits` 는 해당 face 가
@@ -1079,7 +1079,7 @@ pub const CoreTextFontContext = struct {
             slots[i] = .{
                 .glyph_index = glyphs_buf[i],
                 .natural_glyph_index = natural[cp_idx],
-                .x_offset = @intFromFloat(@round(offset_x)),
+                .x_offset = @round(offset_x),
                 .y_offset = 0,
             };
         }

--- a/src/font/spec.zig
+++ b/src/font/spec.zig
@@ -36,7 +36,7 @@ pub const Spec = struct {
 
 pub fn ceilPositivePx(value: anytype) u32 {
     const wide: f64 = @floatCast(value);
-    return @intFromFloat(@max(1.0, @ceil(wide)));
+    return @ceil(@max(1.0, wide));
 }
 
 pub fn scaledRatioCeilPx(base: f32, ratio: f32, scale: f32) u32 {

--- a/src/font/windows/font.zig
+++ b/src/font/windows/font.zig
@@ -728,7 +728,7 @@ pub const DWriteFontContext = struct {
         const fam_len = std.unicode.utf16LeToUtf8(&fam_buf, self.primary_family_name[0..self.primary_family_len]) catch 0;
         log.appendLine("font", "primary family={s} cell_w={d} cell_h={d} ascent={d} descent={d}", .{
             fam_buf[0..fam_len],                             self.cell_width_px,                               self.cell_height_px,
-            @as(u32, @intFromFloat(@round(self.ascent_px))), @as(u32, @intFromFloat(@round(self.descent_px))),
+            @as(u32, @round(self.ascent_px)), @as(u32, @round(self.descent_px)),
         });
 
         // 5. Get IDWriteFactory2 for system font fallback
@@ -1469,7 +1469,7 @@ pub const DWriteFontContext = struct {
             slots[i] = .{
                 .glyph_index = indices_buf[i],
                 .natural_glyph_index = natural[cp_idx],
-                .x_offset = @intFromFloat(@round(offsets_buf[i].advanceOffset)),
+                .x_offset = @round(offsets_buf[i].advanceOffset),
                 .y_offset = 0,
             };
         }

--- a/src/host/linux/gl_atlas.zig
+++ b/src/host/linux/gl_atlas.zig
@@ -76,7 +76,7 @@ const Key = struct {
     /// 아이콘 키 — 같은 종류라도 크기 · 굵기가 다르면 다른 그림이다. 굵기는
     /// 1/16 px 로 양자화해 넣는다 (그보다 미세한 차이는 래스터 결과가 같다).
     fn fromIcon(kind: tab_icons.Icon, size: u32, stroke: f32) Key {
-        const stroke_q: u32 = @intFromFloat(@max(0.0, @round(stroke * 16.0)));
+        const stroke_q: u32 = @round(@max(0.0, stroke * 16.0));
         return .{
             .source = icon_source,
             .face = @intFromEnum(kind),

--- a/src/host/linux/software_terminal.zig
+++ b/src/host/linux/software_terminal.zig
@@ -859,10 +859,10 @@ pub const Renderer = struct {
                             d.cov,
                         );
                         self.layer.cell_bg.append(allocator, .{
-                            .x = cell_x + @as(i32, @intFromFloat(d.x)),
-                            .y = cell_y + @as(i32, @intFromFloat(d.y)),
-                            .w = @intFromFloat(d.w),
-                            .h = @intFromFloat(d.h),
+                            .x = cell_x + @as(i32, @trunc(d.x)),
+                            .y = cell_y + @as(i32, @trunc(d.y)),
+                            .w = @trunc(d.w),
+                            .h = @trunc(d.h),
                             .color = .{ .r = blended[0], .g = blended[1], .b = blended[2] },
                         }) catch {};
                     }
@@ -909,10 +909,10 @@ pub const Renderer = struct {
                     );
                     const cw_f: f32 = @floatFromInt(cell_w);
                     const ch_f: f32 = @floatFromInt(ch);
-                    const bx0: i32 = cell_x + @as(i32, @intFromFloat(br.x0 * cw_f));
-                    const by0: i32 = cell_y + @as(i32, @intFromFloat(br.y0 * ch_f));
-                    const bx1: i32 = cell_x + @as(i32, @intFromFloat(br.x1 * cw_f));
-                    const by1: i32 = cell_y + @as(i32, @intFromFloat(br.y1 * ch_f));
+                    const bx0: i32 = cell_x + @as(i32, @trunc(br.x0 * cw_f));
+                    const by0: i32 = cell_y + @as(i32, @trunc(br.y0 * ch_f));
+                    const bx1: i32 = cell_x + @as(i32, @trunc(br.x1 * cw_f));
+                    const by1: i32 = cell_y + @as(i32, @trunc(br.y1 * ch_f));
                     self.layer.overlay.append(allocator, .{
                         .x = bx0,
                         .y = by0,
@@ -945,10 +945,10 @@ pub const Renderer = struct {
                                 br.cov,
                             );
                             self.layer.overlay.append(allocator, .{
-                                .x = cell_x + @as(i32, @intFromFloat(br.x)),
-                                .y = cell_y + @as(i32, @intFromFloat(br.y)),
-                                .w = @as(i32, @intFromFloat(br.w)),
-                                .h = @as(i32, @intFromFloat(br.h)),
+                                .x = cell_x + @as(i32, @trunc(br.x)),
+                                .y = cell_y + @as(i32, @trunc(br.y)),
+                                .w = @as(i32, @trunc(br.w)),
+                                .h = @as(i32, @trunc(br.h)),
                                 .color = .{ .r = cov_blend[0], .g = cov_blend[1], .b = cov_blend[2] },
                             }) catch {};
                         }
@@ -1201,7 +1201,7 @@ pub const Renderer = struct {
         self.layer.overlay.append(allocator, .{
             .x = cx,
             .y = tab_bar_h + pad + @as(i32, @intCast(vp.y)) * ch,
-            .w = @intFromFloat(ui_metrics.cursorBarWidthPx(self.scale)),
+            .w = @trunc(ui_metrics.cursorBarWidthPx(self.scale)),
             .h = ch,
             .color = self.render_state.colors.cursor orelse .{ .r = 180, .g = 180, .b = 180 },
         }) catch {};
@@ -1324,11 +1324,11 @@ pub const Renderer = struct {
         const ascent: i32 = @intCast(self.tab_font_ctx.ascent_px);
         const descent: i32 = @intCast(self.tab_font_ctx.descent_px);
         const text_baseline: i32 = @divFloor(tab_bar_h + ascent - descent, 2);
-        const tab_x_inset: i32 = @intFromFloat(@round(ui_metrics.tabGapPx(scale).tab_horizontal_inset));
+        const tab_x_inset: i32 = @round(ui_metrics.tabGapPx(scale).tab_horizontal_inset);
         // max_text_w — #268 per-tab close 제거로 탭 전체 (양쪽 padding 제외).
         const max_text_w: i32 = tab_w - tab_pad * 2;
-        const tab_area_x: i32 = @intFromFloat(in.layout.tab_area_x);
-        const tab_area_end: i32 = tab_area_x + @as(i32, @intFromFloat(in.layout.tab_area_w));
+        const tab_area_x: i32 = @trunc(in.layout.tab_area_x);
+        const tab_area_end: i32 = tab_area_x + @as(i32, @trunc(in.layout.tab_area_w));
 
         // --- 각 탭의 제목 (tab_area 안에서 clipping) ---
         // 탭 x 와 화면 밖 판정도 공통 모듈(`tabX` / `tabClip`) 을 쓴다 — 밑줄과
@@ -1336,7 +1336,7 @@ pub const Renderer = struct {
         for (in.tab_titles, 0..) |title, i| {
             // #343 — 공통 계약: 이 인덱스는 맨 마지막에 그린다 (집어 든 탭이 맨 위 layer).
             if (built.deferred_title) |d| if (d == i) continue;
-            const tab_screen_x: i32 = @intFromFloat(tab_chrome.tabX(i, chrome_in));
+            const tab_screen_x: i32 = @trunc(tab_chrome.tabX(i, chrome_in));
             switch (tab_chrome.tabClip(
                 @floatFromInt(tab_screen_x),
                 @floatFromInt(tab_w),
@@ -1370,7 +1370,7 @@ pub const Renderer = struct {
         // 없으므로 이것만은 지오메트리가 아니라 layer 순서로 표현한다.
         if (built.deferred_title) |di| {
             if (di < in.tab_titles.len) {
-                const dx: i32 = @intFromFloat(tab_chrome.tabX(di, chrome_in));
+                const dx: i32 = @trunc(tab_chrome.tabX(di, chrome_in));
                 if (tab_chrome.tabClip(
                     @floatFromInt(dx),
                     @floatFromInt(tab_w),
@@ -1447,10 +1447,10 @@ pub const Renderer = struct {
                     appendChromeGlyph(&c.renderer.layer.chrome_before, c.allocator, .{
                         .ref = .{ .codepoint = g.cp },
                         .glyph = c.renderer.tab_font_ctx.glyph(g.cp, .regular),
-                        .pen_x = @intFromFloat(g.x),
+                        .pen_x = @trunc(g.x),
                         .baseline = c.t.text_baseline,
                         .box_y = 0,
-                        .box_w = @intFromFloat(g.advance),
+                        .box_w = @trunc(g.advance),
                         .box_h = c.t.tab_bar_h,
                         .fg = c.t.text_color,
                         .clip_x0 = c.viewport_left,
@@ -1484,14 +1484,14 @@ pub const Renderer = struct {
         const more_stroke: f32 = ui_metrics.strokePx(ui_metrics.TAB_MORE_DOT_DIAMETER_PT, scale);
 
         if (layout.arrows_visible) {
-            const arrow_w: i32 = @intFromFloat(layout.arrow_w);
-            self.appendIcon(allocator, list, .chevron_left, @intFromFloat(layout.left_arrow_x), arrow_w, bar_h, size, stroke, if (layout.left_enabled) active_color else disabled_color);
-            self.appendIcon(allocator, list, .chevron_right, @intFromFloat(layout.right_arrow_x), arrow_w, bar_h, size, stroke, if (layout.right_enabled) active_color else disabled_color);
+            const arrow_w: i32 = @trunc(layout.arrow_w);
+            self.appendIcon(allocator, list, .chevron_left, @trunc(layout.left_arrow_x), arrow_w, bar_h, size, stroke, if (layout.left_enabled) active_color else disabled_color);
+            self.appendIcon(allocator, list, .chevron_right, @trunc(layout.right_arrow_x), arrow_w, bar_h, size, stroke, if (layout.right_enabled) active_color else disabled_color);
         }
-        self.appendIcon(allocator, list, .plus, @intFromFloat(layout.plus_x), @intFromFloat(layout.plus_w), bar_h, size, stroke, if (layout.plus_enabled) active_color else disabled_color);
+        self.appendIcon(allocator, list, .plus, @trunc(layout.plus_x), @trunc(layout.plus_w), bar_h, size, stroke, if (layout.plus_enabled) active_color else disabled_color);
         // #268 — 우측 끝 활성 탭 닫기 버튼.
-        self.appendIcon(allocator, list, .close, @intFromFloat(layout.close_x), @intFromFloat(layout.close_w), bar_h, size, stroke, active_color);
-        self.appendIcon(allocator, list, .more, @intFromFloat(layout.more_x), @intFromFloat(layout.more_w), bar_h, size, more_stroke, active_color);
+        self.appendIcon(allocator, list, .close, @trunc(layout.close_x), @trunc(layout.close_w), bar_h, size, stroke, active_color);
+        self.appendIcon(allocator, list, .more, @trunc(layout.more_x), @trunc(layout.more_w), bar_h, size, more_stroke, active_color);
     }
 
     /// 아이콘을 box 가운데에 놓는다.
@@ -1645,8 +1645,8 @@ pub const Renderer = struct {
             @floatFromInt(ui_metrics.TAB_BAR_HEIGHT_PT),
             ui.first_visible,
         );
-        const mx: i32 = @intFromFloat(@round(v.rect.x * scale));
-        const mw: i32 = @intFromFloat(@round(v.rect.w * scale));
+        const mx: i32 = @round(v.rect.x * scale);
+        const mw: i32 = @round(v.rect.w * scale);
         const fg = rgbFromMetrics(self.chrome.menu_label);
         const hint_fg = rgbFromMetrics(self.chrome.menu_hint);
         const list = &self.layer.chrome_after;
@@ -1666,8 +1666,8 @@ pub const Renderer = struct {
             const disabled_fg = rgbFromMetrics(self.chrome.arrow_disabled);
             const sz_i: i32 = @intCast(ind_size);
             const ind_cx: i32 = mx + @divTrunc(mw - sz_i, 2);
-            const up_y: i32 = @intFromFloat(@round((v.rect.y + command_menu.PADDING_PT + command_menu.INDICATOR_HEIGHT_PT * 0.5) * scale - @as(f32, @floatFromInt(sz_i)) * 0.5));
-            const down_y: i32 = @intFromFloat(@round((v.rect.y + v.rect.h - command_menu.PADDING_PT - command_menu.INDICATOR_HEIGHT_PT * 0.5) * scale - @as(f32, @floatFromInt(sz_i)) * 0.5));
+            const up_y: i32 = @round((v.rect.y + command_menu.PADDING_PT + command_menu.INDICATOR_HEIGHT_PT * 0.5) * scale - @as(f32, @floatFromInt(sz_i)) * 0.5);
+            const down_y: i32 = @round((v.rect.y + v.rect.h - command_menu.PADDING_PT - command_menu.INDICATOR_HEIGHT_PT * 0.5) * scale - @as(f32, @floatFromInt(sz_i)) * 0.5);
             const pairs = [2]struct { kind: tab_icons.Icon, y: i32, enabled: bool }{
                 .{ .kind = .chevron_up, .y = up_y, .enabled = v.can_scroll_up },
                 .{ .kind = .chevron_down, .y = down_y, .enabled = v.can_scroll_down },
@@ -1689,10 +1689,10 @@ pub const Renderer = struct {
         for (v.first..v.first + v.count) |i| {
             const command = command_menu.entries[i] orelse continue; // 구분선은 위에서
             const item = command_menu.entryRect(v, i).?;
-            const ix: i32 = @intFromFloat(@round(item.x * scale));
-            const iw: i32 = @intFromFloat(@round(item.w * scale));
-            const ih: i32 = @intFromFloat(@round(item.h * scale));
-            const iy: i32 = @intFromFloat(@round(item.y * scale));
+            const ix: i32 = @round(item.x * scale);
+            const iw: i32 = @round(item.w * scale);
+            const ih: i32 = @round(item.h * scale);
+            const iy: i32 = @round(item.y * scale);
             const baseline = iy + @divFloor(ih - ch, 2) + @as(i32, @intCast(self.tab_font_ctx.ascent_px));
             const label = command_menu.label(command);
             self.collectChromeText(allocator, list, ix + scaledPt(8, scale), baseline, ch, label, fg, in.width);
@@ -1868,8 +1868,8 @@ pub const Renderer = struct {
                 // #344 — terminal scrollbar 와 같은 공통 스냅. dialog track 도
                 // 위·아래 여백이 같아야 한다.
                 const t = scrollbar.thumbPx(@floatFromInt(message_y), g);
-                const thumb_y: i32 = @intFromFloat(t.top);
-                const thumb_h: i32 = @intFromFloat(t.h);
+                const thumb_y: i32 = @trunc(t.top);
+                const thumb_h: i32 = @trunc(t.h);
                 // Terminal scrollbar의 white/30%는 dark theme용이다. 밝은 dialog
                 // 배경에 blend하면 RGB 242→246이라 thumb가 사실상 사라진다.
                 // 중립 회색을 써 가시 대비를 유지하고 제목 accent와 분리한다.
@@ -2100,9 +2100,9 @@ fn tabClipDecision(
 /// 구분, 탭 경계는 세로 구분선 (Tilda 문법, mac/win 동등).
 fn rgbFromMetrics(c: [4]f32) ghostty.color.RGB {
     return .{
-        .r = @intFromFloat(@max(0.0, @min(255.0, c[0] * 255.0))),
-        .g = @intFromFloat(@max(0.0, @min(255.0, c[1] * 255.0))),
-        .b = @intFromFloat(@max(0.0, @min(255.0, c[2] * 255.0))),
+        .r = @trunc(@max(0.0, @min(255.0, c[0] * 255.0))),
+        .g = @trunc(@max(0.0, @min(255.0, c[1] * 255.0))),
+        .b = @trunc(@max(0.0, @min(255.0, c[2] * 255.0))),
     };
 }
 
@@ -2302,8 +2302,8 @@ pub fn colorGlyphFit(cell_w: i32, cell_h: i32, glyph_w: u32, glyph_h: u32) ?Colo
         @as(f64, @floatFromInt(cell_w)) / gw_f,
         @as(f64, @floatFromInt(cell_h)) / gh_f,
     );
-    const w: i32 = @intFromFloat(gw_f * scale);
-    const h: i32 = @intFromFloat(gh_f * scale);
+    const w: i32 = @trunc(gw_f * scale);
+    const h: i32 = @trunc(gh_f * scale);
     if (w <= 0 or h <= 0) return null;
     return .{
         .off_x = @divFloor(cell_w - w, 2),
@@ -2438,9 +2438,9 @@ fn fillRoundedRect(
                 const er: f32 = @floatFromInt((existing >> 16) & 0xff);
                 const eg: f32 = @floatFromInt((existing >> 8) & 0xff);
                 const eb: f32 = @floatFromInt(existing & 0xff);
-                const br: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.r)) * coverage + er * inv));
-                const bg_: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.g)) * coverage + eg * inv));
-                const bb: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.b)) * coverage + eb * inv));
+                const br: u32 = @round(@as(f32, @floatFromInt(color.r)) * coverage + er * inv);
+                const bg_: u32 = @round(@as(f32, @floatFromInt(color.g)) * coverage + eg * inv);
+                const bb: u32 = @round(@as(f32, @floatFromInt(color.b)) * coverage + eb * inv);
                 const blended: u32 = (br << 16) | (bg_ << 8) | bb;
                 std.mem.writeInt(u32, memory[off..][0..4], blended, .little);
             }
@@ -2471,10 +2471,10 @@ fn drawThickLine(
     const len_sq: f32 = dx * dx + dy * dy;
     if (len_sq < 0.0001) return;
 
-    const min_x: i32 = @intFromFloat(@floor(@min(x1, x2) - half_t - 1.0));
-    const max_x: i32 = @intFromFloat(@ceil(@max(x1, x2) + half_t + 1.0));
-    const min_y: i32 = @intFromFloat(@floor(@min(y1, y2) - half_t - 1.0));
-    const max_y: i32 = @intFromFloat(@ceil(@max(y1, y2) + half_t + 1.0));
+    const min_x: i32 = @floor(@min(x1, x2) - half_t - 1.0);
+    const max_x: i32 = @ceil(@max(x1, x2) + half_t + 1.0);
+    const min_y: i32 = @floor(@min(y1, y2) - half_t - 1.0);
+    const max_y: i32 = @ceil(@max(y1, y2) + half_t + 1.0);
 
     const packed_color = pack(color);
 
@@ -2506,9 +2506,9 @@ fn drawThickLine(
                 const er: f32 = @floatFromInt((existing >> 16) & 0xff);
                 const eg: f32 = @floatFromInt((existing >> 8) & 0xff);
                 const eb: f32 = @floatFromInt(existing & 0xff);
-                const br: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.r)) * coverage + er * inv));
-                const bg_: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.g)) * coverage + eg * inv));
-                const bb: u32 = @intFromFloat(@round(@as(f32, @floatFromInt(color.b)) * coverage + eb * inv));
+                const br: u32 = @round(@as(f32, @floatFromInt(color.r)) * coverage + er * inv);
+                const bg_: u32 = @round(@as(f32, @floatFromInt(color.g)) * coverage + eg * inv);
+                const bb: u32 = @round(@as(f32, @floatFromInt(color.b)) * coverage + eb * inv);
                 const blended: u32 = (br << 16) | (bg_ << 8) | bb;
                 std.mem.writeInt(u32, memory[off..][0..4], blended, .little);
             }
@@ -2535,7 +2535,7 @@ fn drawDialogIcon(
             return vb * s;
         }
         fn i(s: f32, vb: f32) i32 {
-            return @intFromFloat(@round(vb * s));
+            return @round(vb * s);
         }
     };
     const fx: f32 = @floatFromInt(icon_x);
@@ -2688,12 +2688,12 @@ fn applyShadowAndMask(
                 const r0: f32 = @floatFromInt(memory[off + 2]);
                 const g0: f32 = @floatFromInt(memory[off + 1]);
                 const b0: f32 = @floatFromInt(memory[off + 0]);
-                memory[off + 2] = @intFromFloat(@round(r0 * rgb_keep));
-                memory[off + 1] = @intFromFloat(@round(g0 * rgb_keep));
-                memory[off + 0] = @intFromFloat(@round(b0 * rgb_keep));
+                memory[off + 2] = @round(r0 * rgb_keep);
+                memory[off + 1] = @round(g0 * rgb_keep);
+                memory[off + 0] = @round(b0 * rgb_keep);
             }
 
-            memory[off + 3] = @intFromFloat(@round(total_alpha));
+            memory[off + 3] = @round(total_alpha);
         }
     }
 }
@@ -2781,8 +2781,10 @@ fn drawGlyphBgra(
     while (dy < fit.h) : (dy += 1) {
         var dx: i32 = 0;
         while (dx < fit.w) : (dx += 1) {
-            const src_x: u32 = @intFromFloat((@as(f64, @floatFromInt(dx)) + 0.5) * gw_f / tw_f);
-            const src_y: u32 = @intFromFloat((@as(f64, @floatFromInt(dy)) + 0.5) * gh_f / th_f);
+            // 여기 `+ 0.5` 는 반올림 보정이 아니라 **목적 픽셀의 중심**을 원본 좌표로
+            // 옮기는 nearest-neighbor 샘플링이다 (`@round` 로 바꾸면 샘플 위치가 어긋난다).
+            const src_x: u32 = @trunc((@as(f64, @floatFromInt(dx)) + 0.5) * gw_f / tw_f);
+            const src_y: u32 = @trunc((@as(f64, @floatFromInt(dy)) + 0.5) * gh_f / th_f);
             if (src_x >= glyph.width or src_y >= glyph.height) continue;
             const src_off: usize = (@as(usize, src_y) * glyph.width + src_x) * 4;
             const b = glyph.bitmap[src_off];

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -463,7 +463,7 @@ fn pctToPx(screen_dim: f32, pct: f32) u32 {
     const clamped = std.math.clamp(pct, 0.0, 100.0);
     const v = screen_dim * clamped / 100.0;
     if (v < 0.0) return 0;
-    return @intFromFloat(@round(v));
+    return @round(v);
 }
 
 /// L8-β — cross-axis margin 계산. `remaining = screen_dim - surface_dim` 의
@@ -471,7 +471,7 @@ fn pctToPx(screen_dim: f32, pct: f32) u32 {
 fn pxOffset(remaining: i32, off_pct: f32) i32 {
     if (remaining <= 0) return 0;
     const rem_f: f32 = @floatFromInt(remaining);
-    return @intFromFloat(@round(rem_f * off_pct / 100.0));
+    return @round(rem_f * off_pct / 100.0);
 }
 
 /// surface 에 attach 하는 buffer 하나. #277 이전엔 `wl_shm` 전용이었고 지금은
@@ -2452,8 +2452,11 @@ const Client = struct {
                 );
                 // 위 값들은 physical px 이고 layer-shell 은 logical 단위다.
                 const scale_f: f32 = if (self.renderer.scale > 0.0) self.renderer.scale else 1.0;
-                want_w = @intFromFloat(@min(sw_f, @ceil(@as(f32, @floatFromInt(vp.w)) / scale_f)));
-                want_h = @intFromFloat(@min(sh_f, @ceil(@as(f32, @floatFromInt(vp.h)) / scale_f)));
+                // `sw_f` · `sh_f` 는 화면 크기를 `@floatFromInt` 한 값이라 이미 정수다.
+                // 그래서 `@min` 을 `@ceil` 안으로 넣어도 결과가 같고, 0.16 에서는
+                // `@ceil` 하나가 곧 정수 변환이다.
+                want_w = @ceil(@min(sw_f, @as(f32, @floatFromInt(vp.w)) / scale_f));
+                want_h = @ceil(@min(sh_f, @as(f32, @floatFromInt(vp.h)) / scale_f));
             }
         }
         const want_w_i: i32 = @intCast(@min(want_w, @as(u32, std.math.maxInt(i32))));
@@ -3750,7 +3753,7 @@ const Client = struct {
             };
             const item_clip: [2]i32 = switch (item) {
                 .glyph => |g| .{ g.clip_x0, g.clip_x1 },
-                else => .{ 0, @intFromFloat(viewport_w) },
+                else => .{ 0, @trunc(viewport_w) },
             };
             if (kind != .none and (item_kind != kind or !std.mem.eql(i32, &item_clip, &clip))) {
                 self.glFlushChrome(ctx, rect_batch, text_batch, atlas, kind == .rect, clip, viewport_w, viewport_h);
@@ -3800,10 +3803,10 @@ const Client = struct {
         viewport_h: f32,
     ) void {
         _ = self;
-        const clipped = clip[0] > 0 or clip[1] < @as(i32, @intFromFloat(viewport_w));
+        const clipped = clip[0] > 0 or clip[1] < @as(i32, @trunc(viewport_w));
         if (clipped) {
             ctx.api.enable(egl.GL_SCISSOR_TEST);
-            ctx.api.scissor(clip[0], 0, @max(0, clip[1] - clip[0]), @intFromFloat(viewport_h));
+            ctx.api.scissor(clip[0], 0, @max(0, clip[1] - clip[0]), @trunc(viewport_h));
         }
         if (is_rect) {
             rect_batch.flush(&ctx.api, viewport_w, viewport_h);
@@ -5025,7 +5028,7 @@ const Client = struct {
                 // 의 `finish` 가 null 반환 → reorder 일어나지 않음.
                 const world_x: f32 = px_f - layout.tab_area_x + self.tab_scroll_x;
                 const tab_w_int: c_int = @intCast(tab_w_px);
-                _ = self.tab_drag.begin(@intFromFloat(world_x), tab_w_int, session.count());
+                _ = self.tab_drag.begin(@trunc(world_x), tab_w_int, session.count());
             },
             .none => {},
         }
@@ -5072,7 +5075,7 @@ const Client = struct {
         // DragState.move 는 world_x (idx 0 의 left edge 부터 측정) — `begin`
         // 과 같은 좌표계. surface_x - tab_area_x + scroll_x.
         const world_x: f32 = px_f - layout.tab_area_x + self.tab_scroll_x;
-        _ = self.tab_drag.move(@intFromFloat(world_x));
+        _ = self.tab_drag.move(@trunc(world_x));
         self.needs_redraw = true;
     }
 
@@ -5545,18 +5548,18 @@ const Client = struct {
         // 어긋나 경계에 ~1px dead band 가 생겼다 (pointer 는 정수 px).
         const scale = self.renderer.scale;
         const v = self.commandMenuView();
-        const mx: i32 = @intFromFloat(@round(v.rect.x * scale));
-        const my: i32 = @intFromFloat(@round(v.rect.y * scale));
-        const mw: i32 = @intFromFloat(@round(v.rect.w * scale));
-        const mh: i32 = @intFromFloat(@round(v.rect.h * scale));
+        const mx: i32 = @round(v.rect.x * scale);
+        const my: i32 = @round(v.rect.y * scale);
+        const mw: i32 = @round(v.rect.w * scale);
+        const mh: i32 = @round(v.rect.h * scale);
         if (x < mx or x >= mx + mw or y < my or y >= my + mh) return null;
         for (v.first..v.first + v.count) |i| {
             const command = command_menu.entries[i] orelse continue;
             const r = command_menu.entryRect(v, i).?;
-            const ix: i32 = @intFromFloat(@round(r.x * scale));
-            const iy: i32 = @intFromFloat(@round(r.y * scale));
-            const iw: i32 = @intFromFloat(@round(r.w * scale));
-            const ih: i32 = @intFromFloat(@round(r.h * scale));
+            const ix: i32 = @round(r.x * scale);
+            const iy: i32 = @round(r.y * scale);
+            const iw: i32 = @round(r.w * scale);
+            const ih: i32 = @round(r.h * scale);
             if (x >= ix and x < ix + iw and y >= iy and y < iy + ih) return command;
         }
         return null;

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -1882,8 +1882,8 @@ fn syncGeometryAfterScreenChange() void {
     //    이동하면 cell/glyph/UI metric 이 init scale 에 고정돼 글자·탭바가 배율만큼
     //    틀어지므로(Windows rebuildFontForDpi / Linux applyScale 동등) 여기서 보정.
     //    같은 scale 이동은 viewport 만 바꾸면 됨(atlas 재생성 낭비 회피).
-    const vp_w_px: u32 = @intFromFloat(cv_bounds.size.width * scale_pt);
-    const vp_h_px: u32 = @intFromFloat(cv_bounds.size.height * scale_pt);
+    const vp_w_px: u32 = @trunc(cv_bounds.size.width * scale_pt);
+    const vp_h_px: u32 = @trunc(cv_bounds.size.height * scale_pt);
     if (@as(f32, @floatCast(scale_pt)) != g_renderer.?.scale) {
         g_renderer.?.applyScale(@floatCast(scale_pt)) catch |err| {
             log.appendLine("geom", "applyScale failed: {s} — skipping cell re-measure", .{@errorName(err)});
@@ -1960,8 +1960,8 @@ fn eventToCell(self_view: objc.id, event: objc.id) ?terminal_interaction.Cell {
 
     const cols = tab.terminal.cols;
     const rows = tab.terminal.rows;
-    const col: u16 = @intCast(@min(@as(u32, @intFromFloat(col_f)), @as(u32, cols) - 1));
-    const row: u16 = @intCast(@min(@as(u32, @intFromFloat(row_f)), @as(u32, rows) - 1));
+    const col: u16 = @intCast(@min(@as(u32, @trunc(col_f)), @as(u32, cols) - 1));
+    const row: u16 = @intCast(@min(@as(u32, @trunc(row_f)), @as(u32, rows) - 1));
     return .{ .col = col, .row = row };
 }
 
@@ -1977,8 +1977,8 @@ fn cellAndDirFromPx(x: f32, y: f32) ?struct { cell: terminal_interaction.Cell, d
     const pad_px: f32 = ui_metrics.scaledPxF(TERMINAL_PADDING_PT, scale);
     const tab_bar_px: f32 = @floatFromInt(tabBarHeightPx(scale));
     const cell_top_px = pad_px + tab_bar_px;
-    const col_i: i32 = @intFromFloat(@floor((x - pad_px) / @as(f32, @floatFromInt(cell_w_px))));
-    const row_i: i32 = @intFromFloat(@floor((y - cell_top_px) / @as(f32, @floatFromInt(cell_h_px))));
+    const col_i: i32 = @floor((x - pad_px) / @as(f32, @floatFromInt(cell_w_px)));
+    const row_i: i32 = @floor((y - cell_top_px) / @as(f32, @floatFromInt(cell_h_px)));
     return .{
         .cell = terminal_interaction.clampCell(col_i, row_i, tab.terminal.cols, tab.terminal.rows),
         .dir = terminal_interaction.edgeScrollDir(row_i, tab.terminal.rows),
@@ -2345,7 +2345,7 @@ fn tildazMouseDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c)
                     g_tab_scroll_user_override = false;
                     const tab_w_int: c_int = ui_metrics.scaledPx(c_int, ui_metrics.TAB_WIDTH_PT, g_renderer.?.scale);
                     const world_x: f32 = (xy.x - layout.tab_area_x) + g_tab_scroll_x_px;
-                    _ = g_drag.begin(@intFromFloat(world_x), tab_w_int, g_session.count());
+                    _ = g_drag.begin(@trunc(world_x), tab_w_int, g_session.count());
                     return;
                 }
                 // tab_area 안인데 탭에는 안 맞음 (마지막 탭 우측 빈 공간 등). 무시.
@@ -2422,7 +2422,7 @@ fn tildazMouseDragged(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(
             }
         }
         const world_x = (xy.x - layout.tab_area_x) + g_tab_scroll_x_px;
-        _ = g_drag.move(@intFromFloat(world_x));
+        _ = g_drag.move(@trunc(world_x));
         return;
     }
 
@@ -2672,7 +2672,7 @@ fn tildazScrollWheel(_: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void 
         if (g_renderer == null) return;
         const step_unit: f64 = 12.0;
         g_command_menu_scroll_accum += delta_y;
-        var steps: i64 = @intFromFloat(@divTrunc(g_command_menu_scroll_accum, step_unit));
+        var steps: i64 = @trunc(@divTrunc(g_command_menu_scroll_accum, step_unit));
         g_command_menu_scroll_accum -= @as(f64, @floatFromInt(steps)) * step_unit;
         while (steps != 0) {
             const down = steps < 0; // deltaY 음수 = 아래로 스크롤
@@ -2689,9 +2689,9 @@ fn tildazScrollWheel(_: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void 
     // 평소 trackpad 사용감 기준 multiplier ~2.
     const scaled = delta_y * 2.0;
     const lines: isize = if (scaled > 0)
-        @as(isize, @intFromFloat(@ceil(scaled)))
+        @as(isize, @ceil(scaled))
     else
-        @as(isize, @intFromFloat(@floor(scaled)));
+        @as(isize, @floor(scaled));
     if (lines == 0) return;
 
     // delta 부호: 양수 deltaY (위로) → scrollback 위쪽 (older) = delta 음수
@@ -3096,8 +3096,8 @@ pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {
 
     // viewport / cell metrics 모두 pixel 단위로 통일 — pt/px mixing 시 글리프
     // 가 cell 일부만 차지해 깨져 보이는 문제 회피 (#75 댓글 6 의 정정 패턴).
-    const vp_w_px: u32 = @intFromFloat(cv_bounds.size.width * scale_pt);
-    const vp_h_px: u32 = @intFromFloat(cv_bounds.size.height * scale_pt);
+    const vp_w_px: u32 = @trunc(cv_bounds.size.width * scale_pt);
+    const vp_h_px: u32 = @trunc(cv_bounds.size.height * scale_pt);
     g_renderer.?.resize(vp_w_px, vp_h_px);
 
     const cell_w_px: u32 = g_renderer.?.font.cell_width_px;

--- a/src/renderer/cell_decoration.zig
+++ b/src/renderer/cell_decoration.zig
@@ -329,9 +329,9 @@ fn emitCov(
 /// 버림이 span 을 모르는 채 한 번만 일어나 밀도가 깨졌다 (아래 `dotted` 분기 주석).
 fn pieceCount(base_w: f32, slot: f32) usize {
     const raw = @round(base_w / slot);
-    // 상한을 먼저 f32 에서 걸어 `@intFromFloat` 에 범위 밖 값이 들어가지 않게 한다.
+    // 상한을 먼저 f32 에서 걸어 `@trunc` 의 정수 변환에 범위 밖 값이 들어가지 않게 한다.
     const capped = @min(raw, @as(f32, @floatFromInt(MAX_UNDERLINE_PIECES)));
-    const per: usize = if (!(capped >= 1)) 1 else @intFromFloat(capped);
+    const per: usize = if (!(capped >= 1)) 1 else @trunc(capped);
     return @max(1, per);
 }
 
@@ -391,7 +391,7 @@ fn waveCenters(r: []const Rect, cell_w: f32) [64]f32 {
     var sum: [64]f32 = @splat(0);
     var wsum: [64]f32 = @splat(0);
     for (r) |d| {
-        const col: usize = @intFromFloat(d.x);
+        const col: usize = @trunc(d.x);
         if (col >= 64 or d.x >= cell_w) continue;
         // 면적 = 높이 × coverage. 가운데 solid 조각은 높이가 1 보다 클 수 있다.
         const weight = d.cov * d.h;
@@ -414,9 +414,9 @@ test "#374 curly — 픽셀 열마다 coverage 로 AA 하고 셀 전체를 덮�
         try std.testing.expectEqual(@as(f32, 1), d.w);
         try std.testing.expect(d.h >= 1);
         try std.testing.expect(d.x >= 0 and d.x < W);
-        seen[@intFromFloat(d.x)] = true;
+        seen[@trunc(d.x)] = true;
     }
-    for (0..@as(usize, @intFromFloat(W))) |i| try std.testing.expect(seen[i]);
+    for (0..@as(usize, @trunc(W))) |i| try std.testing.expect(seen[i]);
 
     // **AA 가 실제로 걸린다** — 곡선이라 부분 coverage 픽셀이 반드시 생긴다.
     var has_partial = false;
@@ -429,7 +429,7 @@ test "#374 curly — 픽셀 열마다 coverage 로 AA 하고 셀 전체를 덮�
 test "#374 curly — 셀 경계가 산 · 중앙이 골이고 좌우 대칭이라 이웃 셀과 이어진다" {
     const got = collect(.{ .flags = .{ .underline = .curly } });
     const c = waveCenters(got.r[0..got.n], W);
-    const last: usize = @as(usize, @intFromFloat(W)) - 1;
+    const last: usize = @as(usize, @trunc(W)) - 1;
     const mid = last / 2;
 
     // 가운데가 가장 **낮다** (y 는 아래로 증가) — 경계에서 시작해 중앙으로 처진다.
@@ -457,7 +457,7 @@ test "#374 curly — wide char 는 산 2 개로 파장을 narrow 와 맞춘다" 
 
     const cn = waveCenters(narrow[0..n_narrow], W);
     const cw = waveCenters(wide[0..n_wide], 2 * W);
-    const wi: usize = @intFromFloat(W);
+    const wi: usize = @trunc(W);
     // wide 의 앞 절반과 뒤 절반이 narrow 와 같은 파형 = 파장이 같다.
     for (0..wi) |i| {
         try std.testing.expectApproxEqAbs(cn[i], cw[i], 0.01);

--- a/src/renderer/macos/glyph_atlas.zig
+++ b/src/renderer/macos/glyph_atlas.zig
@@ -301,8 +301,8 @@ pub const GlyphAtlas = struct {
         const gh_f = y1 - y0;
         if (gw_f <= 0 or gh_f <= 0) return null;
 
-        const gw: u32 = @intFromFloat(gw_f);
-        const gh: u32 = @intFromFloat(gh_f);
+        const gw: u32 = @trunc(gw_f);
+        const gh: u32 = @trunc(gh_f);
         if (gw > 256 or gh > 256) return null; // temp_buf 한계.
 
         const bytes_per_row = gw * 4;
@@ -366,8 +366,8 @@ pub const GlyphAtlas = struct {
             .y = @intCast(atlas_y),
             .w = @intCast(gw),
             .h = @intCast(gh),
-            .bearing_x = @intFromFloat(x0),
-            .bearing_y = @intFromFloat(y0),
+            .bearing_x = @trunc(x0),
+            .bearing_y = @trunc(y0),
             .is_color = is_color,
             .advance = advance_px,
         };
@@ -411,15 +411,15 @@ pub const GlyphAtlas = struct {
                 .y = 0,
                 .w = 0,
                 .h = 0,
-                .bearing_x = @intFromFloat(x0),
-                .bearing_y = @intFromFloat(y0),
+                .bearing_x = @trunc(x0),
+                .bearing_y = @trunc(y0),
                 .is_color = is_color,
                 .advance = advance_px,
             };
         }
 
-        const gw: u32 = @intFromFloat(gw_f);
-        const gh: u32 = @intFromFloat(gh_f);
+        const gw: u32 = @trunc(gw_f);
+        const gh: u32 = @trunc(gh_f);
 
         if (gw > 256 or gh > 256) return null; // temp_buf 한계.
 
@@ -509,8 +509,8 @@ pub const GlyphAtlas = struct {
             .y = @intCast(atlas_y),
             .w = @intCast(gw),
             .h = @intCast(gh),
-            .bearing_x = @intFromFloat(x0),
-            .bearing_y = @intFromFloat(y0),
+            .bearing_x = @trunc(x0),
+            .bearing_y = @trunc(y0),
             .is_color = is_color,
             .advance = advance_px,
         };

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -1798,8 +1798,8 @@ pub const D3d11Renderer = struct {
                     .color = cursor_color,
                 }};
                 self.drawBgInstances(&cursor_inst);
-                self.last_cursor_px_x = @intFromFloat(cx0);
-                self.last_cursor_px_y = @intFromFloat(cy0);
+                self.last_cursor_px_x = @trunc(cx0);
+                self.last_cursor_px_y = @trunc(cy0);
             }
         }
 
@@ -2331,7 +2331,7 @@ pub const D3d11Renderer = struct {
             // #417 류의 문제를 새로 만드는 것이라 [#420](https://github.com/ensky0/tildaz/issues/420)
             // 의 Linux 도 같은 이유로 여기서 멈췄다. 셀 경계까지만 올리면 겹침이 줄고 (한글에서
             // 3 px 남는다) 윗 줄은 그대로다.
-            const top_limit: i32 = -@as(i32, @intFromFloat(self.font.ascent_px));
+            const top_limit: i32 = -@as(i32, @trunc(self.font.ascent_px));
             const cell_h: i32 = @intCast(self.font.cell_height_px);
             const bottom_limit: i32 = cell_h + top_limit - @as(i32, @intCast(me.h));
             const bearing_y = std.math.clamp(stacked, top_limit, bottom_limit);
@@ -2456,8 +2456,9 @@ pub const D3d11Renderer = struct {
         const norm13: f32 = @floatCast(@as(f64, 0x10000) / (255.0 * 255.0) * 4.0);
         const norm24: f32 = @floatCast(@as(f64, 0x100) / 255.0 * 4.0);
 
-        // WT uses nearest-index rounding: clamp(gamma*10 + 0.5, 10, 22) - 10
-        const idx_raw = @as(i32, @intFromFloat(gamma * 10.0 + 0.5));
+        // WT uses nearest-index rounding: clamp(round(gamma*10), 10, 22) - 10
+        // (WT 원본은 `+ 0.5` 후 절단이지만 gamma 는 양수라 `@round` 와 결과가 같다.)
+        const idx_raw = @as(i32, @round(gamma * 10.0));
         const idx_clamped = @max(10, @min(22, idx_raw)) - 10;
         const idx: usize = @intCast(idx_clamped);
         const r = raw[idx];

--- a/src/renderer/windows/glyph_atlas.zig
+++ b/src/renderer/windows/glyph_atlas.zig
@@ -832,10 +832,10 @@ pub const GlyphAtlas = struct {
         // 마진을 양쪽으로 1px 씩 추가해서 글리프가 cell 외곽으로 빠질 위험. round
         // 가 outline 의 visual center 에 가장 가까운 정수.
         const bounds = dw.RECT{
-            .left = @intFromFloat(@round(fbounds.left)),
-            .top = @intFromFloat(@round(fbounds.top)),
-            .right = @intFromFloat(@round(fbounds.right)),
-            .bottom = @intFromFloat(@round(fbounds.bottom)),
+            .left = @round(fbounds.left),
+            .top = @round(fbounds.top),
+            .right = @round(fbounds.right),
+            .bottom = @round(fbounds.bottom),
         };
 
         const gw: i32 = bounds.right - bounds.left;

--- a/src/scrollbar.zig
+++ b/src/scrollbar.zig
@@ -97,7 +97,7 @@ pub fn grabOffset(g: Geom, mouse_rel_y: f64) f64 {
 pub fn targetOffset(total: usize, len: usize, g: Geom, mouse_rel_y: f64, grab: f64) usize {
     const thumb_top = std.math.clamp(mouse_rel_y - grab, 0, g.available);
     const ratio = thumb_top / g.available;
-    return @intFromFloat(ratio * @as(f64, @floatFromInt(total - len)));
+    return @trunc(ratio * @as(f64, @floatFromInt(total - len)));
 }
 
 /// 렌더러·hit-test 공용 단일 진입점. track + geom 을 한 번에 구해 thumb 위치(그리기)

--- a/src/tab_icons.zig
+++ b/src/tab_icons.zig
@@ -127,7 +127,7 @@ pub fn rasterize(icon: Icon, size: u32, stroke_px: f32, out: []u8) void {
                 if (d < min_d) min_d = d;
             }
             const cov = std.math.clamp(half + 0.5 - min_d, 0.0, 1.0);
-            out[y * size + x] = @intFromFloat(cov * 255.0 + 0.5);
+            out[y * size + x] = @round(cov * 255.0);
         }
     }
 }
@@ -161,7 +161,7 @@ test "rasterize — chevron 은 한쪽으로 열린 꺾쇠" {
     const size: u32 = 20;
     rasterize(.chevron_left, size, 2.0, &buf);
     // `<` 의 꼭짓점은 좌측 중앙 (x≈0.3*span) → 채움.
-    const apex_x: u32 = @intFromFloat(1.0 + 0.3 * (@as(f32, @floatFromInt(size)) - 2.0));
+    const apex_x: u32 = @trunc(1.0 + 0.3 * (@as(f32, @floatFromInt(size)) - 2.0));
     try std.testing.expect(buf[(size / 2) * size + apex_x] > 150);
     // 우상단 모서리 안쪽(열린 쪽)은 비어야.
     try std.testing.expectEqual(@as(u8, 0), buf[(size / 2) * size + 1]);

--- a/src/tab_layout.zig
+++ b/src/tab_layout.zig
@@ -408,7 +408,7 @@ pub fn hitTab(
     const local_x = px - layout.tab_area_x;
     const world_x = local_x + scroll_x;
     if (world_x < 0) return null;
-    const tab_index = @as(usize, @intFromFloat(world_x / tab_w));
+    const tab_index = @as(usize, @trunc(world_x / tab_w));
     if (tab_index >= tab_count) return null;
     return tab_index;
 }

--- a/src/ui_metrics.zig
+++ b/src/ui_metrics.zig
@@ -126,7 +126,7 @@ test "viewportForGrid 는 탭바 높이를 더한다" {
 //
 // 이 모듈의 `*_PT` 상수는 logical point 단위이고, 그리는 쪽은 현재 화면 scale 을
 // 곱해 physical px 로 바꿔 쓴다. **그 변환은 여기 세 함수에만 있다** — 호출처가
-// `@intFromFloat(@as(f32, @floatFromInt(X_PT)) * scale)` 을 직접 쓰지 않는다.
+// `@trunc(@as(f32, @floatFromInt(X_PT)) * scale)` 을 직접 쓰지 않는다.
 //
 // 한 곳에 모은 이유. 이전에는 같은 변환이 세 platform 에 61곳으로 복붙돼 있었고
 // **규칙이 갈렸다** — Linux(`scaledPt`) 와 Windows(`app_controller`) 는 `@round`,
@@ -150,7 +150,7 @@ test "viewportForGrid 는 탭바 높이를 더한다" {
 /// 음수 결과는 없다 (`pt` · `scale` 모두 음수가 아니므로). `T` 가 부호 없는
 /// 타입이어도 안전하다.
 pub fn scaledPx(comptime T: type, pt: anytype, scale: f32) T {
-    return @intFromFloat(@round(scaledPxF(pt, scale)));
+    return @round(scaledPxF(pt, scale));
 }
 
 /// `pt × scale` 을 f32 physical px 로 — 정수 스냅 없이 소수를 유지한다. 그리기
@@ -368,7 +368,7 @@ pub fn blendOverU8(src: u8, dst: u8, alpha: f32) u8 {
     const s: f64 = @floatFromInt(src);
     const d: f64 = @floatFromInt(dst);
     const mixed = s * a + d * (1.0 - a);
-    return @intFromFloat(@round(@max(0.0, @min(255.0, mixed))));
+    return @round(@max(0.0, @min(255.0, mixed)));
 }
 
 /// [`blendOverU8`] 을 3 채널에 적용. 합성은 채널 독립이다.
@@ -935,14 +935,14 @@ test "#357 정수 두께는 위치 소수부와 무관하게 두께가 보존된
     // `[round(top), round(top + t))` — `ui_rect.snap` 과 GPU 가 같다.
     const rows = struct {
         fn n(top: f32, t: f32) i32 {
-            return @as(i32, @intFromFloat(@round(top + t))) - @as(i32, @intFromFloat(@round(top)));
+            return @as(i32, @round(top + t)) - @as(i32, @round(top));
         }
     }.n;
 
     // 정수 두께 — 위치 소수부 전부에서 정확히 t 픽셀.
     inline for (.{ 1.0, 2.0, 3.0 }) |t| {
         inline for (.{ 0.0, 0.05, 0.25, 0.45, 0.5, 0.55, 0.75, 0.85, 0.95 }) |frac| {
-            try std.testing.expectEqual(@as(i32, @intFromFloat(t)), rows(100.0 + frac, t));
+            try std.testing.expectEqual(@as(i32, @trunc(t)), rows(100.0 + frac, t));
         }
     }
 
@@ -1007,7 +1007,7 @@ test "#350 strokePx 는 최소 1px 을 보장하고 scaledPxF 는 소수를 유�
 
     // scaledPx 는 scaledPxF 를 반올림한 것과 같다 (한 정의에서 파생).
     inline for (.{ 1.0, 1.25, 1.5, 1.7, 2.0 }) |s| {
-        const expect: u32 = @intFromFloat(@round(scaledPxF(SCROLLBAR_W_PT, s)));
+        const expect: u32 = @round(scaledPxF(SCROLLBAR_W_PT, s));
         try std.testing.expectEqual(expect, scaledPx(u32, SCROLLBAR_W_PT, s));
     }
 }

--- a/src/ui_rect.zig
+++ b/src/ui_rect.zig
@@ -79,10 +79,10 @@ pub fn snap(r: Rect) IRect {
     const x1 = @round(r.x + r.w);
     const y1 = @round(r.y + r.h);
     return .{
-        .x = @intFromFloat(x0),
-        .y = @intFromFloat(y0),
-        .w = @max(1, @as(i32, @intFromFloat(x1 - x0))),
-        .h = @max(1, @as(i32, @intFromFloat(y1 - y0))),
+        .x = @trunc(x0),
+        .y = @trunc(y0),
+        .w = @max(1, @as(i32, @trunc(x1 - x0))),
+        .h = @max(1, @as(i32, @trunc(y1 - y0))),
     };
 }
 
@@ -124,10 +124,10 @@ test "#357 snapped 뒤에는 snap 이 no-op 이다 (#277 대비)" {
     const c = [4]f32{ 0, 0, 0, 1 };
     const r = snapped(.{ .x = 40.8, .y = 0.6, .w = 187.5, .h = 47.6, .color = c });
     const i = snap(r);
-    try testing.expectEqual(@as(i32, @intFromFloat(r.x)), i.x);
-    try testing.expectEqual(@as(i32, @intFromFloat(r.w)), i.w);
-    try testing.expectEqual(@as(i32, @intFromFloat(r.y)), i.y);
-    try testing.expectEqual(@as(i32, @intFromFloat(r.h)), i.h);
+    try testing.expectEqual(@as(i32, @trunc(r.x)), i.x);
+    try testing.expectEqual(@as(i32, @trunc(r.w)), i.w);
+    try testing.expectEqual(@as(i32, @trunc(r.y)), i.y);
+    try testing.expectEqual(@as(i32, @trunc(r.h)), i.h);
 }
 
 test "#343 clipX — 경계에 걸친 조각만 남기고 UV 이동량을 준다" {

--- a/src/window.zig
+++ b/src/window.zig
@@ -1024,18 +1024,18 @@ pub const Window = struct {
         // width = always horizontal %, height = always vertical %.
         // f32 percent → pixel: round 후 c_int. 정수 나눗셈 보다 정확한 세밀 조정
         // (예: 33.3% 가 sw=1920 일 때 639.36 → 639 px).
-        const w: c_int = @intFromFloat(@round(sw_f * width_percent / 100.0));
-        const h: c_int = @intFromFloat(@round(sh_f * height_percent / 100.0));
+        const w: c_int = @round(sw_f * width_percent / 100.0);
+        const h: c_int = @round(sh_f * height_percent / 100.0);
 
         const x: c_int = switch (dock) {
             .left => sx,
             .right => sx + sw - w,
-            .top, .bottom => sx + @as(c_int, @intFromFloat(@round(@as(f32, @floatFromInt(sw - w)) * offset_percent / 100.0))),
+            .top, .bottom => sx + @as(c_int, @round(@as(f32, @floatFromInt(sw - w)) * offset_percent / 100.0)),
         };
         const y: c_int = switch (dock) {
             .top => sy,
             .bottom => sy + sh - h,
-            .left, .right => sy + @as(c_int, @intFromFloat(@round(@as(f32, @floatFromInt(sh - h)) * offset_percent / 100.0))),
+            .left, .right => sy + @as(c_int, @round(@as(f32, @floatFromInt(sh - h)) * offset_percent / 100.0)),
         };
 
         return .{


### PR DESCRIPTION
## 무엇

Zig 0.16 이 `@floor` · `@ceil` · `@round` · `@trunc` 에 정수 변환을 넣으면서 `@intFromFloat` 가 중복이 됐다. 코드의 **153 자리**를 옮긴다 ([#452](https://github.com/ensky0/tildaz/issues/452)).

**의미 보존이 아니라 "0.16 에서 옳은 모양" 을 기준으로 했다.** `+ 0.5` 후 절단이나 `@intFromFloat(@round(x))` 2 단 중첩은 정수 변환을 못 하던 시절의 관용구다. 반올림 함수 하나가 그 자리를 끝낸다.

## 분류 — 66 자리를 하나씩 다시 읽었다

이슈 본문의 *"단순 절단 87 · 반올림 보정 66"* 분류는 실제 코드와 달랐다.

| | 자리 | 어떻게 |
|---|---|---|
| **흡수** | 59 | `@intFromFloat(@round(x))` → `@round(x)` — 바깥 변환이 중복 |
| **`@trunc`** | 89 | 그 밖의 전부. 절단이 곧 `@intFromFloat` 의 의미 |
| **경계 이동** | 5 | `@intFromFloat(clamp(@round(x),0,255))` → `@round(clamp(x,0,255))` |
| **`+0.5` 관용구** | 2 | `@intFromFloat(cov*255+0.5)` → `@round(cov*255)` |

경계 이동이 안전한 근거 — 경계값 (`0.0` · `1.0` · `255.0`) 과 `sw_f` (`@floatFromInt(sw_i)`) 가 **모두 정수값**이라 반올림 함수와 순서를 바꿔도 결과가 같다. 경계가 float 쪽에 있어야 정수 변환에 범위 밖 값이 들어가지 않아 안전성도 낫다.

## `+ 0.5` 가 반올림이 **아닌** 자리가 있다

[`software_terminal.zig`](https://github.com/ensky0/tildaz/blob/main/src/host/linux/software_terminal.zig) 의 glyph 축소는 목적 픽셀의 **중심**을 원본 좌표로 옮기는 nearest-neighbor 샘플링이다.

```zig
const src_x: u32 = @trunc((@as(f64, @floatFromInt(dx)) + 0.5) * gw_f / tw_f);
```

`@round` 로 바꾸면 샘플 위치가 어긋난다. `@trunc` 로 두고 **주석을 달아** 다음 사람이 같은 착각을 하지 않게 했다.

## 방법

괄호 짝을 문자열 리터럴까지 건너뛰며 세는 스크립트로 흡수 · `@trunc` 를 처리하고, 경계 이동과 `+0.5` 는 **손으로 판단**했다 (정규식으로는 중첩 괄호를 못 센다).

## 검증

미니PC · AMD Ryzen 7 8845HS · CachyOS · KDE Plasma Wayland · Zig 0.16.0

| 방법 | 결과 |
|---|---|
| `zig build check` (6 타겟) · `zig build` · `test` (4/4) · `render-test` | ✅ |
| **파생색 · 스케일 픽셀 비트 대조** — `chrome_palette.derive()` 216 색 (배경 12 종 × dark/light × 9 필드) + `ui_metrics.scaledPx` 352 값 (배율 11 종 × pt 16 종 × u32/i32) 을 임시 드라이버로 덤프 | **416 줄 전부 비트 단위 동일** |
| **렌더 픽셀 대조** — 같은 `render-test` 화면을 main 빌드와 이 빌드로 띄워 전체 화면 캡처 | **3840x2160 픽셀 차이 0** (`magick compare -metric AE`) |

렌더 대조는 창에 글리프 · 탭바 · 컨트롤 아이콘이 실제로 담긴 것을 눈으로 확인한 뒤 판정했다 (빈 화면끼리 비교하면 0 이 나와도 의미가 없으므로).

**한계** — 그 화면은 탭 1 개라 탭 스크롤 화살표 (`< >`) 와 scrollbar 는 대조에 포함되지 않았다. 두 요소의 좌표 계산도 같은 변환을 거쳤고 위의 `scaledPx` 비트 대조에 그 경로가 들어간다.

## 문서

`SPEC.md` §8.1 의 `pt → px` 예시를 `@round` 로 맞췄다. 코드에 `@intFromFloat` 가 남지 않았으므로 예시도 사실과 어긋나면 안 된다.

Closes #452