### PR TITLE
feat(perf): 유휴 깨우기의 지연·절전 대가를 잰다 (#439 측정)

### DIFF
--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -43,7 +43,7 @@ zig build stress -Doptimize=ReleaseFast -Dsimd=true -- scrollback --mb 256
 | [`check-input-loss.sh`](check-input-loss.sh) | **응답성 ①** — 폭포 중 입력이 먹히는지 | Linux · macOS |
 | [`measure-input-latency.sh`](measure-input-latency.sh) | **응답성 ②** — 키가 화면에 닿기까지 얼마나 걸리는지 | Linux · macOS · Windows (Git Bash) |
 | [`send-keys.ps1`](send-keys.ps1) | 위 도구의 **Windows 합성 입력** (`SendInput`) — Linux 의 `ydotool` 자리 | 〃 |
-| [`hygiene.sh`](hygiene.sh) | 위 넷이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
+| [`hygiene.sh`](hygiene.sh) | 위 다섯이 **공유하는 측정 위생** — 검사 · 준비 · 복원 | 실행 파일이 아니라 `.` 로 읽어요 |
 
 `measure-repeat` 는 앱을 반복해 띄워 종료 시 자동 덤프 ([#396](https://github.com/ensky0/tildaz/issues/396))
 로 남는 perf 스냅숏을 모으고, **5 회 절사평균 + min~max** 로 표를 내요. 시작 전에 위생을
@@ -898,6 +898,248 @@ Linux · Windows 로 넓히지 않은 이유는 **기대 표본이 바뀌기 때
 행위라 foreground lock 이 안 걸려요). 회수가 쓰이면 회차 줄에 *"포커스를 클릭으로 회수했어요"* 가
 붙어요 — 5 회차 실측 (idle · flood 각 5 회) 에서 **10 회차 중 9 회**가 그랬어요. 즉 이 회수 경로가
 없으면 그 측정은 거의 전부 폐기됐을 거예요.
+
+## 유휴 지연 측정 ([#439](https://github.com/ensky0/tildaz/issues/439))
+
+앞의 두 절이 *사용자 입력* 을 다룬다면, 이쪽은 **입력 없이 PTY 출력만 도착**하는 상황이에요.
+
+```sh
+dist/stress/measure-idle-latency.sh                 # 20 회 · 간격 2 초
+dist/stress/measure-idle-latency.sh --samples 40 --gap 3
+```
+
+### 왜 따로 필요한가 — 입력 측정으로는 못 봐요
+
+`measure-input-latency.sh` 는 **키** 에서 시작하는데, **키가 오면 앱이 즉시 렌더를 요청해서
+유휴 깨우기 경로를 아예 안 타요.** 그래서 유휴 평균이 0.67 ms 로 낮게 나와요. 이 스크립트는
+입력을 아예 보내지 않아요 — 그래서 **합성 입력도 필요 없어요** (`ydotool` · 포커스 · IME 무관).
+
+| | 시작 | 재는 것 |
+|---|---|---|
+| `measure-input-latency.sh` | 키 수신 | 사용자 입력의 왕복 |
+| **`measure-idle-latency.sh`** | **PTY 도착** | **유휴 깨우기 지연** |
+
+### Windows 는 러너가 갈려요 — `.cmd` 예요
+
+**Windows 의 `-e` 는 인자를 받아요.** POSIX 는 PTY 자식의 argv 가 실행파일 하나로 고정이지만
+(`run_options.zig`), Windows 는 `CreateProcessW` 의 `lpCommandLine` 이라
+([`host/windows.zig`](../../src/host/windows.zig) 의 `stress_shell_w`) `cmd.exe /c <배치>` 가
+그대로 서요. 그래서 POSIX `.sh` 러너를 그대로 넘기면 **아예 안 떠요.** 스크립트가 platform 을
+보고 갈라요 (`measure-input-latency.sh` 와 같은 처리예요).
+
+- 러너는 **`%TEMP%` 아래**에 만들어요 — Git Bash 의 `/tmp` 는 설치 경로 안이라
+  (`C:\Program Files\Git\tmp`) 공백이 섞이고, 그러면 `cmd /c "…"` 인용이 갈려요
+- 대기는 **`ping -n <간격+1> 127.0.0.1 >nul`** 이에요. `timeout` 은 stdin 이 리다이렉트되면
+  `ERROR: Input redirection is not supported` 로 떨어져요
+- 배치는 **CRLF + `for /L` 한 줄**로 써요. 여러 줄 괄호 블록을 LF 만으로 쓰면 `cmd.exe` 가
+  블록을 잘못 읽을 수 있어요 (`compare-terminals.sh` 의 `conhost.cmd` 도 CRLF 로 써요)
+- 실행 파일 탐지에 **`.exe`** 를 붙여요 (안 붙이면 `[ -x ]` 가 전부 실패해 `tildaz 없음` 으로 끝나요)
+
+#### ⚠ Windows 는 표본이 **N + 1** 로 잡혀요 — 오염이 아니에요
+
+`output` 계측은 프로세스 시작부터 누적되는데 **ConPTY 가 시작할 때 자체 출력을 한 번 내요**
+(`ESC [ { 1 } t` — 로그에 `ignoring CSI t` 경고로 남아요). 그래서 표본 20 을 요청하면 21 이
+나와요. **표본 0 대조군**으로 그 몫만 따로 재 보면 `samples=1 ms=7.311` 이라, 그 표본도
+*같은 유휴 프레임 대기*예요 (60 Hz 의 균등분포 [0, 16.67] 한가운데). 평균을 끌어내리는 편향이
+아니라서 그대로 둬요. Linux 는 PTY 가 시작 출력을 안 내서 정확히 N 이에요.
+
+### 기록 수치 ① — Linux (노트북 · Intel i5-1240P · CachyOS · KDE Plasma · 60 Hz · 측정 위생 적용)
+
+5 회 절사평균 + min~max — 회차당 표본 20 · 간격 2 초, 전 회차 `input` 표본 0.
+
+| | 절사평균 | min~max |
+|---|---|---|
+| 평균 | **8.71 ms** | 7.64~9.57 |
+| **최악** | **16.39 ms** | 15.77~17.19 |
+
+**Linux 의 `frame_poll_ms` 가 16 ms 예요.** 최악값 5 회가 전부 그 언저리 (15.77~17.19 ms) 라서,
+**`poll` timeout 이 그대로 지연이 된다**는 것이 확인됐어요 (#439 의 가설). 첫 실측 (미니PC ·
+Ryzen 7 8845HS · 60 Hz — **위생 미적용**, 평소 worker 가 떠 있었어요) 도 평균 9.11 / 최악
+16.14 ms 로 같은 모양이었어요. timeout 상수가 값을 지배해서 기기 차이가 거의 안 보여요.
+
+같은 유휴 상태인데 키 → 화면 (`input_latency`) 은 출력 → 화면과 **15 배** 갈려요 (미니PC 동일
+기기 비교: 키 0.67 ms vs 출력 9.11 ms) — 키는 즉시 렌더를 요청해 깨우기 경로를 안 타기
+때문이에요.
+
+### 기록 수치 ② — Windows (**같은 노트북**의 다른 OS · 내장 패널 1920x1080 · 60 Hz · 측정 위생 적용)
+
+위 Linux 회차와 **같은 하드웨어**예요 (Intel Core i5-1240P 듀얼부트). CPU · 패널이 고정이라
+host 구현 차이만 남아요. 주사율 근거는 앱 로그의
+`[startup] frame clock started: refresh=60Hz period=16.67ms` 이고, `window initialized: dpi=96`
+(배율 100 %) · D3D `render_path=hardware` 였어요. 회차당 표본 20 (+ ConPTY 시작 1) · 간격 2 초,
+전 회차 `input` 표본 0.
+
+| | 절사평균 | min~max |
+|---|---|---|
+| 평균 | **8.40 ms** | 7.50~10.78 |
+| **최악** | **18.37 ms** | 16.63~22.25 |
+
+회차별 최악: `16.63 · 18.74 · 17.77 · 22.25 · 18.61`
+
+**평균은 Linux 와 사실상 같은데 (8.40 vs 8.71) 원인이 달라요.** Linux 는 `poll` timeout 상수
+16 ms 고, Windows 는 `frameClockThread` 가 무조건 post 하는 `WM_FRAME_TICK` 의 주기 16.67 ms
+예요. 서로 다른 장치가 거의 같은 값을 내요.
+
+#### ⚠ 최악값이 프레임 주기보다 커요 — 예상과 달라요
+
+예상은 *"최악 ≈ 프레임 주기 (16.67 ms)"* 였는데, 실측 최악 절사평균은 **18.37 ms 로 1.7 ms
+더 커요.** 5 회 중 4 회가 16.67 ms 를 넘었어요.
+
+`completeOutput()` 은 **present 가 끝난 자리**라 (`perf.zig`) 재는 구간이
+`tick 대기 (≤ 16.67) + render + present` 예요 — 상한은 프레임 주기가 아니라 **프레임 주기 +
+render/present** 예요. 같은 회차 덤프의 `render` · `present` 가 합쳐 **0.83~1.00 ms/회**
+(예: `render 11.285/23` + `present 11.643/23`) 라 초과분과 자릿수가 맞아요. 같은 구조가 Linux
+에도 있어요 — 최악 16.39 ms 가 `poll` timeout 16 ms 를 0.39 ms 넘었어요. 다만 **Windows 의
+초과분이 4 배 이상 커요** (1.70 vs 0.39 ms).
+
+회차 4 의 **22.25 ms** 는 초과분이 5.6 ms 라 render/present 로는 설명이 안 돼요 — tick 이 한 번
+밀렸거나 present 가 걸린 것으로 보이지만 **원인 미확정**이에요 (5 회 중 1 회).
+
+#### 곁가지 — Windows 의 유휴 깨우기 빈도도 잡혔어요
+
+같은 덤프의 `onrender calls≈2500 · skip≈2480` (회차당 약 43 초) = **초당 약 58 회**, 그중
+**99 % 가 렌더 skip** 이에요. #439 가 적어 둔 *"유휴에도 주사율만큼 깨어나 게이트만 확인한다"*
+가 Windows 에서 숫자로 확인됐어요. 다만 **전력 대가는 안 쟀어요** — 아래 절전 도구는 Linux
+전용이에요.
+
+### 기록 수치 ③ — macOS (MacBook Pro M5 Pro · macOS 26.6.1 · 내장 Liquid Retina XDR · **120 Hz** · 측정 위생 적용)
+
+**하네스는 손댈 게 없었어요** — macOS 는 POSIX 라 러너가 Linux 와 같고, 로그 경로
+(`~/Library/Logs/tildaz_stress.log`) · EXE 후보 (`zig-out/TildaZ.app/Contents/MacOS/tildaz`) ·
+`hygiene_minimize_macos` 가 이미 다 있어요. 위 Windows 절 같은 platform 분기가 필요 없어요.
+
+빌드는 `zig build -Doptimize=ReleaseFast -Dsimd=true` 예요 (Linux · Windows 회차와 같은 조합).
+**서명 설치 (`build_and_install.sh`) 는 필요 없어요** — 이 측정은 합성 입력을 안 보내서
+*Input Monitoring* 권한을 아예 안 쓰거든요. 회차당 표본 20 · 간격 2 초, 전 회차 `input` 표본 0.
+
+| | 절사평균 | min~max |
+|---|---|---|
+| 평균 | **5.83 ms** | 5.55~6.29 |
+| **최악** | **9.51 ms** | 8.61~11.11 |
+
+회차별 평균 `6.29 · 5.90 · 5.55 · 5.92 · 5.67` / 회차별 최악 `10.98 · 8.89 · 8.66 · 8.61 · 11.11`
+
+#### 주사율은 로그로 **실측**할 수 있어요 (추정 아님)
+
+macOS 는 Windows 의 `[startup] frame clock started: refresh=..Hz` 같은 로그가 없어요 (깨우기가
+`CADisplayLink` 라서요). 그래서 [`hygiene.sh`](hygiene.sh) 도 macOS 주사율은 확인하지 않고
+*"기록할 때 사람이 적는다"* 로 둬요. 그런데 **`onrender` 가 [`displayLinkFire`](../../src/host/macos.zig)
+마다 세지므로** 덤프에서 역산할 수 있어요.
+
+```sh
+# 같은 회차의 [boot] · [exit] 타임스탬프 차이로 나눠요
+onrender calls ÷ 앱 수명(초) = displayLink fire 주파수
+```
+
+5 회 전부 **119.7 회/s** 로 나왔어요 — **ProMotion 은 완전 유휴에도 120 Hz 를 유지하고 낮추지
+않아요.** 적응형 주사율이 값을 흔들었을 가능성을 이 숫자가 직접 배제해요. 그중 **99.3 % 가 렌더
+skip** ([#255](https://github.com/ensky0/tildaz/issues/255)) 이라, #439 가 적어 둔 *"유휴에도 주사율만큼
+깨어나 게이트만 확인한다"* 가 macOS 에서도 숫자로 확인됐어요 (Windows 의 초당 약 58 회와 같은 모양).
+
+#### 상한이 여기서 가장 정확히 맞았어요
+
+Windows 절이 찾아낸 *"상한은 주기가 아니라 **주기 + render + present**"* 를 그대로 대 보면:
+
+| | 프레임 주기 | 그 회차 `render`+`present` | 이론 상한 | **실측 최악 (절사평균)** |
+|---|---|---|---|---|
+| 절사평균 기준 | 8.33 ms | 1.23 ms/회 | **9.57 ms** | **9.51 ms** |
+
+**0.06 ms 차이로 맞아요.** 5 회 중 3 회 (8.61 · 8.66 · 8.89) 는 주기 8.33 ms 를 **0.28~0.56 ms** 만
+넘었고, 이건 Linux 의 초과분 (+0.39 ms) 과 같은 크기이고 Windows (+1.70 ms) 보다 작아요.
+
+#### 세 host 를 나란히 두면 — 서로 다른 장치가 각자의 주기를 따라가요
+
+| | 깨우기 장치 | 그 주기 | 실측 평균 | 주기÷2 + 꼬리 |
+|---|---|---|---|---|
+| Linux 60 Hz | `poll` timeout 상수 (`frame_poll_ms`) | 16.00 ms | **8.71** | 8.71 |
+| **macOS 120 Hz** | **`CADisplayLink`** | **8.33 ms** | **5.83** | 5.40 |
+| Windows 60 Hz | `frameClockThread` 의 `WM_FRAME_TICK` | 16.67 ms | **8.40** | 8.40 |
+
+**세 host 가 서로 다른 장치를 쓰는데 값이 각자의 주기를 따라가고, 주기가 절반인 macOS 만 지연도
+내려갔어요.** 60 Hz 두 host 만으로는 *"주기가 지연"* 과 *"어쩌다 8 ms 대"* 를 못 가르는데,
+주기가 다른 세 번째 host 가 그 둘을 갈라요 — #439 본문 가설의 가장 강한 형태의 증거예요.
+
+#### ⚠ 이상치 2 회는 설명이 안 돼요
+
+회차 1 · 5 의 최악 (**10.98 · 11.11 ms**) 은 그 회차의 이론 상한 (9.67 · 9.64 ms) 을
+**1.3~1.5 ms** 넘어요. Windows 회차 4 의 22.25 ms 와 같은 성격 (tick 이 밀렸거나 present 가
+걸림) 으로 보이지만 **원인 미확정**이에요 (5 회 중 2 회). 절사평균은 이 둘 중 위쪽 하나를
+잘라내지만, 나머지 하나가 남아 최악 절사평균 9.51 ms 를 끌어올린 값이에요.
+
+### ⚠ 측정 중 창을 건드리면 오염돼요
+
+입력이 렌더를 유발해 깨우기 경로를 건너뛰기 때문이에요. 스크립트가 같은 덤프의 `input` 표본
+수를 함께 세어 **0 이 아니면 회차 폐기**로 표시해요.
+
+### ⚠ 이 수치는 **모든 출력**에 붙는 값이 아니에요 — 타이핑 에코는 안 늦어요
+
+위 표의 5.83~8.71 ms 를 *"화면에 뭔가 나올 때마다 붙는 지연"* 으로 읽으면 틀려요. **입력이
+유발하지 않은 출력에만** 붙어요.
+
+`measure-input-latency.sh --mode idle` (실제 셸 + 키 30 회) 을 `output_latency` 계측이 있는
+빌드로 돌려 같은 덤프에서 둘을 나란히 재 봤어요 (macOS · 120 Hz · 5 회).
+
+| | 표본 | 평균 | 최악 |
+|---|---|---|---|
+| **유휴 출력** (입력 없이 도착) | 5 회 × 20 | **5.83 ms** | 9.51 ms |
+| **에코 출력** (키에 딸려 도착) | 5 회 × 30 | **0.39 ms** | 0.54 ms |
+
+`output` 표본은 **30 / 30 으로 다 잡혀요** (에코도 `markOutput()` 을 지나요). 그런데 값이 15 배
+작아요. 같은 회차의 `input` 평균 0.632 ms − `output` 평균 0.393 ms = **0.239 ms 가 PTY 왕복**
+(키 write → 셸 에코 → read) 인데, 이게 **프레임 주기 8.33 ms 보다 35 배 짧아요.** 키가 오면
+`requestRender()` 가 이미 렌더를 예약하고, 에코는 0.24 ms 뒤에 도착하니 **그 예약된 프레임에
+그대로 편승**해요.
+
+| 붙는 것 | 안 붙는 것 |
+|---|---|
+| 명령 결과가 나오기 시작하는 첫 출력 · 빌드 / 로그 스트림 시작 · `tail -f` · 백그라운드 출력 · htop / watch 자동 갱신 | 타이핑 글자 (셸 에코) — **실측**. TUI 키 반응도 같은 구조지만 **직접 재지는 않았어요** |
+
+곁가지로 [#441](https://github.com/ensky0/tildaz/issues/441#issuecomment-5302808426) 이 미해결로
+남긴 *"macOS 유휴 `input` 이 반 프레임보다 낮다"* 도 이 값으로 설명돼요 — 키 직후의 present 는
+아직 아무 글자도 안 그린 프레임이고, 합성 키가 `displayLink` fire 직전에 배달되는 것으로 보여요
+(**추정** — WindowServer 안쪽 위상은 우리 소스로 못 봐요). 자세한 것은
+[#439 코멘트](https://github.com/ensky0/tildaz/issues/439#issuecomment-5306808465)에 있어요.
+
+## 유휴 절전 대가 측정 ([#439](https://github.com/ensky0/tildaz/issues/439) ② · Linux 전용)
+
+위 절이 유휴 깨우기의 **지연** 대가라면, 이쪽은 **절전** 대가예요 — 완전 유휴 (출력도 입력도
+없음, 깨우기는 `frame_poll_ms` 16 ms 의 초당 62 회뿐) 인 TildaZ 1대가 전력으로 얼마인지를
+**ABAB 4 구간** (기준선 → TildaZ → 기준선 → TildaZ, 배경 요동 상쇄) 으로 재요.
+
+```sh
+dist/stress/measure-idle-cstates.sh              # root 불필요 — core-idle 잔류율 (경향만)
+sudo dist/stress/measure-idle-power.sh           # 패키지 전력 (RAPL·turbostat) — 판정은 이쪽
+```
+
+- **`hygiene_begin` 을 일부러 안 써요** — performance 프로파일 강제는 유휴 전력 자체를
+  바꿔요. 재는 대상이 *평소 구성*의 유휴 대가라서, worker 종료만 하고 프로파일은 그대로
+  둬요. 대신 AC · 화면 상태를 결과에 함께 적어요.
+- 측정 중 무입력이에요 — 배경 앱의 CPU 사용도 A/B 한쪽에만 얹히면 비교가 깨져요.
+
+### 실측 (노트북 · Intel i5-1240P · CachyOS · KDE Plasma · AC · balanced · 화면 켬, 2026-08-16)
+
+| | 기준선 ×2 | TildaZ 유휴 ×2 | 차이 |
+|---|---|---|---|
+| PkgWatt | 3.87 · 3.88 W | 3.98 · 3.95 W | **+0.07~0.11 W** |
+| SysWatt | 11.55 · 11.48 W | 11.79 · 11.67 W | **+0.19~0.24 W (~+2 %)** |
+| Pkg%pc8 | 4.08 · 3.71 % | 1.68 · 1.85 % | **잔류율 절반** |
+| IRQ | 1,619~1,635 /s | 1,711~1,717 /s | +82~85 /s (≈ 깨우기 61 /s) |
+
+**core-idle 지표 (`measure-idle-cstates.sh`) 로는 이 대가가 잡음 아래예요** — 시스템 전체
+유휴 진입 (~700~830 회/s) 의 요동이 TildaZ 몫 (61 회/s) 보다 커요. 패키지 수준에서만 보여요.
+상세와 배터리 환산 (~시간당 완충의 0.3 %p) 은 [#439 의 확정 코멘트](https://github.com/ensky0/tildaz/issues/439#issuecomment-5306404629)에 있어요.
+
+### Windows · macOS 판은 만들지 않기로 했어요 (2026-08-16 사용자 결정)
+
+**② 판정은 위 Linux 실측으로 충분해요.** ② 가 재려는 것은 *"주기적 깨우기 한 대가 얼마"* 인데,
+그 깨우기 빈도가 host 를 가리지 않아요 — Linux 초당 **61 회** (`frame_poll_ms` 16 ms) 와
+Windows 초당 약 **58 회** (`WM_FRAME_TICK`, [위 절의 `onrender` 실측](#곁가지--windows-의-유휴-깨우기-빈도도-잡혔어요))
+가 거의 같아요. 같은 빈도의 깨우기라면 전력 대가도 같은 자릿수라, platform 마다 다시 재도
+**방향 결정 ((d) 타이머 정지) 을 바꿀 새 정보가 나오지 않아요.**
+
+그래서 `Get-Counter` (Windows) · `powermetrics` (macOS) 대응 도구는 **만들지 않아요.** Windows 는
+RAPL 을 읽으려면 커널 드라이버가 필요해서 비용도 제일 커요. 나중에 방향이 바뀌어 platform 별
+절대값이 꼭 필요해지면 그때 이 결정을 다시 봐요.
 
 ## 다른 터미널과 비교하기
 

--- a/dist/stress/measure-idle-cstates.sh
+++ b/dist/stress/measure-idle-cstates.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# 유휴 깨우기의 절전 대가 — core-idle 잔류율 비교 ([#439](https://github.com/ensky0/tildaz/issues/439) ②).
+#
+# TildaZ **완전 유휴** 인스턴스 (`-e` 로 `sleep 3600` — 출력도 입력도 없어 `frame_poll_ms`
+# 16 ms 깨우기만 남는다, 초당 62 회) 가 떠 있을 때와 없을 때를 **ABAB 4 구간**으로 재서
+# CPU core 의 idle state 잔류율과 유휴 진입 횟수를 비교한다. root 가 필요 없다
+# (`/sys/devices/system/cpu/cpu*/cpuidle` 은 누구나 읽는다).
+#
+#   dist/stress/measure-idle-cstates.sh                  # 기본 — 구간 60 초 × 4
+#   dist/stress/measure-idle-cstates.sh --duration 120
+#
+# ⚠ **core-idle 지표는 패키지 전력이 아니다.** i5-1240P 실측에서 62 회/s 깨우기가 이
+#   지표로는 잡음 아래였지만 (시스템 전체 유휴 진입 ~700-830 회/s 의 요동이 더 크다),
+#   패키지 수준 (RAPL) 에서는 시스템 +0.2 W 로 뚜렷했다 — 판정은 `measure-idle-power.sh`
+#   (sudo 필요) 로 한다. 이 스크립트는 root 없이 경향을 볼 때만 쓴다.
+#   https://github.com/ensky0/tildaz/issues/439#issuecomment-5305627637
+#
+# ## 왜 `hygiene_begin` 을 안 쓰나 — 일부러다
+#
+# `hygiene_begin` 은 CPU 프로파일을 performance 로 강제하는데, 그건 **유휴 전력 자체를
+# 바꾼다** — 재려는 대상이 *평소 구성*의 유휴 대가라서 프로파일을 바꾸면 측정 대상이
+# 바뀐다. 그래서 worker 종료 (`hygiene_kill_worker`) 만 하고 프로파일 · 절전 설정은
+# 그대로 둔다. 배경 조건의 요동은 A/B 를 교대(ABAB)로 재서 상쇄한다.
+#
+# ⚠ 측정 중 키보드 · 마우스를 건드리면 오염된다 — 입력 처리뿐 아니라 배경 앱의 CPU
+#   사용도 A/B 어느 한쪽에만 얹히면 비교가 깨진다. 시작 전 15 초 가라앉힘이 있어서
+#   실행 명령 입력 자체는 괜찮다.
+set -u
+
+DUR=60
+
+usage() {
+    cat <<'USAGE'
+쓰는 법: dist/stress/measure-idle-cstates.sh [옵션]
+
+  --duration <초>   구간 길이 (기본 60 — A·B 각 2 회, 총 4 구간)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --duration) DUR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[ "$(uname -s)" = Linux ] || { echo "Linux 전용이에요 (cpuidle sysfs). Windows·macOS 는 그 platform 도구로 잰다." >&2; exit 2; }
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+. "$REPO_ROOT/dist/stress/hygiene.sh"
+
+EXE="$REPO_ROOT/zig-out/bin/tildaz"
+[ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+
+RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-idle-XXXXXX.sh")
+printf '#!/bin/sh\nsleep 3600\n' > "$RUNNER"; chmod +x "$RUNNER"
+SNAP0=$(mktemp "${TMPDIR:-/tmp}/tildaz-cstate-XXXXXX")
+SNAP1=$(mktemp "${TMPDIR:-/tmp}/tildaz-cstate-XXXXXX")
+APP=""
+cleanup() { [ -n "$APP" ] && kill "$APP" 2>/dev/null; rm -f "$RUNNER" "$SNAP0" "$SNAP1"; }
+trap cleanup EXIT INT TERM
+
+snap() {
+    for c in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${c##*/cpu}
+        for s in "$c"/cpuidle/state*; do
+            printf '%s %s %s %s\n' "$cpu" "$(cat "$s/name")" "$(cat "$s/time")" "$(cat "$s/usage")"
+        done
+    done
+}
+
+phase() { # $1 = 라벨
+    t0=$(date +%s%N); snap > "$SNAP0"
+    sleep "$DUR"
+    t1=$(date +%s%N); snap > "$SNAP1"
+    awk -v t0="$t0" -v t1="$t1" -v label="$1" '
+        NR==FNR { time0[$1" "$2]=$3; usage0[$1" "$2]=$4; next }
+        { dt[$2]+=$3-time0[$1" "$2]; du[$2]+=$4-usage0[$1" "$2]; cpus[$1]=1 }
+        END {
+            wall=(t1-t0)/1e9; n=0; for (c in cpus) n++
+            total_us=wall*1e6*n; wk=0; idle=0
+            printf "== %s  (wall %.1f s · cpu %d) ==\n", label, wall, n
+            for (s in dt) { printf "  %-6s 잔류 %7.3f %%   진입 %7d 회 (%7.1f /s)\n", s, 100*dt[s]/total_us, du[s], du[s]/wall
+                wk+=du[s]; idle+=dt[s] }
+            printf "  C0(비유휴) %.3f %%   유휴 진입 합계 %.1f /s (전체 CPU)\n", 100*(1-idle/total_us), wk/wall
+        }' "$SNAP0" "$SNAP1"
+}
+
+app_start() {
+    "$EXE" --instance 1 -e "$RUNNER" -size 100x30 >/dev/null 2>&1 &
+    APP=$!
+    sleep 8   # 창 생성 · 초기 렌더가 가라앉을 시간
+    kill -0 "$APP" 2>/dev/null || { echo "❌ tildaz 가 안 떴어요" >&2; exit 1; }
+}
+app_stop() { kill "$APP" 2>/dev/null; APP=""; sleep 3; }
+vctx() { awk '/^voluntary_ctxt_switches/ {print $2}' "/proc/$APP/status" 2>/dev/null || echo 0; }
+
+TOTAL=$(( 15 + DUR * 4 + 30 ))
+cat <<EOF
+
+========= 유휴 절전 대가 — core-idle (#439 ②) =========
+ 구간      : ${DUR} 초 × 4 (기준선 → TildaZ 유휴 → 기준선 → TildaZ 유휴)
+ 예상 소요 : 약 ${TOTAL} 초
+ ⚠ 측정 중 키보드 · 마우스 금지 — 배경 CPU 사용도 오염이에요
+========================================================
+
+EOF
+
+hygiene_kill_worker
+sleep 15   # 직전 활동 (셸 · 에디터) 의 여진이 첫 기준선에 얹히지 않게 가라앉힌다
+
+phase "A1 기준선 (TildaZ 없음)"
+app_start; V0=$(vctx); S0=$(date +%s)
+phase "B1 TildaZ 유휴"
+V1=$(vctx); S1=$(date +%s)
+echo "  TildaZ voluntary_ctxt_switches: $V0 → $V1  (초당 $(( (V1 - V0) / (S1 - S0) )))"
+app_stop
+phase "A2 기준선 (TildaZ 없음)"
+app_start; V0=$(vctx); S0=$(date +%s)
+phase "B2 TildaZ 유휴"
+V1=$(vctx); S1=$(date +%s)
+echo "  TildaZ voluntary_ctxt_switches: $V0 → $V1  (초당 $(( (V1 - V0) / (S1 - S0) )))"
+app_stop
+
+echo "##### 끝 #####"

--- a/dist/stress/measure-idle-latency.sh
+++ b/dist/stress/measure-idle-latency.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# 유휴 응답 지연 측정 ([#439](https://github.com/ensky0/tildaz/issues/439)).
+#
+# **입력 없이 PTY 출력만 도착하는 상황**에서, 그 출력이 화면에 닿기까지 얼마나 걸리는지 잰다.
+# #439 가 *"유휴에서 첫 출력이 한 프레임 늦는다"* 고 가설로 적어 둔 것을 숫자로 만든다.
+#
+#   dist/stress/measure-idle-latency.sh                 # 기본 — 20 회 · 간격 2 초
+#   dist/stress/measure-idle-latency.sh --samples 40 --gap 3
+#
+# ## `measure-input-latency.sh` 와 무엇이 다른가
+#
+# 그쪽은 **키** 에서 시작한다. 그런데 키가 오면 앱이 즉시 렌더를 요청하므로 **유휴 깨우기
+# 경로를 아예 안 탄다** — #441 에서 유휴 평균이 0.67 ms 로 낮게 나온 이유다. 이 스크립트는
+# 입력을 아예 보내지 않는다. 그래서 **합성 입력도 필요 없다** (ydotool · 포커스 · IME 무관).
+#
+# | | 시작 | 재는 것 |
+# |---|---|---|
+# | `measure-input-latency.sh` | 키 수신 | 사용자 입력의 왕복 |
+# | **이 스크립트** | **PTY 도착** | **유휴 깨우기 지연** |
+#
+# ## 무엇이 갈림길인가
+#
+# 깨우기 주기 (Linux `frame_poll_ms` 16 ms · 60 Hz 16.7 ms · 120 Hz 8.3 ms) 에 흡수되면 가설대로다.
+#
+# 단 **상한은 깨우기 주기 그 자체가 아니라 `주기 + render + present`** 다 — `completeOutput()` 이
+# present 가 끝난 자리이기 때문이다 (`perf.zig`). 실측 최악이 Linux 는 주기를 0.39 ms, Windows 는
+# 1.70 ms 넘었고 둘 다 그 회차의 render + present 와 자릿수가 맞았다 (README 의 기록 수치).
+# **그 여유보다 크게 넘으면** 깨우기 말고 다른 것이 끼어 있다는 뜻이라 원인을 다시 찾아야 한다.
+set -u
+
+SAMPLES=20
+GAP=2
+SCROLLBACK=32767
+IGNORE_HYGIENE=0
+
+usage() {
+    cat <<'USAGE'
+쓰는 법: dist/stress/measure-idle-latency.sh [옵션]
+
+  --samples <N>   출력 횟수 (기본 20)
+  --gap <초>      출력 사이 간격 (기본 2 — 앱이 확실히 유휴로 들어갈 만큼)
+  --ignore-hygiene  위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --samples) SAMPLES="$2"; shift 2 ;;
+        --gap) GAP="$2"; shift 2 ;;
+        --ignore-hygiene) IGNORE_HYGIENE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+. "$REPO_ROOT/dist/stress/hygiene.sh"
+
+# 자식이 Windows 실행파일이면 경로를 native 로 바꿔 넘긴다 (`measure-input-latency.sh` 와 같은
+# 함수다). MSYS 는 명령줄 인자를 자동 변환하기도 하지만 기대지 않는다.
+native_path() {
+    if [ "$HYG_PLATFORM" = windows ]; then cygpath -w "$1"; else printf '%s' "$1"; fi
+}
+
+# **Windows 는 `.exe` 다.** 접미사가 없으면 `[ -x ]` 가 전부 실패해 `tildaz 없음` 으로 끝난다.
+EXE_SUFFIX=""
+[ "$HYG_PLATFORM" = windows ] && EXE_SUFFIX=".exe"
+EXE=""
+for _cand in \
+    "$REPO_ROOT/zig-out/TildaZ.app/Contents/MacOS/tildaz" \
+    "$REPO_ROOT/zig-out/bin/tildaz$EXE_SUFFIX"
+do
+    [ -x "$_cand" ] && EXE="$_cand" && break
+done
+[ -n "$EXE" ] || EXE="$REPO_ROOT/zig-out/bin/tildaz$EXE_SUFFIX"
+[ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+
+case "$HYG_PLATFORM" in
+    linux) LOG="${XDG_STATE_HOME:-$HOME/.local/state}/tildaz/tildaz_stress.log" ;;
+    macos) LOG="$HOME/Library/Logs/tildaz_stress.log" ;;
+    windows) LOG="$(cygpath -u "$APPDATA")/tildaz/tildaz_stress.log" ;;
+    *) echo "모르는 platform 이에요 ($(uname -s))." >&2; exit 2 ;;
+esac
+
+# `-e` 러너 — **입력을 읽지 않고 주기적으로 한 줄만 낸다.** 앱은 그 사이 완전히 유휴라
+# 매 출력이 유휴 깨우기 경로를 그대로 탄다. 마지막에 `Ctrl+Shift+F12` 대신 스크립트가
+# 스스로 끝나 앱이 정상 종료되게 둔다 — 종료 덤프(#396)가 값을 남긴다.
+#
+# `RUNNER` 는 지울 임시 파일, `RUN_CMD` 는 `-e` 에 넘길 값이다. **Windows 의 `-e` 는 인자를
+# 받는다** — POSIX 는 PTY 자식의 argv 가 실행파일 하나로 고정이지만 (`run_options.zig`),
+# Windows 는 `CreateProcessW` 의 `lpCommandLine` 이라 (`host/windows.zig` 의 `stress_shell_w`)
+# `cmd.exe /c <배치>` 가 그대로 선다. POSIX `.sh` 를 그대로 넘기면 아예 안 뜬다.
+if [ "$HYG_PLATFORM" = windows ]; then
+    # Windows 의 TEMP 아래에 만든다 — Git Bash 의 `/tmp` 는 설치 경로 안이라
+    # (`C:\Program Files\Git\tmp`) 공백이 섞이고, 그러면 `cmd /c "…"` 인용이 갈린다
+    # (`measure-input-latency.sh` 와 같은 이유).
+    RUNNER=$(TMPDIR="$(cygpath -u "$TEMP")" mktemp "$(cygpath -u "$TEMP")/tildaz-idle-XXXXXX.cmd")
+    # 대기는 **`ping` 이지 `timeout` 이 아니다.** `timeout` 은 stdin 이 리다이렉트되면
+    # `ERROR: Input redirection is not supported` 로 떨어진다. `ping -n K` 는 K-1 초를 쉰다.
+    #
+    # 배치는 **CRLF + `for /L` 한 줄**로 쓴다. 여러 줄 괄호 블록을 LF 만으로 쓰면 `cmd.exe`
+    # 가 블록을 잘못 읽을 수 있다 (`compare-terminals.sh` 의 `conhost.cmd` 도 CRLF 로 쓴다).
+    {
+        printf '@echo off\r\n'
+        printf 'for /L %%%%i in (1,1,%d) do (ping -n %d 127.0.0.1 >nul & echo idle-sample %%%%i)\r\n' \
+            "$SAMPLES" "$((GAP + 1))"
+        printf 'ping -n 2 127.0.0.1 >nul\r\n'
+    } > "$RUNNER"
+    RUN_CMD="cmd.exe /c \"$(native_path "$RUNNER")\""
+else
+    RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-idle-XXXXXX.sh")
+    cat > "$RUNNER" <<EOF
+#!/bin/sh
+i=1
+while [ "\$i" -le $SAMPLES ]; do
+    sleep $GAP
+    printf 'idle-sample %d\\n' "\$i"
+    i=\$((i + 1))
+done
+sleep 1
+EOF
+    chmod +x "$RUNNER"
+    RUN_CMD="$RUNNER"
+fi
+
+TOTAL_WAIT=$(( (SAMPLES * GAP) + 12 ))
+cat <<EOF
+
+============ 유휴 응답 지연 측정 (#439) ============
+ 표본      : ${SAMPLES} 회 · 간격 ${GAP} 초
+ 재는 구간 : PTY 도착 → 그 뒤 첫 present 완료
+ 예상 소요 : 약 ${TOTAL_WAIT} 초
+====================================================
+
+⚠ 이 측정은 **앱이 유휴여야** 성립해요. 창을 클릭하거나 키를 누르면 그 회차가 오염돼요
+   (입력이 렌더를 유발해 깨우기 경로를 건너뜁니다). 시작하면 건드리지 마세요.
+
+EOF
+
+# **측정 위생을 지킨다.** `check-input-loss.sh` 는 판정이 "먹었나 / 안 먹었나" 라는 이산값이라
+# 위생을 건너뛰지만, 이쪽은 **ms 단위 연속값**이라 얘기가 다르다.
+#
+# - **C-state** 가 유휴에서 깨어나는 시간에 직접 영향을 준다 — 이 측정이 재는 것이 바로 그
+#   깨어남이다. 배터리에서는 더 깊은 절전으로 들어가 값이 달라진다.
+# - **평소 쓰는 worker 를 안 내리면** 그 인스턴스가 CPU · 렌더를 나눠 써 값이 눌린다
+#   (`hygiene_begin` ⓪).
+#
+# ⚠ 그래서 이 스크립트는 **평소 쓰던 TildaZ 를 종료시킨다.** 그 안에서 무언가 돌고 있으면
+#    (예: 이 스크립트를 그 창에서 실행하면) 함께 끊긴다 — 다른 터미널에서 돌린다.
+hygiene_check || {
+    [ "$IGNORE_HYGIENE" = 1 ] || {
+        echo "측정 위생 점검에 걸렸어요. 고치거나 --ignore-hygiene 로 강행해요." >&2
+        exit 1
+    }
+}
+# 복원은 어떤 경로로 끝나든 돌아야 한다 (Ctrl+C 포함).
+trap hygiene_end EXIT INT TERM
+hygiene_begin
+
+START_LEN=0
+[ -f "$LOG" ] && START_LEN=$(wc -c < "$LOG" | tr -d ' ')
+
+"$EXE" -e "$RUN_CMD" -size 100x30 -scrollback "$SCROLLBACK" >/dev/null 2>&1 &
+APP=$!
+
+waited=0
+while [ "$waited" -lt "$TOTAL_WAIT" ]; do
+    kill -0 "$APP" 2>/dev/null || break
+    sleep 1
+    waited=$((waited + 1))
+done
+kill "$APP" 2>/dev/null
+sleep 1
+rm -f "$RUNNER"
+
+RAW=$(mktemp "${TMPDIR:-/tmp}/tildaz-idle-log-XXXXXX")
+if [ "$START_LEN" -gt 0 ]; then
+    tail -c "+$((START_LEN + 1))" "$LOG" > "$RAW"
+else
+    cp "$LOG" "$RAW" 2>/dev/null || : > "$RAW"
+fi
+
+# `output   samples=N ms=X max_ms=Y` — perf.zig 의 dumpAndReset 형식.
+awk -v want="$SAMPLES" '
+/^output / {
+    for (i = 1; i <= NF; i++) {
+        if ($i ~ /^samples=/)     { split($i, a, "="); s += a[2] }
+        else if ($i ~ /^ms=/)     { split($i, a, "="); t += a[2] }
+        else if ($i ~ /^max_ms=/) { split($i, a, "="); if (a[2] + 0 > m) m = a[2] + 0 }
+    }
+}
+# 입력이 섞였는지 확인 — 유휴 측정에서는 0 이어야 한다.
+/^input / { for (i = 1; i <= NF; i++) if ($i ~ /^samples=/) { split($i, a, "="); inp += a[2] } }
+END {
+    printf "\n==================== 결과 ====================\n"
+    if (s + 0 == 0) {
+        printf " ❌ 표본 없음 — 출력이 화면에 닿지 않았거나 덤프가 안 남았어요\n"
+    } else {
+        printf " 표본 %d / %d   평균 %6.2f ms   최악 %6.2f ms\n", s, want, t / s, m
+    }
+    if (inp + 0 > 0) printf " ⚠ 입력 표본이 %d 개 섞였어요 — 측정 중 조작이 있었어요 (회차 폐기)\n", inp
+    printf "==============================================\n\n"
+}' "$RAW"
+
+rm -f "$RAW"

--- a/dist/stress/measure-idle-power.sh
+++ b/dist/stress/measure-idle-power.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# 유휴 깨우기의 절전 대가 — 패키지 전력 비교 ([#439](https://github.com/ensky0/tildaz/issues/439) ②).
+#
+# TildaZ **완전 유휴** 인스턴스 (`-e` 로 `sleep 3600` — 깨우기는 `frame_poll_ms` 16 ms
+# 의 초당 62 회뿐) 가 떠 있을 때와 없을 때를 **ABAB 4 구간**으로 재서, `turbostat` 의
+# 패키지 전력 (PkgWatt / SysWatt, RAPL) 과 패키지 C-state 잔류율을 비교한다.
+#
+#   sudo dist/stress/measure-idle-power.sh                  # 기본 — 구간 60 초 × 4
+#   sudo dist/stress/measure-idle-power.sh --duration 120
+#
+# **sudo 가 필요하다** — RAPL 의 `energy_uj` 와 MSR 은 root 전용이다 (root 없이 돌리면
+# turbostat 이 PkgWatt · Pkg%pc* 를 못 얹는다). 측정용 TildaZ 는 root 로 띄우면 사용자의
+# Wayland 세션에 못 붙으므로 **`SUDO_USER` 계정으로** 띄운다.
+#
+# `measure-idle-cstates.sh` (root 불필요) 는 core-idle 잔류율만 본다 — i5-1240P 실측에서
+# 62 회/s 깨우기가 core-idle 로는 잡음 아래였지만 이 스크립트로는 뚜렷했다 (시스템
+# +0.19~0.24 W ≈ 유휴 소비의 +2 %, Pkg%pc8 잔류율 절반). **판정은 이쪽이다.**
+# https://github.com/ensky0/tildaz/issues/439#issuecomment-5306404629
+#
+# ## 왜 `hygiene_begin` 을 안 쓰나 — 일부러다
+#
+# `hygiene_begin` 은 CPU 프로파일을 performance 로 강제하는데, 그건 **유휴 전력 자체를
+# 바꾼다** — 재려는 대상이 *평소 구성*의 유휴 대가라서 프로파일을 바꾸면 측정 대상이
+# 바뀐다. 그래서 worker 종료 (`hygiene_kill_worker`) 만 하고 프로파일 · 절전 설정은
+# 그대로 둔다. 배경 조건의 요동은 A/B 를 교대(ABAB)로 재서 상쇄한다. 대신 **AC · 화면
+# 상태를 결과에 함께 적는다** — 화면이 켜져 있으면 패키지가 pc8 위로 묶여 (Pk%pc10 ·
+# S0ix 0) 화면 끈 대기 상태와는 절대값이 다르다.
+#
+# ⚠ 측정 중 키보드 · 마우스를 건드리면 오염된다 — 시작 전 15 초 가라앉힘이 있어서
+#   실행 명령 입력 자체는 괜찮다.
+set -u
+
+DUR=60
+
+usage() {
+    cat <<'USAGE'
+쓰는 법: sudo dist/stress/measure-idle-power.sh [옵션]
+
+  --duration <초>   구간 길이 (기본 60 — A·B 각 2 회, 총 4 구간)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --duration) DUR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[ "$(uname -s)" = Linux ] || { echo "Linux 전용이에요 (turbostat). macOS 는 powermetrics, Windows 는 별도 도구로 잰다." >&2; exit 2; }
+[ "$(id -u)" = 0 ] || { echo "sudo 로 실행하세요 (RAPL·MSR 이 root 전용이에요)." >&2; exit 1; }
+[ -n "${SUDO_USER:-}" ] || { echo "sudo 를 통해 사용자 세션에서 실행하세요 — 측정용 TildaZ 를 그 사용자의 Wayland 세션에 띄워야 해요." >&2; exit 1; }
+command -v turbostat >/dev/null 2>&1 || { echo "turbostat 없음 — linux-tools 계열 패키지를 설치하세요." >&2; exit 1; }
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+. "$REPO_ROOT/dist/stress/hygiene.sh"
+
+EXE="$REPO_ROOT/zig-out/bin/tildaz"
+[ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+
+RUNTIME=/run/user/$(id -u "$SUDO_USER")
+WD=$(ls "$RUNTIME" 2>/dev/null | grep -m1 '^wayland-[0-9]*$' || echo wayland-0)
+
+RUNNER=$(mktemp "${TMPDIR:-/tmp}/tildaz-idle-XXXXXX.sh")
+printf '#!/bin/sh\nsleep 3600\n' > "$RUNNER"; chmod 755 "$RUNNER"
+TPID=""
+cleanup() { pkill -x tildaz 2>/dev/null; rm -f "$RUNNER"; }
+trap cleanup EXIT INT TERM
+
+# turbostat 한 구간. 원본 행을 그대로 남기고 (열이 기기마다 달라서 기록은 원본이 정본),
+# 판정에 쓰는 열만 헤더 이름으로 뽑아 요약 한 줄을 붙인다.
+ts() {
+    _out=$(turbostat --quiet --Summary --interval "$DUR" --num_iterations 1 2>&1)
+    echo "$_out"
+    echo "$_out" | awk '
+        /PkgWatt/ { for (i = 1; i <= NF; i++) h[$i] = i; next }
+        NF && h["PkgWatt"] {
+            printf "  → PkgWatt %s W", $(h["PkgWatt"])
+            if (h["SysWatt"]) printf " · SysWatt %s W", $(h["SysWatt"])
+            if (h["IRQ"])     printf " · IRQ %s", $(h["IRQ"])
+            if (h["Pkg%pc8"]) printf " · Pkg%%pc8 %s%%", $(h["Pkg%pc8"])
+            if (h["Busy%"])   printf " · Busy %s%%", $(h["Busy%"])
+            printf "\n"; exit
+        }'
+}
+
+app_start() {
+    sudo -u "$SUDO_USER" env XDG_RUNTIME_DIR="$RUNTIME" WAYLAND_DISPLAY="$WD" HOME="$(getent passwd "$SUDO_USER" | cut -d: -f6)" \
+        "$EXE" --instance 1 -e "$RUNNER" -size 100x30 >/dev/null 2>&1 &
+    sleep 8   # 창 생성 · 초기 렌더가 가라앉을 시간
+    TPID=$(pgrep -x tildaz | head -1)
+    [ -n "$TPID" ] || { echo "❌ tildaz 가 안 떴어요 (Wayland 연결 실패?)" >&2; exit 1; }
+}
+app_stop() { pkill -x tildaz 2>/dev/null; TPID=""; sleep 3; }
+vctx() { awk '/^voluntary_ctxt_switches/ {print $2}' "/proc/$TPID/status" 2>/dev/null || echo 0; }
+
+TOTAL=$(( 15 + DUR * 4 + 30 ))
+cat <<EOF
+
+========= 유휴 절전 대가 — 패키지 전력 (#439 ②) =========
+ 구간      : ${DUR} 초 × 4 (기준선 → TildaZ 유휴 → 기준선 → TildaZ 유휴)
+ 사용자    : $SUDO_USER · wayland=$WD
+ 예상 소요 : 약 ${TOTAL} 초
+ ⚠ 측정 중 키보드 · 마우스 금지 — 배경 CPU 사용도 오염이에요
+ ⚠ AC · 화면 상태를 결과에 함께 적어요 (화면 켬 = 패키지가 pc8 위로 묶임)
+==========================================================
+
+EOF
+
+hygiene_kill_worker
+sleep 15   # 직전 활동의 여진이 첫 기준선에 얹히지 않게 가라앉힌다
+
+echo "== A1 기준선 (TildaZ 없음) =="; ts
+app_start; V0=$(vctx); S0=$(date +%s)
+echo "== B1 TildaZ 유휴 =="; ts
+V1=$(vctx); S1=$(date +%s)
+echo "  TildaZ voluntary_ctxt_switches: $V0 → $V1  (초당 $(( (V1 - V0) / (S1 - S0) )))"
+app_stop
+echo "== A2 기준선 (TildaZ 없음) =="; ts
+app_start; V0=$(vctx); S0=$(date +%s)
+echo "== B2 TildaZ 유휴 =="; ts
+V1=$(vctx); S1=$(date +%s)
+echo "  TildaZ voluntary_ctxt_switches: $V0 → $V1  (초당 $(( (V1 - V0) / (S1 - S0) )))"
+app_stop
+
+echo "##### 끝 #####"

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -4238,6 +4238,7 @@ const Client = struct {
         // commit 을 마친 함수 종료 시점이라 present 이후인 것은 같다. `completeInput`
         // 은 자기가 `now()` 를 다시 부르므로 순서 차이가 값에 섞이지 않는다.
         defer perf.completeInput();
+        defer perf.completeOutput();
         // wl_surface.attach (opcode 1) — (buffer_id, x=0, y=0).
         try self.sendArgs(self.surface_id, 1, &.{ buffer.id, 0, 0 });
         // wl_surface.damage_buffer (opcode 9) — viewport 적용된 surface 에서는

--- a/src/perf.zig
+++ b/src/perf.zig
@@ -105,6 +105,48 @@ pub fn completeInput() void {
     }
 }
 
+/// #439 — **PTY 출력이 도착한 순간부터 그 뒤 첫 present 가 끝날 때까지.**
+///
+/// `input_latency` 와 구간이 다르다. 그쪽은 *키* 에서 시작하는데, 키가 오면 앱이 즉시
+/// 렌더를 요청하므로 **유휴 깨우기 경로를 아예 안 탄다** (#441 에서 유휴 평균이 0.67 ms
+/// 로 낮게 나온 이유다). 이쪽은 입력 없이 출력만 도착하는 상황을 재므로 *"유휴에서 첫
+/// 출력이 한 프레임 늦는다"* 는 #439 의 가설을 직접 판정한다.
+///
+/// `calls` = 표본 수 · `ns` = 합 · `extra` = 최악값. 최악을 따로 드는 이유는
+/// `input_latency` 와 같다 — 프레임 주기가 상한이라는 주장은 평균이 아니라 최악에 대한 것이다.
+pub var output_latency: Counter = .{};
+
+/// 대기 중인 출력의 도착 시각(ns). 0 = 없음.
+///
+/// `pending_input_ns` 와 같은 이유로 **이미 대기 중이면 덮지 않는다** — 폭포처럼 연달아
+/// 들어올 때 덮으면 가장 오래 기다린 조각이 사라진다.
+var pending_output_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0);
+
+/// PTY 에서 읽은 바이트를 ring 에 넣는 자리에서 부른다.
+///
+/// **read thread 에서 불린다.** 원자 연산뿐이라 안전하고, 여기서 하는 일은 CAS 하나다 —
+/// 이 함수가 무거워지면 read 경로 전체가 느려진다.
+pub fn markOutput() void {
+    const t = now() orelse return;
+    if (t == 0) return;
+    _ = pending_output_ns.cmpxchgStrong(0, t, .acq_rel, .monotonic);
+}
+
+/// present 가 끝난 자리에서 부른다 (`completeInput` 과 같은 자리).
+pub fn completeOutput() void {
+    const start = pending_output_ns.swap(0, .acq_rel);
+    if (start == 0) return;
+    const t = now() orelse return;
+    if (t <= start) return;
+    const delta = t - start;
+    _ = output_latency.calls.fetchAdd(1, .monotonic);
+    _ = output_latency.ns.fetchAdd(delta, .monotonic);
+    var cur = output_latency.extra.load(.monotonic);
+    while (delta > cur) {
+        cur = output_latency.extra.cmpxchgWeak(cur, delta, .monotonic, .monotonic) orelse break;
+    }
+}
+
 /// Cross-platform working-state timestamp(ns). Linux = CLOCK_MONOTONIC,
 /// macOS = CLOCK_UPTIME_RAW, Windows = QueryUnbiasedInterruptTimePrecise.
 /// 세 clock 모두 system sleep/hibernate를 세지 않는다. 이 모듈의 성능 진단에만
@@ -204,9 +246,11 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
     const on = snapshot(&onrender);
     const sw = snapshot(&swapwait);
     const il = snapshot(&input_latency);
+    const ol = snapshot(&output_latency);
     // 대기 중인 키는 스냅숏 경계를 넘기지 않는다 — 다음 구간에서 present 가 되면
     // *이전 구간에 눌린* 키의 지연이 그쪽에 잡혀 구간 귀속이 어긋난다.
     _ = pending_input_ns.swap(0, .acq_rel);
+    _ = pending_output_ns.swap(0, .acq_rel);
 
     var buf: [4096]u8 = undefined;
     const text = std.fmt.bufPrint(
@@ -227,7 +271,9 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
             "onrender calls={d} ms={d:.3} skip={d}\n" ++
             // #441 축 ② — 키 수신 → 첫 present 완료. `max` 를 함께 내는 이유는
             // 위 `input_latency` 주석 참고 (예산 주장은 평균이 아니라 최악에 대한 것).
-            "input    samples={d} ms={d:.3} max_ms={d:.3}\n",
+            "input    samples={d} ms={d:.3} max_ms={d:.3}\n" ++
+            // #439 — PTY 도착 → present. `input` 과 시작점이 다르다 (위 주석).
+            "output   samples={d} ms={d:.3} max_ms={d:.3}\n",
         .{
             label,
             rt.nowMs(),
@@ -256,6 +302,9 @@ pub fn dumpAndReset(rt: Runtime, label: []const u8) void {
             il[0],
             @as(f64, @floatFromInt(il[1])) / 1_000_000.0,
             @as(f64, @floatFromInt(il[3])) / 1_000_000.0,
+            ol[0],
+            @as(f64, @floatFromInt(ol[1])) / 1_000_000.0,
+            @as(f64, @floatFromInt(ol[3])) / 1_000_000.0,
         },
     ) catch return;
 

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -672,6 +672,7 @@ pub const MetalRenderer = struct {
         perf.addTimed(&perf.present, present_t0);
         // #441 축 ② — 대기 중인 키가 있으면 여기까지가 그 키의 응답 지연이다.
         perf.completeInput();
+        perf.completeOutput();
 
         // Frame end — state reset.
         self.current_encoder = null;

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -1907,6 +1907,7 @@ pub const D3d11Renderer = struct {
         perf.addTimed(&perf.present, present_t0);
         // #441 축 ② — 대기 중인 키가 있으면 여기까지가 그 키의 응답 지연이다.
         perf.completeInput();
+        perf.completeOutput();
     }
 
     /// #329 — 단일 탭 terminal 위에 우측 `[+][×][…]`만 최종 합성한다.

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -504,6 +504,9 @@ pub const Tab = struct {
         // 그 16 byte 는 **손실이 아니다** — 창이 닫히는 참의 모드 해제라 파싱할 것이 없다.
         const wrote = tab.output_ring.push(data);
         perf.addTimedBytes(&perf.push, t0, wrote);
+        // #439 — 유휴 응답 지연의 시작점. 여기부터 present 까지가 *"출력이 화면에 닿는
+        // 시간"* 이다. 한 byte 도 안 들어간 경우 (닫히는 중) 는 잴 것이 없다.
+        if (wrote > 0) perf.markOutput();
     }
 
     fn onPtyExit(userdata: ?*anyopaque) void {


### PR DESCRIPTION
## 무엇

[#439](https://github.com/ensky0/tildaz/issues/439) 는 *"지금은 방향을 정하지 않는다. 먼저 측정한다"* 는 이슈다. 그 **① 지연**과 **② 절전**을 숫자로 만든다. **방향 (a)~(d) 는 건드리지 않는다.**

## #441 의 계측으로는 판정할 수 없었다

`input_latency` 는 **키**에서 시작하는데, 키가 오면 앱이 즉시 렌더를 요청하므로 **유휴 깨우기 경로를 아예 안 탄다** (그래서 #441 의 유휴 평균이 0.67 ms 로 낮게 나왔고, 그 코멘트에 *"#439 가 틀렸다는 증거가 아니다"* 라고 적어 뒀다).

| | 시작 | 끝 |
|---|---|---|
| `input_latency` (#441) | 키 수신 | present |
| **`output_latency` (이번)** | **PTY 도착** | present |

## ① 지연 — 가설이 확인됐다 (Linux · macOS · Windows)

Linux 와 Windows 는 **같은 노트북 (Intel Core i5-1240P) 의 두 OS 를 듀얼부트로 갈아 가며** 쟀다. CPU · 패널이 고정이라 host 구현 차이만 남는다. macOS 는 기기가 다르지만 **주사율이 두 배 (120 Hz)** 라, 뒤에 적는 대로 그 점이 오히려 판정을 가른다.
셋 다 **측정 위생 적용** (worker 종료 · 최고 성능 · 창 최소화/숨김 · AC 연결) · 표본 20 · 간격 2 초 · **5 회 절사평균 + min~max** · 전 회차 `input` 표본 0. 빌드는 셋 다 `-Doptimize=ReleaseFast -Dsimd=true`.

| | Linux (CachyOS · KDE Plasma Wayland · 60 Hz) | macOS (MacBook Pro M5 Pro · 26.6.1 · **120 Hz**) | Windows (내장 패널 1920x1080 · 60 Hz · dpi=96) |
|---|---|---|---|
| 평균 | **8.71 ms** (7.64~9.57) | **5.83 ms** (5.55~6.29) | **8.40 ms** (7.50~10.78) |
| **최악** | **16.39 ms** (15.77~17.19) | **9.51 ms** (8.61~11.11) | **18.37 ms** (16.63~22.25) |

회차별 최악 — Linux `16.93 · 15.96 · 17.19 · 15.77 · 16.28` / macOS `10.98 · 8.89 · 8.66 · 8.61 · 11.11` / Windows `16.63 · 18.74 · 17.77 · 22.25 · 18.61`

**세 host 가 서로 다른 장치를 쓰는데 값이 각자의 깨우기 주기를 따라간다.**

| | 깨우기 장치 | 그 주기 | 실측 평균 | 주기÷2 + 꼬리 |
|---|---|---|---|---|
| Linux 60 Hz | `poll` timeout 상수 (`frame_poll_ms`) | 16.00 ms | **8.71** | 8.71 |
| **macOS 120 Hz** | **`CADisplayLink`** | **8.33 ms** | **5.83** | 5.40 |
| Windows 60 Hz | `frameClockThread` 의 `WM_FRAME_TICK` | 16.67 ms | **8.40** | 8.40 |

60 Hz 두 host 만으로는 *"주기가 곧 지연"* 과 *"어쩌다 8 ms 대"* 를 가를 수 없는데, **주기가 절반인 세 번째 host 에서 지연도 내려간 것**이 그 둘을 가른다 — #439 본문의 가설이 세 host 에서 각각 확인됐다 (Windows 의 주사율 근거는 로그의 `[startup] frame clock started: refresh=60Hz period=16.67ms`, macOS 는 아래 `onrender` 역산).

첫 실측 (미니PC · AMD Ryzen 7 8845HS · 60 Hz — **위생 미적용**, 평소 worker 가 떠 있었다) 은 평균 9.11 / 최악 16.14 ms 였다. 위생을 적용하고 기기를 바꿔도 같은 모양이다 — 주기가 값을 지배해서 기기 차이가 거의 안 보인다.

같은 유휴 상태인데 **키는 0.67 ms, 출력은 9.11 ms — 15 배 차이**다 (미니PC 동일 기기 비교, #441).

### macOS 의 주사율은 추정이 아니라 실측이다 — `onrender` 로 역산한다

macOS 에는 Windows 의 `frame clock started: refresh=..Hz` 같은 로그가 없다 (깨우기가 `CADisplayLink` 라서). 그런데 **`onrender` 가 `displayLinkFire` 마다 세지므로** 같은 덤프의 `[boot]` · `[exit]` 타임스탬프로 나누면 fire 주파수가 나온다. 5 회 전부 **119.7 회/s** 였다 — **ProMotion 은 완전 유휴에도 120 Hz 를 유지하고 낮추지 않는다.** 적응형 주사율이 값을 흔들었을 가능성을 이 숫자가 직접 배제한다. 그중 **99.3 % 가 렌더 skip** (#255) 이라, *"유휴에도 주사율만큼 깨어나 게이트만 확인한다"* 도 macOS 에서 확인됐다 (Windows 의 초당 약 58 회와 같은 모양).

### ⚠ 최악값은 예상과 달랐다 — 상한은 "주기" 가 아니라 "주기 + render + present"

예상은 *"최악 ≈ 프레임 주기 (60 Hz → 16.67 ms)"* 였는데, Windows 실측 최악 절사평균은 **18.37 ms 로 1.7 ms 더 크고 5 회 중 4 회가 16.67 ms 를 넘었다.**

원인은 `completeOutput()` 이 **present 가 끝난 자리**라는 것이다 ([`perf.zig`](../blob/main/src/perf.zig)) — 재는 구간이 `깨우기 대기 + render + present` 라 상한이 주기 그 자체가 아니다. 같은 회차 덤프의 `render` + `present` 가 **0.83~1.00 ms/회** (예: `render 11.285/23` + `present 11.643/23`) 로 초과분과 자릿수가 맞는다.

**같은 구조가 Linux 에도 있었다** — 최악 16.39 ms 가 timeout 16 ms 를 0.39 ms 넘었다. 다만 **Windows 의 초과분이 4 배 이상 크다** (1.70 vs 0.39 ms).

**macOS 가 이 공식에 가장 정확히 맞았다.** 주기 8.33 ms + 그 회차 `render`+`present` 1.23 ms/회 = **이론 상한 9.57 ms** 인데 실측 최악 절사평균이 **9.51 ms** 로 0.06 ms 차이다. 5 회 중 3 회 (8.61 · 8.66 · 8.89) 는 주기를 **0.28~0.56 ms** 만 넘어 Linux 와 같은 크기다.

원인 미확정 이상치는 두 host 에 남는다 — Windows 회차 4 의 **22.25 ms** (초과분 5.6 ms) 와 macOS 회차 1 · 5 의 **10.98 · 11.11 ms** (그 회차 이론 상한을 1.3~1.5 ms 초과) 다. tick 이 밀렸거나 present 가 걸린 것으로 보이지만 확정하지 못했다. macOS 는 그래서 최악 절사평균이 사전 예상 (*"8.3 ms 근처"*) 보다 1.2 ms 크다 — 다만 **3 회는 주기에 붙었고** 상한 공식과는 위처럼 맞는다.

## ② 절전 — 패키지 수준에서 대가가 측정됐다 (Linux)

`measure-idle-cstates.sh` (root 불필요, core-idle) / `measure-idle-power.sh` (sudo, turbostat · RAPL) 가 ABAB 4 구간 (기준선 → TildaZ 완전 유휴 → 기준선 → TildaZ) 으로 잰다. **`hygiene_begin` 은 일부러 안 쓴다** — performance 프로파일 강제는 유휴 전력 자체를 바꾸는데, 재는 대상이 *평소 구성*의 유휴 대가다 (worker 종료만 한다).

같은 노트북 (AC · balanced · 화면 켬) 실측:

- 완전 유휴 인스턴스의 깨우기는 **초당 61 회** (`voluntary_ctxt_switches`, `1000/16 = 62.5` — [미니PC 실측](https://github.com/ensky0/tildaz/issues/439#issuecomment-5305503815)과 일치)
- core-idle 잔류율로는 **잡음 아래** — 시스템 전체 유휴 진입 (~700~830 회/s) 의 요동이 TildaZ 몫 (61 회/s) 보다 크다 ([상세](https://github.com/ensky0/tildaz/issues/439#issuecomment-5305627637))
- 패키지 전력으로는 **뚜렷하다** — PkgWatt **+0.07~0.11 W** · SysWatt **+0.19~0.24 W (유휴 소비의 ~+2 %)** · Pkg%pc8 잔류율 절반, IRQ 증가분 (+82~85 /s) 이 깨우기와 같은 자릿수 ([확정 코멘트](https://github.com/ensky0/tildaz/issues/439#issuecomment-5306404629))

**Windows · macOS 는 깨우기 빈도만 잡혔다.** 지연 측정과 같은 덤프의 `onrender` 로 센 값이다 — Windows 는 `calls≈2500 · skip≈2480` (회차당 약 43 초) = **초당 약 58 회**, macOS 는 `calls≈4970` (회차당 약 41.5 초) = **초당 119.7 회**, 렌더 skip 비율이 각각 **99 % · 99.3 %** 다. *"유휴에도 주사율만큼 깨어나 게이트만 확인한다"* 가 두 host 에서 숫자로 확인됐다.

**②는 이 Linux 실측으로 충분하다고 보고 닫는다** (2026-08-16 사용자 결정). ② 가 재려는 것은 *"주기적 깨우기 한 대가 얼마"* 인데 그 빈도가 host 를 안 가린다 — Linux 초당 61 회와 Windows 초당 약 58 회가 거의 같다. 같은 빈도면 전력 대가도 같은 자릿수라, platform 마다 다시 재도 **방향 결정 ((d) 타이머 정지) 을 바꿀 새 정보가 나오지 않는다.** 그래서 `Get-Counter` (Windows) · `powermetrics` (macOS) 대응 도구는 만들지 않는다 (Windows 는 RAPL 접근에 커널 드라이버까지 필요해 비용도 제일 크다).

## 어떻게 쟀나 — 입력을 아예 안 보낸다

`-e` 러너를 `sleep N; echo …` 반복 (지연) / `sleep 3600` (절전) 으로 두면 앱은 그 사이 완전 유휴이고, 지연 측정에서는 매 출력이 깨우기 경로를 그대로 탄다. **합성 입력이 필요 없어서** `ydotool` · 포커스 · IME 가 전부 무관하다 — #441 축 ② 에서 겪은 함정이 아예 생기지 않는다.

대신 **측정 중 창을 건드리면 오염된다** (입력이 렌더를 유발해 깨우기를 건너뛴다). 같은 덤프의 `input` 표본 수를 함께 세어 **0 이 아니면 회차 폐기**로 표시한다. 위 회차는 세 OS 모두 전부 0 이었다.

### 하네스는 세 platform 공용이다

처음에는 Linux · macOS 만 상정해 Windows 에서 두 곳이 걸렸고, 실기로 확인해 고쳤다 (`measure-input-latency.sh` 가 #441 축 ② 에서 푼 것과 같은 처리다). **macOS 는 실기에서 고칠 게 없었다** — POSIX 라 러너가 Linux 와 같고 로그 경로 (`~/Library/Logs/tildaz_stress.log`) · EXE 후보 (`zig-out/TildaZ.app/Contents/MacOS/tildaz`) · `hygiene_minimize_macos` 가 이미 다 있었다. 서명 설치 (`build_and_install.sh`) 도 필요 없다 — 합성 입력을 안 보내서 *Input Monitoring* 권한을 아예 안 쓴다.

- **EXE 탐지에 `.exe`** — 없으면 `[ -x ]` 가 전부 실패해 `tildaz 없음` 으로 끝난다
- **러너는 `.cmd`** — Windows 의 `-e` 는 `CreateProcessW` 의 `lpCommandLine` 이라 ([`host/windows.zig`](../blob/main/src/host/windows.zig) 의 `stress_shell_w`) POSIX `.sh` 를 그대로 넘기면 안 뜬다. `cmd.exe /c <배치>` 로 세운다. 배치는 `%TEMP%` 아래에 만들고 (Git Bash 의 `/tmp` 는 `C:\Program Files\Git\tmp` 라 공백이 인용을 가른다), 대기는 `timeout` 이 아니라 **`ping -n`** 이며 (`timeout` 은 stdin 리다이렉트에서 떨어진다), **CRLF + `for /L` 한 줄**로 쓴다

**Windows 는 표본이 `N + 1` 로 잡히는데 오염이 아니다.** ConPTY 가 시작할 때 자체 출력을 한 번 낸다 (`ESC [ { 1 } t`). **표본 0 대조군**으로 그 몫만 재면 `samples=1 ms=7.311` 로, 그 표본도 *같은 유휴 프레임 대기*다 (60 Hz 균등분포 [0, 16.67] 한가운데) — 평균을 끌어내리는 편향이 아니라 그대로 둔다. Linux 는 PTY 가 시작 출력을 안 내서 정확히 N 이다.

## 계측

`input_latency` 와 같은 패턴 (`calls` 표본 · `ns` 합 · `extra` 최악값 · 대기 중이면 안 덮음 · 스냅숏 경계에서 비움).

- `markOutput()` — `session_core.pushOutput` 의 ring push 자리. **read thread 에서** 불리므로 원자 연산만 한다
- `completeOutput()` — 세 host 의 present 직후 (`completeInput()` 옆)

## 미검증

**①은 세 platform 모두 쟀다** — 마지막까지 남아 있던 macOS 를 채웠다 ([실측 코멘트](https://github.com/ensky0/tildaz/issues/439#issuecomment-5306719056)). 예상했던 *"120 Hz 면 8.3 ms 주기가 상한"* 은 **상한 공식 (주기 + render + present = 9.57 ms) 기준으로는 0.06 ms 차이로 맞았지만**, 최악 절사평균 자체는 이상치 2 회 때문에 9.51 ms 로 예상보다 1.2 ms 크다.

**남은 미확정은 이상치의 원인 하나다** — Windows 회차 4 의 22.25 ms 와 macOS 회차 1 · 5 의 10.98 · 11.11 ms 가 상한 공식으로 설명되지 않는다. tick 밀림 / present 지연이 의심되지만 확정하지 못했고, 이 PR 은 계측만 넣으므로 그대로 남긴다.

**② 는 미검증 항목이 아니다** — 위 결정대로 Linux 실측으로 닫았다. Windows · macOS 의 전력 대가는 재지 않지만, 그건 남은 갭이 아니라 *안 재기로 한 것*이다.

## 범위

**방향 결정은 하지 않는다** — 다만 이제 *"고치면 얼마나 좋아지는가"* 를 두 축 모두 숫자로 말할 수 있다: (a) `eventfd` 는 Linux 평균 8.71 ms · (b) `PostMessageW` 는 Windows 평균 8.40 ms · (c) `CFRunLoopSourceSignal` 은 macOS 평균 5.83 ms 의 지연 제거, (d) 타이머 정지는 시스템 ~0.2 W 의 유휴 소비 제거가 그 값이다 ((d) 는 (a)~(c) 선행 필요 — 본문 그대로).

그래서 이 PR 은 이슈를 닫지 않는다.

Refs #439

