### PR TITLE
CLA 봇 부트스트랩 실패가 1 회성임을 주석에 명확히 한다 (#485)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,11 +14,17 @@
 # 정해진 문장을 코멘트하면 서명으로 기록한 뒤 status check 를 통과시킨다.
 # 서명은 1 회로 이후 모든 PR 에 유효하다.
 #
-# 알려진 동작 — **첫 실행은 실패한다.** 서명 기록 파일 (signatures/version1/cla.json)
-# 이 아직 없으면 action 이 그 파일을 만들어 main 에 커밋하고 (38baa0f), 그 회차는
-# "Committers of pull request N have to sign the CLA" 로 실패한다. allowlist 에 있는
-# 사용자여도 그렇다. 재실행하면 통과한다 (PR #487 에서 확인 — 첫 회차 FAILURE,
-# 재실행 success). 파일이 생긴 뒤로는 정상이므로 이 부트스트랩 1 회만 해당한다.
+# 부트스트랩 1 회 실패 — **이미 지나갔다. 지금은 해당 없다.**
+#
+# 서명 기록 파일 (signatures/version1/cla.json) 이 없는 상태의 첫 회차는 action 이
+# 그 파일을 만들어 커밋하고 (38baa0f) 그 회차 자체는 실패한다 — allowlist 에 있는
+# 사용자여도 "Committers of pull request N have to sign the CLA" 로 죽는다. PR #487
+# 에서 실제로 겪었다 (첫 회차 FAILURE → 재실행 success).
+#
+# 그 파일이 생긴 뒤로는 재현되지 않는다. **되살아나는 조건은 하나뿐이다** —
+# signatures/version1/cla.json 을 지우거나 아래 path-to-signatures 를 아직 파일이
+# 없는 경로로 바꾸는 것. 그럴 일이 있으면 봇에 맡기지 말고 파일을 손으로 먼저
+# 만들어 두면 (`{"signedContributors": []}`) 이 실패를 건너뛴다.
 
 name: cla-check
 


### PR DESCRIPTION
`29fe1d6` 의 주석이 "첫 실행은 실패한다" 로 읽혀 앞으로도 계속 실패하는 동작처럼 오해된다. 실제로는 서명 기록 파일이 없을 때만이고, 그 파일은 `38baa0f` 로 이미 생겼다.

수정 내용:
- 1 회성이고 **이미 지나갔다** 는 점을 앞에 명시
- 되살아나는 조건을 특정 — `signatures/version1/cla.json` 삭제, 또는 `path-to-signatures` 를 파일 없는 경로로 변경
- 그때의 회피법 — 봇에 맡기지 말고 `{"signedContributors": []}` 로 파일을 손으로 먼저 만들기

## 이 PR 이 실증이다

서명 파일이 있는 상태에서 **새로 연 PR** 의 `cla` check 가 재실행 없이 첫 회차에 통과하는지가 이 PR 로 확인된다. #487 은 파일이 없던 상태의 PR 이었으므로 그 케이스를 가르지 못했다.

통과하면 주석 내용이 맞고, 또 실패하면 부트스트랩이 아니라 다른 원인이라 재조사가 필요하다.