### PR TITLE
feat(stress): 응답 시간 하네스를 macOS · Windows 로 넓힌다 (#441 축 ②)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -41,7 +41,7 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | [`compare-terminals.sh`](compare-terminals.sh) | **다섯 터미널 나란히** 처리량 비교 + 창 캡처 | Windows 는 **Git Bash 필수** |
 | [`measure-repeat.sh`](measure-repeat.sh) | **우리 앱 안의 배분** — `parse` · `render` · `shape` 몫 | 〃 |
 | [`check-input-loss.sh`](check-input-loss.sh) | **응답성 ①** — 폭포 중 입력이 먹히는지 | Linux · macOS |
-| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · Windows (Git Bash) |
+| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · macOS · Windows (Git Bash) |
 | [`send-keys.ps1`](send-keys.ps1) | 위 도구의 **Windows 합성 입력** (`SendInput`) — Linux 의 `ydotool` 자리 | 〃 |
 | [`hygiene.sh`](hygiene.sh) | 위 넷이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
@@ -727,10 +727,21 @@ dist/stress/measure-input-latency.sh                      # idle · flood 둘 �
 dist/stress/measure-input-latency.sh --mode idle --presses 50
 ```
 
-**Linux · Windows 에서 돌아요.** 합성 입력이 platform 마다 달라요 — Linux 는 `ydotool` (uinput),
-Windows 는 `SendInput` ([`send-keys.ps1`](send-keys.ps1)) 이에요. **macOS 는 아직 없어요** —
-`CGEvent` 로 [#387](https://github.com/ensky0/tildaz/issues/387) 이 이미 쓴 경로를 옮겨오면 되지만
-안 했어요. **계측 자체는 세 platform 에 다 있어요** (`perf.input_latency`).
+**세 platform 에서 다 돌아요.** 합성 입력만 platform 마다 달라요.
+
+| | 합성 입력 | 창 포커스 | 덤프 · 종료 키 | 한/영 |
+|---|---|---|---|---|
+| **Linux** | `ydotool` (uinput) | 새 창이 자동으로 받아요 | `Ctrl+Shift+F12` · `Ctrl+Shift+W` | `fcitx5-remote` (전역) |
+| **macOS** | `CGEvent` ([`mac-input.m`](mac-input.m)) — 스크립트가 `clang` 으로 그 자리에서 빌드해요 | **클릭이 필요해요** (CGEvent 로 눌러요) | `Shift+Cmd+F12` · **`Cmd+W`** | `TISSelectInputSource` (전역) |
+| **Windows** | `SendInput` ([`send-keys.ps1`](send-keys.ps1)) | 키마다 확인 + 클릭으로 회수 | `Ctrl+Shift+F12` · `Ctrl+Shift+W` | 창별 IME conversion mode |
+
+**계측 자체도 세 platform 에 다 있어요** (`perf.input_latency`).
+
+**macOS 의 종료 키가 `Cmd+Q` 가 아닌 이유**는 확인창이에요. `Cmd+Q` 는 `applicationShouldTerminate` 가
+`count()==1` 을 보고 confirm 을 띄우는데, `Cmd+W` 는 `closeTab` 이 `orderedRemove` 로 탭을 **먼저 지운
+뒤** terminate 라 `count()==0` → confirm 을 건너뛰어요 ([`session_core.zig`](../../src/session_core.zig) ·
+[`host/macos.zig`](../../src/host/macos.zig)). Linux 가 `Alt+F4` 대신 `Ctrl+Shift+W` 를 쓰는 것과 같은
+이유예요.
 
 **Windows 는 Git Bash 에서 돌려요** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은 제약이에요).
 PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있어요 — #381 에서 두 벌이 실제로
@@ -749,34 +760,43 @@ DRR 이 켜져 있거나 배경 앱이 그리고 있으면 응답 시간도 처�
 
 ### 첫 수치 — **기기가 다르니 나란히 볼 때 주의해요**
 
-둘 다 5 회 절사평균 + min~max 이고 **주사율은 60 Hz 로 같아요.** 하지만 CPU 도 OS 도 달라서
-**절대값 차이를 전부 platform 몫으로 읽으면 안 돼요** (같은 기기에서 OS 만 바꿔 재는 것이 원칙이에요 —
-`AGENTS.md` 의 `# 실행 환경`).
+셋 다 5 회 절사평균 + min~max 예요. **기기도 주사율도 달라서 절대값 차이를 전부 platform 몫으로
+읽으면 안 돼요** (같은 기기에서 OS 만 바꿔 재는 것이 원칙이에요 — `AGENTS.md` 의 `# 실행 환경`).
 
-| | **Linux** · 미니PC Ryzen 7 8845HS · CachyOS · KDE Plasma | **Windows** · 노트북 Intel i5-1240P · Windows 11 26200 |
-|---|---|---|
-| 화면 | 60 Hz | 내장 1920x1080 · 로그 `refresh=60Hz period=16.67ms` |
-| **유휴** 평균 | **0.67 ms** (0.66~0.69) | **9.79 ms** (9.28~10.12) |
-| **유휴** 최악 | **12.35 ms** (12.30~12.38) | **19.85 ms** (16.56~25.83) |
-| **폭포 중** 평균 | **10.69 ms** (10.37~11.72) | **11.01 ms** (10.09~11.69) |
-| **폭포 중** 최악 | **18.64 ms** (18.24~19.14) | **17.62 ms** (16.25~19.79) |
+| | **Linux** · 미니PC Ryzen 7 8845HS · CachyOS · KDE Plasma | **macOS** · MacBook Pro M5 Pro · 26.6.1 | **Windows** · 노트북 Intel i5-1240P · Windows 11 26200 |
+|---|---|---|---|
+| 화면 | 60 Hz | 내장 3024x1964 · **120 Hz** (ProMotion) | 내장 1920x1080 · 로그 `refresh=60Hz period=16.67ms` |
+| **유휴** 평균 | **0.67 ms** (0.66~0.69) | **1.27 ms** (0.63~2.64) | **9.79 ms** (9.28~10.12) |
+| **유휴** 최악 | **12.35 ms** (12.30~12.38) | **4.05 ms** (0.79~**16.58**) | **19.85 ms** (16.56~25.83) |
+| **폭포 중** 평균 | **10.69 ms** (10.37~11.72) | **1.50 ms** (1.40~8.12) | **11.01 ms** (10.09~11.69) |
+| **폭포 중** 최악 | **18.64 ms** (18.24~19.14) | **4.26 ms** (2.01~8.24) | **17.62 ms** (16.25~19.79) |
 
-Windows 의 회차별 값 (실행 순서 그대로 — 위 "반복과 대표값" 규칙). **Linux 회차별 값은 남아 있지
+회차별 값 (실행 순서 그대로 — 위 "반복과 대표값" 규칙). **Linux 회차별 값은 남아 있지
 않아요** — 그때는 min~max 만 기록했어요 ([#441 코멘트](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302521860)).
 
 ```
-유휴  평균 10.12  9.89  9.28  9.50  9.99 ms    최악 20.09 18.21 25.83 16.56 21.25 ms
-폭포  평균 10.45 11.49 11.69 10.09 11.10 ms    최악 17.80 17.64 17.43 16.25 19.79 ms
+macOS    유휴 평균  0.68  0.74  0.63  2.39  2.64 ms    최악  0.89  2.98  0.79 16.58  8.29 ms
+         폭포 평균  1.53  1.42  1.40  8.12  1.54 ms    최악  5.10  2.29  2.01  8.24  5.40 ms
+
+Windows  유휴 평균 10.12  9.89  9.28  9.50  9.99 ms    최악 20.09 18.21 25.83 16.56 21.25 ms
+         폭포 평균 10.45 11.49 11.69 10.09 11.10 ms    최악 17.80 17.64 17.43 16.25 19.79 ms
 ```
 
-**폭포 중 값은 두 platform 이 거의 같은데 (10.69 / 11.01 ms) 유휴가 15 배 갈려요.** 그래서
-"폭포가 흐르면 16 배 느려진다" 는 Linux 의 문장이 Windows 에서는 **+12 % 로 사라져요.**
+⚠️ **macOS 는 회차 폭이 커서 절사평균만 보면 안 돼요.** 앞 세 회차 (유휴 평균 0.63~0.74 ms) 와 뒤 두
+회차 (2.39 · 2.64 ms) 가 **두 무리로 갈려요.** 회차가 갈수록 나빠지는 모양이라 열 누적이 의심되지만
+**확인하지 않았어요.** 유휴 최악의 폭 (0.79~16.58 ms) 은 **Linux 값 12.35 ms 를 품어서**, 이 표만으로
+"macOS 가 유휴 최악에서 낫다" 고 말할 수 없어요.
+
+**폭포 중 값은 Linux · Windows 가 거의 같은데 (10.69 / 11.01 ms) 유휴가 15 배 갈려요.** 그래서
+"폭포가 흐르면 16 배 느려진다" 는 Linux 의 문장이 Windows 에서는 **+12 % 로 사라져요.** macOS 는
+유휴 · 폭포가 둘 다 낮아 또 다른 모양이에요 (0.63~2.64 → 1.40~8.12).
 
 #### 유휴 차이의 원인은 **렌더를 언제 시작하느냐**예요 (소스로 확인)
 
 | platform | 키가 온 뒤 | 근거 |
 |---|---|---|
 | **Linux** | **같은 poll 반복에서 바로 그려요** | 키 이벤트가 `needs_redraw` 를 켜고, 그 다음 줄의 `maybeRedraw` 가 그 자리에서 그려요 ([`wayland_minimal.zig`](../../src/host/linux/wayland_minimal.zig)) |
+| **macOS** | **다음 vsync 를 기다려요** (구조상) | `tildazKeyDown` 은 `requestRender()` 로 `g_needs_render` 만 켜고 ([`macos.zig`](../../src/host/macos.zig)), 실제 렌더는 CADisplayLink 콜백 `renderFrameTick` 이 해요 — **Windows 와 같은 모양이에요** |
 | **Windows** | **다음 frame tick 을 기다려요** | `wndProc` 는 `requestRender()` 로 게이트만 열고 (#386 ②), 실제 렌더는 프레임 클럭이 post 하는 `WM_FRAME_TICK` → `renderFrameTick()` 에서 해요 ([`window.zig`](../../src/window.zig)) |
 
 키가 프레임 주기 안 아무 때나 도착하니 Windows 유휴 평균은 **반 프레임 (16.67 / 2 = 8.3 ms) + 렌더 ·
@@ -787,20 +807,41 @@ present · 셸 왕복**이 되고, 실측 9.79 ms 가 그 값이에요. 최악�
 이건 *"Windows 가 느리다"* 가 아니라 **구조가 다르다**는 뜻이에요 — 유휴에 프레임을 안 그려 CPU 를
 아끼는 #386 ② 의 게이트가 응답 지연으로는 반 프레임을 얹어요. 바꿀지 말지는 별도 판단이에요.
 
+⚠️ **그런데 macOS 는 같은 구조인데 값이 이 설명과 안 맞아요.** 120 Hz 면 반 프레임이 4.17 ms 라
+유휴 평균이 그 언저리여야 하는데 **5 회가 전부 그보다 낮아요** (0.63 · 0.68 · 0.74 · 2.39 · 2.64 ms).
+튄 뒤 두 회차까지 포함해서요.
+
+그래서 **"게이트 구조가 반 프레임을 얹는다" 는 설명이 platform 을 가려요.** 이건
+[#473](https://github.com/ensky0/tildaz/issues/473) 이 *"macOS 는 어느 쪽인가"* 로 남겨 둔 물음의
+답이기도 해요 — 같은 게이트를 쓰는데 그 비용이 안 나와요.
+
+**원인은 확인하지 않았어요.** 키 이벤트 배달이 vsync 와 맞물려 CADisplayLink 발사 직전에 도착하는
+것으로 보이지만 (그러면 대기가 거의 없어요) 그건 WindowServer 안쪽이라 우리 소스로는 못 봐요.
+확인하려면 `markInput` · `completeInput` 시각을 프레임 경계와 함께 찍어 위상을 봐야 해요 — 안 했어요.
+
 **이 값으로 [#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하면 안 돼요.** 그 이슈는
 *"유휴에서 **PTY 출력이 도착**했을 때"* 이고 이 측정은 **키를 눌러** 시작해요 — 키가 오면 앱이 즉시
 렌더를 요청하니 유휴 깨우기 경로를 아예 안 타요. 예산 4 ms 와의 직접 비교도 안 돼요 (그건 드레인
 한 번의 상한이고, 이 값은 거기에 셸 왕복 · 렌더 · present 가 누적된 것이에요).
 
-### ⚠ 입력기 — **Linux 는 표본이 비고 Windows 는 안 비어요**
+### ⚠ 입력기 — **Linux 만 표본이 비고 macOS · Windows 는 안 비어요**
 
-보내는 것이 **문자 키 `a`** 라서 입력기 상태가 측정 전제예요. 그런데 **두 platform 의 결과가 달라요**
-(둘 다 실측이에요).
+보내는 것이 **문자 키 `a`** 라서 입력기 상태가 측정 전제예요. 그런데 **세 platform 의 결과가 달라요**
+(전부 실측이에요).
 
 | platform | 한글 모드에서 문자 키 | 표본 | 도구가 하는 일 |
 |---|---|---|---|
 | **Linux** (fcitx5) | IME 가 조합용으로 가져가요 (`ㅁ` 이 찍혀요) — 앱 키 핸들러를 **안 타요** | **0 개** | `fcitx5-remote` 로 영문 전환 후 측정, 끝나면 복원 |
+| **macOS** (NSTextInputClient) | `keyDown:` 이 우리 뷰에 **먼저 오고** 앱이 `interpretKeyEvents:` 로 IME 에 넘겨요 — `markInput()` 이 `tildazKeyDown` 첫 줄이라 그대로 세어져요 | **정상** (실측 10/10) | `TISSelectInputSource` 로 영문 전환 후 측정, 끝나면 복원 |
 | **Windows** (IMM) | IME 가 쓰는데도 **`WM_KEYDOWN` 은 앱에 도달해요** (`VK_PROCESSKEY`) | **정상** (실측 11/11) | 그래도 영문으로 맞춰요 — 아래 참고 |
+
+macOS 실측 (`a` × 10, 같은 조건). **에코까지 정상이라 폐기 장치가 아예 안 걸려요** — 같은 자음을
+연달아 치면 IME 가 음절을 확정해 PTY 로 흘려보내기 때문이에요.
+
+| | 표본 | 에코 | 평균 | 최악 |
+|---|---:|---:|---:|---:|
+| 영문 | 10 | 10 B | 3.12 ms | 4.11 ms |
+| **한글** | 10 | **27 B** (`ㅁ` 9 개) | 4.33 ms | 5.20 ms |
 
 Windows 실측: 한국어 IME (`hkl=0x04120412`) 를 conversion mode 1 (한글) 로 두고 `a` 10 회를 보냈더니
 `input samples=11` 로 **그대로 잡혔어요.** 그러니 Windows 에서 표본이 비면 원인은 입력기가 아니에요.
@@ -816,11 +857,32 @@ preedit overlay 를 그리는 시간을 재게 돼서 영문 회차와 나란히
 Linux 는 한글 모드에서 preedit 이 그려지는데도 표본이 안 잡혀요 — 즉 그쪽 계측은 **영문 직접 입력
 경로만** 봐요. 한글 입력의 응답 지연을 재려면 계측 지점을 IME 경로에도 놓아야 해요.
 
+### ⚠ macOS 의 조용한 실패 둘 — 값이 그럴듯하게 나와요
+
+둘 다 실측에서 겪었고, **표본 수만 보면 정상으로 보여요.**
+
+| 증상 | 원인 | 막는 법 |
+|---|---|---|
+| 키가 하나도 안 나가요 | 보내는 쪽 (터미널 앱) 에 **손쉬운 사용 (Accessibility) 권한**이 없어요. `CGEventPost` 는 **성공을 반환하면서 아무 일도 안 해요** | `mac-input check` 가 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 불러요 (권한은 자식이 아니라 부모에 붙어요). 회차를 돌기 전에 멈춰요 |
+| 표본은 다 차는데 **화면에 아무것도 안 찍혀요** | 이벤트 소스가 시스템 modifier 상태를 물려받아 직전 조합키의 Cmd 가 남아요. `a` 가 `Cmd+A` 로 읽히면 `macCmdShortcut` 이 인식 못 해 **그냥 return** 하는데, `markInput()` 은 `tildazKeyDown` 첫 줄이라 표본은 세어져요 (그때 평균이 0.33 ms 로 그럴듯했어요) | `mac-input` 이 flags 를 **0 이어도 항상 설정**하고 소스를 `kCGEventSourceStatePrivate` 로 만들어요. 그래도 새면 **에코 검사**가 잡아요 |
+
+**에코 검사가 두 번째를 잡는 장치예요.** macOS 회차만 문자 키 앞뒤를 덤프로 감싸서, 그 구간의
+`drain bytes` 가 곧 에코량이 되게 해요 (`dumpAndReset` 이 읽으면서 리셋하니까요). 키가 PTY 로 안 간
+회차는 **0 B** 로 드러나요 — 표본 수로는 절대 안 보여요.
+
+Linux · Windows 로 넓히지 않은 이유는 **기대 표본이 바뀌기 때문**이에요. 두 platform 은 지금
+`Ctrl+C` 의 modifier 까지 세어 `키 수 + 1` 이 정상인데, 이 배치에서는 정확히 `키 수` 가 돼요. 이미
+5 회씩 측정을 마친 값이 있어서 도구를 바꾸면 재측정이 필요해요 — 그 판단은 각 platform 머신 몫이에요.
+(폭포 모드에서는 에코가 폭포량에 묻혀 사실상 통과만 하므로 그쪽 오염은 표본 수로 봐요.)
+
 ### 회차가 폐기되면 자동으로 다시 돌아요
 
 표본이 기대치의 8 할 미만이면 그 회차는 폐기예요 (`--retries`, 기본 3 회 재시도). 폐기의 알려진
 원인은 **한글 입력기** (Linux 한정, 위에서 미리 막아요) 와 **측정 중 조작**이에요 — 합성 입력은
 포커스된 창으로 가므로 측정 중에 창을 바꾸면 키가 다른 앱으로 새요.
+
+**macOS 는 폐기 사유가 하나 더 있어요** — 에코가 키 수에 못 미치면 (`⚠ 에코 N B`) 표본이 다 차도
+폐기예요. 위 "조용한 실패 둘" 의 두 번째를 잡는 장치예요.
 
 #### ⚠ Windows — **알림 토스트가 뜨면 회차가 통째로 폐기돼요**
 

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -41,7 +41,8 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | [`compare-terminals.sh`](compare-terminals.sh) | **다섯 터미널 나란히** 처리량 비교 + 창 캡처 | Windows 는 **Git Bash 필수** |
 | [`measure-repeat.sh`](measure-repeat.sh) | **우리 앱 안의 배분** — `parse` · `render` · `shape` 몫 | 〃 |
 | [`check-input-loss.sh`](check-input-loss.sh) | **응답성 ①** — 폭포 중 입력이 먹히는지 | Linux · macOS |
-| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux |
+| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · Windows (Git Bash) |
+| [`send-keys.ps1`](send-keys.ps1) | 위 도구의 **Windows 합성 입력** (`SendInput`) — Linux 의 `ydotool` 자리 | 〃 |
 | [`hygiene.sh`](hygiene.sh) | 위 넷이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
 `measure-repeat` 는 앱을 반복해 띄워 종료 시 자동 덤프 ([#396](https://github.com/ensky0/tildaz/issues/396))
@@ -726,9 +727,17 @@ dist/stress/measure-input-latency.sh                      # idle · flood 둘 �
 dist/stress/measure-input-latency.sh --mode idle --presses 50
 ```
 
-**Linux 전용이에요.** 합성 입력이 platform 마다 달라요 — Windows 는 `SendInput`, macOS 는
-`CGEvent` 로 [#387](https://github.com/ensky0/tildaz/issues/387) 이 이미 썼으니 그 경로를 옮겨오면
-되지만 아직 안 했어요. **계측 자체는 세 platform 에 다 있어요** (`perf.input_latency`).
+**Linux · Windows 에서 돌아요.** 합성 입력이 platform 마다 달라요 — Linux 는 `ydotool` (uinput),
+Windows 는 `SendInput` ([`send-keys.ps1`](send-keys.ps1)) 이에요. **macOS 는 아직 없어요** —
+`CGEvent` 로 [#387](https://github.com/ensky0/tildaz/issues/387) 이 이미 쓴 경로를 옮겨오면 되지만
+안 했어요. **계측 자체는 세 platform 에 다 있어요** (`perf.input_latency`).
+
+**Windows 는 Git Bash 에서 돌려요** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은 제약이에요).
+PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있어요 — #381 에서 두 벌이 실제로
+갈렸어요. platform 마다 진짜로 다른 것은 **합성 입력 하나**라 그것만 `.ps1` 로 뺐어요.
+
+**위생 검사가 걸려요** (`hygiene_check` / `hygiene_begin`, `--ignore-hygiene` 로 우회).
+DRR 이 켜져 있거나 배경 앱이 그리고 있으면 응답 시간도 처리량과 같은 오염을 받아요.
 
 ### 재는 구간
 
@@ -738,41 +747,92 @@ dist/stress/measure-input-latency.sh --mode idle --presses 50
 
 못 재는 것: `present → 실제 화면 발광` (외부 장비 필요) 과 `키 눌림 → 앱 수신` (compositor 몫).
 
-### 첫 수치 (미니PC · Ryzen 7 8845HS · CachyOS · KDE Plasma · 60 Hz)
+### 첫 수치 — **기기가 다르니 나란히 볼 때 주의해요**
 
-5 회 절사평균 + min~max.
+둘 다 5 회 절사평균 + min~max 이고 **주사율은 60 Hz 로 같아요.** 하지만 CPU 도 OS 도 달라서
+**절대값 차이를 전부 platform 몫으로 읽으면 안 돼요** (같은 기기에서 OS 만 바꿔 재는 것이 원칙이에요 —
+`AGENTS.md` 의 `# 실행 환경`).
 
-| 상황 | 평균 | 최악 |
+| | **Linux** · 미니PC Ryzen 7 8845HS · CachyOS · KDE Plasma | **Windows** · 노트북 Intel i5-1240P · Windows 11 26200 |
 |---|---|---|
-| **유휴** | **0.67 ms** (0.66~0.69) | **12.35 ms** (12.30~12.38) |
-| **폭포 중** | **10.69 ms** (10.37~11.72) | **18.64 ms** (18.24~19.14) |
+| 화면 | 60 Hz | 내장 1920x1080 · 로그 `refresh=60Hz period=16.67ms` |
+| **유휴** 평균 | **0.67 ms** (0.66~0.69) | **9.79 ms** (9.28~10.12) |
+| **유휴** 최악 | **12.35 ms** (12.30~12.38) | **19.85 ms** (16.56~25.83) |
+| **폭포 중** 평균 | **10.69 ms** (10.37~11.72) | **11.01 ms** (10.09~11.69) |
+| **폭포 중** 최악 | **18.64 ms** (18.24~19.14) | **17.62 ms** (16.25~19.79) |
 
-**폭포가 흐르면 평균 응답이 16 배 느려져요.** 재현성도 좋아요 — 유휴 최악은 5 회가 0.08 ms 폭
-안에 들어왔어요.
+Windows 의 회차별 값 (실행 순서 그대로 — 위 "반복과 대표값" 규칙). **Linux 회차별 값은 남아 있지
+않아요** — 그때는 min~max 만 기록했어요 ([#441 코멘트](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302521860)).
+
+```
+유휴  평균 10.12  9.89  9.28  9.50  9.99 ms    최악 20.09 18.21 25.83 16.56 21.25 ms
+폭포  평균 10.45 11.49 11.69 10.09 11.10 ms    최악 17.80 17.64 17.43 16.25 19.79 ms
+```
+
+**폭포 중 값은 두 platform 이 거의 같은데 (10.69 / 11.01 ms) 유휴가 15 배 갈려요.** 그래서
+"폭포가 흐르면 16 배 느려진다" 는 Linux 의 문장이 Windows 에서는 **+12 % 로 사라져요.**
+
+#### 유휴 차이의 원인은 **렌더를 언제 시작하느냐**예요 (소스로 확인)
+
+| platform | 키가 온 뒤 | 근거 |
+|---|---|---|
+| **Linux** | **같은 poll 반복에서 바로 그려요** | 키 이벤트가 `needs_redraw` 를 켜고, 그 다음 줄의 `maybeRedraw` 가 그 자리에서 그려요 ([`wayland_minimal.zig`](../../src/host/linux/wayland_minimal.zig)) |
+| **Windows** | **다음 frame tick 을 기다려요** | `wndProc` 는 `requestRender()` 로 게이트만 열고 (#386 ②), 실제 렌더는 프레임 클럭이 post 하는 `WM_FRAME_TICK` → `renderFrameTick()` 에서 해요 ([`window.zig`](../../src/window.zig)) |
+
+키가 프레임 주기 안 아무 때나 도착하니 Windows 유휴 평균은 **반 프레임 (16.67 / 2 = 8.3 ms) + 렌더 ·
+present · 셸 왕복**이 되고, 실측 9.79 ms 가 그 값이에요. 최악이 한 주기를 넘는 것 (19.85 ms) 도 같은
+설명이에요. **폭포 중에는 tick 마다 그릴 것이 이미 있어서** 이 대기가 값에서 사라져 두 platform 이
+붙어요.
+
+이건 *"Windows 가 느리다"* 가 아니라 **구조가 다르다**는 뜻이에요 — 유휴에 프레임을 안 그려 CPU 를
+아끼는 #386 ② 의 게이트가 응답 지연으로는 반 프레임을 얹어요. 바꿀지 말지는 별도 판단이에요.
 
 **이 값으로 [#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하면 안 돼요.** 그 이슈는
 *"유휴에서 **PTY 출력이 도착**했을 때"* 이고 이 측정은 **키를 눌러** 시작해요 — 키가 오면 앱이 즉시
 렌더를 요청하니 유휴 깨우기 경로를 아예 안 타요. 예산 4 ms 와의 직접 비교도 안 돼요 (그건 드레인
 한 번의 상한이고, 이 값은 거기에 셸 왕복 · 렌더 · present 가 누적된 것이에요).
 
-### ⚠ 입력기가 한글이면 표본이 안 잡혀요
+### ⚠ 입력기 — **Linux 는 표본이 비고 Windows 는 안 비어요**
 
-보내는 것이 **문자 키 `a`** 라서, 한글 모드에서는 IME 가 그것을 조합용으로 가져가요 (`ㅁ` 이 찍혀요).
-그러면 앱의 키 핸들러를 안 타서 `markInput()` 이 안 불리고 표본이 비어요. 스크립트가
-`fcitx5-remote` 로 **영문으로 바꿨다가 끝나면 되돌려요.**
+보내는 것이 **문자 키 `a`** 라서 입력기 상태가 측정 전제예요. 그런데 **두 platform 의 결과가 달라요**
+(둘 다 실측이에요).
 
-**단축키는 달라요** — `Ctrl+Shift+F12` 는 한글 모드에서도 앱에 도달해요
+| platform | 한글 모드에서 문자 키 | 표본 | 도구가 하는 일 |
+|---|---|---|---|
+| **Linux** (fcitx5) | IME 가 조합용으로 가져가요 (`ㅁ` 이 찍혀요) — 앱 키 핸들러를 **안 타요** | **0 개** | `fcitx5-remote` 로 영문 전환 후 측정, 끝나면 복원 |
+| **Windows** (IMM) | IME 가 쓰는데도 **`WM_KEYDOWN` 은 앱에 도달해요** (`VK_PROCESSKEY`) | **정상** (실측 11/11) | 그래도 영문으로 맞춰요 — 아래 참고 |
+
+Windows 실측: 한국어 IME (`hkl=0x04120412`) 를 conversion mode 1 (한글) 로 두고 `a` 10 회를 보냈더니
+`input samples=11` 로 **그대로 잡혔어요.** 그러니 Windows 에서 표본이 비면 원인은 입력기가 아니에요.
+
+**그래도 `send-keys.ps1` 은 영문으로 맞추고 끝나면 되돌려요** (`-KeepImeMode` 로 끌 수 있어요).
+표본이 잡히더라도 **재는 경로가 달라지기 때문**이에요 — 한글 모드에서는 셸 에코 왕복이 아니라
+preedit overlay 를 그리는 시간을 재게 돼서 영문 회차와 나란히 둘 수 없어요.
+
+**단축키는 또 달라요** — `Ctrl+Shift+F12` 는 Linux 에서도 한글 모드에서 앱에 도달해요
 ([#465](https://github.com/ensky0/tildaz/issues/465)). 위 "입력 손실 검사" 의 ①이 한글 모드에서도
 되는 것과 모순이 아니에요. **키 종류가 다른 거예요.**
 
-곁가지로, 한글 모드에서 preedit 은 화면에 그려지는데 표본은 안 잡혀요 — 즉 지금 계측은
-**영문 직접 입력 경로만** 봐요. 한글 입력의 응답 지연을 재려면 계측 지점을 IME 경로에도 놓아야 해요.
+Linux 는 한글 모드에서 preedit 이 그려지는데도 표본이 안 잡혀요 — 즉 그쪽 계측은 **영문 직접 입력
+경로만** 봐요. 한글 입력의 응답 지연을 재려면 계측 지점을 IME 경로에도 놓아야 해요.
 
 ### 회차가 폐기되면 자동으로 다시 돌아요
 
 표본이 기대치의 8 할 미만이면 그 회차는 폐기예요 (`--retries`, 기본 3 회 재시도). 폐기의 알려진
-원인은 **한글 입력기** (위에서 미리 막아요) 와 **측정 중 조작**이에요 — 합성 입력은 포커스된 창으로
-가므로 측정 중에 창을 바꾸면 키가 다른 앱으로 새요.
+원인은 **한글 입력기** (Linux 한정, 위에서 미리 막아요) 와 **측정 중 조작**이에요 — 합성 입력은
+포커스된 창으로 가므로 측정 중에 창을 바꾸면 키가 다른 앱으로 새요.
+
+#### ⚠ Windows — **알림 토스트가 뜨면 회차가 통째로 폐기돼요**
+
+`send-keys.ps1` 은 키 하나마다 `GetForegroundWindow()` 를 확인하고 어긋나면 **키를 안 보내요**
+(안 그러면 사용자가 보던 창에 그대로 타이핑돼요 — 예전 시연에서 실제로 일어났어요). 그런데 Windows
+알림 (`Windows.UI.Core.CoreWindow` · "새 알림") 이 foreground 를 쥐면 `SetForegroundWindow` 가 **조용히
+거부**돼서, 첫 측정에서 회차가 세 번 연속 폐기됐어요. 앱은 정상으로 떴는데 **활성이 못 된 것**이에요.
+
+그래서 거부되면 **창 client 한가운데를 실제로 클릭해 포커스를 회수**해요 (사용자가 하는 것과 같은
+행위라 foreground lock 이 안 걸려요). 회수가 쓰이면 회차 줄에 *"포커스를 클릭으로 회수했어요"* 가
+붙어요 — 5 회차 실측 (idle · flood 각 5 회) 에서 **10 회차 중 9 회**가 그랬어요. 즉 이 회수 경로가
+없으면 그 측정은 거의 전부 폐기됐을 거예요.
 
 ## 다른 터미널과 비교하기
 

--- a/dist/stress/mac-input.m
+++ b/dist/stress/mac-input.m
@@ -1,0 +1,392 @@
+// macOS 합성 입력 — `measure-input-latency.sh` 가 쓰는 CGEvent 전송 도구 (#441 축 ②).
+//
+//   clang -O2 -Wno-deprecated-declarations \
+//         -framework ApplicationServices -framework Carbon -o /tmp/mac-input mac-input.m
+//
+//   /tmp/mac-input check                    # 손쉬운 사용 권한이 있나
+//   /tmp/mac-input focus <pid>              # 그 pid 의 창을 클릭해 key window 로
+//   /tmp/mac-input send a --repeat 30 --gap 200
+//   /tmp/mac-input send shift+cmd+f12
+//   /tmp/mac-input ime-get                  # 지금 입력 소스 ID
+//   /tmp/mac-input ime-ascii                # 영문(ASCII 가능) 소스로
+//   /tmp/mac-input ime-set com.apple.inputmethod.Korean.2SetKorean
+//
+// ## 왜 `cliclick` 을 안 쓰나
+//
+// [#387](https://github.com/ensky0/tildaz/issues/387#issuecomment-5188395490) 이 macOS 에서 쓴
+// 도구가 `cliclick` 이고 그건 지금도 유효하다 (`osascript keystroke` 는 Accessory mode 때문에
+// 새어 나간다). 다만 그때 보낸 것은 **단축키 하나**였고, 여기서 필요한 것은 **문자 키**다.
+//
+//   - `cliclick` 의 `kp` 는 특수키만 받는다 (`f1`~`f16` · 화살표 · `space` …). 문자는
+//     `t:a` 뿐인데 그건 `CGEventKeyboardSetUnicodeString` 방식이라 IME 를 지나는 길이
+//     실기와 달라질 수 있다 (*추정 — 확인 안 함*).
+//   - 권한이 없을 때 오류 없이 exit 0 이라 **키가 안 나간 회차를 그대로 끝낸다.**
+//
+// ## 권한 — 이 도구가 존재하는 진짜 이유
+//
+// CGEvent 로 키를 보내려면 **보내는 쪽**에 손쉬운 사용 (Accessibility) 권한이 있어야 하고,
+// 없으면 `CGEventPost` 는 **성공을 반환하면서 아무 일도 하지 않는다.** Linux 에서 `ydotoold`
+// 미기동으로 키가 하나도 안 나간 채 회차가 끝난 그 함정과 같은 종류다.
+//
+// 그래서 `AXIsProcessTrusted()` 를 **키를 보내는 이 프로세스 안에서** 부른다. TCC 는 터미널이
+// 띄운 자식의 권한을 부모 (터미널 앱) 기준으로 평가하므로 (AGENTS.md 의 macOS `open` 절),
+// 판정과 전송이 같은 프로세스여야 답이 맞는다.
+#include <ApplicationServices/ApplicationServices.h>
+#include <Carbon/Carbon.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+enum {
+    EXIT_NO_PERMISSION = 2,
+    EXIT_NO_WINDOW = 3,
+    EXIT_USAGE = 4,
+    EXIT_IME = 5,
+};
+
+// macOS 의 가상 키코드는 물리 배치 순서라 알파벳 순이 아니다 (`a` = 0, `s` = 1 …).
+// `<Carbon/HIToolbox/Events.h>` 의 `kVK_*` 와 같은 값이며, 여기서 이름을 붙여 둔다.
+static const struct {
+    const char *name;
+    CGKeyCode code;
+} kKeys[] = {
+    {"a", 0},    {"s", 1},    {"d", 2},     {"f", 3},     {"h", 4},     {"g", 5},
+    {"z", 6},    {"x", 7},    {"c", 8},     {"v", 9},     {"b", 11},    {"q", 12},
+    {"w", 13},   {"e", 14},   {"r", 15},    {"y", 16},    {"t", 17},    {"o", 31},
+    {"u", 32},   {"i", 34},   {"p", 35},    {"l", 37},    {"j", 38},    {"k", 40},
+    {"n", 45},   {"m", 46},
+    {"1", 18},   {"2", 19},   {"3", 20},    {"4", 21},    {"6", 22},    {"5", 23},
+    {"9", 25},   {"7", 26},   {"8", 28},    {"0", 29},
+    {"return", 36}, {"tab", 48}, {"space", 49}, {"delete", 51}, {"esc", 53},
+    {"f1", 122}, {"f2", 120}, {"f3", 99},   {"f4", 118},  {"f5", 96},   {"f6", 97},
+    {"f7", 98},  {"f8", 100}, {"f9", 101},  {"f10", 109}, {"f11", 103}, {"f12", 111},
+};
+
+static int lookupKey(const char *name, CGKeyCode *out) {
+    for (size_t i = 0; i < sizeof(kKeys) / sizeof(kKeys[0]); i++) {
+        if (strcmp(kKeys[i].name, name) == 0) {
+            *out = kKeys[i].code;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/// `shift+cmd+f12` 처럼 `+` 로 이어 붙인 조합을 keyCode + flags 로 가른다.
+static int parseSpec(const char *spec, CGKeyCode *code, CGEventFlags *flags) {
+    char buf[128];
+    if (strlen(spec) >= sizeof(buf)) return 0;
+    strcpy(buf, spec);
+
+    *flags = 0;
+    char *cursor = buf;
+    for (;;) {
+        char *plus = strchr(cursor, '+');
+        if (plus == NULL) break;
+        *plus = '\0';
+        if (strcmp(cursor, "cmd") == 0) *flags |= kCGEventFlagMaskCommand;
+        else if (strcmp(cursor, "shift") == 0) *flags |= kCGEventFlagMaskShift;
+        else if (strcmp(cursor, "ctrl") == 0) *flags |= kCGEventFlagMaskControl;
+        else if (strcmp(cursor, "alt") == 0 || strcmp(cursor, "opt") == 0) *flags |= kCGEventFlagMaskAlternate;
+        else return 0;
+        cursor = plus + 1;
+    }
+    return lookupKey(cursor, code);
+}
+
+/// 모디파이어는 실제 키를 누르지 않고 `CGEventSetFlags` 로만 준다. 우리 앱이 보는 것이
+/// `[event modifierFlags]` 라서 (`host/macos.zig` 의 `tildazKeyDown`) 이걸로 충분하다.
+///
+/// **flags 는 0 이어도 반드시 설정한다.** 처음에는 `flags != 0` 일 때만 불렀는데, 그러면
+/// 새 이벤트가 **직전 조합키의 modifier 를 물려받는다.** Cmd 가 남은 채 `a` 가 나가면 앱은
+/// 그걸 `Cmd+A` 로 보고 `macCmdShortcut` 이 인식 못 해 **그냥 return** 한다 — 화면도 안
+/// 바뀌고 PTY 로도 안 간다. 그런데 `markInput()` 은 `tildazKeyDown` 첫 줄이라 표본은 그대로
+/// 세어져서, **"표본은 다 찼는데 아무것도 안 찍힌"** 회차가 된다 (실측으로 겪었다).
+///
+/// 소스도 `kCGEventSourceStatePrivate` 로 만들어 시스템의 실제 키보드 상태를 물려받지
+/// 않게 한다. 두 겹으로 막는 이유는 이 실패가 **조용해서** — 값이 그럴듯하게 나온다.
+static void postKey(CGKeyCode code, CGEventFlags flags) {
+    CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStatePrivate);
+    CGEventRef down = CGEventCreateKeyboardEvent(src, code, true);
+    CGEventRef up = CGEventCreateKeyboardEvent(src, code, false);
+    CGEventSetFlags(down, flags);
+    CGEventSetFlags(up, flags);
+    CGEventPost(kCGHIDEventTap, down);
+    CGEventPost(kCGHIDEventTap, up);
+    CFRelease(down);
+    CFRelease(up);
+    if (src != NULL) CFRelease(src);
+}
+
+static void warnNoPermission(void) {
+    fprintf(stderr,
+            "손쉬운 사용 (Accessibility) 권한이 없어요 — CGEvent 로 보낸 키가 조용히 사라져요.\n"
+            "  시스템 설정 → 개인정보 보호 및 보안 → 손쉬운 사용 에서\n"
+            "  **이 스크립트를 실행한 터미널 앱**을 켜 주세요 (권한은 자식이 아니라 부모에 붙어요).\n"
+            "  이미 켜져 있는데도 이 메시지가 나오면 토글을 껐다 켜세요 (서명이 바뀌면 stale 해져요).\n");
+}
+
+static int requireTrusted(void) {
+    if (AXIsProcessTrusted()) return 1;
+    warnNoPermission();
+    return 0;
+}
+
+/// 합성 입력은 **포커스된 창**으로 간다. Accessory mode 앱이라 `osascript` 로는 활성화가
+/// 안 새어 나가고 (#387), 창 본문을 클릭하는 것이 실측으로 통한 방법이다. 여기서는 그
+/// 클릭까지 CGEvent 로 해서 사람 개입을 없앤다.
+static int focusWindowOfPid(pid_t pid) {
+    CFArrayRef windows = CGWindowListCopyWindowInfo(
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+    if (windows == NULL) {
+        fprintf(stderr, "창 목록을 못 읽었어요.\n");
+        return EXIT_NO_WINDOW;
+    }
+
+    CGRect best = CGRectZero;
+    int found = 0;
+    for (CFIndex i = 0; i < CFArrayGetCount(windows); i++) {
+        CFDictionaryRef info = CFArrayGetValueAtIndex(windows, i);
+        CFNumberRef owner = CFDictionaryGetValue(info, kCGWindowOwnerPID);
+        CFDictionaryRef bounds_dict = CFDictionaryGetValue(info, kCGWindowBounds);
+        if (owner == NULL || bounds_dict == NULL) continue;
+
+        int owner_pid = 0;
+        CFNumberGetValue(owner, kCFNumberIntType, &owner_pid);
+        if (owner_pid != (int)pid) continue;
+
+        // **`kCGWindowLayer` 로 거르면 안 된다.** drop-down 터미널이라 우리 창은
+        // `NSPopUpMenuWindowLevel` (101) 로 뜨고 (`host/macos.zig` 의 `setPopupWindowLevel`),
+        // 다른 앱이 활성이면 normal (0) 로 내려간다 (#195). 즉 layer 가 **두 값을 오간다.**
+        // 처음에 `layer == 0` 만 봤다가 창을 못 찾았다 (실측). pid 로 이미 좁혔으니
+        // 층은 보지 않고, 같은 pid 의 보조 창 (다이얼로그 · IME 패널) 은 아래 넓이 비교로 밀어낸다.
+        CGRect rect;
+        if (!CGRectMakeWithDictionaryRepresentation(bounds_dict, &rect)) continue;
+        // 한 프로세스가 창을 여럿 들 수 있다 (다이얼로그 등). 가장 큰 것이 본체다.
+        if (rect.size.width * rect.size.height > best.size.width * best.size.height) {
+            best = rect;
+            found = 1;
+        }
+    }
+    CFRelease(windows);
+
+    if (!found) {
+        fprintf(stderr, "pid %d 의 창을 못 찾았어요 (아직 안 떴거나 이미 닫혔어요).\n", (int)pid);
+        return EXIT_NO_WINDOW;
+    }
+
+    // 창 중앙 — 탭바 (위쪽) 와 스크롤바 (오른쪽) 를 피한다. 터미널 본문이라 클릭해도
+    // 같은 자리에서 떼면 빈 selection 이라 화면이 바뀌지 않는다.
+    CGPoint target = CGPointMake(CGRectGetMidX(best), CGRectGetMidY(best));
+
+    // 사용자의 포인터를 빼앗지 않도록 원래 자리를 기억해 둔다.
+    CGEventRef probe = CGEventCreate(NULL);
+    CGPoint origin = (probe != NULL) ? CGEventGetLocation(probe) : target;
+    if (probe != NULL) CFRelease(probe);
+
+    // `CGWarpMouseCursorPosition` 만으로는 이동 이벤트가 없어 hover · 클릭이 안 걸린다
+    // (AGENTS.md 의 macOS 색 실측 절과 같은 함정). 이동 → 누름 → 뗌을 모두 보낸다.
+    CGEventRef move = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, move);
+    CFRelease(move);
+    usleep(50 * 1000);
+
+    CGEventRef down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, down);
+    CFRelease(down);
+    usleep(30 * 1000);
+
+    CGEventRef up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, up);
+    CFRelease(up);
+    usleep(50 * 1000);
+
+    // 포인터를 되돌린다. 창 밖으로 나가므로 탭바 hover 도 함께 풀린다.
+    CGWarpMouseCursorPosition(origin);
+    return 0;
+}
+
+/// 주 화면의 주사율. **응답 시간 측정에서 이 값이 결론을 바꾼다** — 프레임 주기가 곧
+/// 응답 지연의 하한이라, 120 Hz 와 60 Hz 를 나란히 두려면 함께 적어야 한다 (AGENTS.md 의
+/// `# 실행 환경`). `system_profiler` 에는 안 나오고 `hygiene.sh` 도 셸만으로는 못 읽어서
+/// 여기서 `CGDisplayModeGetRefreshRate` 로 낸다.
+///
+/// 창이 뜬 화면이 아니라 **주 화면** 기준이다. 우리 창은 drop-down 이라 주 화면에 뜨지만,
+/// 외장 모니터를 함께 쓰는 환경에서는 사람이 확인한다.
+static int printRefresh(void) {
+    CGDisplayModeRef mode = CGDisplayCopyDisplayMode(CGMainDisplayID());
+    if (mode == NULL) {
+        fprintf(stderr, "화면 모드를 못 읽었어요.\n");
+        return EXIT_IME;
+    }
+    double hz = CGDisplayModeGetRefreshRate(mode);
+    CGDisplayModeRelease(mode);
+    // 일부 화면은 0 을 낸다. 그때는 물음표를 그대로 내보내 **모르는 것을 아는 척하지 않는다.**
+    if (hz <= 0.0) {
+        printf("?\n");
+        return 0;
+    }
+    printf("%.0fHz\n", hz);
+    return 0;
+}
+
+static int imeGet(void) {
+    TISInputSourceRef current = TISCopyCurrentKeyboardInputSource();
+    if (current == NULL) {
+        fprintf(stderr, "현재 입력 소스를 못 읽었어요.\n");
+        return EXIT_IME;
+    }
+    CFStringRef source_id = TISGetInputSourceProperty(current, kTISPropertyInputSourceID);
+    if (source_id == NULL) {
+        CFRelease(current);
+        fprintf(stderr, "입력 소스 ID 가 없어요.\n");
+        return EXIT_IME;
+    }
+    char buf[256];
+    if (!CFStringGetCString(source_id, buf, sizeof(buf), kCFStringEncodingUTF8)) {
+        CFRelease(current);
+        fprintf(stderr, "입력 소스 ID 를 못 옮겼어요.\n");
+        return EXIT_IME;
+    }
+    printf("%s\n", buf);
+    CFRelease(current);
+    return 0;
+}
+
+/// 영문 (ASCII 를 낼 수 있는) 소스로 바꾼다. 한글 모드면 `a` 가 조합에 먹혀서
+/// PTY 왕복이 아니라 preedit 만 재게 된다.
+static int imeAscii(void) {
+    TISInputSourceRef ascii = TISCopyCurrentASCIICapableKeyboardInputSource();
+    if (ascii == NULL) {
+        fprintf(stderr, "ASCII 입력 소스를 못 찾았어요.\n");
+        return EXIT_IME;
+    }
+    OSStatus status = TISSelectInputSource(ascii);
+    CFRelease(ascii);
+    if (status != noErr) {
+        fprintf(stderr, "영문 입력 소스로 못 바꿨어요 (OSStatus %d).\n", (int)status);
+        return EXIT_IME;
+    }
+    return 0;
+}
+
+static int imeSet(const char *wanted) {
+    CFStringRef wanted_cf = CFStringCreateWithCString(NULL, wanted, kCFStringEncodingUTF8);
+    if (wanted_cf == NULL) return EXIT_IME;
+
+    const void *keys[] = {kTISPropertyInputSourceID};
+    const void *values[] = {wanted_cf};
+    CFDictionaryRef filter = CFDictionaryCreate(NULL, keys, values, 1,
+                                                &kCFTypeDictionaryKeyCallBacks,
+                                                &kCFTypeDictionaryValueCallBacks);
+    // `includeAllInstalled = false` — 켜 둔 소스만 본다. 안 켠 소스는 선택해도 안 먹는다.
+    CFArrayRef list = TISCreateInputSourceList(filter, false);
+    CFRelease(filter);
+    CFRelease(wanted_cf);
+
+    if (list == NULL || CFArrayGetCount(list) == 0) {
+        if (list != NULL) CFRelease(list);
+        fprintf(stderr, "입력 소스를 못 찾았어요: %s\n", wanted);
+        return EXIT_IME;
+    }
+    TISInputSourceRef source = (TISInputSourceRef)CFArrayGetValueAtIndex(list, 0);
+    OSStatus status = TISSelectInputSource(source);
+    CFRelease(list);
+    if (status != noErr) {
+        fprintf(stderr, "입력 소스를 못 바꿨어요: %s (OSStatus %d)\n", wanted, (int)status);
+        return EXIT_IME;
+    }
+    return 0;
+}
+
+static void usage(void) {
+    fprintf(stderr,
+            "쓰는 법: mac-input <명령>\n"
+            "\n"
+            "  check                       손쉬운 사용 권한이 있나 (없으면 exit 2)\n"
+            "  focus <pid>                 그 pid 의 창을 클릭해 key window 로\n"
+            "  send <키>... [옵션]         키를 보낸다\n"
+            "  refresh                     주 화면 주사율 (측정 기록용)\n"
+            "  ime-get                     지금 입력 소스 ID\n"
+            "  ime-ascii                   영문 (ASCII 가능) 소스로\n"
+            "  ime-set <id>                그 ID 로\n"
+            "\n"
+            "  send 옵션: --repeat <N> (키 열을 N 번) · --gap <ms> (키 사이 간격, 기본 200)\n"
+            "  키 표기: a · ctrl+c · shift+cmd+f12 · cmd+q\n");
+}
+
+int main(int argc, const char **argv) {
+    if (argc < 2) {
+        usage();
+        return EXIT_USAGE;
+    }
+    const char *cmd = argv[1];
+
+    if (strcmp(cmd, "check") == 0) {
+        return requireTrusted() ? 0 : EXIT_NO_PERMISSION;
+    }
+
+    if (strcmp(cmd, "focus") == 0) {
+        if (argc != 3) { usage(); return EXIT_USAGE; }
+        if (!requireTrusted()) return EXIT_NO_PERMISSION;
+        return focusWindowOfPid((pid_t)atoi(argv[2]));
+    }
+
+    if (strcmp(cmd, "refresh") == 0) return printRefresh();
+    if (strcmp(cmd, "ime-get") == 0) return imeGet();
+    if (strcmp(cmd, "ime-ascii") == 0) return imeAscii();
+    if (strcmp(cmd, "ime-set") == 0) {
+        if (argc != 3) { usage(); return EXIT_USAGE; }
+        return imeSet(argv[2]);
+    }
+
+    if (strcmp(cmd, "send") != 0) {
+        usage();
+        return EXIT_USAGE;
+    }
+
+    // **권한 판정을 보내기 전에** 한다. 이게 없으면 회차를 다 돌고 나서야 표본 0 으로 안다.
+    if (!requireTrusted()) return EXIT_NO_PERMISSION;
+
+    const char *specs[64];
+    int spec_count = 0;
+    long repeat = 1;
+    long gap_ms = 200;
+
+    for (int i = 2; i < argc; i++) {
+        if (strcmp(argv[i], "--repeat") == 0 && i + 1 < argc) {
+            repeat = strtol(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--gap") == 0 && i + 1 < argc) {
+            gap_ms = strtol(argv[++i], NULL, 10);
+        } else {
+            if (spec_count == (int)(sizeof(specs) / sizeof(specs[0]))) {
+                fprintf(stderr, "키가 너무 많아요.\n");
+                return EXIT_USAGE;
+            }
+            specs[spec_count++] = argv[i];
+        }
+    }
+    if (spec_count == 0 || repeat < 1 || gap_ms < 0) {
+        usage();
+        return EXIT_USAGE;
+    }
+
+    // 보내기 전에 전부 파싱한다 — 열 한가운데서 오타로 멈추면 앱이 어중간한 상태로 남는다.
+    CGKeyCode codes[64];
+    CGEventFlags flags[64];
+    for (int i = 0; i < spec_count; i++) {
+        if (!parseSpec(specs[i], &codes[i], &flags[i])) {
+            fprintf(stderr, "모르는 키: %s\n", specs[i]);
+            return EXIT_USAGE;
+        }
+    }
+
+    for (long r = 0; r < repeat; r++) {
+        for (int i = 0; i < spec_count; i++) {
+            postKey(codes[i], flags[i]);
+            if (gap_ms > 0) usleep((useconds_t)gap_ms * 1000);
+        }
+    }
+    return 0;
+}

--- a/dist/stress/measure-input-latency.sh
+++ b/dist/stress/measure-input-latency.sh
@@ -24,16 +24,43 @@
 # 않는다.** 그러면 `completeInput` 이 불리지 않아 표본이 0 이다. 그래서 `a` 를 보내 에코가
 # 화면에 닿기까지를 재고, 끝에 Ctrl+C 로 입력 줄을 비운다.
 #
-# ## 어디서 도는가 — **Linux · Windows**
+# ## 어디서 도는가 — **Linux · macOS · Windows**
 #
-# 합성 입력이 platform 마다 다르다. Linux 는 `ydotool` (uinput), Windows 는 `SendInput`
-# ([`send-keys.ps1`](send-keys.ps1)) 이다. **macOS 는 아직 없다** — `CGEvent` 로 #387 이 이미
-# 쓴 경로를 옮겨오면 되지만 하지 않았다. 계측 자체 (`perf.input_latency`) 는 세 platform 에
-# 다 있다.
+# 합성 입력이 platform 마다 다르다. Linux 는 `ydotool` (uinput), macOS 는 `CGEvent`
+# ([`mac-input.m`](mac-input.m) — 스크립트가 `clang` 으로 그 자리에서 빌드한다), Windows 는
+# `SendInput` ([`send-keys.ps1`](send-keys.ps1)) 이다. 계측 자체 (`perf.input_latency`) 도
+# 세 platform 에 다 있다.
 #
 # **Windows 는 Git Bash 에서 돌린다** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은
 # 제약이다). PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있다 — #381 에서
 # 두 벌이 실제로 갈렸다.
+#
+# ## macOS 가 다른 네 가지
+#
+# 1. **합성 입력에 손쉬운 사용 (Accessibility) 권한이 필요하다.** 없으면 `CGEventPost` 가
+#    성공을 반환하면서 아무 일도 하지 않는다 — Linux 의 `ydotoold` 미기동과 같은 종류의
+#    *조용한 실패*다. `mac-input check` 로 **회차를 돌기 전에** 막는다.
+# 2. **창을 클릭해 key window 로 만든다** (#387 에서 통한 방법 — `osascript keystroke` 는
+#    Accessory mode 때문에 새어 나간다). 그 클릭까지 CGEvent 로 해서 사람 개입이 없다.
+#    클릭이 실패한 회차는 실제 렌더가 838 tick 중 19 회뿐이라 (활성 창은 264 회) 화면이
+#    사실상 멈춘 상태에서 잰 값이었다.
+# 3. **종료 키가 `Cmd+Q` 가 아니라 `Cmd+W` 다.** `Cmd+Q` 는 `applicationShouldTerminate` 가
+#    `count()==1` 을 보고 확인창을 띄워 앱이 안 닫힌다. `Cmd+W` 는 `closeTab` 이
+#    `orderedRemove` 로 탭을 **먼저 지운 뒤** terminate 라 `count()==0` → 확인창을 건너뛴다
+#    (`session_core.zig` · `host/macos.zig`). Linux 가 `Alt+F4` 대신 `Ctrl+Shift+W` 를 쓰는
+#    것과 같은 이유다.
+# 4. **한글 IME 에서도 표본이 다 잡힌다.** Linux 는 fcitx5 가 키를 가져가 표본이 0 이라 폐기
+#    장치에 저절로 걸리는데, macOS 는 `keyDown:` 이 우리 뷰에 먼저 오고 앱이
+#    `interpretKeyEvents:` 로 IME 에 넘기는 순서라 (`markInput()` 이 `tildazKeyDown` 첫 줄)
+#    한글에서도 그대로 세어진다. **값도 영문과 비슷하다** — 실측 (`a` × 10):
+#
+#      영문  표본 10 · 에코 10 B  · 평균 3.12 ms · 최악 4.11 ms
+#      한글  표본 10 · 에코 27 B  · 평균 4.33 ms · 최악 5.20 ms
+#
+#    한글도 PTY 왕복이 있다. 같은 자음을 연달아 치면 IME 가 음절을 확정해 흘려보내기
+#    때문이다 (`ㅁ` 9 개 = 27 B). 즉 **표본으로도 에코로도 못 거른다.** 재는 경로가 달라
+#    나란히 둘 수 없으므로, 폐기에 기대지 말고 **미리 영문으로 바꾸고** 잰다. Windows 가
+#    IME conversion mode 를 맞추는 것과 같은 취지다.
 set -u
 
 PRESSES=30
@@ -57,7 +84,8 @@ usage() {
   --mode <이름>   idle · flood · both (기본 both)
   --mb <N>        flood 모드의 폭포 분량 MiB (기본 2048)
   --gap <초>      키 사이 간격 (기본 0.2 — 각 키가 독립적으로 처리되도록)
-  --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음).
+  --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음). **Linux 전용** —
+                     macOS 는 CGEvent 로, Windows 는 SendInput 으로 직접 클릭한다.
                      표본이 부족하게 나오는 환경에서만 쓴다
   --retries <N>   폐기된 회차를 다시 돌릴 횟수 (기본 3)
   --ignore-hygiene  위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
@@ -82,10 +110,13 @@ REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 . "$REPO_ROOT/dist/stress/hygiene.sh"
 
 case "$HYG_PLATFORM" in
-    linux|windows) ;;
-    *) echo "이 스크립트는 Linux · Windows 전용이에요 ($(uname -s)) — macOS 는 합성 입력(CGEvent)이 아직 없어요." >&2
+    linux|macos|windows) ;;
+    *) echo "이 스크립트는 Linux · macOS · Windows 전용이에요 ($(uname -s))." >&2
        exit 2 ;;
 esac
+
+# macOS 도구는 간격을 ms 로 받는다 (`--gap`). 초 단위 옵션을 한 번만 환산해 둔다.
+GAP_MS=$(awk "BEGIN{printf \"%d\", $GAP * 1000}")
 
 # 자식이 Windows 실행파일이면 경로를 native 로 바꿔 넘긴다 (`measure-repeat.sh` 와 같은
 # 함수다). MSYS 는 명령줄 인자를 자동 변환하기도 하지만 기대지 않는다.
@@ -96,12 +127,20 @@ native_path() {
 EXE_SUFFIX=""
 [ "$HYG_PLATFORM" = windows ] && EXE_SUFFIX=".exe"
 EXE="$REPO_ROOT/zig-out/bin/tildaz$EXE_SUFFIX"
+# macOS 는 서명된 번들 안 바이너리를 먼저 본다 (`check-input-loss.sh` 와 같은 규칙). `-e` ·
+# `-size` 인자가 필요해서 `open` 이 아니라 직접 띄우는데, 전역 핫키를 안 쓰므로 권한이
+# 없어도 된다 (AGENTS.md 의 macOS `open` 절).
+if [ "$HYG_PLATFORM" = macos ] && [ -x "$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz" ]; then
+    EXE="$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz"
+fi
 STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress$EXE_SUFFIX"
 SENDKEYS="$REPO_ROOT/dist/stress/send-keys.ps1"
+MACINPUT_SRC="$REPO_ROOT/dist/stress/mac-input.m"
 
 # `paths.zig` 의 `logDir` 와 같은 규칙이다 (`measure-repeat.sh` 와 같은 표).
 case "$HYG_PLATFORM" in
     linux)   LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log" ;;
+    macos)   LOG="$HOME/Library/Logs/tildaz_stress.log" ;;
     windows) LOG="$(cygpath -u "$APPDATA")/tildaz/tildaz_stress.log" ;;
 esac
 
@@ -110,6 +149,9 @@ esac
 
 YDOTOOLD_PID=""
 IME_RESTORE=""
+MAC_INPUT=""
+MAC_INPUT_DIR=""
+IME_RESTORE_ID=""
 
 if [ "$HYG_PLATFORM" = linux ]; then
     command -v ydotool >/dev/null 2>&1 || { echo "ydotool 없음 — 합성 입력에 필요해요." >&2; exit 1; }
@@ -153,6 +195,29 @@ if [ "$HYG_PLATFORM" = linux ]; then
     else
         echo "  ⚠ fcitx5-remote 가 없어요 — 입력기가 한글이면 표본이 안 잡혀요. 영문인지 확인하세요." >&2
     fi
+elif [ "$HYG_PLATFORM" = macos ]; then
+    # `mac-input.m` 을 그 자리에서 컴파일한다. 저장소에 바이너리를 두지 않는 것은
+    # `dist/macos/color-capture.m` 과 같은 방식이다.
+    command -v clang >/dev/null 2>&1 || { echo "clang 없음 — Xcode Command Line Tools 가 필요해요." >&2; exit 1; }
+    [ -f "$MACINPUT_SRC" ] || { echo "mac-input.m 없음: $MACINPUT_SRC" >&2; exit 1; }
+    MAC_INPUT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tildaz-macinput-XXXXXX")
+    MAC_INPUT="$MAC_INPUT_DIR/mac-input"
+    clang -O2 -Wno-deprecated-declarations \
+          -framework ApplicationServices -framework Carbon \
+          -o "$MAC_INPUT" "$MACINPUT_SRC" || { echo "mac-input 컴파일 실패." >&2; exit 1; }
+
+    # **한글이어도 표본 · 에코가 다 차서 폐기 장치에 안 걸린다** (헤더 주석 ④). 재는 경로가
+    # 달라지는데 값은 그럴듯해서, 전환을 놓치면 모르고 결론을 낸다. 끝나면 되돌린다.
+    IME_BEFORE=$("$MAC_INPUT" ime-get 2>/dev/null || echo "")
+    if "$MAC_INPUT" ime-ascii; then
+        IME_AFTER=$("$MAC_INPUT" ime-get 2>/dev/null || echo "")
+        if [ -n "$IME_BEFORE" ] && [ "$IME_BEFORE" != "$IME_AFTER" ]; then
+            IME_RESTORE_ID="$IME_BEFORE"
+            echo "  입력기가 한글이라 영문으로 바꿨어요: $IME_BEFORE → $IME_AFTER (끝나면 되돌립니다)."
+        fi
+    else
+        echo "  ⚠ 영문 입력 소스로 못 바꿨어요 — 한글이면 재는 경로가 달라져요." >&2
+    fi
 else
     command -v powershell >/dev/null 2>&1 || { echo "powershell 없음 — SendInput 합성 입력에 필요해요." >&2; exit 1; }
     [ -f "$SENDKEYS" ] || { echo "send-keys.ps1 없음: $SENDKEYS" >&2; exit 1; }
@@ -163,6 +228,8 @@ cleanup() {
     [ -n "$APP" ] && kill "$APP" 2>/dev/null
     [ -n "$YDOTOOLD_PID" ] && kill "$YDOTOOLD_PID" 2>/dev/null
     [ -n "$IME_RESTORE" ] && fcitx5-remote -o >/dev/null 2>&1   # 원래대로 한글
+    [ -n "$IME_RESTORE_ID" ] && "$MAC_INPUT" ime-set "$IME_RESTORE_ID" >/dev/null 2>&1
+    [ -n "$MAC_INPUT_DIR" ] && rm -rf "$MAC_INPUT_DIR"
     hygiene_end
 }
 trap cleanup EXIT INT TERM
@@ -181,6 +248,12 @@ hygiene_check || {
 }
 hygiene_begin
 
+# `hygiene.sh` 는 macOS 주사율을 셸만으로 못 읽어서 `?` 로 둔다. **응답 시간에서는 이 값이
+# 결론을 바꾸므로** (프레임 주기가 지연의 하한이다) 우리가 컴파일해 둔 도구로 채운다.
+if [ "$HYG_PLATFORM" = macos ]; then
+    HYG_REFRESH=$("$MAC_INPUT" refresh 2>/dev/null || echo "?")
+fi
+
 # **키가 실제로 나가는지 먼저 확인한다.** 안 나가면 회차를 도는 의미가 없다.
 # 화면을 바꾸지 않는 modifier 한 번으로 왕복만 본다.
 #
@@ -188,15 +261,48 @@ hygiene_begin
 # 때만** 키를 보내므로 (사용자 창으로 새는 것을 막는 가드), 창이 뜨기 전에는 부를 대상이
 # 없다. 대신 그 스크립트가 창 없음 / 포커스 없음 / 전송 중단을 각각 다른 종료 코드로
 # 알려서 회차가 조용히 비는 일이 없다.
+#
+# macOS 는 키를 보내 보는 것으로는 판정이 안 된다 — 권한이 없어도 `CGEventPost` 가 성공을
+# 반환한다. 그래서 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 부른다
+# (`mac-input.m` 의 `requireTrusted`). 권한은 자식이 아니라 **부모 (터미널 앱)** 에 붙으므로
+# 판정과 전송이 같은 프로세스여야 답이 맞는다.
 if [ "$HYG_PLATFORM" = linux ]; then
     if ! ydotool key 42:1 42:0 >/dev/null 2>&1; then
         echo "ydotool 이 키를 보내지 못했어요 — 데몬 · /dev/uinput 권한을 확인하세요." >&2
         exit 1
     fi
+elif [ "$HYG_PLATFORM" = macos ]; then
+    "$MAC_INPUT" check || exit 1
 fi
 
 # evdev 키코드 — `a`=30 · LEFTCTRL=29 · LEFTSHIFT=42 · c=46 · w=17 · F12=88.
 send_keys() {
+    if [ "$HYG_PLATFORM" = macos ]; then
+        # **macOS 만 문자 키 앞뒤를 덤프로 감싼다.** 그러면 그 사이 구간의 `drain bytes` 가
+        # 곧 문자 키의 **에코량**이라 (`dumpAndReset` 이 읽으면서 리셋한다), *"키는 앱에
+        # 닿았는데 PTY 로는 안 간"* 회차를 아래 판정에서 거를 수 있다 — macOS 에서 실제로
+        # 겪은 실패다 (헤더 주석 참고. 표본은 다 차고 평균만 0.33 ms 로 그럴듯했다).
+        # 앞의 `Ctrl+C` 는 프롬프트를 먼저 새로 그려 그 출력까지 앞 구간으로 보낸다.
+        #
+        # Linux · Windows 로 넓히지 않은 이유는 **기대 표본이 바뀌기 때문**이다. 지금 두
+        # platform 은 `Ctrl+C` 의 modifier 까지 세어 `키 수 + 1` 이 정상인데, 이 배치에서는
+        # 정확히 `키 수` 가 된다. 이미 5 회씩 측정을 마친 값이 있어 (Linux · Windows 코멘트)
+        # 도구를 바꾸면 재측정이 필요하다 — 그 판단은 각 platform 머신에서 한다.
+        "$MAC_INPUT" send ctrl+c --gap 700 >/dev/null 2>&1        # 프롬프트를 새로 그린다
+        "$MAC_INPUT" send shift+cmd+f12 --gap 500 >/dev/null 2>&1 # 여기까지를 앞 구간으로 버린다
+        # 한 프로세스가 반복과 간격을 모두 처리한다 — 키마다 프로세스를 새로 띄우는
+        # 기동 시간이 `--gap` 을 지배하지 않도록 (Windows 가 `.ps1` 한 번으로 보내는 것과 같은 이유).
+        "$MAC_INPUT" send a --repeat "$PRESSES" --gap "$GAP_MS" || {
+            echo "⚠ mac-input 전송 실패 — 회차를 중단해요." >&2
+            return 1
+        }
+        sleep 0.5
+        "$MAC_INPUT" send shift+cmd+f12 --gap 600 >/dev/null 2>&1 # 측정 구간 덤프
+        "$MAC_INPUT" send ctrl+c --gap 300 >/dev/null 2>&1        # 입력 줄 비우기
+        "$MAC_INPUT" send cmd+w --gap 200 >/dev/null 2>&1         # 탭 닫기 = 앱 종료 (헤더 ③)
+        return 0
+    fi
+
     if [ "$HYG_PLATFORM" = windows ]; then
         # 한 회차의 키 순서를 **한 번의 호출로** 보낸다. 키마다 powershell 을 띄우면 그
         # 기동 시간이 `--gap` 을 지배한다. 실패 (창 없음 · 포커스 상실) 는 종료 코드로 온다.
@@ -320,9 +426,22 @@ run_one() {
     APP=$!
     sleep 4                     # 창 map + 폰트 init + (flood 면) 폭포 시작
 
-    # 합성 입력은 **포커스된 창** 으로만 간다. 다만 `-e` 로 띄운 새 창은 포커스를 자동으로
-    # 받는다 — 클릭한 회차와 클릭하지 않은 회차의 값이 idle 최악 12.30 / 12.33 ms 로 사실상
-    # 같았다 (실측). 그래서 **사람 개입 없이 돈다.**
+    # macOS 는 창을 클릭해 key window 로 만든다 (헤더 주석 ②). 그 클릭까지 CGEvent 로 하고
+    # 포인터를 원래 자리로 되돌리므로 사람 개입이 없다. Windows 의 포커스 회수 (client
+    # 한가운데 클릭) 와 같은 취지다.
+    if [ "$HYG_PLATFORM" = macos ]; then
+        "$MAC_INPUT" focus "$APP" || {
+            echo "⚠ 창을 클릭하지 못했어요 — 회차를 중단해요." >&2
+            kill "$APP" 2>/dev/null
+            [ -n "$RUNNER" ] && rm -f "$RUNNER"
+            return 1
+        }
+        sleep 0.5
+    fi
+
+    # 합성 입력은 **포커스된 창** 으로만 간다. 다만 Linux 에서 `-e` 로 띄운 새 창은 포커스를
+    # 자동으로 받는다 — 클릭한 회차와 클릭하지 않은 회차의 값이 idle 최악 12.30 / 12.33 ms 로
+    # 사실상 같았다 (실측). 그래서 **사람 개입 없이 돈다.**
     #
     # 한때 표본이 2~4 개로 나와 "포커스를 못 받는다" 고 봤지만, 그 회차들은 다른 원인이었다
     # (ydotool 데몬 미기동 · 측정 중 조작 · 덤프 회수 실패). 포커스가 진짜 문제인 환경이라면
@@ -357,20 +476,49 @@ run_one() {
     # **표본 수를 기대치와 대조한다.** 합성 입력은 *포커스된 창* 으로 가므로, 측정 중에
     # 창을 바꾸거나 마우스를 움직이면 키가 다른 앱으로 새고 표본만 적게 남는다. 그때도
     # 평균은 그럴듯한 값이 나와서 **모르고 결론을 내기 쉽다** (실측으로 겪었다).
-    VERDICT=$(awk -v mode="$MODE_NAME" -v want="$PRESSES" '
+    #
+    # 스냅숏 **블록 단위**로 보고 **표본이 가장 많은 블록 하나만** 쓴다. 종료 덤프 (#396) 와
+    # 섞이지 않고, macOS 처럼 덤프를 두 번 남기는 배치에서도 측정 구간만 잡힌다.
+    #
+    # 표본 부족의 사유가 platform 마다 다르다. **macOS 는 한글 입력기가 사유가 아니다** —
+    # 한글에서도 표본이 다 차기 때문이다 (헤더 주석 ④). 엉뚱한 곳을 보게 하지 않으려고 가른다.
+    case "$HYG_PLATFORM" in
+        macos) SHORT_HINT="창 포커스를 뺏겼거나 측정 중 조작이 있었어요" ;;
+        *)     SHORT_HINT="입력기가 한글이거나 측정 중 조작이 있었어요" ;;
+    esac
+    # 에코 검사는 문자 키를 덤프로 감싸는 macOS 회차에만 뜻이 있다 (`send_keys` 주석).
+    CHECK_ECHO=0
+    [ "$HYG_PLATFORM" = macos ] && [ "$MODE_NAME" = idle ] && CHECK_ECHO=1
+
+    VERDICT=$(awk -v mode="$MODE_NAME" -v want="$PRESSES" -v hint="$SHORT_HINT" -v check_echo="$CHECK_ECHO" '
+    /^=== snapshot/ { snap = 1; cur_drain = 0; next }
+    /^=== /         { snap = 0 }
+    /^drain / {
+        if (snap) for (i = 1; i <= NF; i++) if ($i ~ /^bytes=/) { split($i, a, "="); cur_drain = a[2] + 0 }
+    }
     /^input / {
+        if (!snap) next
+        smp = 0; tot = 0; mx = 0
         for (i = 1; i <= NF; i++) {
-            if ($i ~ /^samples=/)  { split($i, a, "="); s += a[2] }
-            else if ($i ~ /^ms=/)  { split($i, a, "="); t += a[2] }
-            else if ($i ~ /^max_ms=/) { split($i, a, "="); if (a[2] + 0 > m) m = a[2] + 0 }
+            if ($i ~ /^samples=/)     { split($i, a, "="); smp = a[2] + 0 }
+            else if ($i ~ /^ms=/)     { split($i, a, "="); tot = a[2] + 0 }
+            else if ($i ~ /^max_ms=/) { split($i, a, "="); mx = a[2] + 0 }
         }
+        if (smp > s) { s = smp; t = tot; m = mx; echoed = cur_drain }
+        snap = 0
     }
     END {
         if (s + 0 == 0) { printf "  %-6s  ❌ 표본 없음 — 키가 앱에 안 갔거나 화면이 안 바뀌었어요\n", mode; exit }
-        printf "  %-6s  표본 %3d / %d   평균 %6.2f ms   최악 %6.2f ms", mode, s, want, t / s, m
+        printf "  %-6s  표본 %3d / %d", mode, s, want
+        if (check_echo) printf "   에코 %4d B", echoed + 0
+        printf "   평균 %6.2f ms   최악 %6.2f ms", t / s, m
         # 8 할 미만이면 회차를 믿지 않는다 — 남은 표본으로 낸 평균은 그럴듯해 보이지만
         # 어떤 키가 빠졌는지 모르므로 대표성이 없다.
-        if (s < want * 0.8) printf "   ⚠ 표본 부족 — 입력기가 한글이거나 측정 중 조작이 있었어요 (회차 폐기)"
+        if (s < want * 0.8) printf "   ⚠ 표본 부족 — %s (회차 폐기)", hint
+        # **표본이 다 차도 안심할 수 없다.** 키가 앱에는 닿았지만 (표본 증가) PTY 로는 안 간
+        # 회차가 macOS 에서 실제로 있었다 — modifier 가 남은 채 `a` 가 나가 `Cmd+A` 로 읽힌
+        # 경우다. 화면에도 아무것도 안 찍혔는데 평균은 0.33 ms 로 그럴듯했다.
+        else if (check_echo && echoed + 0 < want * 0.8) printf "   ⚠ 에코 %d B — 키가 앱엔 닿았는데 PTY 로 안 갔어요 (회차 폐기)", echoed + 0
         printf "\n"
     }' "$RAW")
     rm -f "$RAW"
@@ -394,10 +542,17 @@ run_with_retry() {
     return 1
 }
 
+# macOS 만 문자 키를 덤프로 감싼다 (`send_keys` 주석 — 에코 검사를 만들기 위해서다).
+case "$HYG_PLATFORM" in
+    macos) KEY_SEQ="Ctrl+C → Shift+Cmd+F12 → 'a' × ${PRESSES} (간격 ${GAP}s) → Shift+Cmd+F12 → Ctrl+C → Cmd+W" ;;
+    *)     KEY_SEQ="'a' × ${PRESSES} (간격 ${GAP}s) → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W" ;;
+esac
+
 cat <<EOF
 
 ============ 응답 시간 측정 (#441 축 ②) ============
- 키        : 'a' × ${PRESSES} (간격 ${GAP}s) → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W
+ platform  : $HYG_PLATFORM
+ 키        : $KEY_SEQ
  모드      : $MODE
  재는 구간 : 키 수신 → 그 뒤 첫 present 완료
              (PTY write · 셸 에코 · parse · render 포함)

--- a/dist/stress/measure-input-latency.sh
+++ b/dist/stress/measure-input-latency.sh
@@ -24,8 +24,16 @@
 # 않는다.** 그러면 `completeInput` 이 불리지 않아 표본이 0 이다. 그래서 `a` 를 보내 에코가
 # 화면에 닿기까지를 재고, 끝에 Ctrl+C 로 입력 줄을 비운다.
 #
-# **Linux 전용이다.** 합성 입력이 platform 마다 다르다 — Windows 는 `SendInput`, macOS 는
-# `CGEvent` 로 #387 이 이미 썼으니 그 경로를 옮겨오면 되지만 아직 하지 않았다.
+# ## 어디서 도는가 — **Linux · Windows**
+#
+# 합성 입력이 platform 마다 다르다. Linux 는 `ydotool` (uinput), Windows 는 `SendInput`
+# ([`send-keys.ps1`](send-keys.ps1)) 이다. **macOS 는 아직 없다** — `CGEvent` 로 #387 이 이미
+# 쓴 경로를 옮겨오면 되지만 하지 않았다. 계측 자체 (`perf.input_latency`) 는 세 platform 에
+# 다 있다.
+#
+# **Windows 는 Git Bash 에서 돌린다** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은
+# 제약이다). PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있다 — #381 에서
+# 두 벌이 실제로 갈렸다.
 set -u
 
 PRESSES=30
@@ -39,6 +47,7 @@ SCROLLBACK=32767
 FOCUS_WAIT=0
 # 표본 부족(포커스 실패)으로 폐기된 회차를 몇 번까지 다시 돌릴지.
 RETRIES=3
+IGNORE_HYGIENE=0
 
 usage() {
     cat <<'USAGE'
@@ -51,6 +60,7 @@ usage() {
   --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음).
                      표본이 부족하게 나오는 환경에서만 쓴다
   --retries <N>   폐기된 회차를 다시 돌릴 횟수 (기본 3)
+  --ignore-hygiene  위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
 USAGE
 }
 
@@ -62,6 +72,7 @@ while [ $# -gt 0 ]; do
         --gap) GAP="$2"; shift 2 ;;
         --focus-wait) FOCUS_WAIT="$2"; shift 2 ;;
         --retries) RETRIES="$2"; shift 2 ;;
+        --ignore-hygiene) IGNORE_HYGIENE=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -70,56 +81,81 @@ done
 REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 . "$REPO_ROOT/dist/stress/hygiene.sh"
 
-[ "$HYG_PLATFORM" = linux ] || {
-    echo "이 스크립트는 Linux 전용이에요 ($(uname -s)) — 합성 입력이 platform 마다 달라요." >&2
-    exit 2
+case "$HYG_PLATFORM" in
+    linux|windows) ;;
+    *) echo "이 스크립트는 Linux · Windows 전용이에요 ($(uname -s)) — macOS 는 합성 입력(CGEvent)이 아직 없어요." >&2
+       exit 2 ;;
+esac
+
+# 자식이 Windows 실행파일이면 경로를 native 로 바꿔 넘긴다 (`measure-repeat.sh` 와 같은
+# 함수다). MSYS 는 명령줄 인자를 자동 변환하기도 하지만 기대지 않는다.
+native_path() {
+    if [ "$HYG_PLATFORM" = windows ]; then cygpath -w "$1"; else printf '%s' "$1"; fi
 }
 
-EXE="$REPO_ROOT/zig-out/bin/tildaz"
-STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress"
-LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log"
+EXE_SUFFIX=""
+[ "$HYG_PLATFORM" = windows ] && EXE_SUFFIX=".exe"
+EXE="$REPO_ROOT/zig-out/bin/tildaz$EXE_SUFFIX"
+STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress$EXE_SUFFIX"
+SENDKEYS="$REPO_ROOT/dist/stress/send-keys.ps1"
+
+# `paths.zig` 의 `logDir` 와 같은 규칙이다 (`measure-repeat.sh` 와 같은 표).
+case "$HYG_PLATFORM" in
+    linux)   LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log" ;;
+    windows) LOG="$(cygpath -u "$APPDATA")/tildaz/tildaz_stress.log" ;;
+esac
 
 [ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
 [ -x "$STRESS" ] || { echo "tildaz-stress 없음: $STRESS  (먼저 zig build stress)" >&2; exit 1; }
-command -v ydotool >/dev/null 2>&1 || { echo "ydotool 없음 — 합성 입력에 필요해요." >&2; exit 1; }
 
-# `wtype` 은 KWin 이 `zwp_virtual_keyboard_v1` 을 지원하지 않아 쓸 수 없다 (#441 실측).
-# `ydotool` 은 uinput 경로라 compositor 를 안 가린다. 대신 데몬과 `/dev/uinput` 접근이 필요하다.
-SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/.ydotool_socket"
 YDOTOOLD_PID=""
-# **소켓 파일의 존재로 데몬을 판정하면 안 된다.** 데몬이 죽어도 소켓 파일은 남고, 그러면
-# "이미 떠 있다" 로 잘못 보고 데몬을 안 띄운다 → 모든 `ydotool` 호출이 조용히 실패해서
-# **키가 하나도 안 나간 채 회차가 끝난다** (실측으로 겪었다). 프로세스로 판정한다.
-if ! pgrep -x ydotoold >/dev/null 2>&1; then
-    command -v ydotoold >/dev/null 2>&1 || { echo "ydotoold 없음 — ydotool 데몬이 필요해요." >&2; exit 1; }
-    [ -w /dev/uinput ] || {
-        echo "/dev/uinput 에 쓸 수 없어요. ACL (setfacl -m u:$USER:rw /dev/uinput) 이나" >&2
-        echo "input 그룹 가입이 필요해요." >&2
-        exit 1
-    }
-    rm -f "$SOCK"          # stale 소켓 정리 — 남아 있으면 데몬이 바인딩에 실패한다
-    ydotoold >/dev/null 2>&1 &
-    YDOTOOLD_PID=$!
-    sleep 2
-    [ -S "$SOCK" ] || { echo "ydotoold 소켓이 안 생겼어요: $SOCK" >&2; exit 1; }
-fi
-
-# **입력기가 한글이면 측정이 성립하지 않는다.** 우리가 보내는 것은 문자 키 `a` 인데,
-# 한글 모드에서는 IME 가 그것을 조합용으로 가져가 (`ㅁ` 이 찍힌다) 앱의 키 핸들러를
-# 타지 않는다 → `markInput()` 이 안 불려 표본이 잡히지 않는다. 실측에서 폐기된 회차가
-# 전부 이것이었다 (포커스 문제로 오해했다).
-#
-# **단축키는 다르다** — `Ctrl+Shift+F12` 는 한글 모드에서도 앱에 도달한다 (#465).
-# 그래서 "IME 는 단축키에 영향이 없다" 는 사실과 여기 제약은 서로 모순이 아니다.
 IME_RESTORE=""
-if command -v fcitx5-remote >/dev/null 2>&1; then
-    if [ "$(fcitx5-remote 2>/dev/null)" = "2" ]; then
-        fcitx5-remote -c >/dev/null 2>&1      # deactivate = 영문
-        IME_RESTORE=1
-        echo "  입력기가 한글이라 영문으로 바꿨어요 (측정이 끝나면 되돌립니다)."
+
+if [ "$HYG_PLATFORM" = linux ]; then
+    command -v ydotool >/dev/null 2>&1 || { echo "ydotool 없음 — 합성 입력에 필요해요." >&2; exit 1; }
+
+    # `wtype` 은 KWin 이 `zwp_virtual_keyboard_v1` 을 지원하지 않아 쓸 수 없다 (#441 실측).
+    # `ydotool` 은 uinput 경로라 compositor 를 안 가린다. 대신 데몬과 `/dev/uinput` 접근이 필요하다.
+    SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/.ydotool_socket"
+    # **소켓 파일의 존재로 데몬을 판정하면 안 된다.** 데몬이 죽어도 소켓 파일은 남고, 그러면
+    # "이미 떠 있다" 로 잘못 보고 데몬을 안 띄운다 → 모든 `ydotool` 호출이 조용히 실패해서
+    # **키가 하나도 안 나간 채 회차가 끝난다** (실측으로 겪었다). 프로세스로 판정한다.
+    if ! pgrep -x ydotoold >/dev/null 2>&1; then
+        command -v ydotoold >/dev/null 2>&1 || { echo "ydotoold 없음 — ydotool 데몬이 필요해요." >&2; exit 1; }
+        [ -w /dev/uinput ] || {
+            echo "/dev/uinput 에 쓸 수 없어요. ACL (setfacl -m u:$USER:rw /dev/uinput) 이나" >&2
+            echo "input 그룹 가입이 필요해요." >&2
+            exit 1
+        }
+        rm -f "$SOCK"          # stale 소켓 정리 — 남아 있으면 데몬이 바인딩에 실패한다
+        ydotoold >/dev/null 2>&1 &
+        YDOTOOLD_PID=$!
+        sleep 2
+        [ -S "$SOCK" ] || { echo "ydotoold 소켓이 안 생겼어요: $SOCK" >&2; exit 1; }
+    fi
+
+    # **입력기가 한글이면 측정이 성립하지 않는다.** 우리가 보내는 것은 문자 키 `a` 인데,
+    # 한글 모드에서는 IME 가 그것을 조합용으로 가져가 (`ㅁ` 이 찍힌다) 앱의 키 핸들러를
+    # 타지 않는다 → `markInput()` 이 안 불려 표본이 잡히지 않는다. 실측에서 폐기된 회차가
+    # 전부 이것이었다 (포커스 문제로 오해했다).
+    #
+    # **단축키는 다르다** — `Ctrl+Shift+F12` 는 한글 모드에서도 앱에 도달한다 (#465).
+    # 그래서 "IME 는 단축키에 영향이 없다" 는 사실과 여기 제약은 서로 모순이 아니다.
+    #
+    # Windows 는 이 자리가 없다 — 한/영이 keyboard layout 이 아니라 **창별 IME conversion
+    # mode** 라서, 측정 창이 뜬 뒤에 `send-keys.ps1` 이 그 창을 상대로 처리한다.
+    if command -v fcitx5-remote >/dev/null 2>&1; then
+        if [ "$(fcitx5-remote 2>/dev/null)" = "2" ]; then
+            fcitx5-remote -c >/dev/null 2>&1      # deactivate = 영문
+            IME_RESTORE=1
+            echo "  입력기가 한글이라 영문으로 바꿨어요 (측정이 끝나면 되돌립니다)."
+        fi
+    else
+        echo "  ⚠ fcitx5-remote 가 없어요 — 입력기가 한글이면 표본이 안 잡혀요. 영문인지 확인하세요." >&2
     fi
 else
-    echo "  ⚠ fcitx5-remote 가 없어요 — 입력기가 한글이면 표본이 안 잡혀요. 영문인지 확인하세요." >&2
+    command -v powershell >/dev/null 2>&1 || { echo "powershell 없음 — SendInput 합성 입력에 필요해요." >&2; exit 1; }
+    [ -f "$SENDKEYS" ] || { echo "send-keys.ps1 없음: $SENDKEYS" >&2; exit 1; }
 fi
 
 APP=""
@@ -127,18 +163,51 @@ cleanup() {
     [ -n "$APP" ] && kill "$APP" 2>/dev/null
     [ -n "$YDOTOOLD_PID" ] && kill "$YDOTOOLD_PID" 2>/dev/null
     [ -n "$IME_RESTORE" ] && fcitx5-remote -o >/dev/null 2>&1   # 원래대로 한글
+    hygiene_end
 }
 trap cleanup EXIT INT TERM
 
+# --- 측정 위생 --------------------------------------------------------------
+#
+# `measure-repeat.sh` 와 같은 로직이다 — worker · AC · 주사율 · CPU 프로파일을 보고,
+# 절전 차단 · 성능 프로파일 · 배경 앱 최소화를 걸고 끝나면 되돌린다. **배경 앱이 그리고
+# 있으면 우리 수치만 눌리고** (README "배경 앱" 절), Windows 는 DRR 이 켜져 있으면 회차가
+# 두 무리로 갈린다 — 응답 시간도 같은 오염을 받는다.
+hygiene_check || {
+    [ "$IGNORE_HYGIENE" = 1 ] || {
+        echo "측정 위생 점검에 걸렸어요. 고치거나 --ignore-hygiene 로 강행해요." >&2
+        exit 1
+    }
+}
+hygiene_begin
+
 # **키가 실제로 나가는지 먼저 확인한다.** 안 나가면 회차를 도는 의미가 없다.
 # 화면을 바꾸지 않는 modifier 한 번으로 왕복만 본다.
-if ! ydotool key 42:1 42:0 >/dev/null 2>&1; then
-    echo "ydotool 이 키를 보내지 못했어요 — 데몬 · /dev/uinput 권한을 확인하세요." >&2
-    exit 1
+#
+# Windows 에는 이 사전 확인이 없다 — `send-keys.ps1` 은 **측정 창을 찾고 그 창이 활성일
+# 때만** 키를 보내므로 (사용자 창으로 새는 것을 막는 가드), 창이 뜨기 전에는 부를 대상이
+# 없다. 대신 그 스크립트가 창 없음 / 포커스 없음 / 전송 중단을 각각 다른 종료 코드로
+# 알려서 회차가 조용히 비는 일이 없다.
+if [ "$HYG_PLATFORM" = linux ]; then
+    if ! ydotool key 42:1 42:0 >/dev/null 2>&1; then
+        echo "ydotool 이 키를 보내지 못했어요 — 데몬 · /dev/uinput 권한을 확인하세요." >&2
+        exit 1
+    fi
 fi
 
 # evdev 키코드 — `a`=30 · LEFTCTRL=29 · LEFTSHIFT=42 · c=46 · w=17 · F12=88.
 send_keys() {
+    if [ "$HYG_PLATFORM" = windows ]; then
+        # 한 회차의 키 순서를 **한 번의 호출로** 보낸다. 키마다 powershell 을 띄우면 그
+        # 기동 시간이 `--gap` 을 지배한다. 실패 (창 없음 · 포커스 상실) 는 종료 코드로 온다.
+        powershell -NoProfile -ExecutionPolicy Bypass -File "$(native_path "$SENDKEYS")" \
+            -Presses "$PRESSES" -GapSec "$GAP" || {
+            echo "⚠ 합성 입력이 실패했어요 — 회차를 중단해요." >&2
+            return 1
+        }
+        return 0
+    fi
+
     i=1
     while [ "$i" -le "$PRESSES" ]; do
         # 첫 키는 실패를 삼키지 않는다 — 조용히 실패하면 표본 0 인 회차가 그대로 끝난다.
@@ -183,7 +252,32 @@ wait_app() {
 
 # `-e` 로 띄워야 stress role 이 되고, 그래야 종료 시 자동 덤프가 남는다 (#396 `dumpOnExit`).
 # idle 모드도 러너를 쓰는 이유가 이것이다 — producer 없이 셸만 올린다.
+#
+# `RUNNER` 는 지울 임시 파일 (없으면 빈 문자열), `RUN_CMD` 는 `-e` 에 넘길 값이다.
+# **Windows 의 `-e` 는 인자를 받는다** — POSIX 는 PTY 자식의 argv 가 고정이라 실행파일
+# 하나뿐이지만 (`run_options.zig`), Windows 는 `CreateProcessW` 의 `lpCommandLine` 이라
+# `cmd.exe /c <배치>` 가 그대로 선다.
 make_runner() {
+    if [ "$HYG_PLATFORM" = windows ]; then
+        if [ "$1" = flood ]; then
+            # Windows 의 TEMP 아래에 만든다 — Git Bash 의 `/tmp` 는 설치 경로 안이라
+            # (`C:\Program Files\Git\tmp`) 공백이 섞이고, 그러면 `cmd /c "…"` 인용이 갈린다.
+            RUNNER=$(TMPDIR="$(cygpath -u "$TEMP")" mktemp "$(cygpath -u "$TEMP")/tildaz-latency-XXXXXX.cmd")
+            # producer 를 배경으로 돌리고 같은 ConPTY 에 셸을 올린다 (Linux 러너와 같은 배치).
+            # `start /b` 라 새 콘솔 창이 생기지 않고 출력이 이 PTY 로 온다.
+            cat > "$RUNNER" <<EOF
+@echo off
+start "" /b "$(native_path "$STRESS")"
+"%COMSPEC%"
+EOF
+            RUN_CMD="cmd.exe /c \"$(native_path "$RUNNER")\""
+        else
+            RUNNER=""
+            RUN_CMD="cmd.exe"
+        fi
+        return 0
+    fi
+
     RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-latency-XXXXXX.sh")
     if [ "$1" = flood ]; then
         cat > "$RUNNER" <<EOF
@@ -201,16 +295,28 @@ exec "${SHELL:-/bin/bash}"
 EOF
     fi
     chmod +x "$RUNNER"
+    RUN_CMD="$RUNNER"
 }
 
 run_one() {
     MODE_NAME="$1"
     make_runner "$MODE_NAME"
 
+    # producer 파라미터는 환경변수로 간다 (`stress.zig`). Linux 는 러너 안에서 export
+    # 하지만 Windows 배치에서 같은 일을 하면 인용이 한 겹 더 붙으므로, **앱 프로세스의
+    # 환경**에 실어 자식까지 물려준다. 두 platform 다 producer 가 같은 값을 받는다.
+    if [ "$MODE_NAME" = flood ] && [ "$HYG_PLATFORM" = windows ]; then
+        TILDAZ_STRESS_WORKLOAD=plain
+        TILDAZ_STRESS_BYTES=$((MB * 1024 * 1024))
+        export TILDAZ_STRESS_WORKLOAD TILDAZ_STRESS_BYTES
+    else
+        unset TILDAZ_STRESS_WORKLOAD TILDAZ_STRESS_BYTES 2>/dev/null || true
+    fi
+
     START_LEN=0
     [ -f "$LOG" ] && START_LEN=$(wc -c < "$LOG" | tr -d ' ')
 
-    "$EXE" -e "$RUNNER" -size 120x40 -scrollback "$SCROLLBACK" >/dev/null 2>&1 &
+    "$EXE" -e "$RUN_CMD" -size 120x40 -scrollback "$SCROLLBACK" >/dev/null 2>&1 &
     APP=$!
     sleep 4                     # 창 map + 폰트 init + (flood 면) 폭포 시작
 
@@ -235,10 +341,10 @@ run_one() {
         printf '\r     키 전송 시작.     \n'
     fi
 
-    send_keys || { kill "$APP" 2>/dev/null; rm -f "$RUNNER"; return 1; }
+    send_keys || { kill "$APP" 2>/dev/null; [ -n "$RUNNER" ] && rm -f "$RUNNER"; return 1; }
     wait_app
     APP=""
-    rm -f "$RUNNER"
+    [ -n "$RUNNER" ] && rm -f "$RUNNER"
 
     RAW=$(mktemp "${TMPDIR:-/tmp}/tildaz-latency-log-XXXXXX")
     if [ "$START_LEN" -gt 0 ]; then
@@ -295,6 +401,7 @@ cat <<EOF
  모드      : $MODE
  재는 구간 : 키 수신 → 그 뒤 첫 present 완료
              (PTY write · 셸 에코 · parse · render 포함)
+ 환경      : $(hygiene_status)
 ====================================================
 
 ⚠ 합성 입력은 **포커스된 창**으로 갑니다. 회차마다 새 창이 뜨면 포커스만 확인하고,

--- a/dist/stress/send-keys.ps1
+++ b/dist/stress/send-keys.ps1
@@ -1,0 +1,376 @@
+﻿# 응답 시간 측정 (#441 축 ②) 의 **Windows 합성 입력** — Linux 판의 `ydotool` 자리다.
+#
+# `measure-input-latency.sh` 가 Windows 회차에서 이 파일을 한 번 부르고, 이 스크립트가
+# **한 회차의 키 순서를 통째로** 보낸다 (`a` × N → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W).
+# 키마다 `powershell` 을 새로 띄우면 그 기동 시간 (수백 ms) 이 키 간격을 지배해서
+# `--gap` 이 의미를 잃는다.
+#
+# ## 왜 `SendInput` 인가
+#
+# `keybd_event` 는 Microsoft 가 대체를 권고한 예전 API 이고, `SendKeys` (WScript.Shell) 는
+# **포커스된 창에 blind 로** 넣는 방식이라 아래 포커스 가드를 걸 수 없다. `SendInput` 은
+# 큐에 원자적으로 넣고 실패를 반환값으로 알려 준다.
+#
+# ## 포커스 가드 — 이게 없으면 사용자 창에 타이핑된다
+#
+# 합성 입력은 **포커스된 창**으로 간다. 예전 Windows 시연에서 `SetForegroundWindow` 가
+# 간헐적으로 거부됐고, 그때 키가 그대로 **사용자가 보고 있던 창**에 들어갔다 (Claude Code
+# 프롬프트에 명령이 타이핑됐다). 그래서 **키 하나마다** `GetForegroundWindow()` 를 확인하고,
+# 어긋나면 그 자리에서 회차를 실패로 끝낸다 — blind 로 계속 치지 않는다.
+#
+# 그리고 **`SetForegroundWindow` 하나로는 부족하다.** 이 도구 첫 측정에서 Windows 알림 토스트
+# (`Windows.UI.Core.CoreWindow` · "새 알림") 가 foreground 를 쥐고 있어 회차가 세 번 연속
+# 폐기됐다 — 앱은 정상으로 떴는데 **활성이 못 됐다.** 거부되면 창 안쪽 (client 한가운데) 을
+# 실제로 클릭해 회수한다. 사용자가 하는 것과 같은 행위라 foreground lock 이 걸리지 않는다.
+#
+# ## 이 파일은 UTF-8 **BOM** 으로 저장한다
+#
+# Windows PowerShell 5.1 은 BOM 이 없으면 `.ps1` 을 ANSI (한국어 Windows 는 CP949) 로 읽어
+# 주석의 한글이 깨진다. 편집 후 BOM 이 남아 있는지 확인한다.
+
+param(
+    # 보낼 문자 키 횟수.
+    [int]$Presses = 30,
+    # 키 사이 간격 (초). 각 키가 독립적으로 처리되도록 넉넉히 둔다.
+    [double]$GapSec = 0.2,
+    # 측정 인스턴스의 창. `instances.zig` 의 `stress_window_title` 과 `window.zig` 의
+    # class 이름이다. **둘 다 준다** — class 를 쓰는 창이 둘이라 (숨겨진 owner 창 =
+    # `TildaZOwner`, 실제 창 = 아래 title) class 만 주면 owner 를 집는다.
+    [string]$WindowTitle = 'TildaZ-stress',
+    [string]$WindowClass = 'TildaZWindow',
+    # 한글 입력 상태에서 문자 키가 어떻게 되는지 보려는 회차. 기본은 영문으로 맞춘다.
+    [switch]$KeepImeMode,
+    # 마지막 종료 키 (Ctrl+Shift+W) 를 보내지 않는다 — 창을 남겨 두고 확인할 때.
+    [switch]$NoQuit
+)
+
+$ErrorActionPreference = 'Stop'
+# Git Bash 로 돌려보내는 출력은 UTF-8 이어야 한다 (PowerShell 5.1 의 기본은 CP949).
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+
+if ([IntPtr]::Size -ne 8) {
+    Write-Error '32 비트 PowerShell 이에요 — 아래 INPUT 구조체 배치가 64 비트 기준이에요.'
+    exit 2
+}
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class TzInput
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MOUSEINPUT
+    {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    // x64 의 INPUT 은 union 정렬 때문에 type(4) 뒤 4 byte 가 비고 전체가 40 byte 다.
+    [StructLayout(LayoutKind.Explicit, Size = 40)]
+    public struct INPUT
+    {
+        [FieldOffset(0)] public uint type;
+        [FieldOffset(8)] public KEYBDINPUT ki;
+        [FieldOffset(8)] public MOUSEINPUT mi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int left; public int top; public int right; public int bottom; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT { public int x; public int y; }
+
+    public const uint INPUT_MOUSE = 0;
+    public const uint INPUT_KEYBOARD = 1;
+    public const uint KEYEVENTF_KEYUP = 0x0002;
+    public const uint MOUSEEVENTF_MOVE = 0x0001;
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP = 0x0004;
+    public const uint MOUSEEVENTF_VIRTUALDESK = 0x4000;
+    public const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [DllImport("user32.dll")]
+    public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern IntPtr FindWindowW(string lpClassName, string lpWindowName);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool GetClientRect(IntPtr hWnd, out RECT r);
+
+    [DllImport("user32.dll")]
+    public static extern bool ClientToScreen(IntPtr hWnd, ref POINT p);
+
+    [DllImport("user32.dll")]
+    public static extern int GetSystemMetrics(int index);
+
+    [DllImport("user32.dll")]
+    public static extern bool GetCursorPos(out POINT p);
+
+    [DllImport("imm32.dll")]
+    public static extern IntPtr ImmGetDefaultIMEWnd(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern IntPtr SendMessageTimeoutW(
+        IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam,
+        uint flags, uint timeout, out IntPtr result);
+
+    // 화면 좌표를 눌렀다 뗀다 (포커스 회수용). 좌표는 가상 데스크톱 기준 0..65535 정규화다.
+    public static uint ClickScreen(int x, int y)
+    {
+        uint move = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK;
+        int nx, ny;
+        Normalize(x, y, out nx, out ny);
+        INPUT[] inputs = new INPUT[] {
+            Mouse(nx, ny, move),
+            Mouse(nx, ny, move | MOUSEEVENTF_LEFTDOWN),
+            Mouse(nx, ny, move | MOUSEEVENTF_LEFTUP),
+        };
+        return SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    // **커서를 되돌릴 때는 옮기기만 한다.** 클릭으로 되돌리면 원래 자리에 있던 창 (사용자의
+    // 창일 수 있다) 을 실제로 누르게 된다.
+    public static uint MoveScreen(int x, int y)
+    {
+        int nx, ny;
+        Normalize(x, y, out nx, out ny);
+        INPUT[] inputs = new INPUT[] {
+            Mouse(nx, ny, MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK),
+        };
+        return SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    private static void Normalize(int x, int y, out int nx, out int ny)
+    {
+        int vx = GetSystemMetrics(76); // SM_XVIRTUALSCREEN
+        int vy = GetSystemMetrics(77); // SM_YVIRTUALSCREEN
+        int vw = GetSystemMetrics(78); // SM_CXVIRTUALSCREEN
+        int vh = GetSystemMetrics(79); // SM_CYVIRTUALSCREEN
+        nx = (int)(((long)(x - vx) * 65535) / (vw > 1 ? vw - 1 : 1));
+        ny = (int)(((long)(y - vy) * 65535) / (vh > 1 ? vh - 1 : 1));
+    }
+
+    private static INPUT Mouse(int nx, int ny, uint flags)
+    {
+        INPUT i = new INPUT();
+        i.type = INPUT_MOUSE;
+        i.mi.dx = nx;
+        i.mi.dy = ny;
+        i.mi.mouseData = 0;
+        i.mi.dwFlags = flags;
+        i.mi.time = 0;
+        i.mi.dwExtraInfo = IntPtr.Zero;
+        return i;
+    }
+
+    // 키 하나를 눌렀다 뗀다. 여러 키를 겹쳐 눌러야 하는 chord 는 downs / ups 로 겹쳐 준다.
+    public static uint Send(ushort[] downs, ushort[] ups)
+    {
+        INPUT[] inputs = new INPUT[downs.Length + ups.Length];
+        int n = 0;
+        foreach (ushort vk in downs) inputs[n++] = One(vk, 0);
+        foreach (ushort vk in ups) inputs[n++] = One(vk, KEYEVENTF_KEYUP);
+        return SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    // `wScan` 을 반드시 채운다. scan code 가 0 이면 `TranslateMessage` 의 `ToUnicode` 가
+    // 문자를 못 만들어 **WM_CHAR 가 안 오고**, 그러면 셸 에코가 없어 이 측정이 성립하지
+    // 않는다 (재는 구간이 "키 → 에코가 화면에 닿기까지" 이므로).
+    private static INPUT One(ushort vk, uint flags)
+    {
+        INPUT i = new INPUT();
+        i.type = INPUT_KEYBOARD;
+        i.ki.wVk = vk;
+        i.ki.wScan = (ushort)MapVirtualKeyW(vk, 0); // MAPVK_VK_TO_VSC
+        i.ki.dwFlags = flags;
+        i.ki.time = 0;
+        i.ki.dwExtraInfo = IntPtr.Zero;
+        return i;
+    }
+}
+'@
+
+$VK = @{
+    a = 0x41; c = 0x43; w = 0x57; F12 = 0x7B
+    Ctrl = 0x11; Shift = 0x10
+}
+
+# --- 창 찾기 ---------------------------------------------------------------
+$hwnd = [TzInput]::FindWindowW($WindowClass, $WindowTitle)
+if ($hwnd -eq [IntPtr]::Zero) {
+    Write-Output "  ❌ 측정 창을 못 찾았어요 (class=$WindowClass title=$WindowTitle)"
+    exit 3
+}
+
+# --- 포커스 가드 -----------------------------------------------------------
+#
+# **`SetForegroundWindow` 만으로는 부족하다.** Windows 는 *지금 foreground 를 가진
+# 프로세스* 가 아니면 이 호출을 조용히 거부한다 (foreground lock). 실측에서 알림 토스트
+# (`Windows.UI.Core.CoreWindow` · "새 알림") 가 foreground 를 쥐고 있어 회차가 세 번
+# 연속으로 폐기됐다 — 측정 창은 그때 **뜨지도 못한 게 아니라 활성이 못 된 것**이었다.
+#
+# 그래서 거부되면 **창 안쪽을 실제로 클릭한다.** 사용자가 하는 것과 같은 행위라 foreground
+# lock 이 적용되지 않고, Linux 판의 `--focus-wait` (사람이 클릭할 시간을 준다) 와 같은 자리다.
+# 클릭 지점은 **client 영역 한가운데**다 — 위쪽 탭바 / 우측 컨트롤 (`[+][×][…]`) · scrollbar 를
+# 피해야 버튼이 눌리지 않는다. 커서 위치는 클릭 전 자리로 되돌린다.
+function Get-ClientCenter {
+    # 중첩 타입은 `외부+내부` 이고, PowerShell 에서는 **따옴표로 감싸야** 파서가 `+` 를
+    # 연산자로 읽지 않는다.
+    $r = New-Object -TypeName 'TzInput+RECT'
+    if (-not [TzInput]::GetClientRect($script:hwnd, [ref]$r)) { return $null }
+    $p = New-Object -TypeName 'TzInput+POINT'
+    $p.x = [int](($r.right - $r.left) / 2)
+    $p.y = [int](($r.bottom - $r.top) / 2)
+    if (-not [TzInput]::ClientToScreen($script:hwnd, [ref]$p)) { return $null }
+    return $p
+}
+
+function Assert-Focus {
+    param([switch]$Recover)
+    if ([TzInput]::GetForegroundWindow() -eq $script:hwnd) { return $true }
+    if (-not $Recover) { return $false }
+
+    [void][TzInput]::SetForegroundWindow($script:hwnd)
+    Start-Sleep -Milliseconds 300
+    if ([TzInput]::GetForegroundWindow() -eq $script:hwnd) { return $true }
+
+    $center = Get-ClientCenter
+    if ($null -eq $center) { return $false }
+    $before = New-Object -TypeName 'TzInput+POINT'
+    $have_cursor = [TzInput]::GetCursorPos([ref]$before)
+    [void][TzInput]::ClickScreen($center.x, $center.y)
+    Start-Sleep -Milliseconds 300
+    $ok = ([TzInput]::GetForegroundWindow() -eq $script:hwnd)
+    if ($ok) { $script:focus_clicked = $true }
+    if ($have_cursor) { [void][TzInput]::MoveScreen($before.x, $before.y) }
+    return $ok
+}
+
+$focus_clicked = $false
+if (-not (Assert-Focus -Recover)) {
+    Write-Output '  ❌ 측정 창이 활성이 아니에요 — 키를 보내지 않았어요 (사용자 창으로 샐 수 있어요)'
+    exit 4
+}
+
+# --- IME 상태 --------------------------------------------------------------
+#
+# Windows 의 한/영 은 keyboard layout 이 아니라 **IME conversion mode** 라서, 다른
+# 프로세스의 창이라도 그 창의 default IME 창에 `WM_IME_CONTROL` 을 보내 읽고 쓸 수 있다.
+# (`ImmGetConversionStatus` 는 호출 스레드의 IME context 를 보므로 여기서는 못 쓴다.)
+$WM_IME_CONTROL = 0x0283
+$IMC_GETCONVERSIONMODE = 0x0001
+$IMC_SETCONVERSIONMODE = 0x0002
+$IME_CMODE_NATIVE = 0x0001
+$SMTO_ABORTIFHUNG = 0x0002
+
+function Get-ImeMode {
+    $ime = [TzInput]::ImmGetDefaultIMEWnd($script:hwnd)
+    if ($ime -eq [IntPtr]::Zero) { return $null }
+    $res = [IntPtr]::Zero
+    $ok = [TzInput]::SendMessageTimeoutW($ime, $WM_IME_CONTROL,
+        [IntPtr]$IMC_GETCONVERSIONMODE, [IntPtr]::Zero, $SMTO_ABORTIFHUNG, 1000, [ref]$res)
+    if ($ok -eq [IntPtr]::Zero) { return $null }
+    return [int]$res
+}
+
+function Set-ImeMode {
+    param([int]$Mode)
+    $ime = [TzInput]::ImmGetDefaultIMEWnd($script:hwnd)
+    if ($ime -eq [IntPtr]::Zero) { return $false }
+    $res = [IntPtr]::Zero
+    $ok = [TzInput]::SendMessageTimeoutW($ime, $WM_IME_CONTROL,
+        [IntPtr]$IMC_SETCONVERSIONMODE, [IntPtr]$Mode, $SMTO_ABORTIFHUNG, 1000, [ref]$res)
+    return ($ok -ne [IntPtr]::Zero)
+}
+
+$ime_before = Get-ImeMode
+$ime_restore = $null
+if (-not $KeepImeMode -and $null -ne $ime_before -and ($ime_before -band $IME_CMODE_NATIVE)) {
+    # 한글 모드다. 영문 (native 비트 끔) 으로 바꾸고 끝나면 되돌린다.
+    if (Set-ImeMode -Mode ($ime_before -band (-bnot $IME_CMODE_NATIVE))) {
+        $ime_restore = $ime_before
+        Write-Output '  입력기가 한글이라 영문으로 바꿨어요 (측정이 끝나면 되돌립니다).'
+    } else {
+        Write-Output '  ⚠ 입력기를 영문으로 못 바꿨어요 — 한글 모드 그대로 보냅니다.'
+    }
+}
+$ime_used = Get-ImeMode
+
+# --- 키 전송 ---------------------------------------------------------------
+function Send-Key {
+    # `[ushort]` 는 PowerShell 5.1 에 없는 타입 가속기다 (`Unable to find type [ushort]`).
+    # `.sh` 가 부르는 것이 5.1 이라 여기서는 `[uint16]` 을 쓴다 — C# 쪽 `ushort` 와 같은 타입이다.
+    param([uint16[]]$Downs, [uint16[]]$Ups)
+    if (-not (Assert-Focus)) { return $false }
+    $n = [TzInput]::Send($Downs, $Ups)
+    return ($n -eq ($Downs.Length + $Ups.Length))
+}
+
+$sent = 0
+$fail = ''
+for ($i = 1; $i -le $Presses; $i++) {
+    if (-not (Send-Key -Downs @($VK.a) -Ups @($VK.a))) {
+        $fail = "키 $i 번째에서 멈췄어요 (포커스를 잃었거나 SendInput 이 거부됐어요)"
+        break
+    }
+    $sent++
+    Start-Sleep -Milliseconds ([int]($GapSec * 1000))
+}
+
+if ($fail -eq '') {
+    # Ctrl+C — 입력 줄 비우기.
+    [void](Send-Key -Downs @($VK.Ctrl, $VK.c) -Ups @($VK.c, $VK.Ctrl))
+    Start-Sleep -Milliseconds 300
+    # **덤프를 여기서 직접 남긴다.** 종료 덤프 (#396) 에만 기대면 앱이 제때 안 닫혔을 때
+    # 값이 통째로 사라진다 (Linux 판이 실측으로 겪었다).
+    [void](Send-Key -Downs @($VK.Ctrl, $VK.Shift, $VK.F12) -Ups @($VK.F12, $VK.Shift, $VK.Ctrl))
+    Start-Sleep -Milliseconds 500
+    if (-not $NoQuit) {
+        # `Alt+F4` 가 아니라 `Ctrl+Shift+W` 다 — Alt+F4 는 종료 확인 다이얼로그를 띄우고
+        # 기다려서 앱이 안 닫힌다. 탭이 하나면 탭 닫기가 곧 앱 종료다.
+        [void](Send-Key -Downs @($VK.Ctrl, $VK.Shift, $VK.w) -Ups @($VK.w, $VK.Shift, $VK.Ctrl))
+    }
+}
+
+if ($null -ne $ime_restore) { [void](Set-ImeMode -Mode $ime_restore) }
+
+function Format-Ime {
+    param($mode)
+    if ($null -eq $mode) { return 'none' }
+    if ($mode -band $IME_CMODE_NATIVE) { return "hangul($mode)" }
+    return "alpha($mode)"
+}
+
+$focus_note = if ($focus_clicked) { '   (포커스를 클릭으로 회수했어요)' } else { '' }
+Write-Output ("  보낸 키 {0} / {1}   IME {2} → {3}{4}" -f $sent, $Presses,
+    (Format-Ime $ime_before), (Format-Ime $ime_used), $focus_note)
+if ($fail -ne '') {
+    Write-Output "  ❌ $fail"
+    exit 5
+}
+exit 0


### PR DESCRIPTION
축 ② 의 Windows 부분이다. [계획](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302608627) ·
[실측 결과](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302694474) 는 이슈에 있다.

## 1. 계측 실기 검증 — **동작한다**

[`24f8cf1`](https://github.com/ensky0/tildaz/commit/24f8cf1) 의 Windows 계측 지점 (`WM_KEYDOWN` 진입부 ·
`Present` 직후) 은 컴파일 검증만 거쳤었다. 실기로 `input samples=` 가 기대치대로 잡히고, 본 측정
5 회차 (idle · flood 각 5) 내내 `표본 31 / 30` 으로 **폐기가 한 번도 없었다.** 코드 변경은 필요 없었다.

## 2. 하네스 — `.sh` 에 Windows 분기

`.ps1` 을 따로 만들지 않았다 (사용자 결정). 근거는 `measure-repeat.sh` 헤더와 같다 — #381 에서 두
벌이 실제로 갈렸고, 여기서 갈릴 것도 같은 부류다 (회차 폐기 판정 · 표본 대조 · 통계). platform 마다
진짜로 다른 **합성 입력 하나**만 `send-keys.ps1` (`SendInput`) 로 뺐다 — Linux 의 `ydotool` 자리다.

| 갈리는 것 | Linux | Windows |
|---|---|---|
| 합성 입력 | `ydotool` (uinput) | `SendInput` |
| 로그 경로 | `$XDG_STATE_HOME/tildaz/` | `%APPDATA%\tildaz\` |
| 러너 | `.sh` (producer `&` + `exec $SHELL`) | `.cmd` (`start /b` + `%COMSPEC%`) · `-e "cmd.exe /c <배치>"` |
| 한/영 | `fcitx5-remote` (전역) | 창별 IME conversion mode (`WM_IME_CONTROL`) |

Linux 판이 실패로 배운 여섯 개 (문자 키 · 덤프 먼저 · 표본 대조 · `Ctrl+Shift+W` · 타임아웃 정리 ·
자동 재시도) 는 전부 공유 코드라 Windows 가 다시 만든 것이 없다.

## 3. Windows 에서 새로 배운 것

- **알림 토스트가 foreground 를 쥐면 `SetForegroundWindow` 가 조용히 거부된다** — 첫 측정에서 회차가
  세 번 연속 폐기됐다. 앱은 정상으로 떴는데 활성이 못 된 것이었다. 거부되면 **client 한가운데를 실제로
  클릭해 회수**한다. 본 측정 **10 회차 중 9 회**가 이 경로를 썼다.
- 포커스 가드 자체는 **없으면 안 된다** — 없었다면 그 세 회차의 키가 사용자가 보던 창에 타이핑됐다.
- `SendInput` 의 `wScan` 을 0 으로 두면 `ToUnicode` 가 문자를 못 만들어 `WM_CHAR` 가 안 오고, 셸 에코가
  없어 **측정 자체가 성립하지 않는다.** `MapVirtualKeyW` 로 항상 채운다.
- `[ushort]` 는 PowerShell 5.1 에 없다 (`.sh` 가 부르는 것이 5.1 이다). `.ps1` 은 UTF-8 **BOM** 으로 둔다.

## 4. 곁들여 — 이 도구에도 위생 검사

`hygiene_check` / `hygiene_begin` 을 건다 (`--ignore-hygiene` 로 우회). DRR · 배경 앱 오염은 응답
시간에도 그대로 오기 때문이다. **Linux 회차에도 걸리므로** 앞선 Linux 수치와 비교할 때 감안한다.

## 5. 수치 (요약)

기기가 달라 절대값 비교에는 한계가 있다 (주사율만 60 Hz 로 같다).

| | Linux · 미니PC Ryzen 7 8845HS | **Windows · 노트북 i5-1240P** |
|---|---|---|
| 유휴 평균 | 0.67 ms | **9.79 ms** |
| 폭포 중 평균 | 10.69 ms | **11.01 ms** |

유휴가 갈리는 원인은 소스로 확인했다 — Windows 는 키를 받아도 게이트만 열고 렌더는 `WM_FRAME_TICK`
에서 하므로 (#386 ②) 평균에 **반 프레임**이 얹힌다. 폭포 중에는 그 대기가 사라져 두 platform 이 붙는다.
**이 구조를 바꿀지는 이 PR 에서 정하지 않는다.**

## 검증

- `zig build check` (6 타겟) ✅
- `zig build test` — 242 passed · 5 skipped · 0 failed ✅
- 실기 측정 (위) ✅ — Zig 소스 변경 없음, 문서 · 측정 도구만 바뀐다

축 ② 는 macOS 가 남아 있어 **`Refs #441`** 이다 (닫지 않는다).


---

# macOS 를 이어서 얹었다 ([bed3964](https://github.com/ensky0/tildaz/commit/bed3964), 2026-08-16)

원래 별도 PR (#474) 이었지만 두 번 머지하지 않도록 이 PR 로 합쳤다 (사용자 결정). **이제 세
platform 이 한 스크립트로 돈다** — 갈리는 것은 합성 입력뿐이다 (`ydotool` · **`CGEvent`** ·
`SendInput`). macOS 는 [`dist/stress/mac-input.m`](../blob/feat/441-input-latency-windows/dist/stress/mac-input.m)
을 스크립트가 `clang` 으로 그 자리에서 빌드한다.

## 1. macOS 계측이 실기에서 돈다

[`24f8cf1`](https://github.com/ensky0/tildaz/commit/24f8cf1) 의 macOS 계측 지점은 컴파일 검증만
거쳤었다. `tildazKeyDown` 의 `markInput()` 과 `presentDrawable` 뒤의 `completeInput()` 이 모두
정상이고, **5 회 전부 표본 30 / 30 · 에코 30 B 로 폐기가 없었다.**

## 2. macOS 가 다른 네 가지

| # | 다른 점 | 어떻게 다뤘나 |
|---|---|---|
| ① | **손쉬운 사용 (Accessibility) 권한**이 없으면 `CGEventPost` 가 **성공을 반환하면서 아무 일도 안 한다** | `mac-input check` 가 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 부른다 — 권한은 자식이 아니라 **부모(터미널 앱)** 에 붙어서 판정 위치가 중요하다 |
| ② | **창을 클릭해 key window 로** 만들어야 한다 ([#387](https://github.com/ensky0/tildaz/issues/387#issuecomment-5188395490) 에서 통한 방법) | 클릭까지 CGEvent 로 하고 포인터를 원위치로 되돌린다. 클릭이 실패한 회차는 실제 렌더가 **838 tick 중 19 회**뿐이라 화면이 사실상 멈춘 상태였다 |
| ③ | **종료가 `Cmd+Q` 가 아니라 `Cmd+W`** 다 | `Cmd+Q` 는 `applicationShouldTerminate` 가 `count()==1` 을 보고 확인창을 띄운다. `Cmd+W` 는 `closeTab` 이 `orderedRemove` 로 탭을 **먼저 지운 뒤** terminate 라 `count()==0` → 확인창을 건너뛴다 |
| ④ | **한글 IME 에서도 표본 · 에코가 다 찬다** | Linux 는 표본 0 이라 저절로 걸리는데 macOS 는 안 걸린다 (같은 자음 연타에 음절이 확정돼 PTY 로 흘러간다 — `ㅁ` 9 개 = 27 B). `TISSelectInputSource` 로 **미리** 영문으로 바꾼다 (Windows 가 conversion mode 를 맞추는 것과 같은 취지) |

## 3. 에코 검사 — 표본 수로는 안 보이는 오염

문자 키 앞뒤를 덤프로 감싸 그 구간의 `drain bytes` 가 곧 **에코량**이 되게 했다.

```
focus → Ctrl+C → 덤프(리셋) → 'a' × N → 덤프(측정) → Ctrl+C → Cmd+W
                              ↑ 이 구간 drain bytes = 정확히 에코 (안 갔으면 0 B)
```

**실제로 겪은 실패다.** modifier 가 남은 채 `a` 가 나가면 `Cmd+A` 로 읽혀 앱이 그냥 `return` 하는데,
`markInput()` 은 `tildazKeyDown` 첫 줄이라 **표본은 다 차고 평균만 0.33 ms 로 그럴듯해진다.** 화면에는
아무것도 안 찍혔다. `mac-input` 이 flags 를 **0 이어도 항상 설정**하고 소스를
`kCGEventSourceStatePrivate` 로 두어 원인을 막고, 에코 검사가 이중으로 잡는다.

**Linux · Windows 로는 넓히지 않았다** — 기대 표본이 `키 수 + 1` 에서 `키 수` 로 바뀌어 이미 5 회씩
마친 측정의 재측정이 필요하다. 그 판단은 각 platform 머신 몫이다.

## 4. 수치 (MacBook Pro M5 Pro · 26.6.1 · 내장 **120 Hz** ProMotion · AC)

| | **Linux** 60 Hz | **macOS** 120 Hz | **Windows** 60 Hz |
|---|---|---|---|
| 유휴 평균 | 0.67 ms (0.66~0.69) | **1.27 ms** (0.63~2.64) | 9.79 ms (9.28~10.12) |
| 유휴 최악 | 12.35 ms (12.30~12.38) | **4.05 ms** (0.79~**16.58**) | 19.85 ms (16.56~25.83) |
| 폭포 평균 | 10.69 ms (10.37~11.72) | **1.50 ms** (1.40~8.12) | 11.01 ms (10.09~11.69) |
| 폭포 최악 | 18.64 ms (18.24~19.14) | **4.26 ms** (2.01~8.24) | 17.62 ms (16.25~19.79) |

```
유휴  평균  0.68  0.74  0.63  2.39  2.64 ms    최악  0.89  2.98  0.79 16.58  8.29 ms
폭포  평균  1.53  1.42  1.40  8.12  1.54 ms    최악  5.10  2.29  2.01  8.24  5.40 ms
```

⚠️ **회차 폭이 크다.** 앞 세 회차와 뒤 두 회차가 두 무리로 갈린다. 열 누적이 의심되지만 **확인하지
않았다.** 유휴 최악의 폭 (0.79~16.58 ms) 이 **Linux 값 12.35 ms 를 품어서**, 이 표만으로 *"macOS 가
유휴 최악에서 낫다"* 고 말할 수 없다.

## 5. [#473](https://github.com/ensky0/tildaz/issues/473) 에 대한 입력 — 구조는 같은데 값이 안 따라온다

그 이슈가 *"macOS 는 어느 쪽인가"* 로 남겨 둔 물음의 답이다.

| | 구조 (소스) | 반 프레임 기대 | 실측 유휴 평균 |
|---|---|---|---|
| Windows | `requestRender()` 게이트 → `WM_FRAME_TICK` | 8.3 ms | 9.79 ms — 설명과 맞는다 |
| **macOS** | **같은 구조** — `requestRender()` 가 `g_needs_render` 만 켜고 CADisplayLink 가 그린다 | **4.17 ms** | **0.63 · 0.68 · 0.74 · 2.39 · 2.64** — **5 회가 모두 그보다 낮다** |

즉 위 §5 의 *"게이트 구조가 반 프레임을 얹는다"* 는 설명이 **platform 을 가린다.** 원인은
미확인이다 — 키 배달이 vsync 와 맞물려 CADisplayLink 발사 직전에 도착하는 것으로 보이지만
WindowServer 안쪽이라 우리 소스로는 못 본다.

## macOS 검증

- `zig build check` (6 타겟) ✅ · `zig build test` ✅ (Zig 소스 변경 없음)
- `sh -n` · `clang -Wall` (경고 없음) ✅
- **실기** — 위 5 회 측정, 폐기 회차 없음 ✅
- 판정 장치 대조 실측 — 한글 회차 · modifier 오염 회차를 각각 재현해 확인 ✅
