### PR TITLE
fix(linux/sway): sway 판별을 SO_PEERCRED peer PID 비교로 — stale SWAYSOCK 회귀 (#454)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -208,8 +208,11 @@ Linux 지원 수준은 desktop 이름이 아니라 실제 capability + 검증 �
 - **sway (wlroots).** drop-down 은 **layer-shell 이 아니라 xdg_toplevel + i3 IPC**
   ([#454](https://github.com/ensky0/tildaz/issues/454)) — sway 는 layer-shell
   `on_demand` 에서 map 시 keyboard focus 를 주지 않아 (spec 상 compositor 재량,
-  KWin·Hyprland·COSMIC 셋은 줌) 토글 직후 타이핑이 안 됐다. `SWAYSOCK` 이 잡히면
-  layer-shell 을 기록하지 않고 xdg fallback 으로 뜬 뒤, 배치는 `for_window` 규칙
+  KWin·Hyprland·COSMIC 셋은 줌) 토글 직후 타이핑이 안 됐다. 판별은 `SWAYSOCK` 의
+  주인과 현재 Wayland compositor 의 `SO_PEERCRED` PID 가 **같은 프로세스**일 때만이다
+  — 존재만 보면 sway 세션이 systemd user 환경에 남긴 stale 변수가 다음 KDE 세션에서
+  sway 경로를 오발동시킨다 (KDE 실기 회귀로 확정). 성립하면 layer-shell 을 기록하지
+  않고 xdg fallback 으로 뜬 뒤, 배치는 `for_window` 규칙
   (floating·sticky·border·크기 — **명령당 규칙 하나**, 콤마 체인은 sway 가 첫
   명령까지만 규칙으로 받고 나머지를 focus 창에 즉시 실행) + map 후 `move`(ppt) 로,
   토글은 scratchpad 로 한다 (sway 1.12 실기 확인). hotkey 는 `$SWAYSOCK`의 i3-ipc

--- a/src/host/linux/sway_ipc.zig
+++ b/src/host/linux/sway_ipc.zig
@@ -88,14 +88,25 @@ pub fn registerToggleIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *con
 /// 이 세션에서 sway 의 xdg_toplevel + IPC 경로를 쓸 것인가
 /// ([#454](https://github.com/ensky0/tildaz/issues/454)).
 ///
-/// 판정은 **`SWAYSOCK` 존재 하나**다. 이 경로는 layer-shell 을 버리는 대신 배치 ·
-/// 토글을 전부 i3 IPC 로 하므로, IPC 가 불가능하면 layer-shell 유지가 항상 낫다 —
-/// `XDG_CURRENT_DESKTOP` 에 sway 토큰이 있어도 `SWAYSOCK` 이 없으면 배치 없는
-/// 기본 창만 남는다. 반대 방향은 걱정할 것이 없다: nested sway 는
-/// `XDG_CURRENT_DESKTOP` 이 부모 것 (`KDE`) 이지만 `SWAYSOCK` 은 잡히고 (실측),
-/// 실기 sway 세션은 둘 다 잡힌다.
-pub fn isSwaySession(rt: Runtime) bool {
-    return rt.environ.getPosix("SWAYSOCK") != null;
+/// 판정: `SWAYSOCK` 이 있고, 그 소켓의 주인 (`SO_PEERCRED` PID) 이 **지금 그리기로
+/// 연결한 Wayland compositor 와 같은 프로세스**일 때만 true. 이 경로는 layer-shell 을
+/// 버리는 대신 배치 · 토글을 전부 그 IPC 로 하므로, "IPC 상대 = 내 compositor" 가
+/// 성립하지 않으면 layer-shell 유지가 항상 낫다.
+///
+/// **존재 여부만으로는 오판한다** (KDE Plasma 실기 회귀로 확정): sway 세션이
+/// `import-environment` 로 넣은 `SWAYSOCK` 은 로그아웃해도 systemd user 환경에 남아,
+/// 다음 KDE 세션의 autostart 앱이 죽은 소켓을 물려받는다 — 그 상태로 sway 경로를
+/// 타면 KWin 에서 배치 없는 기본 창이 된다. peer PID 비교는 네 경우를 전부 가른다:
+/// 죽은 소켓 (connect 실패 → false) · 다른 VT 에 살아 있는 sway (PID 다름 → false) ·
+/// nested sway (같음 → true) · 실기 sway 세션 (같음 → true).
+pub fn isSwayCompositor(rt: Runtime, wayland_fd: posix.fd_t) bool {
+    const sock_path = rt.environ.getPosix("SWAYSOCK") orelse return false;
+    const fd = unix_socket.openSocket(posix.SOCK.CLOEXEC) catch return false;
+    defer unix_socket.closeFd(fd);
+    unix_socket.connect(fd, sock_path) catch return false;
+    const sway_pid = unix_socket.peerPid(fd) orelse return false;
+    const compositor_pid = unix_socket.peerPid(wayland_fd) orelse return false;
+    return sway_pid == compositor_pid;
 }
 
 /// #454 — sway 전용 창 규칙을 **창이 뜨기 전에** 등록한다.

--- a/src/host/linux/unix_socket.zig
+++ b/src/host/linux/unix_socket.zig
@@ -85,6 +85,31 @@ pub fn closeFd(fd: posix.fd_t) void {
     _ = posix.system.close(fd);
 }
 
+/// `SO_PEERCRED` — 연결된 Unix 소켓 상대편 프로세스의 PID. 실패면 `null`.
+///
+/// [#454](https://github.com/ensky0/tildaz/issues/454) 의 sway 판별에 쓴다 — "`SWAYSOCK`
+/// 의 주인"과 "지금 그리기로 연결한 compositor"가 **같은 프로세스**인지를 커널에게 직접
+/// 묻는다. 환경변수는 세션 전환 후에도 systemd user 환경에 남을 수 있어 (sway 세션의
+/// `import-environment` 를 로그아웃이 안 지움 — KDE 실기에서 확정) 존재 여부만으로는
+/// 판별이 안 된다.
+pub fn peerPid(fd: posix.fd_t) ?posix.pid_t {
+    // `std.os.linux.ucred` 와 같은 배치 — libc 구성 (`std.c`) 에는 이 구조체가 없어서
+    // 여기 정의를 둔다 (`getsockopt` 자체는 두 구성 모두 있다).
+    const Ucred = extern struct { pid: posix.pid_t, uid: posix.uid_t, gid: posix.gid_t };
+    var cred: Ucred = undefined;
+    var len: posix.socklen_t = @sizeOf(Ucred);
+    const rc = posix.system.getsockopt(
+        fd,
+        posix.SOL.SOCKET,
+        posix.SO.PEERCRED,
+        @as([*]u8, @ptrCast(&cred)),
+        &len,
+    );
+    if (checkErr(rc) != null) return null;
+    if (len != @sizeOf(Ucred) or cred.pid <= 0) return null;
+    return cred.pid;
+}
+
 /// 열려 있는 fd 를 `path` 의 Unix 소켓에 연결한다. 실패는 errno 를 그대로 돌려준다 —
 /// 호출부마다 의미 있는 이름이 달라서다 (`NoRunningInstance` vs Wayland 진단 메시지).
 pub fn connect(fd: posix.fd_t, path: []const u8) error{ PathTooLong, ConnectFailed }!void {

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1327,7 +1327,9 @@ const Client = struct {
         const theme = cfg.theme orelse fallback_theme;
         return .{
             .rt = rt,
-            .is_sway = sway_ipc.isSwaySession(rt),
+            // #454 — SWAYSOCK 존재가 아니라 peer PID 비교다: stale 환경변수가 KDE 에서
+            // sway 경로를 오발동시킨 회귀의 fix (`sway_ipc.isSwayCompositor` 주석).
+            .is_sway = sway_ipc.isSwayCompositor(rt, wayland_fd),
             .allocator = allocator,
             .wayland_fd = wayland_fd,
             .renderer = renderer,
@@ -1610,8 +1612,10 @@ const Client = struct {
 
             log.appendLine("linux", "Wayland terminal window mapped", .{});
             // #454 — sway 는 크기를 `for_window` 가 잡고 **위치는 map 후**에 준다
-            // (`sway_ipc.moveWindowIfSway` 주석). sway 가 아니면 no-op 이다.
-            sway_ipc.moveWindowIfSway(self.rt, self.allocator, self.config);
+            // (`sway_ipc.moveWindowIfSway` 주석). gate 는 `is_sway` (peer PID 비교) —
+            // 함수 내부의 SWAYSOCK 존재 확인만 믿으면 stale 변수가 남은 세션에서
+            // 무의미한 IPC 가 나가고, 응답 없는 소켓이면 map 직후 hang 이다.
+            if (self.is_sway) sway_ipc.moveWindowIfSway(self.rt, self.allocator, self.config);
         }
 
         // #304 — listener만 먼저 열린 시점이 아니라 Wayland globals, 입력,
@@ -8300,11 +8304,17 @@ pub fn runBaselineWindow(
     // `bindsym` 으로 자동 등록 (config = source of truth). 비-sway 면 no-op.
     // 측정 모드는 자기 단축키를 DE 에 등록하지 않는다 (#382) — 사용자의 기존 binding 을
     // 덮어쓰면 측정이 끝난 뒤에도 그 상태가 남는다.
-    if (!opts.isStressRun()) sway_ipc.registerToggleIfSway(rt, allocator, cfg);
+    // #454 — 이 호출도 `client.is_sway` (peer PID 비교) 뒤에 있어야 한다. 렌더링하지
+    // 않는 compositor 에 bindsym 을 등록하는 것은 무의미하고, 무엇보다 stale `SWAYSOCK`
+    // 이 **응답 없는 소켓**을 가리키면 `runCommand` 의 read 가 부팅을 영원히 막는다
+    // (KDE 실기 — mute 소켓 시뮬레이션에서 boot 로그 후 hang 확정).
+    if (!opts.isStressRun() and client.is_sway) sway_ipc.registerToggleIfSway(rt, allocator, cfg);
     // #454 — sway 면 창 규칙(`for_window`)을 **창을 만들기 전에** 등록한다. layer-shell 을
     // 쓰지 않는 대신 배치를 이 규칙이 맡는다. `client.run()` 안에서 창이 뜨므로 순서가
     // 여기서 보장된다. 측정 인스턴스는 제외 — 사용자의 드롭다운이 아니다 (#382).
-    if (!opts.isStressRun()) sway_ipc.registerWindowRuleIfSway(rt, allocator, cfg);
+    // gate 는 `client.is_sway` (peer PID 비교) 다 — SWAYSOCK 존재만 보면 stale 변수가
+    // 남은 KDE 세션에서 무의미한 IPC 시도가 나간다 (`isSwayCompositor` 주석).
+    if (!opts.isStressRun() and client.is_sway) sway_ipc.registerWindowRuleIfSway(rt, allocator, cfg);
     // #207 / #229 — GNOME · Cinnamon 세션이면 `tildaz --toggle`을
     // custom keybinding (GSettings)
     // 으로 자동 등록. 그 외 DE 면 no-op.


### PR DESCRIPTION
Closes #454

## 무엇

#471 머지 직후 **KDE Plasma 실기에서 회귀**: sway 세션이 systemd user 환경에 남긴 stale `SWAYSOCK` 때문에 KWin 에서도 sway 경로를 타서, 드롭다운이 배치 없는 기본 640x420 창으로 중앙에 떴다 ([재오픈 진단](https://github.com/ensky0/tildaz/issues/454#issuecomment-5305258259)).

판별을 존재 확인이 아니라 **커널에 직접 묻는 것**으로 바꾼다: `SWAYSOCK` 연결과 현재 Wayland 연결의 `SO_PEERCRED` PID 가 **같은 프로세스**일 때만 sway 경로.

## 판별 매트릭스 — 전부 실기 검증 (KDE Plasma · i5-1240P · KWin)

| 경우 | 판정 | 검증 방법 |
|---|---|---|
| 죽은 소켓 (이번 회귀) | ✅ 비-sway (`layer_shell=true`) | 실기 재현 + 죽은 경로 시뮬레이션 |
| 살아 있는 오(誤)소켓 | ✅ 비-sway | mute unix 리스너 시뮬레이션 |
| nested sway | ✅ sway (`layer_shell=false` · 배치·scratchpad 정상) | nested sway 1.12 실기 |
| 실기 sway | ✅ sway | nested 와 동일 경로 |

## 함께 잡은 것 — mute 소켓 부팅 hang

sway IPC 호출 세 곳 (`registerToggleIfSway` · `registerWindowRuleIfSway` · map 후 `moveWindowIfSway`) 이 gate 밖에 있었다. stale 변수가 **응답 없는 소켓**을 가리키면 `runCommand` 의 read 가 **부팅을 영원히 막는 것**을 시뮬레이션으로 실측했고 (boot 로그 후 hang), 셋 다 `client.is_sway` 뒤로 넣어 세 케이스 모두 IPC 시도 0회 · mapped 정상을 확인했다.

`zig build check` / `zig build test` 통과. SPEC.md 의 판별 서술도 갱신.