### PR TITLE
feat(linux/sway): 드롭다운을 xdg_toplevel + i3 IPC 로 — 토글 직후 keyboard focus (#454)

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -24,10 +24,13 @@ Cross-platform shortcut convention: each platform follows its native modifier (A
 
 On Linux the drop-down is normally sized from config (`dock_position` /
 `width_percent` / `height_percent`). Fullscreen is delegated to the compositor:
-layer-shell desktops (KDE Plasma, sway, Hyprland, COSMIC) re-anchor the surface
+layer-shell desktops (KDE Plasma, Hyprland, COSMIC) re-anchor the surface
 to all four edges — Alt+Enter covers the panels (`exclusive_zone = -1`),
 Shift+Alt+Enter keeps them visible (`exclusive_zone = 0`); GNOME and Cinnamon
-(no layer-shell) use `xdg_toplevel.set_fullscreen` / `set_maximized`. The toggle
+(no layer-shell) use `xdg_toplevel.set_fullscreen` / `set_maximized`; sway uses
+a regular window placed over i3 IPC (#454) — Alt+Enter is
+`xdg_toplevel.set_fullscreen`, Shift+Alt+Enter fills the workspace area (panels
+stay visible) via IPC. The toggle
 applies only while the terminal is visible, and the fullscreen state is
 preserved across F1 hide/show. Each fullscreen mode is exited only by its own
 shortcut: pressing the *other* combination while fullscreen is ignored on all

--- a/SPEC.md
+++ b/SPEC.md
@@ -179,7 +179,7 @@ tildaz 는 **Wayland 전용** (X11 backend 없음 — §0 / ARCHITECTURE 의 Des
 | compositor 카테고리 | layer-shell drop-down | hotkey 자동 적용 메커니즘 | 대표 DE | 상태 |
 |---|---|---|---|---|
 | **KWin** | ✅ layer-shell | direct KGlobalAccel D-Bus 등록·Pressed signal | KDE Plasma | ✅완료 (실기 확인) |
-| **wlroots** | ✅ layer-shell | Hyprland = `hyprctl keyword bind`→`tildaz --toggle N`, sway = `bindsym` i3-ipc→`--toggle N` | Hyprland / sway (Wayfire / river / niri 동계열) | ✅완료 (Hyprland / sway 실기 확인) |
+| **wlroots** | Hyprland = ✅ layer-shell · sway = xdg_toplevel + i3 IPC 배치/scratchpad 토글 ([#454](https://github.com/ensky0/tildaz/issues/454) — sway 는 layer-shell `on_demand` 에서 map 시 keyboard focus 를 안 줌) | Hyprland = `hyprctl keyword bind`→`tildaz --toggle N`, sway = `bindsym` i3-ipc→`--toggle N` | Hyprland / sway (Wayfire / river / niri 동계열) | ✅완료 (Hyprland / sway 실기 확인) |
 | **mutter** | tildaz 전용 Shell extension (xdg-shell 창 배치) | gsettings custom keybinding (libgio) + extension 충돌 시 자동 skip | GNOME (Ubuntu / Budgie / Pantheon 동계열) | ✅완료 (실기 확인) |
 | **muffin** | tildaz 전용 Shell extension | gsettings custom keybinding (Cinnamon strv schema) + extension 충돌 skip | Cinnamon | ✅완료 (실기 확인) |
 | **smithay** | ✅ layer-shell | RON custom shortcut→`tildaz --toggle N` | COSMIC | ✅완료 (실기 확인) |
@@ -205,13 +205,21 @@ Linux 지원 수준은 desktop 이름이 아니라 실제 capability + 검증 �
   `tildaz.instanceN`인 항목만 비교해 config 에 없는 번호의 `toggle-N` action 을
   증분 해제한다. drop-down 재표시는 KWin 만 `#205` unmap/remap 워크어라운드(아래
   부록 B 참조).
-- **sway (wlroots).** `$SWAYSOCK`의 i3-ipc `RUN_COMMAND`로
-  `bindsym <accel> exec <self_exe> --toggle N`
-  를 런타임 등록. hotkey 실동작은 번호별 socket (`$XDG_RUNTIME_DIR/tildaz-N.sock`).
+- **sway (wlroots).** drop-down 은 **layer-shell 이 아니라 xdg_toplevel + i3 IPC**
+  ([#454](https://github.com/ensky0/tildaz/issues/454)) — sway 는 layer-shell
+  `on_demand` 에서 map 시 keyboard focus 를 주지 않아 (spec 상 compositor 재량,
+  KWin·Hyprland·COSMIC 셋은 줌) 토글 직후 타이핑이 안 됐다. `SWAYSOCK` 이 잡히면
+  layer-shell 을 기록하지 않고 xdg fallback 으로 뜬 뒤, 배치는 `for_window` 규칙
+  (floating·sticky·border·크기 — **명령당 규칙 하나**, 콤마 체인은 sway 가 첫
+  명령까지만 규칙으로 받고 나머지를 focus 창에 즉시 실행) + map 후 `move`(ppt) 로,
+  토글은 scratchpad 로 한다 (sway 1.12 실기 확인). hotkey 는 `$SWAYSOCK`의 i3-ipc
+  `RUN_COMMAND`로 `bindsym <accel> exec <self_exe> --toggle N` 를 런타임 등록.
+  hotkey 실동작은 번호별 socket (`$XDG_RUNTIME_DIR/tildaz-N.sock`).
   runtime-only 라 매 실행 등록 = config 가 source of truth. 단 sway IPC 는 현재
   binding 열거 요청을 제공하지 않아 세션 중 stale binding 증분 제거는 지원하지
   않는다. config 삭제/변경 전에 등록된 binding 은 sway 세션 재시작 때 사라진다.
-- **Hyprland (wlroots).** layer-shell drop-down 은 sway 와 같은 경로(코드 동일).
+- **Hyprland (wlroots).** layer-shell drop-down (KWin·COSMIC 과 같은 경로 —
+  sway 는 #454 로 xdg_toplevel + IPC 로 분리됨).
   hotkey는 실행 시 `hyprctl -j binds` actual과 config desired를
   비교해 TildaZ `--toggle N` binding 의 차이만 `unbind/bind`한다. `install.sh`는
   `~/.config/hypr/` config의
@@ -325,10 +333,10 @@ TildaZ icon을 사용한다([Apple `NSCriticalAlertStyle`](https://developer.app
 
 | 동작 | Windows | macOS | Linux | Win | Mac | Linux |
 |---|---|---|---|---|---|---|
-| 전체화면 — taskbar/dock **덮음** | Alt+Enter | Cmd+Enter | Alt+Enter — layer-shell DE(KWin/sway/Hyprland/COSMIC)는 4-edge anchor + size 0 + `exclusive_zone=-1` 로 패널 위까지 덮음; GNOME/Cinnamon(layer-shell 부재)은 `xdg_toplevel.set_fullscreen` ([#87](https://github.com/ensky0/tildaz/issues/87)) | ✅ | ✅ | ✅ |
-| 전체화면 — taskbar/dock **회피** | Shift+Alt+Enter | Shift+Cmd+Enter | Shift+Alt+Enter — layer-shell 은 `exclusive_zone=0` (패널 유지); GNOME/Cinnamon 은 `xdg_toplevel.set_maximized` ([#87](https://github.com/ensky0/tildaz/issues/87)) | ✅ | ✅ | ✅ |
+| 전체화면 — taskbar/dock **덮음** | Alt+Enter | Cmd+Enter | Alt+Enter — layer-shell DE(KWin/Hyprland/COSMIC)는 4-edge anchor + size 0 + `exclusive_zone=-1` 로 패널 위까지 덮음; GNOME/Cinnamon(layer-shell 부재)과 sway(xdg_toplevel + IPC, [#454](https://github.com/ensky0/tildaz/issues/454))는 `xdg_toplevel.set_fullscreen` ([#87](https://github.com/ensky0/tildaz/issues/87)) | ✅ | ✅ | ✅ |
+| 전체화면 — taskbar/dock **회피** | Shift+Alt+Enter | Shift+Cmd+Enter | Shift+Alt+Enter — layer-shell 은 `exclusive_zone=0` (패널 유지); GNOME/Cinnamon 은 `xdg_toplevel.set_maximized` ([#87](https://github.com/ensky0/tildaz/issues/87)); sway 는 floating 창의 `set_maximized` 를 무시해 IPC 로 workspace 영역(패널 제외)을 채움 ([#454](https://github.com/ensky0/tildaz/issues/454), sway 1.12 실기) | ✅ | ✅ | ✅ |
 | 같은 키 재입력 → dock 복귀 / 다른 모드 → no-op | Alt+Enter↔Shift+Alt+Enter | Cmd+Enter↔Shift+Cmd+Enter | 동일 (`FullscreenMode {none,cover,avoid}` toggle 로직 — Win 동등) | ✅ | ✅ | ✅ |
-| 토글된 fullscreen **상태**가 F1 hide→show 간 유지 | ✅ | ✅ | layer-shell 은 `fullscreen_mode` 필드로 show 시 재적용; GNOME/Cinnamon 은 compositor 가 minimize↔복원 간 maximize/fullscreen 보존 | ✅ | ✅ | ✅ |
+| 토글된 fullscreen **상태**가 F1 hide→show 간 유지 | ✅ | ✅ | layer-shell 은 `fullscreen_mode` 필드로 show 시 재적용; GNOME/Cinnamon 은 compositor 가 minimize↔복원 간 maximize/fullscreen 보존; sway 는 scratchpad 이동이 fullscreen 을 해제하므로 show 때 `fullscreen_mode` 를 재적용 ([#454](https://github.com/ensky0/tildaz/issues/454)) | ✅ | ✅ | ✅ |
 
 > **숨김(hide) 상태에선 전체화면 토글 no-op** — 보이는 창에만 적용되는 윈도우 동작. Win/Mac 은 숨김 시 창이 keyboard focus 를 잃어 키 미수신으로 자연 보장. Linux layer-shell DE 도 hide 시 surface 를 파괴해 키가 안 와 동일 보장. GNOME/Cinnamon 은 mutter/muffin 이 sticky+above 인 tildaz 를 minimize 해도 focus 를 자동 이양하지 않으므로, extension 이 hide 시 keyboard focus 를 다른 창으로 넘겨 동일 보장한다 — 숨김 중엔 Alt+Enter 토글뿐 아니라 모든 키 입력이 tildaz 로 안 들어간다 ([#247](https://github.com/ensky0/tildaz/issues/247)).
 
@@ -582,7 +590,7 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 | 확인 다이얼로그 (`showConfirm`) | OK / Cancel 선택 — destructive 작업 confirm (Alt+F4 / 단일·다중 탭 모두). mac `applicationShouldTerminate:` / Win `onQuitRequest` 동등 — count==0 (PTY 자동 종료) 만 skip, 단일·다중 탭 *항상* confirm. | 짧으면 `MessageBoxW MB_OKCANCEL`, overflow면 고정 OK/Cancel + scroll 본문 — `app_controller.onQuitRequest` 가 호출 | 짧으면 NSAlert OK/Cancel, overflow면 고정 button + scroll 본문 — `applicationShouldTerminate:` 가 호출 | `dialog.showConfirm` → host `dialogShowConfirmCb` 의 inner wayland event pump (deferred dismiss + 단일 OK/Cancel 두 버튼 layer-shell overlay). Alt+F4 는 KWin 이 *F4 system shortcut* 으로 가로채고 `closed` event 발송 — `handleEvent` 가 `pending_quit_request=true`, main loop `drainQuitRequest` 가 confirm 호출. Cancel 시 main surface 재생성 (KWin 측 unmap 후 다음 close 이벤트 안 옴 회피, #203 Phase C step 4). | ✅ | ✅ | ✅ |
 | Click 정책 (modal) | dialog 떠 있는 동안 *OK 버튼 / Enter / Esc 만* dismiss. 본문 click / 같은 client 의 main click / 다른 app 영역 모두 dismiss X. | native dialog 또는 소유자 window를 disable한 overflow modal loop | OS modal 표준 자체 | dialog overlay surface 의 pointer button + xkb keysym 처리. `last_pointer_enter_surface_id == dialog.surface_id` + OK 버튼 좌표 hit-test → dismiss. overflow scrollbar drag 외 본문 / main click 은 swallow (focus 만 회복). Enter / Esc → dismiss. | ✅ | ✅ | ✅ |
 | dismiss 후 focus return | dismiss 후 main 에 keyboard focus 자동 양도 | OS 자체 (modal close 후 caller window 복귀) | OS 자체 | `xdg_activation_v1` 표준 — dismiss 직전 dialog 가 token 발급 → main 에 `activate`. dialog 가 *실제 focus* 일 때만 (focus 가드, KWin protocol error 회피). dismiss 호출은 main loop deferred (inner roundtrip reentrancy 차단). | ✅ | ✅ | ✅ |
-| Dialog 위치 | 현재 monitor 중앙 | overflow window와 prompt는 같은 TildaZ process의 foreground window를 owner로 삼고 그 monitor work area 중앙. 다른 process window는 owner로 사용하지 않음 | NSAlert의 OS modal 배치 | layer-shell 경로(KDE Plasma, COSMIC, Hyprland, sway)는 `anchor=0`으로 현재 output 중앙에 두며 main 창의 dock/width margin과 분리 ([#314](https://github.com/ensky0/tildaz/issues/314), KDE Plasma 1.7x 실기). xdg-toplevel fallback(GNOME, Cinnamon)은 Wayland에 절대 위치 지정 API가 없어 compositor의 transient 배치를 따름 | ✅ | ✅ | ✅ (layer-shell) / 🟨 (xdg compositor 배치) |
+| Dialog 위치 | 현재 monitor 중앙 | overflow window와 prompt는 같은 TildaZ process의 foreground window를 owner로 삼고 그 monitor work area 중앙. 다른 process window는 owner로 사용하지 않음 | NSAlert의 OS modal 배치 | layer-shell 경로(KDE Plasma, COSMIC, Hyprland)는 `anchor=0`으로 현재 output 중앙에 두며 main 창의 dock/width margin과 분리 ([#314](https://github.com/ensky0/tildaz/issues/314), KDE Plasma 1.7x 실기). xdg-toplevel fallback(GNOME, Cinnamon, sway [#454](https://github.com/ensky0/tildaz/issues/454))은 Wayland에 절대 위치 지정 API가 없어 compositor의 transient 배치를 따름 (sway 1.12 실기: floating 중앙 배치·Esc dismiss·focus 복귀 확인) | ✅ | ✅ | ✅ (layer-shell) / 🟨 (xdg compositor 배치) |
 | Dialog 시각 크기·배치 scale-aware | DPI / fractional scale 환경에서 일관 시각 크기 | overflow window는 현재 monitor DPI와 work area 사용, 최대 폭 960 logical pt | NSAlert native, overflow accessory 폭은 최대 580pt | 본문·버튼 15pt, 제목 18pt 고정 logical 크기이며 terminal `font.size_point`와 독립. corner radius / shadow margin / button w/h / icon size도 PT 단위로 scale 변환한다. 실제 본문 폭과 wrap 후 행 수로 surface를 키우되 basis output에서 16pt씩 여백을 남긴다. 현재 일반 메시지는 640×480 logical viewport에서 1.0x / 1.7x / 2.0x 모두 scroll 없이 표시하고, 더 긴 본문은 종류와 무관하게 overflow viewport를 사용한다 ([#306](https://github.com/ensky0/tildaz/issues/306), [#318](https://github.com/ensky0/tildaz/issues/318)). About은 최대 폭 960 logical pt다 ([#314](https://github.com/ensky0/tildaz/issues/314)). config parse fatal은 Wayland 연결 전 stderr + log fallback이라 overlay 저장/화면 상한을 거치지 않는다 ([#316](https://github.com/ensky0/tildaz/issues/316)). | ✅ | ✅ | ✅ |
 
 ---

--- a/src/host/linux/sway_ipc.zig
+++ b/src/host/linux/sway_ipc.zig
@@ -27,6 +27,7 @@ const log = @import("../../log.zig");
 const config_mod = @import("../../config.zig");
 const hotkey_format = @import("hotkey_format.zig");
 const instance_context = @import("../../instance_context.zig");
+const instance_identity = @import("instance_identity.zig");
 
 const native_endian = builtin.target.cpu.arch.endian();
 
@@ -82,6 +83,223 @@ pub fn registerToggleIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *con
     } else {
         log.appendLine("sway", "bindsym auto-register rejected (sway success=false) — accel={s}", .{accel});
     }
+}
+
+/// 이 세션에서 sway 의 xdg_toplevel + IPC 경로를 쓸 것인가
+/// ([#454](https://github.com/ensky0/tildaz/issues/454)).
+///
+/// 판정은 **`SWAYSOCK` 존재 하나**다. 이 경로는 layer-shell 을 버리는 대신 배치 ·
+/// 토글을 전부 i3 IPC 로 하므로, IPC 가 불가능하면 layer-shell 유지가 항상 낫다 —
+/// `XDG_CURRENT_DESKTOP` 에 sway 토큰이 있어도 `SWAYSOCK` 이 없으면 배치 없는
+/// 기본 창만 남는다. 반대 방향은 걱정할 것이 없다: nested sway 는
+/// `XDG_CURRENT_DESKTOP` 이 부모 것 (`KDE`) 이지만 `SWAYSOCK` 은 잡히고 (실측),
+/// 실기 sway 세션은 둘 다 잡힌다.
+pub fn isSwaySession(rt: Runtime) bool {
+    return rt.environ.getPosix("SWAYSOCK") != null;
+}
+
+/// #454 — sway 전용 창 규칙을 **창이 뜨기 전에** 등록한다.
+///
+/// sway 는 layer-shell 의 `on_demand` 에서 map 시 keyboard focus 를 주지 않는다 (spec 이
+/// compositor 재량으로 남긴 자리다). 그래서 sway 에서는 layer-shell 을 쓰지 않고
+/// (`wayland_minimal.Capabilities.record`) 일반 xdg_toplevel 로 뜬 뒤, layer-shell 이 해 주던
+/// 배치를 이 규칙이 대신한다. focus 는 sway 가 일반 창에게 정상적으로 준다.
+///
+/// **`for_window` 여야 한다.** 창이 map 된 뒤 같은 명령을 보내면 그 뒤의 xdg configure 가
+/// 크기를 덮는다 — nested sway 실측에서 `resize` 가 성공 응답을 받고도 적용되지 않았고
+/// (640x432 요청 → 1276x666), 한참 뒤 같은 명령을 손으로 보내면 정확히 먹었다.
+///
+/// **단위는 `ppt`** 다. 화면 크기를 몰라도 되고, sway 가 **workspace 영역** (패널을 뺀
+/// 사용 가능 영역) 기준으로 계산해 준다 — 다중 모니터 · 해상도 변경에도 규칙이 그대로다.
+pub fn registerWindowRuleIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *const config_mod.Config) void {
+    const sock_path = rt.environ.getPosix("SWAYSOCK") orelse return;
+
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return;
+
+    const w = std.math.clamp(cfg.width_percent, 0.0, 100.0);
+    const h = std.math.clamp(cfg.height_percent, 0.0, 100.0);
+    // **`move` 는 여기 넣지 않는다.** `for_window` 가 도는 시점에는 창 크기가 아직 확정되지
+    // 않아 sway 가 그 뒤에 floating 창을 중앙으로 배치해 버린다 (nested 실측: 규칙에
+    // `move position 50 ppt 0 ppt` 를 넣었는데 결과가 정확히 화면 중앙 +320+162 였다).
+    // 위치는 창이 뜬 뒤 `moveWindowIfSway` 가 준다 — map 후 `move` 는 정상으로 먹는다.
+    //
+    // **명령마다 `for_window` 를 따로 쓴다 — 콤마 체인 금지.** 콤마는 i3 문법의 최상위
+    // 명령 구분자라, `for_window [x] floating enable, sticky enable, …` 을 sway 는
+    // "규칙(floating enable 까지) + 즉시 실행 명령들" 로 파싱한다. 즉 sticky · border ·
+    // resize 는 규칙에 안 묶이고 **그 순간 focus 된 무관한 창에 바로 적용**된다 (실기
+    // sway 1.12 에서 foot 대조군으로 확정 — 창은 640x420 기본 크기로 뜨고, 떠 있던 다른
+    // 창이 리사이즈 + sticky 됐다). 세미콜론으로 이은 독립 규칙 4개는 한 IPC 왕복에
+    // 전부 등록되고 전부 적용된다 (같은 실기에서 확인).
+    var cmd_buf: [512]u8 = undefined;
+    const command = std.fmt.bufPrint(
+        &cmd_buf,
+        "for_window [app_id=\"{s}\"] floating enable; " ++
+            "for_window [app_id=\"{s}\"] sticky enable; " ++
+            "for_window [app_id=\"{s}\"] border none; " ++
+            "for_window [app_id=\"{s}\"] resize set width {d} ppt height {d} ppt",
+        .{ app_id, app_id, app_id, app_id, @round(w), @round(h) },
+    ) catch {
+        log.appendLine("sway", "for_window command too long — skip", .{});
+        return;
+    };
+
+    log.appendLineVerbose("sway", "RUN_COMMAND payload=[{s}]", .{command});
+    const ok = runCommand(allocator, sock_path, command) catch |err| {
+        log.appendLine("sway", "for_window IPC failed: {s} — 창이 기본 위치로 뜬다", .{@errorName(err)});
+        return;
+    };
+    if (ok) {
+        log.appendLine("sway", "for_window registered — {s} {d}x{d} ppt", .{ app_id, @round(w), @round(h) });
+    } else {
+        log.appendLine("sway", "for_window rejected (sway success=false) — app_id={s}", .{app_id});
+    }
+}
+
+/// #454 — 창이 뜬 뒤 위치를 준다. 크기는 `registerWindowRuleIfSway` 의 `for_window` 가
+/// 이미 잡았다 (그쪽 주석에 왜 갈라야 하는지 적혀 있다).
+///
+/// 단위는 `ppt` 라 화면 크기가 필요 없고, sway 가 workspace 영역 기준으로 계산한다.
+pub fn moveWindowIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *const config_mod.Config) void {
+    if (rt.environ.getPosix("SWAYSOCK") == null) return;
+
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return;
+
+    const w = std.math.clamp(cfg.width_percent, 0.0, 100.0);
+    const h = std.math.clamp(cfg.height_percent, 0.0, 100.0);
+    const off = std.math.clamp(cfg.offset_percent, 0.0, 100.0);
+    // 남는 축을 offset 비율로 민다 — layer-shell 의 "anchor 가 잡은 edge 는 margin 0,
+    // 반대쪽을 offset 으로" 와 같은 의미를 퍼센트로 옮긴 것이다.
+    const cross_x = (100.0 - w) * off / 100.0;
+    const cross_y = (100.0 - h) * off / 100.0;
+    const pos: struct { x: f32, y: f32 } = switch (cfg.dock_position) {
+        .top => .{ .x = cross_x, .y = 0.0 },
+        .bottom => .{ .x = cross_x, .y = 100.0 - h },
+        .left => .{ .x = 0.0, .y = cross_y },
+        .right => .{ .x = 100.0 - w, .y = cross_y },
+    };
+
+    var cmd_buf: [128]u8 = undefined;
+    const cmd = std.fmt.bufPrint(&cmd_buf, "move position {d} ppt {d} ppt", .{ @round(pos.x), @round(pos.y) }) catch return;
+    const ok = runForAppId(rt, allocator, app_id, cmd);
+    log.appendLine("sway", "move {s} — {s} to ({d},{d}) ppt", .{ if (ok) "ok" else "rejected", app_id, @round(pos.x), @round(pos.y) });
+}
+
+/// #454 — sway 의 "패널 회피" 전체화면 (Shift+Alt+Enter, `FullscreenMode.avoid`).
+///
+/// xdg fallback 의 avoid 는 `xdg_toplevel.set_maximized` 인데 **sway 는 floating 창의
+/// maximize 요청을 무시한다** (실기 sway 1.12 — 요청 후 rect 무변화). 대신 IPC 로
+/// workspace 영역을 채운다: `resize set 100 ppt` + `move position 0 0 ppt`. sway 의
+/// workspace rect 는 패널 (exclusive zone) 을 뺀 영역이라 layer-shell avoid
+/// (`exclusive_zone=0`, 4-edge anchor) 와 의미가 정확히 같다.
+///
+/// 해제와 scratchpad 복귀 시 재적용은 `restoreDockLayoutIfSway` / 호출처가 맡는다.
+pub fn applyAvoidLayoutIfSway(rt: Runtime, allocator: std.mem.Allocator) bool {
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return false;
+    const resized = runForAppId(rt, allocator, app_id, "resize set width 100 ppt height 100 ppt");
+    const moved = runForAppId(rt, allocator, app_id, "move position 0 ppt 0 ppt");
+    const ok = resized and moved;
+    log.appendLine("sway", "fullscreen avoid layout {s} — {s}", .{ if (ok) "ok" else "rejected", app_id });
+    return ok;
+}
+
+/// #454 — avoid 전체화면 해제: config 의 dock 크기 · 위치로 되돌린다.
+///
+/// map 후 `resize set` 은 실기에서 정확히 적용된다 (map **전** for_window 가 필요한
+/// 것은 최초 배치뿐 — `registerWindowRuleIfSway` 주석). 위치는 `moveWindowIfSway` 재사용.
+pub fn restoreDockLayoutIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *const config_mod.Config) void {
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return;
+    const w = std.math.clamp(cfg.width_percent, 0.0, 100.0);
+    const h = std.math.clamp(cfg.height_percent, 0.0, 100.0);
+    var cmd_buf: [96]u8 = undefined;
+    const cmd = std.fmt.bufPrint(
+        &cmd_buf,
+        "resize set width {d} ppt height {d} ppt",
+        .{ @round(w), @round(h) },
+    ) catch return;
+    _ = runForAppId(rt, allocator, app_id, cmd);
+    moveWindowIfSway(rt, allocator, cfg);
+}
+
+/// #454 — cover 전체화면 재적용. **`scratchpad show` 보다 먼저** 보내야 한다.
+///
+/// sway 1.12 실기로 세 구조를 가른 결과다:
+/// - show **후** xdg `set_fullscreen` 재전송 — 상태만 서고 크기 configure 유실
+///   (트리 `fullscreen_mode=1` 인데 rect 는 이전 크기 `960x1055+0+0`).
+/// - show **후** IPC `fullscreen enable` — 같은 증상. 채널이 아니라 un-scratchpad
+///   전환 트랜잭션과 겹치는 것 자체가 문제다.
+/// - scratchpad **안에서** `fullscreen enable` → 그 뒤 `scratchpad show` — 상태가
+///   먼저 서 있어서 **맵 configure 자체가 전체화면 크기**로 온다
+///   (`terminal resized cols=210 rows=56` 즉시 수신). ✅ 이 순서만 성립한다.
+///
+/// 해제는 평소 경로 (xdg `unset_fullscreen`) 그대로다 — fullscreen 상태는 단일해서
+/// 어느 쪽으로 세웠든 xdg 해제가 먹는다 (실기 확인).
+pub fn fullscreenEnableIfSway(rt: Runtime, allocator: std.mem.Allocator) bool {
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return false;
+    const ok = runForAppId(rt, allocator, app_id, "fullscreen enable");
+    log.appendLine("sway", "fullscreen reapply {s} — {s}", .{ if (ok) "ok" else "rejected", app_id });
+    return ok;
+}
+
+/// #454 — sway 에서 드롭다운을 숨긴다. **surface 를 destroy 하지 않는다.**
+///
+/// 앱의 기본 hide 는 surface destroy 이고 다음 show 에서 다시 만든다. layer-shell 에서는
+/// 그 왕복이 성립하지만 **xdg_toplevel 경로에서는 창이 돌아오지 않는다** (실측: `--toggle`
+/// 두 번에 창이 sway 트리에서 사라진 채 남았고 scratchpad 에도 없었다). GNOME · Cinnamon 은
+/// extension 이 `minimize` / `show` 로 처리해 이 문제가 없는데 sway 에는 그 주체가 없다.
+///
+/// 그래서 sway 에서는 **scratchpad** 를 쓴다 — surface 는 살아 있고 sway 가 보관한다.
+/// i3-quickterm 등 sway 네이티브 드롭다운이 쓰는 방식이다.
+pub fn hideToScratchpad(rt: Runtime, allocator: std.mem.Allocator) bool {
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return false;
+    const ok = runForAppId(rt, allocator, app_id, "move scratchpad");
+    log.appendLineVerbose("sway", "hide → scratchpad {s} — {s}", .{ if (ok) "ok" else "rejected", app_id });
+    return ok;
+}
+
+/// #454 — scratchpad 에서 꺼내 다시 배치한다.
+///
+/// **꺼낸 뒤 위치를 다시 준다** (`reposition=true`). scratchpad 에서 나온 창은 sway 가
+/// 중앙에 놓기 때문이다 (`registerWindowRuleIfSway` 의 `move` 를 for_window 에 넣지
+/// 못하는 것과 같은 성질). 크기는 `for_window` 규칙이 계속 잡고 있어 다시 줄 필요가 없다.
+///
+/// **cover 전체화면 복귀는 `reposition=false`** — 위치가 fullscreen origin 인데 `move`
+/// 를 보내면 전체화면 컨테이너 자체가 dock 위치로 밀려난다 (실기: rect 가
+/// `1920x1080+960+25` 로 화면 밖까지 밀림). unfullscreen 시 floating 저장 위치는
+/// move 와 무관하게 유지된다 (실기 확인).
+///
+/// **focus 는 sway 가 준다** — 이 이슈 (#454) 의 본체가 여기서 풀린다. layer-shell 의
+/// `on_demand` 와 달리 scratchpad 는 사용자가 부른 일반 창이라 sway 가 focus 를 넘긴다.
+pub fn showFromScratchpad(rt: Runtime, allocator: std.mem.Allocator, cfg: *const config_mod.Config, reposition: bool) bool {
+    var app_id_buf: [32]u8 = undefined;
+    const app_id = instance_identity.appId(&app_id_buf, instance_context.requireWorkerIndex()) catch return false;
+    const shown = runForAppId(rt, allocator, app_id, "scratchpad show");
+    if (reposition) moveWindowIfSway(rt, allocator, cfg);
+    log.appendLineVerbose("sway", "show ← scratchpad {s} — {s}", .{ if (shown) "ok" else "rejected", app_id });
+    return shown;
+}
+
+/// 창 하나를 지목해 sway 명령을 보낸다 (`[app_id="…"] <command>`).
+///
+/// `SWAYSOCK` 이 없거나 IPC 가 실패하면 **조용히 false** 다 — 배치가 안 되어도 창은
+/// 이미 떠 있고, 여기서 죽으면 sway 사용자가 터미널 자체를 못 쓴다.
+pub fn runForAppId(rt: Runtime, allocator: std.mem.Allocator, app_id: []const u8, command: []const u8) bool {
+    const sock_path = rt.environ.getPosix("SWAYSOCK") orelse return false;
+    var buf: [512]u8 = undefined;
+    const full = std.fmt.bufPrint(&buf, "[app_id=\"{s}\"] {s}", .{ app_id, command }) catch {
+        log.appendLine("sway", "command too long — skipped: {s}", .{command});
+        return false;
+    };
+    log.appendLineVerbose("sway", "RUN_COMMAND payload=[{s}]", .{full});
+    return runCommand(allocator, sock_path, full) catch |err| {
+        log.appendLine("sway", "IPC failed: {s} — command skipped: {s}", .{ @errorName(err), command });
+        return false;
+    };
 }
 
 /// `XDG_CURRENT_DESKTOP` (콜론 구분 다중 토큰) 에 sway 토큰 포함 여부.
@@ -142,8 +360,15 @@ fn runCommand(allocator: std.mem.Allocator, sock_path: []const u8, command: []co
     try readAll(fd, payload);
     // sway 의 wire 형식은 `[ { "success": true } ]` — 콜론 뒤 공백 포함 (swaymsg
     // CLI 의 compact 표시와 다름, nested 시연 확인). 공백 유무 둘 다 수용.
-    const ok = std.mem.find(u8, payload, "\"success\": true") != null or
+    //
+    // 세미콜론으로 이은 다중 명령은 결과가 명령 수만큼 배열로 온다. "true 가 하나라도
+    // 있으면 성공" 으로 두면 부분 실패 (예: 규칙 4개 중 1개만 등록) 를 성공으로 읽으므로,
+    // **false 가 하나라도 있으면 실패**로 판정한다.
+    const any_true = std.mem.find(u8, payload, "\"success\": true") != null or
         std.mem.find(u8, payload, "\"success\":true") != null;
+    const any_false = std.mem.find(u8, payload, "\"success\": false") != null or
+        std.mem.find(u8, payload, "\"success\":false") != null;
+    const ok = any_true and !any_false;
     if (!ok) log.appendLineVerbose("sway", "RUN_COMMAND resp(success=false)=[{s}]", .{payload});
     return ok;
 }

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -401,7 +401,14 @@ const Capabilities = struct {
     // #277 — GPU (dma-buf) 렌더 경로. 미advertise 면 software `wl_shm` 으로 돈다.
     linux_dmabuf: Global = .{},
 
-    fn record(self: *Capabilities, name: u32, interface: []const u8, version: u32) void {
+    /// `skip_layer_shell` 은 sway 전용이다 ([#454](https://github.com/ensky0/tildaz/issues/454)).
+    /// sway 는 layer-shell 의 `on_demand` 에서 **map 시 keyboard focus 를 주지 않아**
+    /// 토글 직후 타이핑이 안 된다 (spec 이 compositor 재량으로 남긴 자리라 sway 는
+    /// 버그가 아니다 — 다만 KWin · Hyprland · COSMIC 셋은 자동으로 준다). 그래서 sway
+    /// 에서는 layer-shell 을 **아예 못 본 것으로 두고**, GNOME · Cinnamon 이 이미 쓰는
+    /// xdg_toplevel fallback 경로로 보낸 뒤 배치 · 토글을 i3 IPC 로 한다.
+    fn record(self: *Capabilities, name: u32, interface: []const u8, version: u32, skip_layer_shell: bool) void {
+        if (skip_layer_shell and std.mem.eql(u8, interface, "zwlr_layer_shell_v1")) return;
         if (std.mem.eql(u8, interface, "wl_compositor")) {
             self.compositor = .{ .name = name, .version = version };
         } else if (std.mem.eql(u8, interface, "wl_shm")) {
@@ -852,6 +859,10 @@ fn kwinCompositor(rt: Runtime) bool {
 const Client = struct {
     /// #451 — 진입점이 만든 `Io` · 환경변수. `App` · `Window` 와 같은 자리다.
     rt: Runtime,
+    /// #454 — sway 세션인가. layer-shell 을 건너뛰고 xdg_toplevel + i3 IPC 로 가는
+    /// 분기 하나에만 쓴다. 부팅에서 한 번 계산해 둔다 (registry 이벤트마다 환경변수를
+    /// 다시 읽지 않으려고).
+    is_sway: bool,
     allocator: std.mem.Allocator,
     /// #451 — 예전 `std.net.Stream`. 0.16 의 `Io.net` 으로는 Wayland 를 태울 수 없어서
     /// (`unix_socket.zig` 의 이유 절) raw fd 로 내렸다. `recvmsg` · `poll` 은 원래부터
@@ -1316,6 +1327,7 @@ const Client = struct {
         const theme = cfg.theme orelse fallback_theme;
         return .{
             .rt = rt,
+            .is_sway = sway_ipc.isSwaySession(rt),
             .allocator = allocator,
             .wayland_fd = wayland_fd,
             .renderer = renderer,
@@ -1597,6 +1609,9 @@ const Client = struct {
             self.logBootElapsed("first frame");
 
             log.appendLine("linux", "Wayland terminal window mapped", .{});
+            // #454 — sway 는 크기를 `for_window` 가 잡고 **위치는 map 후**에 준다
+            // (`sway_ipc.moveWindowIfSway` 주석). sway 가 아니면 no-op 이다.
+            sway_ipc.moveWindowIfSway(self.rt, self.allocator, self.config);
         }
 
         // #304 — listener만 먼저 열린 시점이 아니라 Wayland globals, 입력,
@@ -2342,11 +2357,13 @@ const Client = struct {
     /// #87 — Alt+Enter (cover) / Shift+Alt+Enter (avoid) fullscreen 토글.
     /// Win `toggleFullscreenMode` 동등 — 같은 모드 키 = dock 복귀(none), none →
     /// 그 모드, 다른 모드 = no-op.
-    ///   • layer-shell(KWin/sway/Hyprland/COSMIC): sendLayerSurfaceLayout 가
+    ///   • layer-shell(KWin/Hyprland/COSMIC): sendLayerSurfaceLayout 가
     ///     anchor/size/exclusive_zone 를 재전송 → configure → resize + redraw.
     ///   • xdg-shell fallback(GNOME/Cinnamon): 위치/크기를 Shell 확장이 잡으므로
     ///     layer 식 재배치 불가. xdg_toplevel 표준 상태 요청을 compositor 에 위임
     ///     (cover=set_fullscreen, avoid=set_maximized) — applyXdgFullscreen 참조.
+    ///   • sway(#454, xdg_toplevel + IPC): cover 는 xdg set_fullscreen, avoid 는
+    ///     IPC workspace 채우기 — applySwayFullscreen 참조.
     fn toggleFullscreen(self: *Client, mode: FullscreenMode) void {
         const prev = self.fullscreen_mode;
         const next: FullscreenMode = if (prev == mode)
@@ -2363,7 +2380,13 @@ const Client = struct {
                 return;
             };
         } else if (self.toplevel_id != 0) {
-            self.applyXdgFullscreen(prev, next) catch |err| {
+            const apply = if (self.is_sway)
+                // #454 — sway 는 floating 창의 set_maximized 를 무시하므로 avoid 를
+                // IPC 로 구현한다 (applySwayFullscreen). cover 는 xdg 표준이 먹는다.
+                self.applySwayFullscreen(prev, next)
+            else
+                self.applyXdgFullscreen(prev, next);
+            apply catch |err| {
                 log.appendLine("wayland", "fullscreen xdg request failed: {s}", .{@errorName(err)});
                 return;
             };
@@ -2392,6 +2415,29 @@ const Client = struct {
         }
         // wl_surface.commit (opcode 6) — 상태 요청 반영.
         try self.sendNoArgs(self.surface_id, 6);
+    }
+
+    /// #454 sway 경로 — cover 는 xdg `set_fullscreen` 을 그대로 쓰고 (sway 가 floating
+    /// 창에도 정상 적용, 실기 확인), avoid 만 IPC 배치로 바꾼다: sway 는 floating 창의
+    /// `set_maximized` 를 무시해서 (실기 sway 1.12 — 요청 후 rect 무변화) xdg 경로의
+    /// avoid 가 no-op 이 된다. `sway_ipc.applyAvoidLayoutIfSway` 주석 참조.
+    fn applySwayFullscreen(self: *Client, prev: FullscreenMode, next: FullscreenMode) !void {
+        switch (prev) {
+            .cover => {
+                try self.sendNoArgs(self.toplevel_id, xdg_toplevel_request_unset_fullscreen);
+                try self.sendNoArgs(self.surface_id, 6);
+            },
+            .avoid => sway_ipc.restoreDockLayoutIfSway(self.rt, self.allocator, self.config),
+            .none => {},
+        }
+        switch (next) {
+            .cover => {
+                try self.sendArgs(self.toplevel_id, xdg_toplevel_request_set_fullscreen, &.{0});
+                try self.sendNoArgs(self.surface_id, 6);
+            },
+            .avoid => _ = sway_ipc.applyAvoidLayoutIfSway(self.rt, self.allocator),
+            .none => {},
+        }
     }
 
     /// #351 — layout 계산의 기준이 되는 **logical work-area**. 우선순위:
@@ -6455,7 +6501,7 @@ const Client = struct {
         var p = Parser{ .buf = payload[4..] };
         const interface = try p.readString();
         const version = try p.readU32();
-        self.caps.record(name, interface, version);
+        self.caps.record(name, interface, version, self.is_sway);
         // #241/#295 — wl_output 의 global 추가(모니터 연결/재구성). 이번 batch
         // 안에서 들어오는 layer-surface closed 는 사용자 Alt+F4 가 아니라 output
         // re-home 이다 → drain 단계에서 quit 대신 recreate 로 전환(batch-local 판정).
@@ -6639,6 +6685,36 @@ const Client = struct {
             // 안 만들어졌으므로 full create. 이후 hide/show cycle 은 unmap/remap
             // path (#205 — wl_surface + layer_surface 유지가 ~165ms → ~16ms 줄임,
             // KWin Bug 503121 의 kitty workaround pattern).
+            // #454 — sway 는 surface 를 유지한 채 scratchpad 로 숨겼다. 그래서 show 도
+            // 재생성이 아니라 scratchpad 에서 꺼내는 것이다 (`sway_ipc.showFromScratchpad`).
+            // 첫 show (hidden_start) 는 아직 surface 가 없으므로 아래 create 로 간다.
+            if (self.is_sway and self.surface_id != 0) {
+                // #454 — sway 는 scratchpad 로 옮기는 순간 fullscreen 을 해제한다 (실기
+                // 확인 — hide 중 트리의 fullscreen_mode 가 0 으로 떨어짐). 앱의
+                // fullscreen_mode 는 그대로이므로 show 때 같은 상태를 재적용해
+                // hide/show 간 유지 (SPEC §2.8) 와 상태 동기화를 함께 지킨다.
+                //
+                // cover 는 **scratchpad show 보다 먼저** 상태를 세워야 맵 configure 가
+                // 전체화면 크기로 온다 — show 후에 보내면 (xdg 든 IPC 든) 전환
+                // 트랜잭션과 겹쳐 configure 가 유실된다. `fullscreenEnableIfSway` 주석.
+                if (self.fullscreen_mode == .cover)
+                    _ = sway_ipc.fullscreenEnableIfSway(self.rt, self.allocator);
+                // cover 는 reposition 금지 — move 가 전체화면 컨테이너를 dock 위치로
+                // 밀어낸다 (`showFromScratchpad` 주석). floating 저장 위치는 유지된다.
+                _ = sway_ipc.showFromScratchpad(
+                    self.rt,
+                    self.allocator,
+                    self.config,
+                    self.fullscreen_mode != .cover,
+                );
+                // avoid 는 일반 배치 명령이라 전환 트랜잭션 문제가 없다 — show 후
+                // 재적용이 실기에서 그대로 먹는다 (2차 재검증 [2]).
+                if (self.fullscreen_mode == .avoid)
+                    _ = sway_ipc.applyAvoidLayoutIfSway(self.rt, self.allocator);
+                self.logShowElapsed("scratchpad show");
+                log.appendLineVerbose("toggle", "show — scratchpad show (#454 sway)", .{});
+                return;
+            }
             if (self.surface_id == 0) {
                 try self.createShellObjects();
                 self.logShowElapsed("createShellObjects (first show)");
@@ -6663,6 +6739,14 @@ const Client = struct {
         // (wl_surface/layer_surface 유지) 워크어라운드를 쓴다 — 예외는 버그 있는 KWin
         // 한 곳뿐. (smithay/cosmic-comp 은 remap 미지원 #230, wlroots 는 recreate 도 빠름.)
         // 세션(PTY/shell)은 destroyShellObjects 가 안 건드림 → 재표시 후 그대로 유지.
+        // #454 — sway 는 surface 를 **살려 둔 채** scratchpad 로 보낸다. destroy/recreate 로
+        // 가면 xdg_toplevel 경로에서 창이 돌아오지 않는다 (`sway_ipc.hideToScratchpad`).
+        if (self.is_sway) {
+            _ = sway_ipc.hideToScratchpad(self.rt, self.allocator);
+            self.surface_hidden = true;
+            log.appendLineVerbose("toggle", "hide — moved to scratchpad (#454 sway)", .{});
+            return;
+        }
         if (kwinCompositor(self.rt)) {
             try self.unmapShellObjects();
             self.surface_hidden = true;
@@ -8217,6 +8301,10 @@ pub fn runBaselineWindow(
     // 측정 모드는 자기 단축키를 DE 에 등록하지 않는다 (#382) — 사용자의 기존 binding 을
     // 덮어쓰면 측정이 끝난 뒤에도 그 상태가 남는다.
     if (!opts.isStressRun()) sway_ipc.registerToggleIfSway(rt, allocator, cfg);
+    // #454 — sway 면 창 규칙(`for_window`)을 **창을 만들기 전에** 등록한다. layer-shell 을
+    // 쓰지 않는 대신 배치를 이 규칙이 맡는다. `client.run()` 안에서 창이 뜨므로 순서가
+    // 여기서 보장된다. 측정 인스턴스는 제외 — 사용자의 드롭다운이 아니다 (#382).
+    if (!opts.isStressRun()) sway_ipc.registerWindowRuleIfSway(rt, allocator, cfg);
     // #207 / #229 — GNOME · Cinnamon 세션이면 `tildaz --toggle`을
     // custom keybinding (GSettings)
     // 으로 자동 등록. 그 외 DE 면 no-op.


### PR DESCRIPTION
Closes #454

## 무엇

sway 는 layer-shell 의 `on_demand` 에서 map 시 keyboard focus 를 주지 않는다 — spec 이 compositor 재량으로 남긴 자리라 버그가 아니지만, **KWin · Hyprland · COSMIC 셋은 자동으로 준다** ([4 compositor 측정](https://github.com/ensky0/tildaz/issues/454)). 드롭다운 터미널의 본분이 *"핫키로 띄우면 바로 친다"* 라서 sway 에서만 그것이 깨진다.

**안 C** (sway 에서만 xdg_toplevel + i3 IPC) 로 간다. 추가 코드는 전부 `SWAYSOCK` 뒤에 있어 **다른 DE 경로는 한 줄도 안 바뀐다.**

## 구조

| # | 내용 |
|---|---|
| **1** | `SWAYSOCK` 세션이면 `zwlr_layer_shell_v1` 을 기록하지 않는다 → 기존 xdg-shell fallback. 판별은 SWAYSOCK 하나 (IPC 불가 세션은 layer-shell 유지가 낫다) |
| **2** | 배치: `for_window` 규칙 (floating·sticky·border·크기 ppt, **명령당 규칙 하나**) + map 후 `move`(ppt) |
| **3** | 토글: scratchpad — surface 를 살려 두고, show 가 focus 를 정상으로 넘긴다 (**이슈 본체 해결 지점**) |
| **4** | 전체화면: avoid 는 IPC workspace 채우기 (sway 가 floating `set_maximized` 무시), cover 의 hide/show 유지는 `fullscreen enable` 을 scratchpad show **앞에** |

## 실기에서만 드러난 함정들 (nested 로는 안 보였다)

- **`for_window` 콤마 체인은 첫 명령만 규칙이 된다.** 나머지는 그 순간 focus 된 **무관한 창에 즉시 실행**된다 — 검증 중 실제로 다른 앱 창이 리사이즈 + sticky 로 오염됐다. 세미콜론으로 이은 독립 규칙 4개가 정답. nested 에서 "배치가 config 대로" 로 보였던 것은 기대값 640x420 이 `default_width/height` 하드코딩과 우연히 일치했던 것.
- **cover 전체화면 재적용은 순서가 전부다.** scratchpad show **후**에 보내면 (xdg 든 IPC 든) 전환 트랜잭션과 겹쳐 크기 configure 가 유실된다 (상태만 서고 rect 는 이전 크기). scratchpad **안에서** 상태를 먼저 세우면 맵 configure 자체가 전체화면 크기로 온다.
- `runCommand` 성공 판정을 `success:false` 하나라도 있으면 실패로 강화 (다중 명령 부분 실패 오판 방지).

## 검증 — 실기 sway 1.12 (wlroots 0.20.2) · 노트북 i5-1240P · 1920x1080@59.997Hz

| 항목 | 결과 |
|---|---|
| ① 핫키 토글 직후 **클릭 없이** 타이핑 (PTY 파일 생성 판정) | ✅ 토글 5회 전부 |
| ② 떠 있는 동안 다른 창 타이핑 (#195 정책) | ✅ |
| ③ 배치 config 대로 (dock 4방향) · 토글 5회 · sticky ws 추종 · 탭/폰트 · 다중 인스턴스 | ✅ |
| ④ 로그 (`layer_shell=false` · `for_window registered` · `move ok`) | ✅ |
| 전체화면 cover/avoid 진입·해제·hide/show 유지·교차 no-op | ✅ |
| About 다이얼로그 (compositor 중앙·Esc·focus 복귀) | ✅ |
| `zig build check` / `zig build test` | ✅ |

문서 (`SPEC.md` 4곳 · `KEYBINDINGS.md`) 의 "sway = layer-shell" 서술도 같은 PR 에서 갱신했다.

상세 진단 트레일: [#454 검증 계획](https://github.com/ensky0/tildaz/issues/454#issuecomment-5302753960) → [1차 결과·원인 확정](https://github.com/ensky0/tildaz/issues/454#issuecomment-5302849035) → [fix 기록](https://github.com/ensky0/tildaz/issues/454#issuecomment-5302996281)