### PR TITLE
fix(exit): SIGTERM 을 정상 종료로 받아 PTY 자식을 거둔다 (#458)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -45,6 +45,7 @@ const unix_socket = @import("unix_socket.zig");
 const closeFd = unix_socket.closeFd;
 const checkErr = unix_socket.checkErr;
 const sway_ipc = @import("sway_ipc.zig");
+const signal_exit = @import("../../signal_exit.zig");
 const gsettings_hotkey = @import("gsettings_hotkey.zig");
 const about = @import("../../about.zig");
 const paths = @import("../../paths.zig");
@@ -1700,6 +1701,14 @@ const Client = struct {
             // #245 — drag-select auto-scroll tick (포인터가 grid 경계 밖에 머물면 연속).
             self.maybeAutoScrollSelection();
             if (self.shell_exited.load(.acquire)) {
+                self.running = false;
+                break;
+            }
+            // #458 — SIGTERM 을 받았으면 평소의 종료 경로로 빠진다. 그래야 `deinit` 이
+            // 돌아 PTY 자식 정리 (#129) 가 실행된다. 시그널이 `poll` 을 EINTR 로 깨우므로
+            // 대기 중이어도 곧 이 검사에 닿는다.
+            if (signal_exit.requested()) {
+                log.appendLine("exit", "SIGTERM received — shutting down cleanly", .{});
                 self.running = false;
                 break;
             }
@@ -8304,6 +8313,12 @@ pub fn runBaselineWindow(
     // `bindsym` 으로 자동 등록 (config = source of truth). 비-sway 면 no-op.
     // 측정 모드는 자기 단축키를 DE 에 등록하지 않는다 (#382) — 사용자의 기존 binding 을
     // 덮어쓰면 측정이 끝난 뒤에도 그 상태가 남는다.
+    // #458 — SIGTERM 을 정상 종료로 바꾼다. **검사하는 쪽과 같은 자리에서 건다** —
+    // 핸들러만 걸고 아무도 플래그를 안 보면 SIGTERM 이 무시돼 앱이 안 죽는다 (기본 동작을
+    // 없앤 셈이라 지금보다 나쁘다). Linux 는 아래 main loop 가 `signal_exit.requested()` 를
+    // 매 바퀴 검사하므로 여기서 거는 것이 안전하다. macOS · Windows 는 loop 구조가 달라
+    // 각자의 host 가 검사를 갖출 때 함께 건다.
+    signal_exit.install();
     // #454 — 이 호출도 `client.is_sway` (peer PID 비교) 뒤에 있어야 한다. 렌더링하지
     // 않는 compositor 에 bindsym 을 등록하는 것은 무의미하고, 무엇보다 stale `SWAYSOCK`
     // 이 **응답 없는 소켓**을 가리키면 `runCommand` 의 read 가 부팅을 영원히 막는다

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,6 +88,7 @@ fn initLogging(rt: Runtime, arena: std.mem.Allocator) void {
 /// `std.process.argsAlloc` 은 없어졌다.
 pub fn main(init: std.process.Init) void {
     const rt: Runtime = .fromInit(init);
+
     const arena = init.arena.allocator();
     // arena 는 process lifetime 이라 (`Init.arena` 주석) 예전 `argsFree` 가 하던 일이 없다.
     const args = init.minimal.args.toSlice(arena) catch std.process.exit(2);

--- a/src/signal_exit.zig
+++ b/src/signal_exit.zig
@@ -1,0 +1,61 @@
+//! `SIGTERM` 을 **정상 종료**로 바꾼다 ([#458](https://github.com/ensky0/tildaz/issues/458)).
+//!
+//! 핸들러가 없으면 `SIGTERM` 의 기본 동작이 즉시 종료라, `defer` 와 `deinit` 이 하나도
+//! 돌지 않는다. 그러면 PTY 의 자식 정리가 통째로 건너뛰어진다 — `pty.zig` 의 `deinit` 은
+//! [#129](https://github.com/ensky0/tildaz/issues/129) 에서 이미 *프로세스 그룹에 `SIGHUP`
+//! → 500 ms grace → `SIGKILL`* 을 하고 있는데, 그 자리에 **도달을 못 한다.**
+//!
+//! 그래서 `-e` 로 띄운 프로그램이 `SIGHUP` 을 무시하면 앱을 `kill` 한 뒤 고아로 남는다
+//! (실측: `trap '' HUP` 을 건 스크립트가 앱 종료 후 `ppid=1` 로 입양돼 살아남았다).
+//!
+//! **정리 코드를 새로 만들지 않는다.** 이 모듈이 하는 일은 *그 경로에 도달시키는 것* 뿐이다 —
+//! 핸들러는 플래그 하나만 세우고, main loop 가 그것을 보고 평소의 종료 경로로 빠진다.
+//!
+//! 곁가지로 종료 시 로그 flush 와 perf 덤프 (#396) 도 함께 정상화된다. 그 둘도 같은
+//! `defer` 에 걸려 있어서 지금까지 `SIGTERM` 회차에서는 남지 않았다.
+//!
+//! Windows 는 no-op 이다. `SIGTERM` 이 POSIX 개념이고, Windows 의 종료 통보 (`WM_CLOSE` ·
+//! `CTRL_CLOSE_EVENT`) 는 이미 다른 경로로 다룬다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+
+const is_posix = builtin.os.tag != .windows;
+
+/// 핸들러가 세우고 main loop 가 읽는다. 시그널 문맥에서 만질 수 있는 것은 이 정도뿐이다
+/// (async-signal-safe) — 로그도 정리도 여기서 하지 않는다.
+var term_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+fn onTerm(_: posix.SIG) callconv(.c) void {
+    term_requested.store(true, .release);
+}
+
+/// **`requested()` 를 검사하는 loop 와 같은 자리에서 부른다.** 핸들러만 걸고 아무도 플래그를
+/// 안 보면 `SIGTERM` 이 무시돼 앱이 종료되지 않는다 — 기본 동작을 없앤 셈이라 고치기 전보다
+/// 나쁘다. 지금은 Linux host 만 검사하므로 그쪽에서만 건다.
+///
+/// 실패해도 조용히 넘어간다 — 핸들러가 없으면 예전 동작 (즉시 종료) 으로 돌아갈 뿐이다.
+pub fn install() void {
+    if (!is_posix) return;
+    var act: posix.Sigaction = .{
+        .handler = .{ .handler = onTerm },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(posix.SIG.TERM, &act, null);
+}
+
+/// main loop 가 매 바퀴 검사한다. `true` 면 평소의 종료 경로로 빠지면 된다.
+pub fn requested() bool {
+    if (!is_posix) return false;
+    return term_requested.load(.acquire);
+}
+
+test "install 은 두 번 불러도 안전하고 기본은 요청 없음" {
+    if (!is_posix) return error.SkipZigTest;
+    try std.testing.expect(!requested());
+    install();
+    install();
+    try std.testing.expect(!requested());
+}


### PR DESCRIPTION
## 무엇

`-e <프로그램>` 으로 띄운 인스턴스를 `kill` 로 내리면 그 프로그램이 **고아로 남았다** ([#458](https://github.com/ensky0/tildaz/issues/458)).

## 원인 — 이슈의 추정보다 단순했다

이슈는 *"`SIGHUP` 무시 + `SIGTERM` 강제 종료"* 조합으로 봤는데, 실측해 보니 **앱에 `SIGTERM` 핸들러가 없는 것**이 원인이었다. 기본 동작이 즉시 종료라 `defer` 와 `deinit` 이 하나도 돌지 않고, 그래서 PTY 의 자식 정리에 **도달을 못 했다.**

**그 정리는 이미 있다** — [#129](https://github.com/ensky0/tildaz/issues/129) 가 만든 `pty.zig` 의 `deinit` 이 *프로세스 그룹에 `SIGHUP` → 500 ms grace → `SIGKILL`* 을 한다. 이슈의 안 A 가 요구하는 동작 그대로다.

## 고침 — 정리 코드를 새로 만들지 않는다

`signal_exit.zig` 가 핸들러를 걸어 **플래그 하나만** 세우고 (async-signal-safe), main loop 가 그것을 보고 **평소의 종료 경로**로 빠진다. 시그널이 `poll` 을 EINTR 로 깨우므로 대기 중이어도 곧 검사에 닿는다.

## `install` 은 `requested` 를 검사하는 host 에서 부른다

처음에는 진입점 (`main.zig`) 에 뒀는데 **그게 회귀였다.** macOS 에도 핸들러가 걸리면서 검사하는 쪽이 없어 **`SIGTERM` 이 무시돼 앱이 안 죽는다** — 기본 동작을 없앤 셈이라 고치기 전보다 나쁘다. 지금은 Linux host 만 검사하므로 그 자리에서만 건다.

**macOS · Windows 의 종료 동작은 이 PR 로 전혀 달라지지 않는다** — 두 host 는 이 모듈을 아예 참조하지 않는다. 각자 loop 에 검사를 갖출 때 함께 걸면 된다.

## 검증

미니PC · AMD Ryzen 7 8845HS · CachyOS · KDE Plasma Wayland. `-e` 에 SIGHUP 을 무시하는 스크립트를 넘기고 앱을 `kill` 했다.

| | 자식 프로세스 |
|---|---|
| fix 전 | ❌ `ppid=1` 로 입양돼 살아남음 |
| **fix 후** | ✅ **함께 정리됨** |

로그가 경로를 그대로 보여준다.

```
[exit] SIGTERM received — shutting down cleanly
[pty] SIGHUP ignored after 500ms, sent SIGKILL pgid=2774182
[tab] shell exited: title=Tab 1
=== stress @ ts=…                      (perf 덤프)
[exit] tildaz v0.8.2-dev.2  pid=…
```

`SIGHUP` 을 무시하는 프로그램이라 grace 후 `SIGKILL` 로 넘어갔다 — **#129 의 fallback 이 설계대로 동작한 것**이 확인된다.

`zig build check` (6 타겟) · `zig build test` (286 pass · 3 skip, 별도 4 pass) 통과. **`main` 최신 (#477 포함) 위에 rebase 한 뒤 재검증**했다 — 충돌은 `registerToggleIfSway` 한 줄이었고 (#477 의 `client.is_sway` 가드) 양쪽을 모두 살렸다.

## 곁가지 이득

종료 시 **로그 flush 와 perf 덤프 (#396)** 도 같은 `defer` 에 걸려 있어서 지금까지 `SIGTERM` 회차에서는 남지 않았는데, 이제 남는다. [#441](https://github.com/ensky0/tildaz/issues/441) 의 응답 시간 측정에서 앱이 안 닫혀 정리했을 때 덤프가 없어 *"표본 없음"* 으로 보이던 것과 같은 뿌리다.

Closes #458