### PR TITLE
fix(system_open): 연결된 앱이 없으면 config 를 메모장으로 연다 (#456)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -966,7 +966,7 @@ onrender 진단 수치에만 적용한다. instance timeout이나 Linux startup/
 [Windows unbiased interrupt time](https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttimeprecise)).
 
 **메커니즘:**
-- Windows: `ShellExecuteW(NULL, "open", path, ...)` — 사용자 default editor (`.json` / `.log` 의 file association).
+- Windows: `ShellExecuteW(NULL, "open", path, ...)` — 사용자 default editor (`.json` / `.log` 의 file association). **연결이 없으면 `notepad.exe` 로 연다** ([#456](https://github.com/ensky0/tildaz/issues/456)). 확장자에 기본 앱이 없으면 Windows 는 아무 것도 열지 않으면서 `ShellExecuteW` 는 성공을 반환해서 (실측: 연결 있는 `.log` 과 연결 없는 `.json` 이 **둘 다 42**, 창은 한쪽만 뜸) 호출 결과로는 성패를 알 수 없다. 그래서 열기 **전에** 연결을 조회한다 — `UserChoice` → `HKCR\<ext>` 기본값 → 그 ProgId 의 `shell\open\command` 순. `AssocQueryString` 계열은 `OpenWithProgids` 후보까지 답해서 이 판정에 쓸 수 없다. 확실히 없을 때만 fallback 하고, 조회가 불확실하면 OS 에 맡긴다.
 - macOS: `/usr/bin/open <path>` 를 자식 process 로 — Finder 가 file extension 따라 default app.
 - Linux: `xdg-open <path>` 를 자식 process 로 — XDG MIME database.
 

--- a/src/system_open.zig
+++ b/src/system_open.zig
@@ -28,6 +28,28 @@ fn openWindows(allocator: std.mem.Allocator, path: []const u8) void {
     const wpath = std.unicode.utf8ToUtf16LeAllocZ(allocator, path) catch return;
     defer allocator.free(wpath);
     const verb_w = std.unicode.utf8ToUtf16LeStringLiteral("open");
+
+    // 연결된 앱이 없는 확장자면 Windows 는 편집기 대신 "앱 선택" 프롬프트로 넘기는데,
+    // `ShellExecuteW` 는 그것도 성공으로 보고한다. `SEE_MASK_FLAG_NO_UI` 를 줘도
+    // `SE_ERR_NOASSOC` 가 오지 않는 것을 실측으로 확인했다 — **호출 결과만으로는
+    // 편집기가 실제로 떴는지 알 수 없다** (#456). 그래서 열기 전에 연결 유무를 직접
+    // 조회하고, 없을 때만 메모장으로 연다. 사용자가 지정해 둔 편집기가 있으면 지금처럼
+    // 그쪽이 뜬다 — `.json` 에 아무것도 연결돼 있지 않아 Ctrl+Shift+P 가 조용히 아무 일도
+    // 안 하던 것만 사라진다.
+    if (!hasOpenAssociation(allocator, path)) {
+        log.appendLine("open", "no file association for '{s}'; opening with notepad instead", .{extensionOf(path)});
+        // 경로에 공백이 있어도 한 인자로 가도록 따옴표로 감싼다.
+        const params = std.fmt.allocPrint(allocator, "\"{s}\"", .{path}) catch return;
+        defer allocator.free(params);
+        const wparams = std.unicode.utf8ToUtf16LeAllocZ(allocator, params) catch return;
+        defer allocator.free(wparams);
+        // notepad.exe 는 Windows 10 / 11 에 항상 있다 (메모장이 Store 앱이 된 뒤에도
+        // System32 의 실행 스텁이 남는다).
+        const notepad_w = std.unicode.utf8ToUtf16LeStringLiteral("notepad.exe");
+        _ = ShellExecuteW(null, verb_w, notepad_w, wparams.ptr, null, 1);
+        return;
+    }
+
     _ = ShellExecuteW(null, verb_w, wpath.ptr, null, null, 1);
 }
 
@@ -76,3 +98,96 @@ extern "shell32" fn ShellExecuteW(
     lpDirectory: ?[*:0]const u16,
     nShowCmd: c_int,
 ) callconv(.c) ?*anyopaque;
+
+// ── 확장자 연결 조회 (Windows-only, #456) ────────────────────────────────────
+//
+// `AssocQueryStringW(ASSOCSTR_EXECUTABLE)` 는 못 쓴다 — 기본 앱이 Store 앱이면 exe
+// 경로가 없어서 *연결이 있는* `.log` 도 `0x80070483` 로 실패한다 (실측). 그래서
+// 레지스트리를 직접 본다: 사용자가 고른 앱은 `UserChoice` 에, 시스템 기본 연결은
+// `HKCR\<ext>` 의 ProgId 에 남는다.
+
+const HKEY_CLASSES_ROOT: ?*anyopaque = @ptrFromInt(0x80000000);
+const HKEY_CURRENT_USER: ?*anyopaque = @ptrFromInt(0x80000001);
+const RRF_RT_REG_SZ: u32 = 0x00000002;
+
+extern "advapi32" fn RegGetValueW(
+    hkey: ?*anyopaque,
+    lpSubKey: ?[*:0]const u16,
+    lpValue: ?[*:0]const u16,
+    dwFlags: u32,
+    pdwType: ?*u32,
+    pvData: ?*anyopaque,
+    pcbData: ?*u32,
+) callconv(.c) i32;
+
+/// 경로의 확장자 (`.json` 처럼 점 포함). 없으면 빈 문자열.
+fn extensionOf(path: []const u8) []const u8 {
+    const name_start = if (std.mem.lastIndexOfAny(u8, path, "\\/")) |i| i + 1 else 0;
+    const name = path[name_start..];
+    const dot = std.mem.lastIndexOfScalar(u8, name, '.') orelse return "";
+    if (dot == 0) return ""; // `.gitignore` 같은 이름은 확장자가 아니다
+    return name[dot..];
+}
+
+/// `root\subkey` 의 `value` (null 이면 기본값) 를 REG_SZ 로 읽는다. 값이 없거나
+/// 비어 있으면 null. 반환 slice 는 `out` 을 가리킨다.
+fn regReadString(
+    allocator: std.mem.Allocator,
+    root: ?*anyopaque,
+    subkey: []const u8,
+    value: ?[]const u8,
+    out: []u16,
+) ?[]const u16 {
+    const wsub = std.unicode.utf8ToUtf16LeAllocZ(allocator, subkey) catch return null;
+    defer allocator.free(wsub);
+    const wval: ?[:0]u16 = if (value) |v|
+        (std.unicode.utf8ToUtf16LeAllocZ(allocator, v) catch return null)
+    else
+        null;
+    defer if (wval) |w| allocator.free(w);
+
+    var size: u32 = @intCast(out.len * @sizeOf(u16));
+    const rc = RegGetValueW(
+        root,
+        wsub.ptr,
+        if (wval) |w| w.ptr else null,
+        RRF_RT_REG_SZ,
+        null,
+        @ptrCast(out.ptr),
+        &size,
+    );
+    if (rc != 0) return null;
+    // `RegGetValueW` 는 종료 NUL 을 보장하고 그 몫까지 크기에 넣는다.
+    const chars = size / @sizeOf(u16);
+    if (chars <= 1) return null;
+    return out[0 .. chars - 1];
+}
+
+/// 이 경로의 확장자에 "열기" 로 이어지는 앱이 있는지. **확실히 없을 때만 false** —
+/// 조회가 불확실한 경우엔 기존 동작 (OS 에 맡김) 을 유지한다.
+fn hasOpenAssociation(allocator: std.mem.Allocator, path: []const u8) bool {
+    const ext = extensionOf(path);
+    if (ext.len == 0) return true; // 확장자가 없으면 판정 대상이 아니다
+
+    var buf: [512]u16 = undefined;
+
+    // ① 사용자가 고른 기본 앱. Store 앱 (`AppX…`) 도 여기엔 ProgId 로 남는다.
+    const user_choice = std.fmt.allocPrint(
+        allocator,
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\{s}\\UserChoice",
+        .{ext},
+    ) catch return true;
+    defer allocator.free(user_choice);
+    if (regReadString(allocator, HKEY_CURRENT_USER, user_choice, "ProgId", &buf) != null) return true;
+
+    // ② 시스템 기본 연결. ProgId 만 있고 `shell\open\command` 가 없으면 열리지 않으므로
+    //    거기까지 확인한다.
+    const prog_id_w = regReadString(allocator, HKEY_CLASSES_ROOT, ext, null, &buf) orelse return false;
+    const prog_id = std.unicode.utf16LeToUtf8Alloc(allocator, prog_id_w) catch return true;
+    defer allocator.free(prog_id);
+    const command_key = std.fmt.allocPrint(allocator, "{s}\\shell\\open\\command", .{prog_id}) catch return true;
+    defer allocator.free(command_key);
+
+    var command_buf: [512]u16 = undefined;
+    return regReadString(allocator, HKEY_CLASSES_ROOT, command_key, null, &command_buf) != null;
+}


### PR DESCRIPTION
## 무엇

Windows 에서 `Ctrl+Shift+P` (Open config in editor) 가 조용히 아무 일도 하지 않던 문제를 고쳐요 ([#456](https://github.com/ensky0/tildaz/issues/456)). 확장자에 연결된 앱이 **확실히 없을 때만** `notepad.exe` 로 열어요. 연결이 있으면 지금처럼 사용자 기본 편집기가 떠요.

## 전제 — 호출 결과로는 판정이 안 돼요

앱 밖 독립 probe 로 다시 확인했어요 (직전/직후 창·프로세스 스냅샷 비교).

| 대상 | `ShellExecuteW` | 새로 뜬 창 |
|---|---|---|
| `.json` (연결 없음) | **42** | 없음 |
| `.log` (연결 있음) | **42** | 메모장 |
| 없는 파일 | 2 | 없음 |

**성공/실패가 아니라 "창이 떴다/안 떴다" 가 42 안에서 갈려요.** 사후 판정도 성립하지 않아요 — Store 앱은 `DelegateExecute` 로 비동기 활성화라 얼마나 기다릴지 정할 수 없고, VS Code 처럼 기존 창에 탭으로 여는 편집기는 새 창도 새 프로세스도 만들지 않아 "안 떴다" 로 오판해요. 그래서 **사전 조회**만 남아요.

## 조회 방법 — 레지스트리 직접 조회

`AssocQueryString` 계열은 쓸 수 없어요. 양쪽으로 다 틀려요.

- 기본 앱이 Store 앱이면 exe 경로가 없어서 **연결이 있는 `.log` 도 `0x80070483`** 로 실패해요.
- 반대로 `OpenWithProgids` 후보까지 답해서, 기본값이 없는 **`.json` 을 VS Code 로 답해요** (`IApplicationAssociationRegistration(AL_EFFECTIVE)` 도 마찬가지). 그런데 실제로 열면 아무 것도 안 떠요.

그래서 `UserChoice` → `HKCR\<ext>` 기본값 → 그 ProgId 의 `shell\open\command` 순으로 봐요. 이 판정이 `.json`(안 열림)·`.log`(열림) 실제 동작과 일치했어요. **확실히 없을 때만** fallback 하고, 조회가 불확실하거나 확장자가 없으면 OS 에 맡겨요.

## 검증

노트북 · Intel Core i5-1240P · Windows 11 10.0.26200

- `.json` 에 연결이 없는 상태에서 `Ctrl+Shift+P` → **`config_1.json - 메모장` 창이 실제로 뜸**, 로그에 `[open] no file association for '.json'; opening with notepad instead`
- `zig build check` 6 타겟 통과 · `zig build test` 242 passed / 5 skipped / 0 failed

## 문서

`SPEC.md` §11.2 의 메커니즘 서술을 같은 PR 에 담았어요 (`grep` 으로 확인 — `KEYBINDINGS.md` 는 단축키 표만 있어 변경 없음).

## #457 과의 관계

변경은 `openWindows` 안과 **파일 끝**에만 뒀어요. `openSpawn` (Linux `xdg-open`) 주변은 건드리지 않았어요. 다만 파일 상단 import 블록에 `const log = @import("log.zig");` 한 줄이 추가돼서, #457 쪽에서도 import 를 추가하면 **그 한 줄에서 충돌**이 날 수 있어요 (두 줄 모두 남기면 해소).



Closes #
456
