### PR TITLE
feat(stress): 응답 시간 하네스를 macOS 로 넓힌다 (#441 축 ②)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -41,7 +41,7 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | [`compare-terminals.sh`](compare-terminals.sh) | **다섯 터미널 나란히** 처리량 비교 + 창 캡처 | Windows 는 **Git Bash 필수** |
 | [`measure-repeat.sh`](measure-repeat.sh) | **우리 앱 안의 배분** — `parse` · `render` · `shape` 몫 | 〃 |
 | [`check-input-loss.sh`](check-input-loss.sh) | **응답성 ①** — 폭포 중 입력이 먹히는지 | Linux · macOS |
-| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · Windows (Git Bash) |
+| [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · macOS · Windows (Git Bash) |
 | [`send-keys.ps1`](send-keys.ps1) | 위 도구의 **Windows 합성 입력** (`SendInput`) — Linux 의 `ydotool` 자리 | 〃 |
 | [`hygiene.sh`](hygiene.sh) | 위 넷이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
@@ -727,10 +727,21 @@ dist/stress/measure-input-latency.sh                      # idle · flood 둘 �
 dist/stress/measure-input-latency.sh --mode idle --presses 50
 ```
 
-**Linux · Windows 에서 돌아요.** 합성 입력이 platform 마다 달라요 — Linux 는 `ydotool` (uinput),
-Windows 는 `SendInput` ([`send-keys.ps1`](send-keys.ps1)) 이에요. **macOS 는 아직 없어요** —
-`CGEvent` 로 [#387](https://github.com/ensky0/tildaz/issues/387) 이 이미 쓴 경로를 옮겨오면 되지만
-안 했어요. **계측 자체는 세 platform 에 다 있어요** (`perf.input_latency`).
+**세 platform 에서 다 돌아요.** 합성 입력만 platform 마다 달라요.
+
+| | 합성 입력 | 창 포커스 | 덤프 · 종료 키 | 한/영 |
+|---|---|---|---|---|
+| **Linux** | `ydotool` (uinput) | 새 창이 자동으로 받아요 | `Ctrl+Shift+F12` · `Ctrl+Shift+W` | `fcitx5-remote` (전역) |
+| **macOS** | `CGEvent` ([`mac-input.m`](mac-input.m)) — 스크립트가 `clang` 으로 그 자리에서 빌드해요 | **클릭이 필요해요** (CGEvent 로 눌러요) | `Shift+Cmd+F12` · **`Cmd+W`** | `TISSelectInputSource` (전역) |
+| **Windows** | `SendInput` ([`send-keys.ps1`](send-keys.ps1)) | 키마다 확인 + 클릭으로 회수 | `Ctrl+Shift+F12` · `Ctrl+Shift+W` | 창별 IME conversion mode |
+
+**계측 자체도 세 platform 에 다 있어요** (`perf.input_latency`).
+
+**macOS 의 종료 키가 `Cmd+Q` 가 아닌 이유**는 확인창이에요. `Cmd+Q` 는 `applicationShouldTerminate` 가
+`count()==1` 을 보고 confirm 을 띄우는데, `Cmd+W` 는 `closeTab` 이 `orderedRemove` 로 탭을 **먼저 지운
+뒤** terminate 라 `count()==0` → confirm 을 건너뛰어요 ([`session_core.zig`](../../src/session_core.zig) ·
+[`host/macos.zig`](../../src/host/macos.zig)). Linux 가 `Alt+F4` 대신 `Ctrl+Shift+W` 를 쓰는 것과 같은
+이유예요.
 
 **Windows 는 Git Bash 에서 돌려요** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은 제약이에요).
 PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있어요 — #381 에서 두 벌이 실제로
@@ -749,34 +760,43 @@ DRR 이 켜져 있거나 배경 앱이 그리고 있으면 응답 시간도 처�
 
 ### 첫 수치 — **기기가 다르니 나란히 볼 때 주의해요**
 
-둘 다 5 회 절사평균 + min~max 이고 **주사율은 60 Hz 로 같아요.** 하지만 CPU 도 OS 도 달라서
-**절대값 차이를 전부 platform 몫으로 읽으면 안 돼요** (같은 기기에서 OS 만 바꿔 재는 것이 원칙이에요 —
-`AGENTS.md` 의 `# 실행 환경`).
+셋 다 5 회 절사평균 + min~max 예요. **기기도 주사율도 달라서 절대값 차이를 전부 platform 몫으로
+읽으면 안 돼요** (같은 기기에서 OS 만 바꿔 재는 것이 원칙이에요 — `AGENTS.md` 의 `# 실행 환경`).
 
-| | **Linux** · 미니PC Ryzen 7 8845HS · CachyOS · KDE Plasma | **Windows** · 노트북 Intel i5-1240P · Windows 11 26200 |
-|---|---|---|
-| 화면 | 60 Hz | 내장 1920x1080 · 로그 `refresh=60Hz period=16.67ms` |
-| **유휴** 평균 | **0.67 ms** (0.66~0.69) | **9.79 ms** (9.28~10.12) |
-| **유휴** 최악 | **12.35 ms** (12.30~12.38) | **19.85 ms** (16.56~25.83) |
-| **폭포 중** 평균 | **10.69 ms** (10.37~11.72) | **11.01 ms** (10.09~11.69) |
-| **폭포 중** 최악 | **18.64 ms** (18.24~19.14) | **17.62 ms** (16.25~19.79) |
+| | **Linux** · 미니PC Ryzen 7 8845HS · CachyOS · KDE Plasma | **macOS** · MacBook Pro M5 Pro · 26.6.1 | **Windows** · 노트북 Intel i5-1240P · Windows 11 26200 |
+|---|---|---|---|
+| 화면 | 60 Hz | 내장 3024x1964 · **120 Hz** (ProMotion) | 내장 1920x1080 · 로그 `refresh=60Hz period=16.67ms` |
+| **유휴** 평균 | **0.67 ms** (0.66~0.69) | **1.27 ms** (0.63~2.64) | **9.79 ms** (9.28~10.12) |
+| **유휴** 최악 | **12.35 ms** (12.30~12.38) | **4.05 ms** (0.79~**16.58**) | **19.85 ms** (16.56~25.83) |
+| **폭포 중** 평균 | **10.69 ms** (10.37~11.72) | **1.50 ms** (1.40~8.12) | **11.01 ms** (10.09~11.69) |
+| **폭포 중** 최악 | **18.64 ms** (18.24~19.14) | **4.26 ms** (2.01~8.24) | **17.62 ms** (16.25~19.79) |
 
-Windows 의 회차별 값 (실행 순서 그대로 — 위 "반복과 대표값" 규칙). **Linux 회차별 값은 남아 있지
+회차별 값 (실행 순서 그대로 — 위 "반복과 대표값" 규칙). **Linux 회차별 값은 남아 있지
 않아요** — 그때는 min~max 만 기록했어요 ([#441 코멘트](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302521860)).
 
 ```
-유휴  평균 10.12  9.89  9.28  9.50  9.99 ms    최악 20.09 18.21 25.83 16.56 21.25 ms
-폭포  평균 10.45 11.49 11.69 10.09 11.10 ms    최악 17.80 17.64 17.43 16.25 19.79 ms
+macOS    유휴 평균  0.68  0.74  0.63  2.39  2.64 ms    최악  0.89  2.98  0.79 16.58  8.29 ms
+         폭포 평균  1.53  1.42  1.40  8.12  1.54 ms    최악  5.10  2.29  2.01  8.24  5.40 ms
+
+Windows  유휴 평균 10.12  9.89  9.28  9.50  9.99 ms    최악 20.09 18.21 25.83 16.56 21.25 ms
+         폭포 평균 10.45 11.49 11.69 10.09 11.10 ms    최악 17.80 17.64 17.43 16.25 19.79 ms
 ```
 
-**폭포 중 값은 두 platform 이 거의 같은데 (10.69 / 11.01 ms) 유휴가 15 배 갈려요.** 그래서
-"폭포가 흐르면 16 배 느려진다" 는 Linux 의 문장이 Windows 에서는 **+12 % 로 사라져요.**
+⚠️ **macOS 는 회차 폭이 커서 절사평균만 보면 안 돼요.** 앞 세 회차 (유휴 평균 0.63~0.74 ms) 와 뒤 두
+회차 (2.39 · 2.64 ms) 가 **두 무리로 갈려요.** 회차가 갈수록 나빠지는 모양이라 열 누적이 의심되지만
+**확인하지 않았어요.** 유휴 최악의 폭 (0.79~16.58 ms) 은 **Linux 값 12.35 ms 를 품어서**, 이 표만으로
+"macOS 가 유휴 최악에서 낫다" 고 말할 수 없어요.
+
+**폭포 중 값은 Linux · Windows 가 거의 같은데 (10.69 / 11.01 ms) 유휴가 15 배 갈려요.** 그래서
+"폭포가 흐르면 16 배 느려진다" 는 Linux 의 문장이 Windows 에서는 **+12 % 로 사라져요.** macOS 는
+유휴 · 폭포가 둘 다 낮아 또 다른 모양이에요 (0.63~2.64 → 1.40~8.12).
 
 #### 유휴 차이의 원인은 **렌더를 언제 시작하느냐**예요 (소스로 확인)
 
 | platform | 키가 온 뒤 | 근거 |
 |---|---|---|
 | **Linux** | **같은 poll 반복에서 바로 그려요** | 키 이벤트가 `needs_redraw` 를 켜고, 그 다음 줄의 `maybeRedraw` 가 그 자리에서 그려요 ([`wayland_minimal.zig`](../../src/host/linux/wayland_minimal.zig)) |
+| **macOS** | **다음 vsync 를 기다려요** (구조상) | `tildazKeyDown` 은 `requestRender()` 로 `g_needs_render` 만 켜고 ([`macos.zig`](../../src/host/macos.zig)), 실제 렌더는 CADisplayLink 콜백 `renderFrameTick` 이 해요 — **Windows 와 같은 모양이에요** |
 | **Windows** | **다음 frame tick 을 기다려요** | `wndProc` 는 `requestRender()` 로 게이트만 열고 (#386 ②), 실제 렌더는 프레임 클럭이 post 하는 `WM_FRAME_TICK` → `renderFrameTick()` 에서 해요 ([`window.zig`](../../src/window.zig)) |
 
 키가 프레임 주기 안 아무 때나 도착하니 Windows 유휴 평균은 **반 프레임 (16.67 / 2 = 8.3 ms) + 렌더 ·
@@ -787,20 +807,41 @@ present · 셸 왕복**이 되고, 실측 9.79 ms 가 그 값이에요. 최악�
 이건 *"Windows 가 느리다"* 가 아니라 **구조가 다르다**는 뜻이에요 — 유휴에 프레임을 안 그려 CPU 를
 아끼는 #386 ② 의 게이트가 응답 지연으로는 반 프레임을 얹어요. 바꿀지 말지는 별도 판단이에요.
 
+⚠️ **그런데 macOS 는 같은 구조인데 값이 이 설명과 안 맞아요.** 120 Hz 면 반 프레임이 4.17 ms 라
+유휴 평균이 그 언저리여야 하는데 **5 회가 전부 그보다 낮아요** (0.63 · 0.68 · 0.74 · 2.39 · 2.64 ms).
+튄 뒤 두 회차까지 포함해서요.
+
+그래서 **"게이트 구조가 반 프레임을 얹는다" 는 설명이 platform 을 가려요.** 이건
+[#473](https://github.com/ensky0/tildaz/issues/473) 이 *"macOS 는 어느 쪽인가"* 로 남겨 둔 물음의
+답이기도 해요 — 같은 게이트를 쓰는데 그 비용이 안 나와요.
+
+**원인은 확인하지 않았어요.** 키 이벤트 배달이 vsync 와 맞물려 CADisplayLink 발사 직전에 도착하는
+것으로 보이지만 (그러면 대기가 거의 없어요) 그건 WindowServer 안쪽이라 우리 소스로는 못 봐요.
+확인하려면 `markInput` · `completeInput` 시각을 프레임 경계와 함께 찍어 위상을 봐야 해요 — 안 했어요.
+
 **이 값으로 [#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하면 안 돼요.** 그 이슈는
 *"유휴에서 **PTY 출력이 도착**했을 때"* 이고 이 측정은 **키를 눌러** 시작해요 — 키가 오면 앱이 즉시
 렌더를 요청하니 유휴 깨우기 경로를 아예 안 타요. 예산 4 ms 와의 직접 비교도 안 돼요 (그건 드레인
 한 번의 상한이고, 이 값은 거기에 셸 왕복 · 렌더 · present 가 누적된 것이에요).
 
-### ⚠ 입력기 — **Linux 는 표본이 비고 Windows 는 안 비어요**
+### ⚠ 입력기 — **Linux 만 표본이 비고 macOS · Windows 는 안 비어요**
 
-보내는 것이 **문자 키 `a`** 라서 입력기 상태가 측정 전제예요. 그런데 **두 platform 의 결과가 달라요**
-(둘 다 실측이에요).
+보내는 것이 **문자 키 `a`** 라서 입력기 상태가 측정 전제예요. 그런데 **세 platform 의 결과가 달라요**
+(전부 실측이에요).
 
 | platform | 한글 모드에서 문자 키 | 표본 | 도구가 하는 일 |
 |---|---|---|---|
 | **Linux** (fcitx5) | IME 가 조합용으로 가져가요 (`ㅁ` 이 찍혀요) — 앱 키 핸들러를 **안 타요** | **0 개** | `fcitx5-remote` 로 영문 전환 후 측정, 끝나면 복원 |
+| **macOS** (NSTextInputClient) | `keyDown:` 이 우리 뷰에 **먼저 오고** 앱이 `interpretKeyEvents:` 로 IME 에 넘겨요 — `markInput()` 이 `tildazKeyDown` 첫 줄이라 그대로 세어져요 | **정상** (실측 10/10) | `TISSelectInputSource` 로 영문 전환 후 측정, 끝나면 복원 |
 | **Windows** (IMM) | IME 가 쓰는데도 **`WM_KEYDOWN` 은 앱에 도달해요** (`VK_PROCESSKEY`) | **정상** (실측 11/11) | 그래도 영문으로 맞춰요 — 아래 참고 |
+
+macOS 실측 (`a` × 10, 같은 조건). **에코까지 정상이라 폐기 장치가 아예 안 걸려요** — 같은 자음을
+연달아 치면 IME 가 음절을 확정해 PTY 로 흘려보내기 때문이에요.
+
+| | 표본 | 에코 | 평균 | 최악 |
+|---|---:|---:|---:|---:|
+| 영문 | 10 | 10 B | 3.12 ms | 4.11 ms |
+| **한글** | 10 | **27 B** (`ㅁ` 9 개) | 4.33 ms | 5.20 ms |
 
 Windows 실측: 한국어 IME (`hkl=0x04120412`) 를 conversion mode 1 (한글) 로 두고 `a` 10 회를 보냈더니
 `input samples=11` 로 **그대로 잡혔어요.** 그러니 Windows 에서 표본이 비면 원인은 입력기가 아니에요.
@@ -816,11 +857,32 @@ preedit overlay 를 그리는 시간을 재게 돼서 영문 회차와 나란히
 Linux 는 한글 모드에서 preedit 이 그려지는데도 표본이 안 잡혀요 — 즉 그쪽 계측은 **영문 직접 입력
 경로만** 봐요. 한글 입력의 응답 지연을 재려면 계측 지점을 IME 경로에도 놓아야 해요.
 
+### ⚠ macOS 의 조용한 실패 둘 — 값이 그럴듯하게 나와요
+
+둘 다 실측에서 겪었고, **표본 수만 보면 정상으로 보여요.**
+
+| 증상 | 원인 | 막는 법 |
+|---|---|---|
+| 키가 하나도 안 나가요 | 보내는 쪽 (터미널 앱) 에 **손쉬운 사용 (Accessibility) 권한**이 없어요. `CGEventPost` 는 **성공을 반환하면서 아무 일도 안 해요** | `mac-input check` 가 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 불러요 (권한은 자식이 아니라 부모에 붙어요). 회차를 돌기 전에 멈춰요 |
+| 표본은 다 차는데 **화면에 아무것도 안 찍혀요** | 이벤트 소스가 시스템 modifier 상태를 물려받아 직전 조합키의 Cmd 가 남아요. `a` 가 `Cmd+A` 로 읽히면 `macCmdShortcut` 이 인식 못 해 **그냥 return** 하는데, `markInput()` 은 `tildazKeyDown` 첫 줄이라 표본은 세어져요 (그때 평균이 0.33 ms 로 그럴듯했어요) | `mac-input` 이 flags 를 **0 이어도 항상 설정**하고 소스를 `kCGEventSourceStatePrivate` 로 만들어요. 그래도 새면 **에코 검사**가 잡아요 |
+
+**에코 검사가 두 번째를 잡는 장치예요.** macOS 회차만 문자 키 앞뒤를 덤프로 감싸서, 그 구간의
+`drain bytes` 가 곧 에코량이 되게 해요 (`dumpAndReset` 이 읽으면서 리셋하니까요). 키가 PTY 로 안 간
+회차는 **0 B** 로 드러나요 — 표본 수로는 절대 안 보여요.
+
+Linux · Windows 로 넓히지 않은 이유는 **기대 표본이 바뀌기 때문**이에요. 두 platform 은 지금
+`Ctrl+C` 의 modifier 까지 세어 `키 수 + 1` 이 정상인데, 이 배치에서는 정확히 `키 수` 가 돼요. 이미
+5 회씩 측정을 마친 값이 있어서 도구를 바꾸면 재측정이 필요해요 — 그 판단은 각 platform 머신 몫이에요.
+(폭포 모드에서는 에코가 폭포량에 묻혀 사실상 통과만 하므로 그쪽 오염은 표본 수로 봐요.)
+
 ### 회차가 폐기되면 자동으로 다시 돌아요
 
 표본이 기대치의 8 할 미만이면 그 회차는 폐기예요 (`--retries`, 기본 3 회 재시도). 폐기의 알려진
 원인은 **한글 입력기** (Linux 한정, 위에서 미리 막아요) 와 **측정 중 조작**이에요 — 합성 입력은
 포커스된 창으로 가므로 측정 중에 창을 바꾸면 키가 다른 앱으로 새요.
+
+**macOS 는 폐기 사유가 하나 더 있어요** — 에코가 키 수에 못 미치면 (`⚠ 에코 N B`) 표본이 다 차도
+폐기예요. 위 "조용한 실패 둘" 의 두 번째를 잡는 장치예요.
 
 #### ⚠ Windows — **알림 토스트가 뜨면 회차가 통째로 폐기돼요**
 

--- a/dist/stress/mac-input.m
+++ b/dist/stress/mac-input.m
@@ -1,0 +1,392 @@
+// macOS 합성 입력 — `measure-input-latency.sh` 가 쓰는 CGEvent 전송 도구 (#441 축 ②).
+//
+//   clang -O2 -Wno-deprecated-declarations \
+//         -framework ApplicationServices -framework Carbon -o /tmp/mac-input mac-input.m
+//
+//   /tmp/mac-input check                    # 손쉬운 사용 권한이 있나
+//   /tmp/mac-input focus <pid>              # 그 pid 의 창을 클릭해 key window 로
+//   /tmp/mac-input send a --repeat 30 --gap 200
+//   /tmp/mac-input send shift+cmd+f12
+//   /tmp/mac-input ime-get                  # 지금 입력 소스 ID
+//   /tmp/mac-input ime-ascii                # 영문(ASCII 가능) 소스로
+//   /tmp/mac-input ime-set com.apple.inputmethod.Korean.2SetKorean
+//
+// ## 왜 `cliclick` 을 안 쓰나
+//
+// [#387](https://github.com/ensky0/tildaz/issues/387#issuecomment-5188395490) 이 macOS 에서 쓴
+// 도구가 `cliclick` 이고 그건 지금도 유효하다 (`osascript keystroke` 는 Accessory mode 때문에
+// 새어 나간다). 다만 그때 보낸 것은 **단축키 하나**였고, 여기서 필요한 것은 **문자 키**다.
+//
+//   - `cliclick` 의 `kp` 는 특수키만 받는다 (`f1`~`f16` · 화살표 · `space` …). 문자는
+//     `t:a` 뿐인데 그건 `CGEventKeyboardSetUnicodeString` 방식이라 IME 를 지나는 길이
+//     실기와 달라질 수 있다 (*추정 — 확인 안 함*).
+//   - 권한이 없을 때 오류 없이 exit 0 이라 **키가 안 나간 회차를 그대로 끝낸다.**
+//
+// ## 권한 — 이 도구가 존재하는 진짜 이유
+//
+// CGEvent 로 키를 보내려면 **보내는 쪽**에 손쉬운 사용 (Accessibility) 권한이 있어야 하고,
+// 없으면 `CGEventPost` 는 **성공을 반환하면서 아무 일도 하지 않는다.** Linux 에서 `ydotoold`
+// 미기동으로 키가 하나도 안 나간 채 회차가 끝난 그 함정과 같은 종류다.
+//
+// 그래서 `AXIsProcessTrusted()` 를 **키를 보내는 이 프로세스 안에서** 부른다. TCC 는 터미널이
+// 띄운 자식의 권한을 부모 (터미널 앱) 기준으로 평가하므로 (AGENTS.md 의 macOS `open` 절),
+// 판정과 전송이 같은 프로세스여야 답이 맞는다.
+#include <ApplicationServices/ApplicationServices.h>
+#include <Carbon/Carbon.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+enum {
+    EXIT_NO_PERMISSION = 2,
+    EXIT_NO_WINDOW = 3,
+    EXIT_USAGE = 4,
+    EXIT_IME = 5,
+};
+
+// macOS 의 가상 키코드는 물리 배치 순서라 알파벳 순이 아니다 (`a` = 0, `s` = 1 …).
+// `<Carbon/HIToolbox/Events.h>` 의 `kVK_*` 와 같은 값이며, 여기서 이름을 붙여 둔다.
+static const struct {
+    const char *name;
+    CGKeyCode code;
+} kKeys[] = {
+    {"a", 0},    {"s", 1},    {"d", 2},     {"f", 3},     {"h", 4},     {"g", 5},
+    {"z", 6},    {"x", 7},    {"c", 8},     {"v", 9},     {"b", 11},    {"q", 12},
+    {"w", 13},   {"e", 14},   {"r", 15},    {"y", 16},    {"t", 17},    {"o", 31},
+    {"u", 32},   {"i", 34},   {"p", 35},    {"l", 37},    {"j", 38},    {"k", 40},
+    {"n", 45},   {"m", 46},
+    {"1", 18},   {"2", 19},   {"3", 20},    {"4", 21},    {"6", 22},    {"5", 23},
+    {"9", 25},   {"7", 26},   {"8", 28},    {"0", 29},
+    {"return", 36}, {"tab", 48}, {"space", 49}, {"delete", 51}, {"esc", 53},
+    {"f1", 122}, {"f2", 120}, {"f3", 99},   {"f4", 118},  {"f5", 96},   {"f6", 97},
+    {"f7", 98},  {"f8", 100}, {"f9", 101},  {"f10", 109}, {"f11", 103}, {"f12", 111},
+};
+
+static int lookupKey(const char *name, CGKeyCode *out) {
+    for (size_t i = 0; i < sizeof(kKeys) / sizeof(kKeys[0]); i++) {
+        if (strcmp(kKeys[i].name, name) == 0) {
+            *out = kKeys[i].code;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/// `shift+cmd+f12` 처럼 `+` 로 이어 붙인 조합을 keyCode + flags 로 가른다.
+static int parseSpec(const char *spec, CGKeyCode *code, CGEventFlags *flags) {
+    char buf[128];
+    if (strlen(spec) >= sizeof(buf)) return 0;
+    strcpy(buf, spec);
+
+    *flags = 0;
+    char *cursor = buf;
+    for (;;) {
+        char *plus = strchr(cursor, '+');
+        if (plus == NULL) break;
+        *plus = '\0';
+        if (strcmp(cursor, "cmd") == 0) *flags |= kCGEventFlagMaskCommand;
+        else if (strcmp(cursor, "shift") == 0) *flags |= kCGEventFlagMaskShift;
+        else if (strcmp(cursor, "ctrl") == 0) *flags |= kCGEventFlagMaskControl;
+        else if (strcmp(cursor, "alt") == 0 || strcmp(cursor, "opt") == 0) *flags |= kCGEventFlagMaskAlternate;
+        else return 0;
+        cursor = plus + 1;
+    }
+    return lookupKey(cursor, code);
+}
+
+/// 모디파이어는 실제 키를 누르지 않고 `CGEventSetFlags` 로만 준다. 우리 앱이 보는 것이
+/// `[event modifierFlags]` 라서 (`host/macos.zig` 의 `tildazKeyDown`) 이걸로 충분하다.
+///
+/// **flags 는 0 이어도 반드시 설정한다.** 처음에는 `flags != 0` 일 때만 불렀는데, 그러면
+/// 새 이벤트가 **직전 조합키의 modifier 를 물려받는다.** Cmd 가 남은 채 `a` 가 나가면 앱은
+/// 그걸 `Cmd+A` 로 보고 `macCmdShortcut` 이 인식 못 해 **그냥 return** 한다 — 화면도 안
+/// 바뀌고 PTY 로도 안 간다. 그런데 `markInput()` 은 `tildazKeyDown` 첫 줄이라 표본은 그대로
+/// 세어져서, **"표본은 다 찼는데 아무것도 안 찍힌"** 회차가 된다 (실측으로 겪었다).
+///
+/// 소스도 `kCGEventSourceStatePrivate` 로 만들어 시스템의 실제 키보드 상태를 물려받지
+/// 않게 한다. 두 겹으로 막는 이유는 이 실패가 **조용해서** — 값이 그럴듯하게 나온다.
+static void postKey(CGKeyCode code, CGEventFlags flags) {
+    CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStatePrivate);
+    CGEventRef down = CGEventCreateKeyboardEvent(src, code, true);
+    CGEventRef up = CGEventCreateKeyboardEvent(src, code, false);
+    CGEventSetFlags(down, flags);
+    CGEventSetFlags(up, flags);
+    CGEventPost(kCGHIDEventTap, down);
+    CGEventPost(kCGHIDEventTap, up);
+    CFRelease(down);
+    CFRelease(up);
+    if (src != NULL) CFRelease(src);
+}
+
+static void warnNoPermission(void) {
+    fprintf(stderr,
+            "손쉬운 사용 (Accessibility) 권한이 없어요 — CGEvent 로 보낸 키가 조용히 사라져요.\n"
+            "  시스템 설정 → 개인정보 보호 및 보안 → 손쉬운 사용 에서\n"
+            "  **이 스크립트를 실행한 터미널 앱**을 켜 주세요 (권한은 자식이 아니라 부모에 붙어요).\n"
+            "  이미 켜져 있는데도 이 메시지가 나오면 토글을 껐다 켜세요 (서명이 바뀌면 stale 해져요).\n");
+}
+
+static int requireTrusted(void) {
+    if (AXIsProcessTrusted()) return 1;
+    warnNoPermission();
+    return 0;
+}
+
+/// 합성 입력은 **포커스된 창**으로 간다. Accessory mode 앱이라 `osascript` 로는 활성화가
+/// 안 새어 나가고 (#387), 창 본문을 클릭하는 것이 실측으로 통한 방법이다. 여기서는 그
+/// 클릭까지 CGEvent 로 해서 사람 개입을 없앤다.
+static int focusWindowOfPid(pid_t pid) {
+    CFArrayRef windows = CGWindowListCopyWindowInfo(
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+    if (windows == NULL) {
+        fprintf(stderr, "창 목록을 못 읽었어요.\n");
+        return EXIT_NO_WINDOW;
+    }
+
+    CGRect best = CGRectZero;
+    int found = 0;
+    for (CFIndex i = 0; i < CFArrayGetCount(windows); i++) {
+        CFDictionaryRef info = CFArrayGetValueAtIndex(windows, i);
+        CFNumberRef owner = CFDictionaryGetValue(info, kCGWindowOwnerPID);
+        CFDictionaryRef bounds_dict = CFDictionaryGetValue(info, kCGWindowBounds);
+        if (owner == NULL || bounds_dict == NULL) continue;
+
+        int owner_pid = 0;
+        CFNumberGetValue(owner, kCFNumberIntType, &owner_pid);
+        if (owner_pid != (int)pid) continue;
+
+        // **`kCGWindowLayer` 로 거르면 안 된다.** drop-down 터미널이라 우리 창은
+        // `NSPopUpMenuWindowLevel` (101) 로 뜨고 (`host/macos.zig` 의 `setPopupWindowLevel`),
+        // 다른 앱이 활성이면 normal (0) 로 내려간다 (#195). 즉 layer 가 **두 값을 오간다.**
+        // 처음에 `layer == 0` 만 봤다가 창을 못 찾았다 (실측). pid 로 이미 좁혔으니
+        // 층은 보지 않고, 같은 pid 의 보조 창 (다이얼로그 · IME 패널) 은 아래 넓이 비교로 밀어낸다.
+        CGRect rect;
+        if (!CGRectMakeWithDictionaryRepresentation(bounds_dict, &rect)) continue;
+        // 한 프로세스가 창을 여럿 들 수 있다 (다이얼로그 등). 가장 큰 것이 본체다.
+        if (rect.size.width * rect.size.height > best.size.width * best.size.height) {
+            best = rect;
+            found = 1;
+        }
+    }
+    CFRelease(windows);
+
+    if (!found) {
+        fprintf(stderr, "pid %d 의 창을 못 찾았어요 (아직 안 떴거나 이미 닫혔어요).\n", (int)pid);
+        return EXIT_NO_WINDOW;
+    }
+
+    // 창 중앙 — 탭바 (위쪽) 와 스크롤바 (오른쪽) 를 피한다. 터미널 본문이라 클릭해도
+    // 같은 자리에서 떼면 빈 selection 이라 화면이 바뀌지 않는다.
+    CGPoint target = CGPointMake(CGRectGetMidX(best), CGRectGetMidY(best));
+
+    // 사용자의 포인터를 빼앗지 않도록 원래 자리를 기억해 둔다.
+    CGEventRef probe = CGEventCreate(NULL);
+    CGPoint origin = (probe != NULL) ? CGEventGetLocation(probe) : target;
+    if (probe != NULL) CFRelease(probe);
+
+    // `CGWarpMouseCursorPosition` 만으로는 이동 이벤트가 없어 hover · 클릭이 안 걸린다
+    // (AGENTS.md 의 macOS 색 실측 절과 같은 함정). 이동 → 누름 → 뗌을 모두 보낸다.
+    CGEventRef move = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, move);
+    CFRelease(move);
+    usleep(50 * 1000);
+
+    CGEventRef down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, down);
+    CFRelease(down);
+    usleep(30 * 1000);
+
+    CGEventRef up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, target, kCGMouseButtonLeft);
+    CGEventPost(kCGHIDEventTap, up);
+    CFRelease(up);
+    usleep(50 * 1000);
+
+    // 포인터를 되돌린다. 창 밖으로 나가므로 탭바 hover 도 함께 풀린다.
+    CGWarpMouseCursorPosition(origin);
+    return 0;
+}
+
+/// 주 화면의 주사율. **응답 시간 측정에서 이 값이 결론을 바꾼다** — 프레임 주기가 곧
+/// 응답 지연의 하한이라, 120 Hz 와 60 Hz 를 나란히 두려면 함께 적어야 한다 (AGENTS.md 의
+/// `# 실행 환경`). `system_profiler` 에는 안 나오고 `hygiene.sh` 도 셸만으로는 못 읽어서
+/// 여기서 `CGDisplayModeGetRefreshRate` 로 낸다.
+///
+/// 창이 뜬 화면이 아니라 **주 화면** 기준이다. 우리 창은 drop-down 이라 주 화면에 뜨지만,
+/// 외장 모니터를 함께 쓰는 환경에서는 사람이 확인한다.
+static int printRefresh(void) {
+    CGDisplayModeRef mode = CGDisplayCopyDisplayMode(CGMainDisplayID());
+    if (mode == NULL) {
+        fprintf(stderr, "화면 모드를 못 읽었어요.\n");
+        return EXIT_IME;
+    }
+    double hz = CGDisplayModeGetRefreshRate(mode);
+    CGDisplayModeRelease(mode);
+    // 일부 화면은 0 을 낸다. 그때는 물음표를 그대로 내보내 **모르는 것을 아는 척하지 않는다.**
+    if (hz <= 0.0) {
+        printf("?\n");
+        return 0;
+    }
+    printf("%.0fHz\n", hz);
+    return 0;
+}
+
+static int imeGet(void) {
+    TISInputSourceRef current = TISCopyCurrentKeyboardInputSource();
+    if (current == NULL) {
+        fprintf(stderr, "현재 입력 소스를 못 읽었어요.\n");
+        return EXIT_IME;
+    }
+    CFStringRef source_id = TISGetInputSourceProperty(current, kTISPropertyInputSourceID);
+    if (source_id == NULL) {
+        CFRelease(current);
+        fprintf(stderr, "입력 소스 ID 가 없어요.\n");
+        return EXIT_IME;
+    }
+    char buf[256];
+    if (!CFStringGetCString(source_id, buf, sizeof(buf), kCFStringEncodingUTF8)) {
+        CFRelease(current);
+        fprintf(stderr, "입력 소스 ID 를 못 옮겼어요.\n");
+        return EXIT_IME;
+    }
+    printf("%s\n", buf);
+    CFRelease(current);
+    return 0;
+}
+
+/// 영문 (ASCII 를 낼 수 있는) 소스로 바꾼다. 한글 모드면 `a` 가 조합에 먹혀서
+/// PTY 왕복이 아니라 preedit 만 재게 된다.
+static int imeAscii(void) {
+    TISInputSourceRef ascii = TISCopyCurrentASCIICapableKeyboardInputSource();
+    if (ascii == NULL) {
+        fprintf(stderr, "ASCII 입력 소스를 못 찾았어요.\n");
+        return EXIT_IME;
+    }
+    OSStatus status = TISSelectInputSource(ascii);
+    CFRelease(ascii);
+    if (status != noErr) {
+        fprintf(stderr, "영문 입력 소스로 못 바꿨어요 (OSStatus %d).\n", (int)status);
+        return EXIT_IME;
+    }
+    return 0;
+}
+
+static int imeSet(const char *wanted) {
+    CFStringRef wanted_cf = CFStringCreateWithCString(NULL, wanted, kCFStringEncodingUTF8);
+    if (wanted_cf == NULL) return EXIT_IME;
+
+    const void *keys[] = {kTISPropertyInputSourceID};
+    const void *values[] = {wanted_cf};
+    CFDictionaryRef filter = CFDictionaryCreate(NULL, keys, values, 1,
+                                                &kCFTypeDictionaryKeyCallBacks,
+                                                &kCFTypeDictionaryValueCallBacks);
+    // `includeAllInstalled = false` — 켜 둔 소스만 본다. 안 켠 소스는 선택해도 안 먹는다.
+    CFArrayRef list = TISCreateInputSourceList(filter, false);
+    CFRelease(filter);
+    CFRelease(wanted_cf);
+
+    if (list == NULL || CFArrayGetCount(list) == 0) {
+        if (list != NULL) CFRelease(list);
+        fprintf(stderr, "입력 소스를 못 찾았어요: %s\n", wanted);
+        return EXIT_IME;
+    }
+    TISInputSourceRef source = (TISInputSourceRef)CFArrayGetValueAtIndex(list, 0);
+    OSStatus status = TISSelectInputSource(source);
+    CFRelease(list);
+    if (status != noErr) {
+        fprintf(stderr, "입력 소스를 못 바꿨어요: %s (OSStatus %d)\n", wanted, (int)status);
+        return EXIT_IME;
+    }
+    return 0;
+}
+
+static void usage(void) {
+    fprintf(stderr,
+            "쓰는 법: mac-input <명령>\n"
+            "\n"
+            "  check                       손쉬운 사용 권한이 있나 (없으면 exit 2)\n"
+            "  focus <pid>                 그 pid 의 창을 클릭해 key window 로\n"
+            "  send <키>... [옵션]         키를 보낸다\n"
+            "  refresh                     주 화면 주사율 (측정 기록용)\n"
+            "  ime-get                     지금 입력 소스 ID\n"
+            "  ime-ascii                   영문 (ASCII 가능) 소스로\n"
+            "  ime-set <id>                그 ID 로\n"
+            "\n"
+            "  send 옵션: --repeat <N> (키 열을 N 번) · --gap <ms> (키 사이 간격, 기본 200)\n"
+            "  키 표기: a · ctrl+c · shift+cmd+f12 · cmd+q\n");
+}
+
+int main(int argc, const char **argv) {
+    if (argc < 2) {
+        usage();
+        return EXIT_USAGE;
+    }
+    const char *cmd = argv[1];
+
+    if (strcmp(cmd, "check") == 0) {
+        return requireTrusted() ? 0 : EXIT_NO_PERMISSION;
+    }
+
+    if (strcmp(cmd, "focus") == 0) {
+        if (argc != 3) { usage(); return EXIT_USAGE; }
+        if (!requireTrusted()) return EXIT_NO_PERMISSION;
+        return focusWindowOfPid((pid_t)atoi(argv[2]));
+    }
+
+    if (strcmp(cmd, "refresh") == 0) return printRefresh();
+    if (strcmp(cmd, "ime-get") == 0) return imeGet();
+    if (strcmp(cmd, "ime-ascii") == 0) return imeAscii();
+    if (strcmp(cmd, "ime-set") == 0) {
+        if (argc != 3) { usage(); return EXIT_USAGE; }
+        return imeSet(argv[2]);
+    }
+
+    if (strcmp(cmd, "send") != 0) {
+        usage();
+        return EXIT_USAGE;
+    }
+
+    // **권한 판정을 보내기 전에** 한다. 이게 없으면 회차를 다 돌고 나서야 표본 0 으로 안다.
+    if (!requireTrusted()) return EXIT_NO_PERMISSION;
+
+    const char *specs[64];
+    int spec_count = 0;
+    long repeat = 1;
+    long gap_ms = 200;
+
+    for (int i = 2; i < argc; i++) {
+        if (strcmp(argv[i], "--repeat") == 0 && i + 1 < argc) {
+            repeat = strtol(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--gap") == 0 && i + 1 < argc) {
+            gap_ms = strtol(argv[++i], NULL, 10);
+        } else {
+            if (spec_count == (int)(sizeof(specs) / sizeof(specs[0]))) {
+                fprintf(stderr, "키가 너무 많아요.\n");
+                return EXIT_USAGE;
+            }
+            specs[spec_count++] = argv[i];
+        }
+    }
+    if (spec_count == 0 || repeat < 1 || gap_ms < 0) {
+        usage();
+        return EXIT_USAGE;
+    }
+
+    // 보내기 전에 전부 파싱한다 — 열 한가운데서 오타로 멈추면 앱이 어중간한 상태로 남는다.
+    CGKeyCode codes[64];
+    CGEventFlags flags[64];
+    for (int i = 0; i < spec_count; i++) {
+        if (!parseSpec(specs[i], &codes[i], &flags[i])) {
+            fprintf(stderr, "모르는 키: %s\n", specs[i]);
+            return EXIT_USAGE;
+        }
+    }
+
+    for (long r = 0; r < repeat; r++) {
+        for (int i = 0; i < spec_count; i++) {
+            postKey(codes[i], flags[i]);
+            if (gap_ms > 0) usleep((useconds_t)gap_ms * 1000);
+        }
+    }
+    return 0;
+}

--- a/dist/stress/measure-input-latency.sh
+++ b/dist/stress/measure-input-latency.sh
@@ -24,16 +24,43 @@
 # 않는다.** 그러면 `completeInput` 이 불리지 않아 표본이 0 이다. 그래서 `a` 를 보내 에코가
 # 화면에 닿기까지를 재고, 끝에 Ctrl+C 로 입력 줄을 비운다.
 #
-# ## 어디서 도는가 — **Linux · Windows**
+# ## 어디서 도는가 — **Linux · macOS · Windows**
 #
-# 합성 입력이 platform 마다 다르다. Linux 는 `ydotool` (uinput), Windows 는 `SendInput`
-# ([`send-keys.ps1`](send-keys.ps1)) 이다. **macOS 는 아직 없다** — `CGEvent` 로 #387 이 이미
-# 쓴 경로를 옮겨오면 되지만 하지 않았다. 계측 자체 (`perf.input_latency`) 는 세 platform 에
-# 다 있다.
+# 합성 입력이 platform 마다 다르다. Linux 는 `ydotool` (uinput), macOS 는 `CGEvent`
+# ([`mac-input.m`](mac-input.m) — 스크립트가 `clang` 으로 그 자리에서 빌드한다), Windows 는
+# `SendInput` ([`send-keys.ps1`](send-keys.ps1)) 이다. 계측 자체 (`perf.input_latency`) 도
+# 세 platform 에 다 있다.
 #
 # **Windows 는 Git Bash 에서 돌린다** (`compare-terminals.sh` · `measure-repeat.sh` 와 같은
 # 제약이다). PowerShell 판을 따로 두지 않는 이유는 `measure-repeat.sh` 헤더에 있다 — #381 에서
 # 두 벌이 실제로 갈렸다.
+#
+# ## macOS 가 다른 네 가지
+#
+# 1. **합성 입력에 손쉬운 사용 (Accessibility) 권한이 필요하다.** 없으면 `CGEventPost` 가
+#    성공을 반환하면서 아무 일도 하지 않는다 — Linux 의 `ydotoold` 미기동과 같은 종류의
+#    *조용한 실패*다. `mac-input check` 로 **회차를 돌기 전에** 막는다.
+# 2. **창을 클릭해 key window 로 만든다** (#387 에서 통한 방법 — `osascript keystroke` 는
+#    Accessory mode 때문에 새어 나간다). 그 클릭까지 CGEvent 로 해서 사람 개입이 없다.
+#    클릭이 실패한 회차는 실제 렌더가 838 tick 중 19 회뿐이라 (활성 창은 264 회) 화면이
+#    사실상 멈춘 상태에서 잰 값이었다.
+# 3. **종료 키가 `Cmd+Q` 가 아니라 `Cmd+W` 다.** `Cmd+Q` 는 `applicationShouldTerminate` 가
+#    `count()==1` 을 보고 확인창을 띄워 앱이 안 닫힌다. `Cmd+W` 는 `closeTab` 이
+#    `orderedRemove` 로 탭을 **먼저 지운 뒤** terminate 라 `count()==0` → 확인창을 건너뛴다
+#    (`session_core.zig` · `host/macos.zig`). Linux 가 `Alt+F4` 대신 `Ctrl+Shift+W` 를 쓰는
+#    것과 같은 이유다.
+# 4. **한글 IME 에서도 표본이 다 잡힌다.** Linux 는 fcitx5 가 키를 가져가 표본이 0 이라 폐기
+#    장치에 저절로 걸리는데, macOS 는 `keyDown:` 이 우리 뷰에 먼저 오고 앱이
+#    `interpretKeyEvents:` 로 IME 에 넘기는 순서라 (`markInput()` 이 `tildazKeyDown` 첫 줄)
+#    한글에서도 그대로 세어진다. **값도 영문과 비슷하다** — 실측 (`a` × 10):
+#
+#      영문  표본 10 · 에코 10 B  · 평균 3.12 ms · 최악 4.11 ms
+#      한글  표본 10 · 에코 27 B  · 평균 4.33 ms · 최악 5.20 ms
+#
+#    한글도 PTY 왕복이 있다. 같은 자음을 연달아 치면 IME 가 음절을 확정해 흘려보내기
+#    때문이다 (`ㅁ` 9 개 = 27 B). 즉 **표본으로도 에코로도 못 거른다.** 재는 경로가 달라
+#    나란히 둘 수 없으므로, 폐기에 기대지 말고 **미리 영문으로 바꾸고** 잰다. Windows 가
+#    IME conversion mode 를 맞추는 것과 같은 취지다.
 set -u
 
 PRESSES=30
@@ -57,7 +84,8 @@ usage() {
   --mode <이름>   idle · flood · both (기본 both)
   --mb <N>        flood 모드의 폭포 분량 MiB (기본 2048)
   --gap <초>      키 사이 간격 (기본 0.2 — 각 키가 독립적으로 처리되도록)
-  --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음).
+  --focus-wait <초>  창을 클릭할 시간을 준다 (기본 0 = 개입 없음). **Linux 전용** —
+                     macOS 는 CGEvent 로, Windows 는 SendInput 으로 직접 클릭한다.
                      표본이 부족하게 나오는 환경에서만 쓴다
   --retries <N>   폐기된 회차를 다시 돌릴 횟수 (기본 3)
   --ignore-hygiene  위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
@@ -82,10 +110,13 @@ REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 . "$REPO_ROOT/dist/stress/hygiene.sh"
 
 case "$HYG_PLATFORM" in
-    linux|windows) ;;
-    *) echo "이 스크립트는 Linux · Windows 전용이에요 ($(uname -s)) — macOS 는 합성 입력(CGEvent)이 아직 없어요." >&2
+    linux|macos|windows) ;;
+    *) echo "이 스크립트는 Linux · macOS · Windows 전용이에요 ($(uname -s))." >&2
        exit 2 ;;
 esac
+
+# macOS 도구는 간격을 ms 로 받는다 (`--gap`). 초 단위 옵션을 한 번만 환산해 둔다.
+GAP_MS=$(awk "BEGIN{printf \"%d\", $GAP * 1000}")
 
 # 자식이 Windows 실행파일이면 경로를 native 로 바꿔 넘긴다 (`measure-repeat.sh` 와 같은
 # 함수다). MSYS 는 명령줄 인자를 자동 변환하기도 하지만 기대지 않는다.
@@ -96,12 +127,20 @@ native_path() {
 EXE_SUFFIX=""
 [ "$HYG_PLATFORM" = windows ] && EXE_SUFFIX=".exe"
 EXE="$REPO_ROOT/zig-out/bin/tildaz$EXE_SUFFIX"
+# macOS 는 서명된 번들 안 바이너리를 먼저 본다 (`check-input-loss.sh` 와 같은 규칙). `-e` ·
+# `-size` 인자가 필요해서 `open` 이 아니라 직접 띄우는데, 전역 핫키를 안 쓰므로 권한이
+# 없어도 된다 (AGENTS.md 의 macOS `open` 절).
+if [ "$HYG_PLATFORM" = macos ] && [ -x "$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz" ]; then
+    EXE="$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz"
+fi
 STRESS="$REPO_ROOT/zig-out/bin/tildaz-stress$EXE_SUFFIX"
 SENDKEYS="$REPO_ROOT/dist/stress/send-keys.ps1"
+MACINPUT_SRC="$REPO_ROOT/dist/stress/mac-input.m"
 
 # `paths.zig` 의 `logDir` 와 같은 규칙이다 (`measure-repeat.sh` 와 같은 표).
 case "$HYG_PLATFORM" in
     linux)   LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log" ;;
+    macos)   LOG="$HOME/Library/Logs/tildaz_stress.log" ;;
     windows) LOG="$(cygpath -u "$APPDATA")/tildaz/tildaz_stress.log" ;;
 esac
 
@@ -110,6 +149,9 @@ esac
 
 YDOTOOLD_PID=""
 IME_RESTORE=""
+MAC_INPUT=""
+MAC_INPUT_DIR=""
+IME_RESTORE_ID=""
 
 if [ "$HYG_PLATFORM" = linux ]; then
     command -v ydotool >/dev/null 2>&1 || { echo "ydotool 없음 — 합성 입력에 필요해요." >&2; exit 1; }
@@ -153,6 +195,29 @@ if [ "$HYG_PLATFORM" = linux ]; then
     else
         echo "  ⚠ fcitx5-remote 가 없어요 — 입력기가 한글이면 표본이 안 잡혀요. 영문인지 확인하세요." >&2
     fi
+elif [ "$HYG_PLATFORM" = macos ]; then
+    # `mac-input.m` 을 그 자리에서 컴파일한다. 저장소에 바이너리를 두지 않는 것은
+    # `dist/macos/color-capture.m` 과 같은 방식이다.
+    command -v clang >/dev/null 2>&1 || { echo "clang 없음 — Xcode Command Line Tools 가 필요해요." >&2; exit 1; }
+    [ -f "$MACINPUT_SRC" ] || { echo "mac-input.m 없음: $MACINPUT_SRC" >&2; exit 1; }
+    MAC_INPUT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tildaz-macinput-XXXXXX")
+    MAC_INPUT="$MAC_INPUT_DIR/mac-input"
+    clang -O2 -Wno-deprecated-declarations \
+          -framework ApplicationServices -framework Carbon \
+          -o "$MAC_INPUT" "$MACINPUT_SRC" || { echo "mac-input 컴파일 실패." >&2; exit 1; }
+
+    # **한글이어도 표본 · 에코가 다 차서 폐기 장치에 안 걸린다** (헤더 주석 ④). 재는 경로가
+    # 달라지는데 값은 그럴듯해서, 전환을 놓치면 모르고 결론을 낸다. 끝나면 되돌린다.
+    IME_BEFORE=$("$MAC_INPUT" ime-get 2>/dev/null || echo "")
+    if "$MAC_INPUT" ime-ascii; then
+        IME_AFTER=$("$MAC_INPUT" ime-get 2>/dev/null || echo "")
+        if [ -n "$IME_BEFORE" ] && [ "$IME_BEFORE" != "$IME_AFTER" ]; then
+            IME_RESTORE_ID="$IME_BEFORE"
+            echo "  입력기가 한글이라 영문으로 바꿨어요: $IME_BEFORE → $IME_AFTER (끝나면 되돌립니다)."
+        fi
+    else
+        echo "  ⚠ 영문 입력 소스로 못 바꿨어요 — 한글이면 재는 경로가 달라져요." >&2
+    fi
 else
     command -v powershell >/dev/null 2>&1 || { echo "powershell 없음 — SendInput 합성 입력에 필요해요." >&2; exit 1; }
     [ -f "$SENDKEYS" ] || { echo "send-keys.ps1 없음: $SENDKEYS" >&2; exit 1; }
@@ -163,6 +228,8 @@ cleanup() {
     [ -n "$APP" ] && kill "$APP" 2>/dev/null
     [ -n "$YDOTOOLD_PID" ] && kill "$YDOTOOLD_PID" 2>/dev/null
     [ -n "$IME_RESTORE" ] && fcitx5-remote -o >/dev/null 2>&1   # 원래대로 한글
+    [ -n "$IME_RESTORE_ID" ] && "$MAC_INPUT" ime-set "$IME_RESTORE_ID" >/dev/null 2>&1
+    [ -n "$MAC_INPUT_DIR" ] && rm -rf "$MAC_INPUT_DIR"
     hygiene_end
 }
 trap cleanup EXIT INT TERM
@@ -181,6 +248,12 @@ hygiene_check || {
 }
 hygiene_begin
 
+# `hygiene.sh` 는 macOS 주사율을 셸만으로 못 읽어서 `?` 로 둔다. **응답 시간에서는 이 값이
+# 결론을 바꾸므로** (프레임 주기가 지연의 하한이다) 우리가 컴파일해 둔 도구로 채운다.
+if [ "$HYG_PLATFORM" = macos ]; then
+    HYG_REFRESH=$("$MAC_INPUT" refresh 2>/dev/null || echo "?")
+fi
+
 # **키가 실제로 나가는지 먼저 확인한다.** 안 나가면 회차를 도는 의미가 없다.
 # 화면을 바꾸지 않는 modifier 한 번으로 왕복만 본다.
 #
@@ -188,15 +261,48 @@ hygiene_begin
 # 때만** 키를 보내므로 (사용자 창으로 새는 것을 막는 가드), 창이 뜨기 전에는 부를 대상이
 # 없다. 대신 그 스크립트가 창 없음 / 포커스 없음 / 전송 중단을 각각 다른 종료 코드로
 # 알려서 회차가 조용히 비는 일이 없다.
+#
+# macOS 는 키를 보내 보는 것으로는 판정이 안 된다 — 권한이 없어도 `CGEventPost` 가 성공을
+# 반환한다. 그래서 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 부른다
+# (`mac-input.m` 의 `requireTrusted`). 권한은 자식이 아니라 **부모 (터미널 앱)** 에 붙으므로
+# 판정과 전송이 같은 프로세스여야 답이 맞는다.
 if [ "$HYG_PLATFORM" = linux ]; then
     if ! ydotool key 42:1 42:0 >/dev/null 2>&1; then
         echo "ydotool 이 키를 보내지 못했어요 — 데몬 · /dev/uinput 권한을 확인하세요." >&2
         exit 1
     fi
+elif [ "$HYG_PLATFORM" = macos ]; then
+    "$MAC_INPUT" check || exit 1
 fi
 
 # evdev 키코드 — `a`=30 · LEFTCTRL=29 · LEFTSHIFT=42 · c=46 · w=17 · F12=88.
 send_keys() {
+    if [ "$HYG_PLATFORM" = macos ]; then
+        # **macOS 만 문자 키 앞뒤를 덤프로 감싼다.** 그러면 그 사이 구간의 `drain bytes` 가
+        # 곧 문자 키의 **에코량**이라 (`dumpAndReset` 이 읽으면서 리셋한다), *"키는 앱에
+        # 닿았는데 PTY 로는 안 간"* 회차를 아래 판정에서 거를 수 있다 — macOS 에서 실제로
+        # 겪은 실패다 (헤더 주석 참고. 표본은 다 차고 평균만 0.33 ms 로 그럴듯했다).
+        # 앞의 `Ctrl+C` 는 프롬프트를 먼저 새로 그려 그 출력까지 앞 구간으로 보낸다.
+        #
+        # Linux · Windows 로 넓히지 않은 이유는 **기대 표본이 바뀌기 때문**이다. 지금 두
+        # platform 은 `Ctrl+C` 의 modifier 까지 세어 `키 수 + 1` 이 정상인데, 이 배치에서는
+        # 정확히 `키 수` 가 된다. 이미 5 회씩 측정을 마친 값이 있어 (Linux · Windows 코멘트)
+        # 도구를 바꾸면 재측정이 필요하다 — 그 판단은 각 platform 머신에서 한다.
+        "$MAC_INPUT" send ctrl+c --gap 700 >/dev/null 2>&1        # 프롬프트를 새로 그린다
+        "$MAC_INPUT" send shift+cmd+f12 --gap 500 >/dev/null 2>&1 # 여기까지를 앞 구간으로 버린다
+        # 한 프로세스가 반복과 간격을 모두 처리한다 — 키마다 프로세스를 새로 띄우는
+        # 기동 시간이 `--gap` 을 지배하지 않도록 (Windows 가 `.ps1` 한 번으로 보내는 것과 같은 이유).
+        "$MAC_INPUT" send a --repeat "$PRESSES" --gap "$GAP_MS" || {
+            echo "⚠ mac-input 전송 실패 — 회차를 중단해요." >&2
+            return 1
+        }
+        sleep 0.5
+        "$MAC_INPUT" send shift+cmd+f12 --gap 600 >/dev/null 2>&1 # 측정 구간 덤프
+        "$MAC_INPUT" send ctrl+c --gap 300 >/dev/null 2>&1        # 입력 줄 비우기
+        "$MAC_INPUT" send cmd+w --gap 200 >/dev/null 2>&1         # 탭 닫기 = 앱 종료 (헤더 ③)
+        return 0
+    fi
+
     if [ "$HYG_PLATFORM" = windows ]; then
         # 한 회차의 키 순서를 **한 번의 호출로** 보낸다. 키마다 powershell 을 띄우면 그
         # 기동 시간이 `--gap` 을 지배한다. 실패 (창 없음 · 포커스 상실) 는 종료 코드로 온다.
@@ -320,9 +426,22 @@ run_one() {
     APP=$!
     sleep 4                     # 창 map + 폰트 init + (flood 면) 폭포 시작
 
-    # 합성 입력은 **포커스된 창** 으로만 간다. 다만 `-e` 로 띄운 새 창은 포커스를 자동으로
-    # 받는다 — 클릭한 회차와 클릭하지 않은 회차의 값이 idle 최악 12.30 / 12.33 ms 로 사실상
-    # 같았다 (실측). 그래서 **사람 개입 없이 돈다.**
+    # macOS 는 창을 클릭해 key window 로 만든다 (헤더 주석 ②). 그 클릭까지 CGEvent 로 하고
+    # 포인터를 원래 자리로 되돌리므로 사람 개입이 없다. Windows 의 포커스 회수 (client
+    # 한가운데 클릭) 와 같은 취지다.
+    if [ "$HYG_PLATFORM" = macos ]; then
+        "$MAC_INPUT" focus "$APP" || {
+            echo "⚠ 창을 클릭하지 못했어요 — 회차를 중단해요." >&2
+            kill "$APP" 2>/dev/null
+            [ -n "$RUNNER" ] && rm -f "$RUNNER"
+            return 1
+        }
+        sleep 0.5
+    fi
+
+    # 합성 입력은 **포커스된 창** 으로만 간다. 다만 Linux 에서 `-e` 로 띄운 새 창은 포커스를
+    # 자동으로 받는다 — 클릭한 회차와 클릭하지 않은 회차의 값이 idle 최악 12.30 / 12.33 ms 로
+    # 사실상 같았다 (실측). 그래서 **사람 개입 없이 돈다.**
     #
     # 한때 표본이 2~4 개로 나와 "포커스를 못 받는다" 고 봤지만, 그 회차들은 다른 원인이었다
     # (ydotool 데몬 미기동 · 측정 중 조작 · 덤프 회수 실패). 포커스가 진짜 문제인 환경이라면
@@ -357,20 +476,49 @@ run_one() {
     # **표본 수를 기대치와 대조한다.** 합성 입력은 *포커스된 창* 으로 가므로, 측정 중에
     # 창을 바꾸거나 마우스를 움직이면 키가 다른 앱으로 새고 표본만 적게 남는다. 그때도
     # 평균은 그럴듯한 값이 나와서 **모르고 결론을 내기 쉽다** (실측으로 겪었다).
-    VERDICT=$(awk -v mode="$MODE_NAME" -v want="$PRESSES" '
+    #
+    # 스냅숏 **블록 단위**로 보고 **표본이 가장 많은 블록 하나만** 쓴다. 종료 덤프 (#396) 와
+    # 섞이지 않고, macOS 처럼 덤프를 두 번 남기는 배치에서도 측정 구간만 잡힌다.
+    #
+    # 표본 부족의 사유가 platform 마다 다르다. **macOS 는 한글 입력기가 사유가 아니다** —
+    # 한글에서도 표본이 다 차기 때문이다 (헤더 주석 ④). 엉뚱한 곳을 보게 하지 않으려고 가른다.
+    case "$HYG_PLATFORM" in
+        macos) SHORT_HINT="창 포커스를 뺏겼거나 측정 중 조작이 있었어요" ;;
+        *)     SHORT_HINT="입력기가 한글이거나 측정 중 조작이 있었어요" ;;
+    esac
+    # 에코 검사는 문자 키를 덤프로 감싸는 macOS 회차에만 뜻이 있다 (`send_keys` 주석).
+    CHECK_ECHO=0
+    [ "$HYG_PLATFORM" = macos ] && [ "$MODE_NAME" = idle ] && CHECK_ECHO=1
+
+    VERDICT=$(awk -v mode="$MODE_NAME" -v want="$PRESSES" -v hint="$SHORT_HINT" -v check_echo="$CHECK_ECHO" '
+    /^=== snapshot/ { snap = 1; cur_drain = 0; next }
+    /^=== /         { snap = 0 }
+    /^drain / {
+        if (snap) for (i = 1; i <= NF; i++) if ($i ~ /^bytes=/) { split($i, a, "="); cur_drain = a[2] + 0 }
+    }
     /^input / {
+        if (!snap) next
+        smp = 0; tot = 0; mx = 0
         for (i = 1; i <= NF; i++) {
-            if ($i ~ /^samples=/)  { split($i, a, "="); s += a[2] }
-            else if ($i ~ /^ms=/)  { split($i, a, "="); t += a[2] }
-            else if ($i ~ /^max_ms=/) { split($i, a, "="); if (a[2] + 0 > m) m = a[2] + 0 }
+            if ($i ~ /^samples=/)     { split($i, a, "="); smp = a[2] + 0 }
+            else if ($i ~ /^ms=/)     { split($i, a, "="); tot = a[2] + 0 }
+            else if ($i ~ /^max_ms=/) { split($i, a, "="); mx = a[2] + 0 }
         }
+        if (smp > s) { s = smp; t = tot; m = mx; echoed = cur_drain }
+        snap = 0
     }
     END {
         if (s + 0 == 0) { printf "  %-6s  ❌ 표본 없음 — 키가 앱에 안 갔거나 화면이 안 바뀌었어요\n", mode; exit }
-        printf "  %-6s  표본 %3d / %d   평균 %6.2f ms   최악 %6.2f ms", mode, s, want, t / s, m
+        printf "  %-6s  표본 %3d / %d", mode, s, want
+        if (check_echo) printf "   에코 %4d B", echoed + 0
+        printf "   평균 %6.2f ms   최악 %6.2f ms", t / s, m
         # 8 할 미만이면 회차를 믿지 않는다 — 남은 표본으로 낸 평균은 그럴듯해 보이지만
         # 어떤 키가 빠졌는지 모르므로 대표성이 없다.
-        if (s < want * 0.8) printf "   ⚠ 표본 부족 — 입력기가 한글이거나 측정 중 조작이 있었어요 (회차 폐기)"
+        if (s < want * 0.8) printf "   ⚠ 표본 부족 — %s (회차 폐기)", hint
+        # **표본이 다 차도 안심할 수 없다.** 키가 앱에는 닿았지만 (표본 증가) PTY 로는 안 간
+        # 회차가 macOS 에서 실제로 있었다 — modifier 가 남은 채 `a` 가 나가 `Cmd+A` 로 읽힌
+        # 경우다. 화면에도 아무것도 안 찍혔는데 평균은 0.33 ms 로 그럴듯했다.
+        else if (check_echo && echoed + 0 < want * 0.8) printf "   ⚠ 에코 %d B — 키가 앱엔 닿았는데 PTY 로 안 갔어요 (회차 폐기)", echoed + 0
         printf "\n"
     }' "$RAW")
     rm -f "$RAW"
@@ -394,10 +542,17 @@ run_with_retry() {
     return 1
 }
 
+# macOS 만 문자 키를 덤프로 감싼다 (`send_keys` 주석 — 에코 검사를 만들기 위해서다).
+case "$HYG_PLATFORM" in
+    macos) KEY_SEQ="Ctrl+C → Shift+Cmd+F12 → 'a' × ${PRESSES} (간격 ${GAP}s) → Shift+Cmd+F12 → Ctrl+C → Cmd+W" ;;
+    *)     KEY_SEQ="'a' × ${PRESSES} (간격 ${GAP}s) → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W" ;;
+esac
+
 cat <<EOF
 
 ============ 응답 시간 측정 (#441 축 ②) ============
- 키        : 'a' × ${PRESSES} (간격 ${GAP}s) → Ctrl+C → Ctrl+Shift+F12 → Ctrl+Shift+W
+ platform  : $HYG_PLATFORM
+ 키        : $KEY_SEQ
  모드      : $MODE
  재는 구간 : 키 수신 → 그 뒤 첫 present 완료
              (PTY write · 셸 에코 · parse · render 포함)


### PR DESCRIPTION
[#472](https://github.com/ensky0/tildaz/pull/472) (Windows) **위에 쌓은 PR** 이에요. 그쪽이 머지되면
이 PR 의 diff 는 macOS 커밋 하나만 남아요.

세 platform 이 한 스크립트로 돌게 됐어요. 갈리는 것은 합성 입력뿐이에요 — Linux 는 `ydotool`,
Windows 는 `SendInput`, macOS 는 **`CGEvent`** ([`dist/stress/mac-input.m`](../blob/feat/441-input-latency-macos/dist/stress/mac-input.m),
스크립트가 `clang` 으로 그 자리에서 빌드해요).

## 1. macOS 계측이 실기에서 돈다 (첫 목표)

[`24f8cf1`](https://github.com/ensky0/tildaz/commit/24f8cf1) 의 macOS 계측 지점은 `zig build check`
6 타겟 컴파일만 거쳤었어요. 실기로 확인했어요 — `tildazKeyDown` 의 `markInput()` 과
`presentDrawable` 뒤의 `completeInput()` 이 모두 정상이고, **5 회 전부 표본 30 / 30 으로 폐기가
없었어요.**

## 2. macOS 가 다른 네 가지

| # | 다른 점 | 어떻게 다뤘나 |
|---|---|---|
| ① | **합성 입력에 손쉬운 사용 (Accessibility) 권한이 필요해요.** 없으면 `CGEventPost` 가 **성공을 반환하면서 아무 일도 안 해요** | `mac-input check` 가 `AXIsProcessTrusted()` 를 **키를 보내는 그 프로세스 안에서** 불러 회차를 돌기 전에 멈춰요. 권한은 자식이 아니라 **부모(터미널 앱)** 에 붙어서 판정 위치가 중요해요 |
| ② | **창을 클릭해 key window 로** 만들어야 해요 ([#387](https://github.com/ensky0/tildaz/issues/387#issuecomment-5188395490) 에서 통한 방법) | 그 클릭까지 CGEvent 로 하고 포인터를 원래 자리로 되돌려요. 클릭이 실패한 회차는 실제 렌더가 **838 tick 중 19 회**뿐이라 화면이 사실상 멈춘 상태였어요 |
| ③ | **종료가 `Cmd+Q` 가 아니라 `Cmd+W`** 예요 | `Cmd+Q` 는 `applicationShouldTerminate` 가 `count()==1` 을 보고 확인창을 띄워요. `Cmd+W` 는 `closeTab` 이 `orderedRemove` 로 탭을 **먼저 지운 뒤** terminate 라 `count()==0` → 확인창을 건너뛰어요 |
| ④ | **한글 IME 에서도 표본 · 에코가 다 차요** | Linux 는 표본 0 이라 폐기 장치에 저절로 걸리는데 macOS 는 안 걸려요 (같은 자음 연타에 음절이 확정돼 PTY 로 흘러가요 — `ㅁ` 9 개 = 27 B). 폐기에 기대지 않고 `TISSelectInputSource` 로 **미리** 바꿔요 |

## 3. 에코 검사 — 표본 수로는 안 보이는 오염을 잡아요

문자 키 앞뒤를 덤프로 감싸서 그 구간의 `drain bytes` 가 곧 **에코량**이 되게 했어요.

```
focus → Ctrl+C → 덤프(리셋) → 'a' × N → 덤프(측정) → Ctrl+C → Cmd+W
                              ↑ 이 구간 drain bytes = 정확히 에코 (키가 안 갔으면 0 B)
```

**실제로 겪은 실패예요.** modifier 가 남은 채 `a` 가 나가면 `Cmd+A` 로 읽혀 앱이 그냥 `return` 하는데,
`markInput()` 은 `tildazKeyDown` 첫 줄이라 **표본은 다 차고 평균만 0.33 ms 로 그럴듯해져요.** 화면에는
아무것도 안 찍혔고요. `mac-input` 이 flags 를 **0 이어도 항상 설정**하고 소스를
`kCGEventSourceStatePrivate` 로 두어 원인을 막고, 에코 검사가 이중으로 잡아요.

**Linux · Windows 로는 넓히지 않았어요.** 기대 표본이 `키 수 + 1` 에서 `키 수` 로 바뀌어 이미 5 회씩
마친 측정의 재측정이 필요하고, 그 판단은 각 platform 머신 몫이에요.

## 4. 수치

**MacBook Pro (M5 Pro) · macOS 26.6.1 · 내장 3024x1964 · 120 Hz (ProMotion) · AC · 배경 앱 최소화 ·
v0.8.2-dev.2 · ReleaseFast · simd=true.** 5 회 절사평균 + min~max.

| | **Linux** 60 Hz | **macOS** 120 Hz | **Windows** 60 Hz |
|---|---|---|---|
| 유휴 평균 | 0.67 ms (0.66~0.69) | **1.27 ms** (0.63~2.64) | 9.79 ms (9.28~10.12) |
| 유휴 최악 | 12.35 ms (12.30~12.38) | **4.05 ms** (0.79~**16.58**) | 19.85 ms (16.56~25.83) |
| 폭포 평균 | 10.69 ms (10.37~11.72) | **1.50 ms** (1.40~8.12) | 11.01 ms (10.09~11.69) |
| 폭포 최악 | 18.64 ms (18.24~19.14) | **4.26 ms** (2.01~8.24) | 17.62 ms (16.25~19.79) |

```
유휴  평균  0.68  0.74  0.63  2.39  2.64 ms    최악  0.89  2.98  0.79 16.58  8.29 ms
폭포  평균  1.53  1.42  1.40  8.12  1.54 ms    최악  5.10  2.29  2.01  8.24  5.40 ms
```

⚠️ **회차 폭이 커요.** 앞 세 회차와 뒤 두 회차가 두 무리로 갈려요. 회차가 갈수록 나빠지는 모양이라
열 누적이 의심되지만 **확인하지 않았어요.** 유휴 최악의 폭 (0.79~16.58 ms) 이 **Linux 값 12.35 ms 를
품어서**, 이 표만으로 "macOS 가 유휴 최악에서 낫다" 고 말할 수 없어요.

## 5. [#473](https://github.com/ensky0/tildaz/issues/473) 에 대한 입력

그 이슈가 *"macOS 는 어느 쪽인가"* 로 남겨 둔 물음의 답이에요. **구조는 Windows 와 같은데 값이 안
따라와요.**

| | 구조 (소스) | 반 프레임 기대 | 실측 유휴 평균 |
|---|---|---|---|
| Windows | `requestRender()` 게이트 → `WM_FRAME_TICK` | 8.3 ms | 9.79 ms — 설명과 맞아요 |
| **macOS** | **같은 구조** — `requestRender()` 가 `g_needs_render` 만 켜고 CADisplayLink 가 그려요 | **4.17 ms** | **0.63 · 0.68 · 0.74 · 2.39 · 2.64** — **5 회가 모두 그보다 낮아요** |

즉 *"게이트 구조가 반 프레임을 얹는다"* 는 설명이 **platform 을 가려요.** 원인은 미확인이에요 —
키 배달이 vsync 와 맞물려 CADisplayLink 발사 직전에 도착하는 것으로 보이지만 WindowServer 안쪽이라
우리 소스로는 못 봐요.

## 검증

- `zig build check` (6 타겟) · `zig build test` — 둘 다 통과 (zig 코드 변경 없음)
- `sh -n dist/stress/measure-input-latency.sh` · `clang -Wall` (경고 없음)
- **실기** — 위 5 회 측정. 폐기 회차 없음, 에코 30 B 로 PTY 왕복까지 확인
- 판정 장치 대조 실측 — 한글 회차 · modifier 오염 회차를 각각 재현해 확인

## 안 하는 것

- **`Closes` 를 걸지 않았어요.** 축 ②는 macOS 로 세 platform 이 찼지만 [#441](https://github.com/ensky0/tildaz/issues/441)
  본문에 남은 항목이 있어 사용자 판단 전까지 열어 둬요.
- **[#439](https://github.com/ensky0/tildaz/issues/439) 를 판정하지 않아요.** 이 측정은 **키를 눌러**
  시작해서 유휴 깨우기 경로를 안 타요. 예산 4 ms 와의 직접 비교도 성립하지 않아요.

Refs #441, #473
