### PR TITLE
fix(package): package.ps1 이 자기 PSModulePath 전제를 스스로 세운다 (#455)

### DIFF
--- a/dist/windows/package.ps1
+++ b/dist/windows/package.ps1
@@ -10,7 +10,8 @@
 # 있어야 하고, tildaz.exe 는 <exe dir>\_internal\conpty.dll 을 절대경로로 로드해요.
 # 소스는 zig-out\bin (tildaz.exe) + zig-out\bin\_internal (런타임 2개)로, build.zig
 # install 단계가 같은 구조로 떨궈요. Windows PowerShell 5.1의 Compress-Archive /
-# Get-FileHash만 사용하므로 WSL과 Git Bash가 필요하지 않아요.
+# Get-FileHash만 사용하므로 WSL과 Git Bash가 필요하지 않아요. 그 두 cmdlet 이 부모 셸에
+# 따라 사라지지 않도록 스크립트 첫머리에서 PSModulePath를 정규화해요 (#455).
 #
 # 사용법:
 #   powershell.exe -NoProfile -ExecutionPolicy Bypass -File dist\windows\package.ps1 -Version 0.6.2
@@ -24,6 +25,37 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+# 부모 사슬에 PowerShell 7 이 있으면 이 5.1 세션이 PS7 의 `PSModulePath` 를 그대로
+# 물려받아요. 그러면 5.1 이 PS7 쪽 `Microsoft.PowerShell.Utility` 를 물어서, 모듈은
+# 로드되는데 그 안의 cmdlet 은 못 쓰는 상태가 돼요 — `Get-FileHash` 가 사라져 zip 은
+# 만들어지고 `.sha256` 단계에서만 깨졌어요 (#455). `Compress-Archive` 도 같은 노출이라
+# 우연히 동작했을 뿐이에요.
+#
+# pwsh 는 `powershell.exe` 를 **자기가 직접** 띄울 때만 PS7 의 User / System / $PSHOME
+# 모듈 경로를 뺀 값 (`WinPSModulePath`) 을 자식에게 줘요 (about_PSModulePath 의
+# "Starting Windows PowerShell from PowerShell 7"). `zig build package` 는 사이에
+# `zig.exe` 가 끼어서 그 정리가 걸리지 않아요 — 그 전이 문제는 upstream 미해결이에요
+# (PowerShell/PowerShell#20804).
+#
+# 그래서 스크립트가 자기 전제를 스스로 세워요. 문서가 정의한 그 제거 규칙을 그대로
+# 적용하므로 build.zig 경유든 `-File` 직접 실행이든 같은 보호를 받아요. 5.1 (Desktop)
+# 에서만 해요 — PS7 자신으로 돌릴 때 PS7 경로를 지우면 오히려 그 세션이 깨져요.
+if ($PSVersionTable.PSEdition -eq "Desktop") {
+    $WinPSHomeModules = Join-Path $PSHOME "Modules"
+    $KeptModulePaths = @($env:PSModulePath -split ';' | Where-Object {
+        # `\PowerShell\` 는 PS7 경로 (`…\Documents\PowerShell\Modules`,
+        # `…\Program Files\PowerShell\7\Modules`) 에만 걸려요. 5.1 은
+        # `\WindowsPowerShell\` 이라 "PowerShell" 앞이 백슬래시가 아니에요.
+        # Store 설치본은 `…\WindowsApps\microsoft.powershell_7.6.4.0_…\Modules`
+        # 형태라 그 이름도 함께 걸러요.
+        $_ -and $_ -notmatch '(?i)\\PowerShell\\' -and $_ -notmatch '(?i)microsoft\.powershell_'
+    })
+    if ($KeptModulePaths -notcontains $WinPSHomeModules) {
+        $KeptModulePaths += $WinPSHomeModules
+    }
+    $env:PSModulePath = $KeptModulePaths -join ';'
+}
 
 if ($Version -notmatch '^[0-9A-Za-z][0-9A-Za-z.+-]*$') {
     throw "Version must be a SemVer-compatible filename component (got '$Version')."


### PR DESCRIPTION
## 무엇

부모 셸이 PowerShell 7 이면 `zig build package` 가 `.sha256` 단계에서 `Get-FileHash` 를 못 찾아 실패하던 문제를 고쳐요 ([#455](https://github.com/ensky0/tildaz/issues/455)).

## 근본 원인

Microsoft 문서 [about_PSModulePath](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath?view=powershell-7.6) 의 *Starting Windows PowerShell from PowerShell 7*:

> The value of `$Env:PSModulePath` is copied to `WinPSModulePath` with the following modifications: Remove PS7 the User module path / Remove PS7 the System module path / Remove PS7 the `$PSHOME` module path.

이 정리는 **pwsh 가 `powershell.exe` 를 직접 띄울 때만** 걸려요. `zig build package` 는 사이에 `zig.exe` 가 끼어서 정리가 전이되지 않고, 5.1 이 PS7 쪽 `Microsoft.PowerShell.Utility` 를 물어 모듈은 로드되는데 cmdlet 을 못 쓰는 상태가 돼요. 그 전이 문제는 upstream 미해결이에요 ([PowerShell#20804](https://github.com/PowerShell/PowerShell/issues/20804), [#12997](https://github.com/PowerShell/PowerShell/issues/12997)).

실측으로 갈랐어요 — 부모가 pwsh 면 자식이 깨끗하고(pwsh 가 고쳐 줌), 부모가 `cmd.exe` 면 오염된 값이 그대로 내려가 `Get-FileHash` 가 사라져요.

## 어떻게

`package.ps1` 첫머리에서 문서가 정의한 그 제거 규칙을 스스로 적용해요.

- **한 곳만 고쳐도 모든 호출 경로가 덮여요** — build.zig 의 package step, `-File` 직접 실행, CI 의 `zig build package`.
- `Get-FileHash` 뿐 아니라 같은 노출이 있던 **`Compress-Archive` 도 함께** 닫혀요.
- `$PSVersionTable.PSEdition -eq "Desktop"` 일 때만 해요 — PS7 자신으로 돌릴 때 PS7 경로를 지우면 그 세션이 깨져요.
- 사용자가 따로 더한 모듈 경로는 남겨요.

## 검증

노트북 · Intel Core i5-1240P · Windows 11 10.0.26200 · pwsh 7.6.4 / Windows PowerShell 5.1.26100.9168

| 조합 | 결과 |
|---|---|
| 수정 전 · 부모 pwsh 7 | ❌ 이슈 본문과 같은 `Get-FileHash … CommandNotFoundException` 재현 |
| 수정 후 · 부모 pwsh 7 | ✅ zip + `.sha256` 생성 (exit 0) |
| 수정 후 · 부모 Windows PowerShell 5.1 | ✅ zip + `.sha256` 생성 (exit 0) |

## 문서

바뀐 동작을 서술한 문서는 없어요 (`grep` 확인). 스크립트 헤더 주석에 한 줄 덧붙였어요.



Closes #
455
