### PR TITLE
feat(stress): 폭포 중 입력이 먹히는지 재는 검사를 넣는다 (#441 축 ①)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -5,6 +5,10 @@
 [#278](https://github.com/ensky0/tildaz/issues/278) (stress test harness) 이 함께
 쓰는 도구예요.
 
+**처리량 말고 응답성도 여기 있어요** — 폭포가 흐르는 동안 입력이 먹히는지 보는 검사는
+아래 "[응답성 — 입력 손실 검사](#응답성--입력-손실-검사-441-축-)" 절이에요. 드레인을 건드리는
+변경은 두 축이 거래 관계라 한쪽만 재면 판정이 반쪽이에요.
+
 **Linux · macOS · Windows 에서 같은 명령으로 돌아요.** 셸 스크립트가 아니라 Zig
 프로그램인 이유는 [#371 코멘트 1 절](https://github.com/ensky0/tildaz/issues/371#issuecomment-5163867655)
 에 있어요 — 요약하면 부하를 주는 층과 시간을 재는 층이 platform 마다 갈려서, 셸로
@@ -36,7 +40,8 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | `zig build stress` (아래) | **층별 상한** — 파서 / PTY / 프레임 각각의 처리량 | 아무거나 |
 | [`compare-terminals.sh`](compare-terminals.sh) | **다섯 터미널 나란히** 처리량 비교 + 창 캡처 | Windows 는 **Git Bash 필수** |
 | [`measure-repeat.sh`](measure-repeat.sh) | **우리 앱 안의 배분** — `parse` · `render` · `shape` 몫 | 〃 |
-| [`hygiene.sh`](hygiene.sh) | 위 둘이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
+| [`check-input-loss.sh`](check-input-loss.sh) | **응답성** — 폭포 중 입력이 먹히는지 (처리량이 아니에요, 아래 절) | Linux · macOS |
+| [`hygiene.sh`](hygiene.sh) | 위 셋이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
 `measure-repeat` 는 앱을 반복해 띄워 종료 시 자동 덤프 ([#396](https://github.com/ensky0/tildaz/issues/396))
 로 남는 perf 스냅숏을 모으고, **5 회 절사평균 + min~max** 로 표를 내요. 시작 전에 위생을
@@ -579,6 +584,141 @@ Intel i5-1240P · `--repeat 5` · 배경 정리).
 - **scrollback 메모리는 줄당 약 1 KiB 예요** (120 열 기준, macOS 실측: 100만 줄 =
   1,008 MiB, 기본값 10만 줄 = 120 MiB). 셀 하나가 8 byte 이고 page 가 고정 폭이라
   `줄 수 × 열 수 × 8 byte` 에 가까워요. 열 수가 많은 창에서는 그만큼 늘어나요.
+## 응답성 — 입력 손실 검사 ([#441](https://github.com/ensky0/tildaz/issues/441) 축 ①)
+
+여기까지가 *얼마나 빨리 소화하나* 였다면, 이 절은 **그 동안 사용자를 잃지 않나** 예요.
+
+**드레인 구조를 건드리는 변경은 전부 처리량과 응답성의 거래예요** — 사양 A ([#387](https://github.com/ensky0/tildaz/issues/387)),
+예산 8 → 4 ms (SPEC §13.3), Windows waitable swapchain ([#435](https://github.com/ensky0/tildaz/issues/435)),
+Linux poll timeout ([#436](https://github.com/ensky0/tildaz/issues/436)), 유휴 깨우기
+([#439](https://github.com/ensky0/tildaz/issues/439)). 처리량 쪽만 도구가 있으면 *"처리량은 숫자로,
+응답성은 괜찮아 보인다로"* 남아요. #436 의 거래 (120 Hz cluster fps 121 → 93~104) 를 판단할 때
+이 비대칭이 그대로 걸렸어요.
+
+```sh
+dist/stress/check-input-loss.sh                 # 기본 — 10 회 · plain · 2 GiB
+dist/stress/check-input-loss.sh --presses 20
+```
+
+**Linux · macOS 전용이에요.** Windows 는 아래 "Windows 에서는 손으로" 를 보세요.
+
+### ⚠ 분량은 처리량 측정의 64 MiB 를 쓰면 안 돼요
+
+기록용 처리량은 64 MiB 로 내지만 (위 "기록용은 64 MiB"), **이 검사에서 그 값은 못 써요.** Linux 에서
+plain 은 200 MB/s 급이라 **0.3 초면 끝나서** 누를 시간이 없어요. 그러면 폭포가 없는 상태에서 누른
+것이 되고, ①은 당연히 다 먹고 ②는 버퍼에 쌓일 이유조차 없어요 — **판정이 성립하지 않는데 결과는
+`10 / 10` 으로 보여요.** 첫 회차에서 실제로 그렇게 나왔어요 (#441). 기본을 2 GiB 로 두는 이유예요.
+
+### ⚠ 입력기(IME)를 영문 모드로 두세요
+
+**한글 모드면 ①②가 둘 다 0 으로 나와요** (#441 실측 — 미니PC · CachyOS · KDE Plasma · fcitx5).
+타이핑은 한글로 조합돼 `touch` 가 명령이 되지 않고, 키 이벤트도 IME 를 먼저 지나가서
+`Ctrl+Shift+F12` 가 앱까지 오지 않아요. 폭포는 정상으로 흘렀는데 (2.17 GB · drain 21.9 초)
+로그에 `=== snapshot` 이 하나도 없는 회차가 그것이었어요.
+
+스크립트가 이 조합 (`폭포 ✅` + `① 0` + `② 실패`) 을 만나면 IME 를 의심하라고 알려 줘요.
+
+### 폭포 중이었는지를 함께 판정해요 — 개수만 세면 속아요
+
+그래서 **`=== snapshot` 개수만 세지 않아요.** 각 스냅숏의 `drain bytes` 를 함께 봐요.
+
+`dumpAndReset` 은 읽으면서 카운터를 리셋하니, 한 스냅숏의 bytes 는 *직전 스냅숏 이후* 의 몫이에요.
+**0 이면 그 사이에 아무것도 안 흘렀다** = 폭포 밖에서 눌렀다는 뜻이에요. 통과 조건은 "눌린 횟수" 가
+아니라 **"폭포 중에 눌린 횟수"** 예요.
+
+```
+==================== 결과 ====================
+ 폭포                      ✅ 2013 MiB 흘렀어요
+ ① 앱 단축키 · 앱이 소비   ✅ 10 / 10   (전체 눌림 10)
+ ② PTY 전달 · 타이핑       ✅ 성공 (파일 생성됨)
+==============================================
+```
+
+producer 가 안 돌면 `폭포` 줄이 `❌ 231 byte 뿐` 으로 나와요. 그 회차는 나머지 판정이 무의미하니
+버려요.
+
+### producer 는 **환경변수 두 개로만** 켜져요
+
+`stress.zig` 의 `producerRequest` 가 `TILDAZ_STRESS_WORKLOAD` 와 `TILDAZ_STRESS_BYTES` 를 **둘 다**
+요구하고, 하나라도 빠지면 조용히 일반 모드로 둬요. 그리고 **인자를 주면 안 돼요** — 인자가 있으면
+`throughput` 같은 *독립 측정* 모드라 자기 안에서 재고 끝나서, 앱 PTY 로는 폭포가 흐르지 않아요.
+(첫 회차의 실수가 정확히 이것이었어요.)
+
+### 두 경로를 따로 봐요 — 하나로 뭉치면 판정이 안 돼요
+
+| # | 경로 | 어떻게 판정하나 | 왜 되나 |
+|---|---|---|---|
+| **①** | **앱 단축키** (앱이 소비) | 폭포 중 `Ctrl+Shift+F12` (macOS 는 `Shift+Cmd+F12`) 를 N 회 누르고 로그의 `=== snapshot` 블록 수를 센다 | 처리되면 블록이 **정확히 하나** 남아요. 화면을 볼 필요가 없고 개수가 곧 손실률이에요 |
+| **②** | **PTY 전달** (타이핑) | 폭포 중 `touch /tmp/tz-ok` 를 타이핑하고, 폭포가 끝난 뒤 그 파일이 생겼는지 본다 | producer 가 **foreground** 라 셸이 stdin 을 읽지 않아 입력이 termios 버퍼에 남고, 폭포가 끝나는 순간 실행돼요 |
+
+**둘 다 필요해요** — ①은 `Ctrl+Shift` 분기에서 앱이 소비하므로 **PTY write 경로를 지나지 않아요.**
+②가 그 경로를 봐요. 그리고 ②의 배치는 **Ctrl+C 검사도 함께 성립**시켜요 (producer 가 foreground 라
+SIGINT 를 받아요).
+
+`=== snapshot` 만 세면 되는 이유는 **두 덤프가 라벨로 갈리기** 때문이에요. 단축키는
+[`perf.zig`](../../src/perf.zig) 의 `dumpAndReset(rt, "snapshot")` 이고, 종료 시 자동 덤프
+([#396](https://github.com/ensky0/tildaz/issues/396)) 는 `dumpOnExit` 이 **워크로드 이름**을 라벨로 써요.
+
+### `-e` 에 러너 스크립트를 넘겨요 — 그냥 producer 를 넘기면 ②가 성립 안 해요
+
+`measure-repeat.sh` 처럼 `-e <producer>` 로 띄우면 **폭포가 끝날 때 앱이 함께 종료돼서, 버퍼에 쌓인
+입력을 실행할 셸이 없어요.** 그래서 스크립트가 이런 러너를 만들어 넘겨요.
+
+```sh
+#!/bin/sh
+"$STRESS" throughput --layer pty --mb 64   # foreground 폭포 (stdin 을 안 읽어요)
+exec "$SHELL"                              # 폭포 후 셸 — 같은 PTY slave 를 물려받아 버퍼를 읽어요
+```
+
+`-e` 가 인자를 못 받는 것도 같은 이유예요 (`run_options.zig` — POSIX PTY 의 argv 가 `{shell}` 로 고정).
+
+### 로그는 `tildaz_stress.log` 로 가요
+
+`-e` 로 띄운 회차는 stress run 으로 판정돼 (`instance_context.isStress`) 평소의 `tildaz_N.log` 가
+아니라 **`tildaz_stress.log`** 에 남아요. 판정이 안 나올 때 이걸 먼저 확인해요 — 다른 작업에서도
+`tildaz_1.log` 가 비어 있어 한참 헤맨 적이 있어요.
+
+| platform | 경로 |
+|---|---|
+| Linux | `${XDG_STATE_HOME:-~/.local/state}/tildaz/tildaz_stress.log` |
+| macOS | `~/Library/Logs/tildaz_stress.log` |
+| Windows | `%APPDATA%\tildaz\tildaz_stress.log` |
+
+### ❌ 이렇게는 판정이 안 돼요 — 다시 만들지 않으려고 적어 둬요
+
+| 안 되는 방법 | 왜 |
+|---|---|
+| 폭포 중 에코를 **눈으로** 보기 | 초당 100 MiB 넘게 흐르면 1 초에 수만 줄이 지나가서, 에코된 글자가 나타난 순간 이미 스크롤 위로 밀려요. **"안 보인다" 와 "안 먹는다" 가 구분되지 않아요** |
+| 백그라운드 job (`( … ) &`) 에 **Ctrl+C** | SIGINT 는 foreground process group (셸) 에만 가요. 앱과 무관하게 **원래 안 멈춰요** |
+
+첫 시연이 이 둘을 겹쳐 놓아서 판정이 아예 불가능한 설계였어요 ([#436 코멘트](https://github.com/ensky0/tildaz/issues/436#issuecomment-5236928407)).
+
+### 위생은 처리량만큼 안 따져요
+
+`hygiene_check` 를 부르지 않아요. 판정이 *"먹었나 / 안 먹었나"* 라는 **이산값**이라 AC · 주사율 ·
+배경 앱이 결과를 뒤집지 않아요 (나쁘면 폭포가 느려질 뿐이에요). 처리량 표를 낼 때의 규칙
+(위 "측정 위생") 과는 요구가 다르다는 뜻이에요.
+
+### Windows 에서는 손으로
+
+`-e` 에 러너 스크립트를 넘길 수 없어요 — `CreateProcess` 가 `.cmd` 를 직접 실행하지 않아요.
+절차는 같으니 손으로 해요.
+
+1. `zig build stress` 로 `tildaz-stress.exe` 를 만들어요.
+2. TildaZ 를 평소대로 띄우고 탭에서 producer 를 **foreground** 로 실행해요
+   (`zig-out\bin\tildaz-stress.exe throughput --layer pty --mb 64`).
+3. 폭포 중 `Ctrl+Shift+F12` 를 10 회 누르고, 결과가 파일로 남는 명령을 타이핑해요
+   (PowerShell 이면 `ni $env:TEMP\tz-ok`).
+4. `%APPDATA%\tildaz\tildaz_stress.log` 에서 `=== snapshot` 블록 수를 세고 파일 생성을 확인해요.
+
+### 아직 없는 것 — 응답 **시간** (축 ②)
+
+이 절은 *"먹었나"* 만 봐요. **얼마나 늦게 반영되는지는 전혀 못 봐요.** 예산 4 ms 가 실제 체감
+지연으로 얼마인지 우리는 한 번도 재지 않았어요. 방법 후보 (앱 계측 · 합성 입력 · PTY 왕복) 와
+걸림돌은 [#441](https://github.com/ensky0/tildaz/issues/441) 에 정리돼 있어요 — Linux Wayland 의
+합성 입력이 걸려요. [#439](https://github.com/ensky0/tildaz/issues/439) (유휴 깨우기) 를 *가설*이
+아니라 숫자로 판정하려면 그 축이 필요해요.
+
 ## 다른 터미널과 비교하기
 
 ```sh

--- a/dist/stress/check-input-loss.sh
+++ b/dist/stress/check-input-loss.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# 응답성 — **입력 손실** 검사 (#441 축 ①).
+#
+# 폭포가 흐르는 동안 입력이 먹히는지 본다. 처리량 하네스 (`measure-repeat.sh`) 가
+# *얼마나 빨리 소화하나* 를 재는 것과 달리, 이쪽은 *그 동안 사용자를 잃지 않나* 를 본다.
+# 드레인 구조를 건드리는 변경은 전부 처리량과 응답성의 거래라서 (#387 · #435 · #436 ·
+# #439) 두 축이 함께 있어야 판정이 성립한다.
+#
+#   dist/stress/check-input-loss.sh                 # 기본 — 10 회 · plain · 2 GiB
+#   dist/stress/check-input-loss.sh --presses 20
+#
+# **두 경로를 따로 본다.** 하나로 뭉치면 판정이 안 된다 (#436 실측).
+#
+#   ① 앱 단축키 — 앱이 소비하는 키. 처리되면 로그에 `=== snapshot` 블록이 정확히 하나 남는다.
+#      **PTY write 경로를 지나지 않는다** (Ctrl+Shift 분기에서 앱이 먹는다).
+#   ② PTY 전달 — 타이핑한 명령이 폭포 후 실행되는지. ①이 못 보는 write 경로를 본다.
+#      producer 가 foreground 라 **Ctrl+C 검사도 함께 성립**한다.
+#
+# 사람이 하는 것은 *키를 누르고 타이핑하는 것* 뿐이고 판정은 이 스크립트가 한다.
+# 합성 입력을 갖추지 않은 이유는 Linux Wayland 가 걸리기 때문이다 (#441 본문) —
+# 응답 **시간** 측정 (축 ②) 과 함께 남겨 둔 몫이다.
+#
+# **Linux · macOS 전용이다.** Windows 는 `-e` 에 러너 스크립트를 넘길 수 없어
+# (CreateProcess 가 `.cmd` 를 직접 실행하지 않는다) 절차를 README 에 글로 적어 두었다.
+set -u
+
+PRESSES=10
+WORKLOAD=plain
+# **처리량 측정의 64 MiB 를 그대로 쓰면 안 된다.** Linux 에서 plain 은 200 MB/s 급이라
+# 64 MiB 는 0.3 초에 끝나고, 그러면 누를 시간이 없어 부하 없는 상태에서 누른 것이 된다
+# (#441 첫 회차에서 실제로 그렇게 나왔다 — 스냅숏마다 `drain bytes=0`). 10 회를 여유 있게
+# 누르려면 몇 초는 흘러야 해서 기본을 2 GiB 로 둔다. 느린 머신에서는 더 오래 흐를 뿐이라 안전하다.
+MB=2048
+SCROLLBACK=32767
+KEEP_RUNNER=0
+
+usage() {
+    cat <<'USAGE'
+쓰는 법: dist/stress/check-input-loss.sh [옵션]
+
+  --presses <N>      폭포 중 누를 단축키 횟수 (기본 10 — SPEC 13.2 의 "입력 10 회")
+  --workload <이름>  폭포 워크로드 (기본 plain)
+  --mb <N>           쏟아부을 MiB (기본 2048 — 64 MiB 는 0.3 초에 끝나 누를 시간이 없다)
+  --scrollback <N>   앱에 넘길 scrollback 줄 수 (기본 32767)
+  --keep-runner      임시 러너 스크립트를 지우지 않는다 (진단용)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --presses) PRESSES="$2"; shift 2 ;;
+        --workload) WORKLOAD="$2"; shift 2 ;;
+        --mb) MB="$2"; shift 2 ;;
+        --scrollback) SCROLLBACK="$2"; shift 2 ;;
+        --keep-runner) KEEP_RUNNER=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# platform 판정만 빌려 쓴다 (`HYG_PLATFORM`). 처리량 측정과 달리 위생 (AC · 주사율 ·
+# 배경 앱) 이 판정을 바꾸지 않아서 `hygiene_check` 는 부르지 않는다 — 여기 판정은
+# "먹었나 / 안 먹었나" 라는 이산값이고, 위생이 나쁘면 폭포가 느려질 뿐이다.
+. "$REPO_ROOT/dist/stress/hygiene.sh"
+
+EXE=""
+for _cand in \
+    "$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz" \
+    "$REPO_ROOT/zig-out/bin/tildaz"
+do
+    [ -x "$_cand" ] && EXE="$_cand" && break
+done
+[ -n "$EXE" ] || EXE="$REPO_ROOT/zig-out/bin/tildaz"
+STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress"
+
+case "$HYG_PLATFORM" in
+    # `paths.zig` 의 `logDir` 와 같은 규칙이다. `-e` 로 띄운 회차는 **`tildaz_stress.log`**
+    # 로 간다 (`instance_context.isStress`) — 평소의 `tildaz_N.log` 가 아니다.
+    linux) LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log" ;;
+    macos) LOG="$HOME/Library/Logs/tildaz_stress.log" ;;
+    *)
+        echo "이 스크립트는 Linux · macOS 전용이에요 ($(uname -s))." >&2
+        echo "Windows 는 dist/stress/README.md 의 '입력 손실' 절에 수동 절차가 있어요." >&2
+        exit 2
+        ;;
+esac
+
+[ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+[ -x "$STRESS" ] || { echo "tildaz-stress 없음: $STRESS  (먼저 zig build stress)" >&2; exit 1; }
+
+# platform 별 단축키 — `dump_perf` 를 부르는 키다 (`wayland_minimal.zig` · `macos.zig`).
+case "$HYG_PLATFORM" in
+    macos) KEY="Shift+Cmd+F12" ;;
+    *) KEY="Ctrl+Shift+F12" ;;
+esac
+
+MARKER=/tmp/tz-ok
+rm -f "$MARKER"
+
+# `-e` 는 인자를 못 넘긴다 (`run_options.zig` — POSIX PTY 의 argv 가 `{shell}` 로 고정).
+# 그래서 러너 스크립트를 만들어 넘긴다.
+#
+# **`exec <셸>` 이 이 검사의 핵심이다.** producer 를 그냥 `-e` 로 띄우면 폭포가 끝날 때
+# 앱이 함께 종료돼, 버퍼에 쌓인 입력을 실행할 셸이 없다. producer 가 stdin 을 읽지 않으므로
+# 폭포 중 타이핑은 termios 버퍼에 남고, `exec` 로 올라온 셸이 같은 PTY slave 를 물려받아
+# 그것을 읽는다.
+# **producer 모드는 환경변수 두 개로만 켜진다** (`stress.zig` 의 `producerRequest` —
+# `TILDAZ_STRESS_WORKLOAD` + `TILDAZ_STRESS_BYTES` 가 둘 다 유효해야 하고, 하나라도
+# 빠지면 조용히 일반 모드로 둔다). 인자를 주면 그건 *독립 측정* 모드라 자기 안에서
+# 재고 끝나 **앱 PTY 로는 폭포가 흐르지 않는다** — #441 첫 회차가 이 실수였다.
+RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-input-check-XXXXXX.sh")
+SHELL_PATH="${SHELL:-/bin/bash}"
+BYTES=$((MB * 1024 * 1024))
+cat > "$RUNNER" <<EOF
+#!/bin/sh
+TILDAZ_STRESS_WORKLOAD=$WORKLOAD
+TILDAZ_STRESS_BYTES=$BYTES
+export TILDAZ_STRESS_WORKLOAD TILDAZ_STRESS_BYTES
+"$STRESS"
+exec "$SHELL_PATH"
+EOF
+chmod +x "$RUNNER"
+
+cat <<EOF
+
+================ 입력 손실 검사 (#441 축 ①) ================
+ 폭포      : $WORKLOAD · ${MB} MiB
+ 단축키    : $KEY 를 ${PRESSES} 회
+ marker    : $MARKER
+ 로그      : $LOG
+============================================================
+
+⚠ **입력기(IME)를 영문 모드로 두세요.** 한글 모드면 둘 다 판정이 안 나와요 —
+   타이핑이 한글로 조합돼 명령이 되지 않고, 키 이벤트도 IME 를 먼저 지나가서
+   단축키가 앱까지 오지 않아요 (#441 실측: fcitx5 · KDE 에서 0/10).
+
+창이 뜨면 **폭포가 흐르는 동안** 아래 둘을 하세요.
+
+  ① $KEY 를 ${PRESSES} 회 누른다   (앱이 소비 — 로그에 흔적이 남는다)
+  ② touch $MARKER  를 타이핑한다    (PTY 전달 — 폭포가 끝나면 셸이 실행한다)
+
+  ②는 폭포 중에 화면에 안 보이는 것이 정상이에요. 초당 수만 줄이 지나가서
+  에코가 나타난 순간 이미 스크롤 위로 밀려요 — 그래서 눈으로 판정하지 않아요.
+
+폭포가 끝나면 셸 프롬프트가 돌아와요. 확인 후 창을 닫으면 (Alt+F4 · Cmd+Q)
+판정이 나옵니다.
+
+EOF
+printf '준비되면 Enter — '
+read -r _
+
+# 이번 회차에 추가된 로그만 잘라 내려고 현재 크기를 기록한다 (`measure-repeat.sh` 와 같은 패턴).
+START_LEN=0
+[ -f "$LOG" ] && START_LEN=$(wc -c < "$LOG" | tr -d ' ')
+
+"$EXE" -e "$RUNNER" -size 120x40 -scrollback "$SCROLLBACK"
+
+RAW=$(mktemp "${TMPDIR:-/tmp}/tildaz-input-check-log-XXXXXX")
+if [ "$START_LEN" -gt 0 ]; then
+    tail -c "+$((START_LEN + 1))" "$LOG" > "$RAW"
+elif [ -f "$LOG" ]; then
+    cp "$LOG" "$RAW"
+else
+    : > "$RAW"
+fi
+
+# 단축키 덤프는 라벨이 `snapshot` 이고, 종료 시 자동 덤프 (#396) 는 워크로드 이름이다
+# (`perf.zig` 의 `dumpAndReset` / `dumpOnExit`). 그래서 그 패턴만 세면 자동 덤프가 안 섞인다.
+#
+# **개수만 세면 안 된다.** 폭포가 없는 상태에서 누른 것도 10/10 이 나오는데, 그건 이 검사가
+# 보려던 것이 아니다 (#441 첫 회차가 그랬다). 그래서 각 스냅숏의 `drain bytes` 로 **그 시점에
+# 폭포가 흐르고 있었는지** 를 함께 본다 — `dumpAndReset` 은 읽으면서 리셋하므로 한 스냅숏의
+# bytes 는 *직전 스냅숏 이후* 의 몫이고, 0 이면 그 사이에 아무것도 안 흘렀다는 뜻이다.
+eval "$(awk '
+/^=== snapshot @/ { snap = 1; next }
+/^=== /           { snap = 0 }
+/^readloop / {
+    for (i = 1; i <= NF; i++) if ($i ~ /^bytes=/) { split($i, a, "="); total += a[2] }
+}
+/^drain / {
+    if (snap) {
+        snaps++
+        for (i = 1; i <= NF; i++) if ($i ~ /^bytes=/) { split($i, a, "="); if (a[2] + 0 > 0) busy++ }
+        snap = 0
+    }
+}
+END { printf "SNAPS=%d BUSY=%d TOTAL_BYTES=%d\n", snaps + 0, busy + 0, total + 0 }
+' "$RAW")"
+
+# 폭포가 실제로 흘렀나. 기대 분량의 절반이면 충분하다 — 사용자가 폭포 도중에 창을 닫을 수도 있고,
+# 여기서 보려는 것은 "producer 가 돌았나" 이지 정확한 처리량이 아니다.
+FLOW_OK=0
+[ "$TOTAL_BYTES" -ge "$((BYTES / 2))" ] && FLOW_OK=1
+FLOW_MIB=$((TOTAL_BYTES / 1024 / 1024))
+
+if [ -f "$MARKER" ]; then PTY_VERDICT="✅ 성공 (파일 생성됨)"; PTY_OK=1
+else PTY_VERDICT="❌ 실패 (파일 없음)"; PTY_OK=0; fi
+
+# 통과 조건은 "눌린 횟수" 가 아니라 **"폭포 중에 눌린 횟수"** 다.
+if [ "$BUSY" -eq "$PRESSES" ]; then KEY_VERDICT="✅ $BUSY / $PRESSES"; KEY_OK=1
+else KEY_VERDICT="❌ $BUSY / $PRESSES"; KEY_OK=0; fi
+
+if [ "$FLOW_OK" -eq 1 ]; then FLOW_VERDICT="✅ ${FLOW_MIB} MiB 흘렀어요"
+else FLOW_VERDICT="❌ ${TOTAL_BYTES} byte 뿐 — producer 가 안 돌았어요"; fi
+
+cat <<EOF
+
+==================== 결과 ====================
+ 폭포                      $FLOW_VERDICT
+ ① 앱 단축키 · 앱이 소비   $KEY_VERDICT   (전체 눌림 $SNAPS)
+ ② PTY 전달 · 타이핑       $PTY_VERDICT
+==============================================
+
+EOF
+
+if [ "$FLOW_OK" -eq 0 ]; then
+    cat >&2 <<'HINT'
+⚠ 폭포가 흐르지 않았어요 — 이 회차는 판정이 성립하지 않아요.
+  부하 없이 누르면 ①은 당연히 다 먹고 ②도 버퍼에 쌓일 이유가 없어요.
+  producer 모드는 TILDAZ_STRESS_WORKLOAD + TILDAZ_STRESS_BYTES 가 둘 다 유효할 때만 켜져요
+  (stress.zig 의 producerRequest). --keep-runner 로 러너를 남겨 확인해 보세요.
+HINT
+elif [ "$SNAPS" -eq 0 ] && [ "$PTY_OK" -eq 0 ]; then
+    cat >&2 <<'HINT'
+⚠ 폭포는 흘렀는데 ①②가 둘 다 0 이면 **입력기(IME)가 한글 모드였을 가능성이 큽니다.**
+  타이핑은 한글로 조합돼 명령이 되지 않고, 키 이벤트도 IME 를 먼저 지나가 단축키가
+  앱까지 오지 않아요. 영문 모드로 바꾸고 다시 돌려 보세요 (#441 실측: fcitx5 · KDE).
+HINT
+elif [ "$SNAPS" -gt "$BUSY" ]; then
+    echo "⚠ $((SNAPS - BUSY)) 회는 폭포가 끝난 뒤에 눌렸어요 — 그건 이 검사의 대상이 아니에요." >&2
+    echo "  --mb 를 늘려 폭포를 길게 하거나, 더 일찍 누르세요." >&2
+fi
+if [ "$SNAPS" -gt "$PRESSES" ]; then
+    echo "⚠ 센 횟수가 기대보다 많아요 — 더 눌렀거나 이전 회차 로그가 섞였을 수 있어요." >&2
+fi
+if [ "$KEY_OK" -eq 0 ] || [ "$PTY_OK" -eq 0 ] || [ "$FLOW_OK" -eq 0 ]; then
+    echo "로그 원문: $RAW" >&2
+fi
+
+[ "$KEEP_RUNNER" -eq 1 ] || rm -f "$RUNNER"
+rm -f "$MARKER"
+
+[ "$KEY_OK" -eq 1 ] && [ "$PTY_OK" -eq 1 ] && [ "$FLOW_OK" -eq 1 ]


### PR DESCRIPTION
## 무엇

드레인 구조를 건드리는 변경은 전부 **처리량과 응답성의 거래**인데 ([#387](https://github.com/ensky0/tildaz/issues/387) · [#435](https://github.com/ensky0/tildaz/issues/435) · [#436](https://github.com/ensky0/tildaz/issues/436) · [#439](https://github.com/ensky0/tildaz/issues/439)) 처리량 쪽만 도구가 있었다. [#436 에서 통한 두 방법](https://github.com/ensky0/tildaz/issues/436#issuecomment-5236928407)을 도구로 만든다.

```sh
dist/stress/check-input-loss.sh                 # 10 회 · plain · 2 GiB
dist/stress/check-input-loss.sh --presses 20
```

## 두 경로를 따로 본다

| # | 경로 | 판정 | 왜 따로 필요한가 |
|---|---|---|---|
| **①** | 앱 단축키 | 로그의 `=== snapshot` 블록 수 | 화면을 볼 필요가 없다 |
| **②** | PTY 전달 | 타이핑한 `touch` 가 폭포 후 실행됐는지 | ①은 `Ctrl+Shift` 분기에서 앱이 소비해 **PTY write 경로를 지나지 않는다.** ②의 배치는 **Ctrl+C 검사도 함께 성립**시킨다 |

`=== snapshot` 만 세면 되는 이유 — 두 덤프가 **라벨로 갈린다** (단축키는 `dumpAndReset(rt, "snapshot")`, 종료 시 자동 덤프 [#396](https://github.com/ensky0/tildaz/issues/396) 은 워크로드 이름).

## `-e` 에 러너 스크립트를 넘긴다

producer 를 그냥 `-e` 로 띄우면 **폭포가 끝날 때 앱이 함께 종료돼 버퍼에 쌓인 입력을 실행할 셸이 없다.** 러너가 producer 를 foreground 로 돌리고 `exec <셸>` 로 떨어지면, 같은 PTY slave 를 물려받은 셸이 termios 버퍼를 읽는다.

## 개수만 세면 속는다 — 만들면서 실측으로 배운 것을 도구에 넣었다

**첫 회차는 `10 / 10` 이 나왔지만 판정이 성립하지 않은 회차였다.** 폭포가 231 byte 밖에 안 흘렀는데도 그렇게 보였다. 부하 없이 누르면 ①은 당연히 다 먹고 ②도 버퍼에 쌓일 이유가 없다.

| # | 무엇이 틀렸나 | 어떻게 고쳤나 |
|---|---|---|
| ① | **producer 진입 실패** — `producerRequest` 는 `TILDAZ_STRESS_WORKLOAD` + `TILDAZ_STRESS_BYTES` 가 둘 다 유효해야 켜지는데 하나만 줬고, 인자를 붙여 *독립 측정* 모드로 돌았다 | 인자를 빼고 두 환경변수를 준다 |
| ② | **64 MiB 는 0.3 초** — 처리량 기록용 값이라 누를 시간이 없다 | 기본 2 GiB (실측 22 초) |
| ③ | **폭포 중인지 안 봤다** | 각 스냅숏의 `drain bytes` 로 함께 판정. 통과 조건은 **"폭포 중에 눌린 횟수"** |

③ 의 awk 판정을 실패한 그 회차 로그에 돌려 확인했다 — `SNAPS=3 BUSY=0 TOTAL_BYTES=231`.

**입력기(IME)가 한글이면 ①②가 둘 다 0 이 된다.** 타이핑이 한글로 조합되고 키 이벤트도 IME 를 먼저 지나가 단축키가 앱까지 오지 않는다 (fcitx5 · KDE 실측). 안내에 넣고, 그 조합을 만나면 IME 를 의심하라고 알려 준다.

## 설계 결정 둘 (실기 확인)

- **위생 검사를 안 부른다** — 판정이 이산값이라 AC · 주사율 · 배경 앱이 결과를 뒤집지 않는다
- **`--instance` 를 안 준다** — `isStressRun()` 이면 worker lock 을 안 잡고 역할이 `.stress` 로 갈려 daily 인스턴스와 공존한다

## 검증

미니PC · AMD Ryzen 7 8845HS · CachyOS · KDE Plasma Wayland · Zig 0.16.0

```
==================== 결과 ====================
 폭포                      ✅ 2073 MiB 흘렀어요
 ① 앱 단축키 · 앱이 소비   ✅ 10 / 10   (전체 눌림 10)
 ② PTY 전달 · 타이핑       ✅ 성공 (파일 생성됨)
==============================================
```

`전체 눌림 10` 과 `10 / 10` 이 같으므로 **누른 10 회가 전부 폭포 중이었고 전부 처리됐다.** 폭포는 2.17 GB · drain 21.9 초.

## 문서

`dist/stress/README.md` 에 절 추가 — 두 방법, `-e` 러너가 필요한 이유, 분량 주의, 폭포 중 판정, IME 전제, 로그가 **`tildaz_stress.log`** 로 가는 것, Windows 수동 절차, 그리고 **실패한 방법 두 가지** (폭포 중 에코를 눈으로 보기 · 백그라운드 job 에 Ctrl+C).

## 범위

**축 ① 만이다.** 축 ② (응답 **시간**) 는 설계가 필요하고 Linux Wayland 합성 입력이 걸려 있어 [#441](https://github.com/ensky0/tildaz/issues/441) 에 남긴다. 그래서 이 PR 은 이슈를 닫지 않는다.

Refs #441