### PR TITLE
feat(perf): 키가 화면에 닿기까지를 재는 계측과 하네스 (#441 축 ②)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -40,8 +40,9 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | `zig build stress` (아래) | **층별 상한** — 파서 / PTY / 프레임 각각의 처리량 | 아무거나 |
 | [`compare-terminals.sh`](compare-terminals.sh) | **다섯 터미널 나란히** 처리량 비교 + 창 캡처 | Windows 는 **Git Bash 필수** |
 | [`measure-repeat.sh`](measure-repeat.sh) | **우리 앱 안의 배분** — `parse` · `render` · `shape` 몫 | 〃 |
-| [`check-input-loss.sh`](check-input-loss.sh) | **응답성** — 폭포 중 입력이 먹히는지 (처리량이 아니에요, 아래 절) | Linux · macOS |
-| [`hygiene.sh`](hygiene.sh) | 위 셋이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
+| [`check-input-loss.sh`](check-input-loss.sh) | **응답성 ①** — 폭포 중 입력이 먹히는지 | Linux · macOS |
+| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux |
+| [`hygiene.sh`](hygiene.sh) | 위 넷이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
 `measure-repeat` 는 앱을 반복해 띄워 종료 시 자동 덤프 ([#396](https://github.com/ensky0/tildaz/issues/396))
 로 남는 perf 스냅숏을 모으고, **5 회 절사평균 + min~max** 로 표를 내요. 시작 전에 위생을
@@ -716,13 +717,62 @@ exec "$SHELL"                              # 폭포 후 셸 — 같은 PTY slave
    (PowerShell 이면 `ni $env:TEMP\tz-ok`).
 4. `%APPDATA%\tildaz\tildaz_stress.log` 에서 `=== snapshot` 블록 수를 세고 파일 생성을 확인해요.
 
-### 아직 없는 것 — 응답 **시간** (축 ②)
+## 응답 **시간** 측정 ([#441](https://github.com/ensky0/tildaz/issues/441) 축 ②)
 
-이 절은 *"먹었나"* 만 봐요. **얼마나 늦게 반영되는지는 전혀 못 봐요.** 예산 4 ms 가 실제 체감
-지연으로 얼마인지 우리는 한 번도 재지 않았어요. 방법 후보 (앱 계측 · 합성 입력 · PTY 왕복) 와
-걸림돌은 [#441](https://github.com/ensky0/tildaz/issues/441) 에 정리돼 있어요 — Linux Wayland 의
-합성 입력이 걸려요. [#439](https://github.com/ensky0/tildaz/issues/439) (유휴 깨우기) 를 *가설*이
-아니라 숫자로 판정하려면 그 축이 필요해요.
+위 절이 *"먹었나"* 를 본다면 이쪽은 **"얼마나 늦게 반영되나"** 예요.
+
+```sh
+dist/stress/measure-input-latency.sh                      # idle · flood 둘 다
+dist/stress/measure-input-latency.sh --mode idle --presses 50
+```
+
+**Linux 전용이에요.** 합성 입력이 platform 마다 달라요 — Windows 는 `SendInput`, macOS 는
+`CGEvent` 로 [#387](https://github.com/ensky0/tildaz/issues/387) 이 이미 썼으니 그 경로를 옮겨오면
+되지만 아직 안 했어요. **계측 자체는 세 platform 에 다 있어요** (`perf.input_latency`).
+
+### 재는 구간
+
+앱이 `perf.markInput()` (키 수신) 부터 `perf.completeInput()` (그 뒤 첫 present 완료) 까지를 재요.
+그래서 **키 → PTY write → 셸 에코 → PTY read → parse → render → present** 가 전부 들어가요.
+셸 왕복이 섞이지만 **그게 사용자가 실제로 기다리는 시간**이에요.
+
+못 재는 것: `present → 실제 화면 발광` (외부 장비 필요) 과 `키 눌림 → 앱 수신` (compositor 몫).
+
+### 첫 수치 (미니PC · Ryzen 7 8845HS · CachyOS · KDE Plasma · 60 Hz)
+
+5 회 절사평균 + min~max.
+
+| 상황 | 평균 | 최악 |
+|---|---|---|
+| **유휴** | **0.67 ms** (0.66~0.69) | **12.35 ms** (12.30~12.38) |
+| **폭포 중** | **10.69 ms** (10.37~11.72) | **18.64 ms** (18.24~19.14) |
+
+**폭포가 흐르면 평균 응답이 16 배 느려져요.** 재현성도 좋아요 — 유휴 최악은 5 회가 0.08 ms 폭
+안에 들어왔어요.
+
+**이 값으로 [#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하면 안 돼요.** 그 이슈는
+*"유휴에서 **PTY 출력이 도착**했을 때"* 이고 이 측정은 **키를 눌러** 시작해요 — 키가 오면 앱이 즉시
+렌더를 요청하니 유휴 깨우기 경로를 아예 안 타요. 예산 4 ms 와의 직접 비교도 안 돼요 (그건 드레인
+한 번의 상한이고, 이 값은 거기에 셸 왕복 · 렌더 · present 가 누적된 것이에요).
+
+### ⚠ 입력기가 한글이면 표본이 안 잡혀요
+
+보내는 것이 **문자 키 `a`** 라서, 한글 모드에서는 IME 가 그것을 조합용으로 가져가요 (`ㅁ` 이 찍혀요).
+그러면 앱의 키 핸들러를 안 타서 `markInput()` 이 안 불리고 표본이 비어요. 스크립트가
+`fcitx5-remote` 로 **영문으로 바꿨다가 끝나면 되돌려요.**
+
+**단축키는 달라요** — `Ctrl+Shift+F12` 는 한글 모드에서도 앱에 도달해요
+([#465](https://github.com/ensky0/tildaz/issues/465)). 위 "입력 손실 검사" 의 ①이 한글 모드에서도
+되는 것과 모순이 아니에요. **키 종류가 다른 거예요.**
+
+곁가지로, 한글 모드에서 preedit 은 화면에 그려지는데 표본은 안 잡혀요 — 즉 지금 계측은
+**영문 직접 입력 경로만** 봐요. 한글 입력의 응답 지연을 재려면 계측 지점을 IME 경로에도 놓아야 해요.
+
+### 회차가 폐기되면 자동으로 다시 돌아요
+
+표본이 기대치의 8 할 미만이면 그 회차는 폐기예요 (`--retries`, 기본 3 회 재시도). 폐기의 알려진
+원인은 **한글 입력기** (위에서 미리 막아요) 와 **측정 중 조작**이에요 — 합성 입력은 포커스된 창으로
+가므로 측정 중에 창을 바꾸면 키가 다른 앱으로 새요.
 
 ## 다른 터미널과 비교하기
 

--- a/dist/stress/measure-input-latency.sh
+++ b/dist/stress/measure-input-latency.sh
@@ -1,0 +1,312 @@
+#!/bin/sh
+# 응답 **시간** 측정 (#441 축 ②).
+#
+# `check-input-loss.sh` 가 *"먹었나"* 를 본다면 이쪽은 **"얼마나 늦게 반영되나"** 를 잰다.
+# 예산 4 ms (SPEC §13.3) 가 최악 지연 상한이라는 주장은 지금까지 한 번도 숫자로 확인된 적이
+# 없다. 그리고 [#439](https://github.com/ensky0/tildaz/issues/439) 의 *"유휴에서 첫 출력이 한
+# 프레임 늦는다"* 도 가설로만 있다 — 이 도구가 그 둘을 숫자로 만든다.
+#
+#   dist/stress/measure-input-latency.sh                 # idle · flood 둘 다
+#   dist/stress/measure-input-latency.sh --mode idle --presses 50
+#
+# ## 무엇이 재지는가
+#
+# 앱이 `perf.markInput()` (키 수신) 부터 `perf.completeInput()` (그 뒤 첫 present 완료) 까지를
+# 잰다. 그래서 이 값은 **키 → PTY write → 셸 에코 → PTY read → parse → render → present** 를
+# 전부 포함한다. 셸 왕복이 섞이지만 **그게 사용자가 실제로 기다리는 시간**이다.
+#
+# 못 재는 것: `present → 실제 화면 발광` (외부 장비가 필요하다) 과 `키 눌림 → 앱 수신`
+# (compositor / OS 몫이 섞인다).
+#
+# ## 왜 문자 키를 보내는가
+#
+# `Ctrl+Shift+F12` 같은 앱 단축키로는 못 잰다 — **화면을 안 바꾸므로 present 가 일어나지
+# 않는다.** 그러면 `completeInput` 이 불리지 않아 표본이 0 이다. 그래서 `a` 를 보내 에코가
+# 화면에 닿기까지를 재고, 끝에 Ctrl+C 로 입력 줄을 비운다.
+#
+# **Linux 전용이다.** 합성 입력이 platform 마다 다르다 — Windows 는 `SendInput`, macOS 는
+# `CGEvent` 로 #387 이 이미 썼으니 그 경로를 옮겨오면 되지만 아직 하지 않았다.
+set -u
+
+PRESSES=30
+MODE=both
+MB=2048
+GAP=0.2
+SCROLLBACK=32767
+# 창을 클릭해 포커스를 줄 시간. **기본은 0 (사람 개입 없음)** 이다 — 새 창은 포커스를
+# 자동으로 받는 것이 실측으로 확인됐다 (클릭한 회차와 안 한 회차의 값이 idle 최악
+# 12.30 / 12.33 ms 로 사실상 같았다). 표본이 부족하게 나오는 환경에서만 쓴다.
+FOCUS_WAIT=0
+# 표본 부족(포커스 실패)으로 폐기된 회차를 몇 번까지 다시 돌릴지.
+RETRIES=3
+
+usage() {
+    cat <<'USAGE'
+쓰는 법: dist/stress/measure-input-latency.sh [옵션]
+
+  --presses <N>   보낼 키 횟수 (기본 30)
+  --mode <이름>   idle · flood · both (기본 both)
+  --mb <N>        flood 모드의 폭포 분량 MiB (기본 2048)
+  --gap <초>      키 사이 간격 (기본 0.2 — 각 키가 독립적으로 처리되도록)
+  --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음).
+                     표본이 부족하게 나오는 환경에서만 쓴다
+  --retries <N>   폐기된 회차를 다시 돌릴 횟수 (기본 3)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --presses) PRESSES="$2"; shift 2 ;;
+        --mode) MODE="$2"; shift 2 ;;
+        --mb) MB="$2"; shift 2 ;;
+        --gap) GAP="$2"; shift 2 ;;
+        --focus-wait) FOCUS_WAIT="$2"; shift 2 ;;
+        --retries) RETRIES="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+. "$REPO_ROOT/dist/stress/hygiene.sh"
+
+[ "$HYG_PLATFORM" = linux ] || {
+    echo "이 스크립트는 Linux 전용이에요 ($(uname -s)) — 합성 입력이 platform 마다 달라요." >&2
+    exit 2
+}
+
+EXE="$REPO_ROOT/zig-out/bin/tildaz"
+STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress"
+LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log"
+
+[ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+[ -x "$STRESS" ] || { echo "tildaz-stress 없음: $STRESS  (먼저 zig build stress)" >&2; exit 1; }
+command -v ydotool >/dev/null 2>&1 || { echo "ydotool 없음 — 합성 입력에 필요해요." >&2; exit 1; }
+
+# `wtype` 은 KWin 이 `zwp_virtual_keyboard_v1` 을 지원하지 않아 쓸 수 없다 (#441 실측).
+# `ydotool` 은 uinput 경로라 compositor 를 안 가린다. 대신 데몬과 `/dev/uinput` 접근이 필요하다.
+SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/.ydotool_socket"
+YDOTOOLD_PID=""
+# **소켓 파일의 존재로 데몬을 판정하면 안 된다.** 데몬이 죽어도 소켓 파일은 남고, 그러면
+# "이미 떠 있다" 로 잘못 보고 데몬을 안 띄운다 → 모든 `ydotool` 호출이 조용히 실패해서
+# **키가 하나도 안 나간 채 회차가 끝난다** (실측으로 겪었다). 프로세스로 판정한다.
+if ! pgrep -x ydotoold >/dev/null 2>&1; then
+    command -v ydotoold >/dev/null 2>&1 || { echo "ydotoold 없음 — ydotool 데몬이 필요해요." >&2; exit 1; }
+    [ -w /dev/uinput ] || {
+        echo "/dev/uinput 에 쓸 수 없어요. ACL (setfacl -m u:$USER:rw /dev/uinput) 이나" >&2
+        echo "input 그룹 가입이 필요해요." >&2
+        exit 1
+    }
+    rm -f "$SOCK"          # stale 소켓 정리 — 남아 있으면 데몬이 바인딩에 실패한다
+    ydotoold >/dev/null 2>&1 &
+    YDOTOOLD_PID=$!
+    sleep 2
+    [ -S "$SOCK" ] || { echo "ydotoold 소켓이 안 생겼어요: $SOCK" >&2; exit 1; }
+fi
+
+# **입력기가 한글이면 측정이 성립하지 않는다.** 우리가 보내는 것은 문자 키 `a` 인데,
+# 한글 모드에서는 IME 가 그것을 조합용으로 가져가 (`ㅁ` 이 찍힌다) 앱의 키 핸들러를
+# 타지 않는다 → `markInput()` 이 안 불려 표본이 잡히지 않는다. 실측에서 폐기된 회차가
+# 전부 이것이었다 (포커스 문제로 오해했다).
+#
+# **단축키는 다르다** — `Ctrl+Shift+F12` 는 한글 모드에서도 앱에 도달한다 (#465).
+# 그래서 "IME 는 단축키에 영향이 없다" 는 사실과 여기 제약은 서로 모순이 아니다.
+IME_RESTORE=""
+if command -v fcitx5-remote >/dev/null 2>&1; then
+    if [ "$(fcitx5-remote 2>/dev/null)" = "2" ]; then
+        fcitx5-remote -c >/dev/null 2>&1      # deactivate = 영문
+        IME_RESTORE=1
+        echo "  입력기가 한글이라 영문으로 바꿨어요 (측정이 끝나면 되돌립니다)."
+    fi
+else
+    echo "  ⚠ fcitx5-remote 가 없어요 — 입력기가 한글이면 표본이 안 잡혀요. 영문인지 확인하세요." >&2
+fi
+
+APP=""
+cleanup() {
+    [ -n "$APP" ] && kill "$APP" 2>/dev/null
+    [ -n "$YDOTOOLD_PID" ] && kill "$YDOTOOLD_PID" 2>/dev/null
+    [ -n "$IME_RESTORE" ] && fcitx5-remote -o >/dev/null 2>&1   # 원래대로 한글
+}
+trap cleanup EXIT INT TERM
+
+# **키가 실제로 나가는지 먼저 확인한다.** 안 나가면 회차를 도는 의미가 없다.
+# 화면을 바꾸지 않는 modifier 한 번으로 왕복만 본다.
+if ! ydotool key 42:1 42:0 >/dev/null 2>&1; then
+    echo "ydotool 이 키를 보내지 못했어요 — 데몬 · /dev/uinput 권한을 확인하세요." >&2
+    exit 1
+fi
+
+# evdev 키코드 — `a`=30 · LEFTCTRL=29 · LEFTSHIFT=42 · c=46 · w=17 · F12=88.
+send_keys() {
+    i=1
+    while [ "$i" -le "$PRESSES" ]; do
+        # 첫 키는 실패를 삼키지 않는다 — 조용히 실패하면 표본 0 인 회차가 그대로 끝난다.
+        if [ "$i" -eq 1 ]; then
+            ydotool key 30:1 30:0 || { echo "⚠ ydotool 전송 실패 — 회차를 중단해요." >&2; return 1; }
+        else
+            ydotool key 30:1 30:0 >/dev/null 2>&1
+        fi
+        sleep "$GAP"
+        i=$((i + 1))
+    done
+    ydotool key 29:1 46:1 46:0 29:0 >/dev/null 2>&1   # Ctrl+C — 입력 줄 비우기
+    sleep 0.3
+    # **덤프를 여기서 직접 남긴다.** 종료 시 자동 덤프 (#396) 에만 기대면, 앱이 제때
+    # 안 닫혀 정리 대상이 됐을 때 값이 통째로 사라진다 — 실측에서 `Alt+F4` 가 도달해
+    # `pending_quit_request` 까지 갔는데도 종료가 안 끝나 `kill -9` 했고, 그 회차는
+    # `input` 줄 자체가 없어 "표본 없음" 으로 보였다.
+    ydotool key 29:1 42:1 88:1 88:0 42:0 29:0 >/dev/null 2>&1   # Ctrl+Shift+F12 — perf 덤프
+    sleep 0.5
+    # **`Alt+F4` 가 아니라 `Ctrl+Shift+W` 다.** `Alt+F4` 는 종료 확인 다이얼로그를 띄우고
+    # 기다려서 앱이 안 닫힌다 (그 다이얼로그가 포커스까지 가져간다). 탭이 하나면
+    # `Ctrl+Shift+W` (탭 닫기) 가 곧 앱 종료다.
+    ydotool key 29:1 42:1 17:1 17:0 42:0 29:0 >/dev/null 2>&1   # Ctrl+Shift+W
+}
+
+# 종료 키가 안 먹으면 `wait` 가 영원히 매달린다 (실측으로 겪었다). 유예를 두고 그래도
+# 살아 있으면 정리한다. 값은 위에서 `Ctrl+Shift+F12` 로 이미 남겼으므로 여기서 정리해도
+# 회차가 통째로 날아가지는 않는다.
+wait_app() {
+    waited=0
+    while [ "$waited" -lt 15 ]; do
+        kill -0 "$APP" 2>/dev/null || return 0
+        sleep 1
+        waited=$((waited + 1))
+    done
+    echo "⚠ 앱이 안 닫혀서 정리해요 (종료 키가 안 먹었을 수 있어요 — 값은 이미 덤프됐어요)." >&2
+    kill "$APP" 2>/dev/null
+    sleep 1
+    kill -9 "$APP" 2>/dev/null
+    return 1
+}
+
+# `-e` 로 띄워야 stress role 이 되고, 그래야 종료 시 자동 덤프가 남는다 (#396 `dumpOnExit`).
+# idle 모드도 러너를 쓰는 이유가 이것이다 — producer 없이 셸만 올린다.
+make_runner() {
+    RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-latency-XXXXXX.sh")
+    if [ "$1" = flood ]; then
+        cat > "$RUNNER" <<EOF
+#!/bin/sh
+TILDAZ_STRESS_WORKLOAD=plain
+TILDAZ_STRESS_BYTES=$((MB * 1024 * 1024))
+export TILDAZ_STRESS_WORKLOAD TILDAZ_STRESS_BYTES
+"$STRESS" &
+exec "${SHELL:-/bin/bash}"
+EOF
+    else
+        cat > "$RUNNER" <<EOF
+#!/bin/sh
+exec "${SHELL:-/bin/bash}"
+EOF
+    fi
+    chmod +x "$RUNNER"
+}
+
+run_one() {
+    MODE_NAME="$1"
+    make_runner "$MODE_NAME"
+
+    START_LEN=0
+    [ -f "$LOG" ] && START_LEN=$(wc -c < "$LOG" | tr -d ' ')
+
+    "$EXE" -e "$RUNNER" -size 120x40 -scrollback "$SCROLLBACK" >/dev/null 2>&1 &
+    APP=$!
+    sleep 4                     # 창 map + 폰트 init + (flood 면) 폭포 시작
+
+    # 합성 입력은 **포커스된 창** 으로만 간다. 다만 `-e` 로 띄운 새 창은 포커스를 자동으로
+    # 받는다 — 클릭한 회차와 클릭하지 않은 회차의 값이 idle 최악 12.30 / 12.33 ms 로 사실상
+    # 같았다 (실측). 그래서 **사람 개입 없이 돈다.**
+    #
+    # 한때 표본이 2~4 개로 나와 "포커스를 못 받는다" 고 봤지만, 그 회차들은 다른 원인이었다
+    # (ydotool 데몬 미기동 · 측정 중 조작 · 덤프 회수 실패). 포커스가 진짜 문제인 환경이라면
+    # 표본 부족 경고가 뜨므로, 그때 `--focus-wait` 로 클릭할 시간을 주면 된다.
+    # **Enter 로 신호를 받으면 안 된다.** Enter 를 치려면 이 터미널로 돌아와야 하고,
+    # 그 순간 포커스가 여기로 옮겨와 방금 준 포커스가 사라진다. 그래서 고정 대기를 두고
+    # 그 사이에 **클릭만** 하게 한다 — 클릭 후 손을 떼면 포커스가 그대로 남는다.
+    if [ "$FOCUS_WAIT" -gt 0 ]; then
+        printf '\n  ▶ 새 창이 활성이 아니면 %d 초 안에 한 번 클릭하세요 (활성이면 그대로).\n' "$FOCUS_WAIT"
+        i="$FOCUS_WAIT"
+        while [ "$i" -gt 0 ]; do
+            printf '\r     %2d 초...' "$i"
+            sleep 1
+            i=$((i - 1))
+        done
+        printf '\r     키 전송 시작.     \n'
+    fi
+
+    send_keys || { kill "$APP" 2>/dev/null; rm -f "$RUNNER"; return 1; }
+    wait_app
+    APP=""
+    rm -f "$RUNNER"
+
+    RAW=$(mktemp "${TMPDIR:-/tmp}/tildaz-latency-log-XXXXXX")
+    if [ "$START_LEN" -gt 0 ]; then
+        tail -c "+$((START_LEN + 1))" "$LOG" > "$RAW"
+    else
+        cp "$LOG" "$RAW" 2>/dev/null || : > "$RAW"
+    fi
+
+    # `input    samples=N ms=X max_ms=Y` — perf.zig 의 dumpAndReset 형식.
+    # **표본 수를 기대치와 대조한다.** 합성 입력은 *포커스된 창* 으로 가므로, 측정 중에
+    # 창을 바꾸거나 마우스를 움직이면 키가 다른 앱으로 새고 표본만 적게 남는다. 그때도
+    # 평균은 그럴듯한 값이 나와서 **모르고 결론을 내기 쉽다** (실측으로 겪었다).
+    VERDICT=$(awk -v mode="$MODE_NAME" -v want="$PRESSES" '
+    /^input / {
+        for (i = 1; i <= NF; i++) {
+            if ($i ~ /^samples=/)  { split($i, a, "="); s += a[2] }
+            else if ($i ~ /^ms=/)  { split($i, a, "="); t += a[2] }
+            else if ($i ~ /^max_ms=/) { split($i, a, "="); if (a[2] + 0 > m) m = a[2] + 0 }
+        }
+    }
+    END {
+        if (s + 0 == 0) { printf "  %-6s  ❌ 표본 없음 — 키가 앱에 안 갔거나 화면이 안 바뀌었어요\n", mode; exit }
+        printf "  %-6s  표본 %3d / %d   평균 %6.2f ms   최악 %6.2f ms", mode, s, want, t / s, m
+        # 8 할 미만이면 회차를 믿지 않는다 — 남은 표본으로 낸 평균은 그럴듯해 보이지만
+        # 어떤 키가 빠졌는지 모르므로 대표성이 없다.
+        if (s < want * 0.8) printf "   ⚠ 표본 부족 — 입력기가 한글이거나 측정 중 조작이 있었어요 (회차 폐기)"
+        printf "\n"
+    }' "$RAW")
+    rm -f "$RAW"
+    printf '%s\n' "$VERDICT"
+    # 폐기 회차는 호출부가 다시 돌릴 수 있게 실패로 돌려준다.
+    case "$VERDICT" in *"회차 폐기"*|*"표본 없음"*) return 1 ;; esac
+    return 0
+}
+
+# 회차가 폐기되면 여기서 되풀이한다. 알려진 원인은 **입력기가 한글인 것** (위에서 미리
+# 막는다) 과 측정 중 조작이다. 값 자체는 회차마다 매우 안정적이라 (idle 최악 12.30 /
+# 12.33 / 12.38 ms) 유효 회차만 모으면 대표값이 성립한다.
+run_with_retry() {
+    attempt=1
+    while [ "$attempt" -le "$RETRIES" ]; do
+        if run_one "$1"; then return 0; fi
+        [ "$attempt" -lt "$RETRIES" ] && echo "     ↻ 다시 시도해요 ($attempt/$RETRIES)" >&2
+        attempt=$((attempt + 1))
+        sleep 3
+    done
+    return 1
+}
+
+cat <<EOF
+
+============ 응답 시간 측정 (#441 축 ②) ============
+ 키        : 'a' × ${PRESSES} (간격 ${GAP}s) → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W
+ 모드      : $MODE
+ 재는 구간 : 키 수신 → 그 뒤 첫 present 완료
+             (PTY write · 셸 에코 · parse · render 포함)
+====================================================
+
+⚠ 합성 입력은 **포커스된 창**으로 갑니다. 회차마다 새 창이 뜨면 포커스만 확인하고,
+   키가 나가기 시작하면 키보드 · 마우스를 건드리지 마세요 (건드리면 그 회차는 폐기됩니다).
+
+EOF
+
+case "$MODE" in
+    idle)  run_with_retry idle ;;
+    flood) run_with_retry flood ;;
+    both)  run_with_retry idle; sleep 2; run_with_retry flood ;;
+    *) echo "모르는 모드: $MODE (idle · flood · both)" >&2; exit 2 ;;
+esac
+
+echo

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -4174,6 +4174,11 @@ const Client = struct {
         // #160 — present(attach + damage + commit) 계측. Windows present(swap) 동등.
         const present_t0 = perf.now();
         defer perf.addTimed(&perf.present, present_t0);
+        // #441 축 ② — 대기 중인 키가 있으면 여기까지가 그 키의 응답 지연이다.
+        // `defer` 는 LIFO 라 이 줄이 위의 `addTimed` 보다 먼저 돌지만, 둘 다 attach +
+        // commit 을 마친 함수 종료 시점이라 present 이후인 것은 같다. `completeInput`
+        // 은 자기가 `now()` 를 다시 부르므로 순서 차이가 값에 섞이지 않는다.
+        defer perf.completeInput();
         // wl_surface.attach (opcode 1) — (buffer_id, x=0, y=0).
         try self.sendArgs(self.surface_id, 1, &.{ buffer.id, 0, 0 });
         // wl_surface.damage_buffer (opcode 9) — viewport 적용된 surface 에서는
@@ -5321,6 +5326,8 @@ const Client = struct {
         const serial = readU32(payload[0..4]);
         const key = readU32(payload[8..12]);
         const state = readU32(payload[12..16]);
+        // #441 축 ② — 응답 지연은 **눌림**에서 시작한다 (뗌은 화면을 안 바꾼다).
+        if (state == wl_keyboard_key_state_pressed) perf.markInput();
         // L12-γ-5 — pressed 면 repeat timer arm, released 면 disarm (같은
         // key 한정 — 다른 key 가 이미 repeat 중이면 그건 새 key 의 press 가
         // swap 했을 때만 cancel).

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -849,6 +849,7 @@ fn macCmdShortcut(kc: c_ushort, shift: bool) ?input_policy.Shortcut {
 }
 
 fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void {
+    perf.markInput(); // #441 축 ② — 응답 지연은 여기서 시작한다.
     requestRender(); // #255 Phase2 — 키 입력 → 렌더 (스크롤백/탭조작 등 출력 없는 변화 포함).
     const tab = g_session.activeTab() orelse return;
     if (event == null) return;

--- a/src/perf.zig
+++ b/src/perf.zig
@@ -63,6 +63,47 @@ pub var onrender: Counter = .{}; // onRender total — extra = skip_swap count
 /// `onrender` 의 `skip` 과 **섞지 않는다** — 그쪽은 *"화면이 안 바뀌어서 안 그렸다"*
 /// (#386 ②) 라 뜻이 다르고, 한 칸에 합치면 그 게이트를 못 본다.
 pub var swapwait: Counter = .{};
+/// #441 축 ② — **키를 받은 순간부터 그 뒤 첫 present 가 끝날 때까지.** 위 카운터들이
+/// *처리량* 의 구간별 몫을 재는 것과 달리 이쪽은 **응답 지연**이다.
+///
+/// `calls` = 표본 수 · `ns` = 합 (평균은 나눠서) · `extra` = **최악값**. 평균만 보면
+/// 안 되는 값이라 최악을 따로 든다 — 예산 4 ms (SPEC §13.3) 가 상한이라는 주장은
+/// *평균*이 아니라 *최악*에 대한 주장이기 때문이다.
+pub var input_latency: Counter = .{};
+
+/// 대기 중인 키의 수신 시각(ns). 0 = 없음.
+///
+/// **이미 대기 중이면 덮지 않는다** (`markInput` 의 CAS). 폭포 중에는 키가 연달아
+/// 들어오는데, 덮으면 *가장 최근* 키의 지연만 남아 **가장 오래 기다린 키가 사라진다** —
+/// 최악값을 보려는 목적과 정반대가 된다.
+var pending_input_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0);
+
+/// 키를 받은 자리에서 부른다 (세 host 의 키 진입점).
+///
+/// `now()` 가 0 을 돌려주면 그 표본은 버려진다 — 0 을 "없음" 으로 쓰기 때문이다.
+/// monotonic clock 이 부팅 직후 0 ns 를 낼 확률은 무시할 수준이고, 대신 sentinel 이
+/// 없는 구조 (별도 flag) 는 hot path 에 원자 연산을 하나 더 늘린다.
+pub fn markInput() void {
+    const t = now() orelse return;
+    if (t == 0) return;
+    _ = pending_input_ns.cmpxchgStrong(0, t, .acq_rel, .monotonic);
+}
+
+/// present 가 끝난 자리에서 부른다. 대기 중인 키가 있으면 지연을 적고 비운다.
+pub fn completeInput() void {
+    const start = pending_input_ns.swap(0, .acq_rel);
+    if (start == 0) return;
+    const t = now() orelse return;
+    if (t <= start) return;
+    const delta = t - start;
+    _ = input_latency.calls.fetchAdd(1, .monotonic);
+    _ = input_latency.ns.fetchAdd(delta, .monotonic);
+    // 최악값 갱신. 경합해도 더 큰 값이 이긴다.
+    var cur = input_latency.extra.load(.monotonic);
+    while (delta > cur) {
+        cur = input_latency.extra.cmpxchgWeak(cur, delta, .monotonic, .monotonic) orelse break;
+    }
+}
 
 /// Cross-platform working-state timestamp(ns). Linux = CLOCK_MONOTONIC,
 /// macOS = CLOCK_UPTIME_RAW, Windows = QueryUnbiasedInterruptTimePrecise.
@@ -162,6 +203,10 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
     const pr = snapshot(&present);
     const on = snapshot(&onrender);
     const sw = snapshot(&swapwait);
+    const il = snapshot(&input_latency);
+    // 대기 중인 키는 스냅숏 경계를 넘기지 않는다 — 다음 구간에서 present 가 되면
+    // *이전 구간에 눌린* 키의 지연이 그쪽에 잡혀 구간 귀속이 어긋난다.
+    _ = pending_input_ns.swap(0, .acq_rel);
 
     var buf: [4096]u8 = undefined;
     const text = std.fmt.bufPrint(
@@ -179,7 +224,10 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
             // #435 — swap chain 이 안 받아서 건너뛴 tick. waitable 이 없는 경로 (legacy
             // DISCARD · DirectComposition) 에서는 항상 0 이다.
             "swapwait ticks={d}\n" ++
-            "onrender calls={d} ms={d:.3} skip={d}\n",
+            "onrender calls={d} ms={d:.3} skip={d}\n" ++
+            // #441 축 ② — 키 수신 → 첫 present 완료. `max` 를 함께 내는 이유는
+            // 위 `input_latency` 주석 참고 (예산 주장은 평균이 아니라 최악에 대한 것).
+            "input    samples={d} ms={d:.3} max_ms={d:.3}\n",
         .{
             label,
             rt.nowMs(),
@@ -205,6 +253,9 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
             on[0],
             @as(f64, @floatFromInt(on[1])) / 1_000_000.0,
             on[3],
+            il[0],
+            @as(f64, @floatFromInt(il[1])) / 1_000_000.0,
+            @as(f64, @floatFromInt(il[3])) / 1_000_000.0,
         },
     ) catch return;
 

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -670,6 +670,8 @@ pub const MetalRenderer = struct {
         objc.msgSendVoid1(self.current_cmd_buf, objc.sel("presentDrawable:"), self.current_drawable);
         objc.msgSendVoid(self.current_cmd_buf, objc.sel("commit"));
         perf.addTimed(&perf.present, present_t0);
+        // #441 축 ② — 대기 중인 키가 있으면 여기까지가 그 키의 응답 지연이다.
+        perf.completeInput();
 
         // Frame end — state reset.
         self.current_encoder = null;

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -1905,6 +1905,8 @@ pub const D3d11Renderer = struct {
         const present_t0 = perf.now();
         _ = self.swap_chain.Present(self.present_sync, 0);
         perf.addTimed(&perf.present, present_t0);
+        // #441 축 ② — 대기 중인 키가 있으면 여기까지가 그 키의 응답 지연이다.
+        perf.completeInput();
     }
 
     /// #329 — 단일 탭 terminal 위에 우측 `[+][×][…]`만 최종 합성한다.

--- a/src/window.zig
+++ b/src/window.zig
@@ -6,6 +6,7 @@ const dialog = @import("dialog.zig");
 const log = @import("log.zig");
 const messages = @import("messages.zig");
 const paths = @import("paths.zig");
+const perf = @import("perf.zig");
 const dwrite_font = @import("font/windows/font.zig");
 const font_spec = @import("font/spec.zig");
 
@@ -1766,6 +1767,7 @@ pub const Window = struct {
                 return 0;
             },
             WM_KEYDOWN => {
+                perf.markInput(); // #441 축 ② — 응답 지연은 여기서 시작한다.
                 // Ctrl keydown이 먼저 끝낸 composition result는 modifier keydown을
                 // 건너뛰어 실제 chord key까지 유지한다. leave 정책이 필요한
                 // C(copy/interrupt), Ctrl+Shift+V(paste), F12(perf)는 app resolver가


### PR DESCRIPTION
## 무엇

축 ① ([`check-input-loss.sh`](https://github.com/ensky0/tildaz/blob/main/dist/stress/check-input-loss.sh)) 이 *"먹었나"* 를 본다면 이쪽은 **"얼마나 늦게 반영되나"** 다. 예산 4 ms (SPEC §13.3) 가 최악 지연 상한이라는 주장은 지금까지 한 번도 숫자로 확인된 적이 없었다.

## 계측 — `perf.input_latency` (세 platform 공통)

키 수신 (`markInput`) → 그 뒤 첫 present 완료 (`completeInput`).

| platform | 키 수신 | present 완료 |
|---|---|---|
| Linux | `handleKeyboardKey` (눌림만) | `attachAndCommit` 의 defer |
| Windows | `WM_KEYDOWN` | `swap_chain.Present` 뒤 |
| macOS | `tildazKeyDown` | `presentDrawable` + `commit` 뒤 |

- **최악값을 따로 든다** (`extra`) — 예산이 상한이라는 주장은 *평균*이 아니라 **최악**에 대한 주장이다
- **대기 중인 키를 덮지 않는다** — 덮으면 가장 오래 기다린 키가 사라져 목적과 정반대가 된다
- **스냅숏 경계에서 대기 키를 비운다** — 구간 귀속이 어긋나지 않게

## 하네스 — `measure-input-latency.sh` (Linux)

`ydotool` 로 문자 키를 보내고 로그의 `input` 줄을 집계한다. **앱 단축키로는 못 잰다** — 화면을 안 바꿔 present 가 없으니 표본이 0 이다.

## 첫 수치

미니PC · AMD Ryzen 7 8845HS · CachyOS · KDE Plasma Wayland · 60 Hz · 5 회 절사평균 + min~max

| 상황 | 평균 | 최악 |
|---|---|---|
| **유휴** | **0.67 ms** (0.66~0.69) | **12.35 ms** (12.30~12.38) |
| **폭포 중** | **10.69 ms** (10.37~11.72) | **18.64 ms** (18.24~19.14) |

**폭포가 흐르면 평균 응답이 16 배 느려진다.** 유휴 최악은 5 회가 0.08 ms 폭 안에 들어와 재현성도 확인됐다.

**이 값으로 [#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하면 안 된다** — 그 이슈는 *"유휴에서 PTY 출력이 도착했을 때"* 이고 이 측정은 키를 눌러 시작한다. 키가 오면 앱이 즉시 렌더를 요청하므로 유휴 깨우기 경로를 안 탄다. 예산 4 ms 와의 직접 비교도 성립하지 않는다.

## 도구를 만들며 배운 것 — 여섯 번 실패했고 전부 스크립트에 넣었다

| 실패 | 원인 | 도구에 남긴 것 |
|---|---|---|
| 키 0 개 | `ydotoold` 가 죽어도 **소켓 파일이 남아** 오판 | 프로세스로 판정 · stale 소켓 제거 · 첫 전송 실패 시 중단 |
| 표본 3~4 | 측정 중 조작 | **표본 수를 기대치와 대조**해 회차 폐기 |
| 표본 0 | 종료 덤프 의존 → `kill -9` 로 값 유실 | `Ctrl+Shift+F12` 로 **덤프 선행** |
| 앱이 안 닫힘 | `Alt+F4` 가 **종료 확인 다이얼로그**를 띄움 | `Ctrl+Shift+W` |
| 표본 2~5 (간헐) | **입력기가 한글** — 문자 키를 IME 가 조합용으로 가져감 (`ㅁ`) | `fcitx5-remote` 로 영문 전환 후 **복원** |
| 수동 재시도 | — | **자동 재시도** (`--retries`) |

마지막 항목은 [#465](https://github.com/ensky0/tildaz/issues/465) 와 모순이 아니다 — **키 종류가 다르다.** 단축키(`Ctrl+Shift+F12`)는 한글 모드에서도 앱에 도달하고, **문자 키**만 IME 가 가져간다.

곁가지 관찰: 한글 모드에서 preedit 은 그려지는데 표본은 안 잡힌다 → 지금 계측은 **영문 직접 입력 경로만** 본다. 한글 입력의 지연을 재려면 IME 경로에도 계측이 필요하다 (범위 밖으로 남김).

## 미검증

**Windows · macOS 의 계측 호출 지점은 실기 검증하지 못했다.** `zig build check` (6 타겟) 만 거쳤다. Linux 만 위 수치로 검증됐다.

## 범위

축 ② 의 첫 삽이다. 응답 시간을 재기 시작했지만 #439 판정용 워크로드 (입력 없이 출력만) 와 Windows · macOS 하네스는 남아 있어 **이 PR 은 이슈를 닫지 않는다.**

Refs #441