### PR TITLE
COSMIC 항목 판정을 우리 표식으로 + hotkey 거부 이유를 원인별로 안내 (#484)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -214,9 +214,15 @@ invalid value shows an error dialog and exits):
   digit, or `Space` with no modifier is rejected.
 - **`Shift` alone is not a valid trigger modifier** — combine it with
   `Ctrl` / `Alt` / `Cmd` (e.g. `Shift+Cmd+T` is fine, `Shift+T` is not).
-- Key names cover letters, digits, `Space`, `` ` `` (backtick / grave), and
-  `F1`–`F12`. macOS and Windows accept a slightly narrower modifier-alias set
-  than Linux; the tokens above work on all three.
+- **Accepted keys**, in full: `F1`–`F12`, `A`–`Z`, `0`–`9`, `Space`, `Tab`,
+  `Escape` (`Esc`), `Return` (`Enter`), and `` ` `` — writable as `` ` ``,
+  `Grave`, or `Backquote`. Letter case does not matter.
+- **Any other key is rejected**, and that includes layout-specific keys such as
+  `²` (`twosuperior`) on French AZERTY. The accepted set is deliberately narrow:
+  it is the set every platform's native hotkey backend is known to map the same
+  way. Widening it means verifying real key codes on Linux, macOS, and Windows,
+  which has not been done yet. A rejected value shows an error dialog naming the
+  accepted keys rather than failing silently.
 
 ### New tab working directory
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -233,6 +233,14 @@ Linux 지원 수준은 desktop 이름이 아니라 실제 capability + 검증 �
   (`~/.config/cosmic/.../custom`) 의 TildaZ 전용 항목을 config_N 전체에 맞춰
   `Spawn("tildaz --toggle N")`로 원자적 갱신하되, 기존 bytes 와 같으면 write/rename 을
   생략한다. XDG autostart는 지원.
+  - **"TildaZ 전용 항목" 의 판정 근거는 우리가 쓰는 description 표식
+    (`description: Some("TildaZ_<index>")`) 하나다** — 명령 문자열이 아니다
+    ([#484](https://github.com/ensky0/tildaz/issues/484)). 이 파일에는 사용자가 만든
+    단축키가 함께 들어 있어서, 판정을 틀리면 양방향으로 깨진다: 자기 항목을 못
+    알아보면 중복 맵 키가 쌓여 COSMIC 이 **파일 전체를 버리고**(사용자 단축키까지
+    사라진다), 남의 항목을 자기 것으로 착각하면 **조용히 지운다**. 명령에는 바이너리
+    경로와 이름이 들어가 사용자가 바꿀 수 있으므로 판정 근거가 될 수 없다. 표식 뒤의
+    번호가 정수인지도 확인한다.
 - **GNOME / Cinnamon (mutter / muffin).** layer-shell 미지원이라 TildaZ 본체는 평범한
   xdg-shell client (`app_id="tildaz.instanceN"`) 로 두고, **Shell extension** 이 창을 잡아
   drop-down 배치 + 토글 + 창 목록 숨김(Alt-Tab / taskbar / window-list / Expo)을

--- a/src/config.zig
+++ b/src/config.zig
@@ -120,7 +120,35 @@ const ParsedHotkey = struct {
     key: HotkeyKeyToken,
 };
 
-fn parseHotkeyString(s: []const u8) ?ParsedHotkey {
+/// hotkey 문자열이 거부된 **이유**. 원인이 둘인데 메시지가 하나여서 사용자를 막다른
+/// 길로 보내고 있었다 (#484): `ctrl+twosuperior` 는 이미 modifier 가 있는데도
+/// "Other keys require Ctrl, Alt, Super, or Cmd" 라고 안내했다. 신고자는 modifier 를
+/// 더해 보고도 같은 메시지를 받아 실제 원인 (모르는 key 이름) 을 알 수 없었다.
+pub const HotkeyFailure = enum {
+    /// key 자리의 이름을 못 알아봤다 — 또는 key 토큰이 아예 없다.
+    unknown_key,
+    /// key 는 유효하지만 modifier 없이 전역 등록할 수 없는 키다 (F1~F12 만 허용).
+    modifier_required,
+};
+
+/// `Hotkey.fromString` 이 왜 null 이었는지. **판정을 재현하지 않고** 같은
+/// `parseHotkeyString` 을 쓴다 — 두 곳에 규칙을 두면 갈라진다 (#484 의 원인이
+/// writer/matcher 가 갈라진 것이었다).
+pub fn hotkeyFailure(s: []const u8) ?HotkeyFailure {
+    return switch (parseHotkeyString(s)) {
+        .ok => null,
+        .unknown_key => .unknown_key,
+        .modifier_required => .modifier_required,
+    };
+}
+
+const HotkeyParse = union(enum) {
+    ok: ParsedHotkey,
+    unknown_key,
+    modifier_required,
+};
+
+fn parseHotkeyString(s: []const u8) HotkeyParse {
     var ctrl = false;
     var shift = false;
     var alt = false;
@@ -142,10 +170,12 @@ fn parseHotkeyString(s: []const u8) ?ParsedHotkey {
             // = Qt Logo. 사용자 친숙한 표기 어떤 것이든 받음.
             super = true;
         } else {
-            key = hotkeyKeyFromName(tok) orelse return null;
+            key = hotkeyKeyFromName(tok) orelse return .unknown_key;
         }
     }
-    const resolved = key orelse return null;
+    // key 토큰이 아예 없는 경우 (예: `"ctrl"` 하나만) 도 "모르는 key" 로 묶는다 —
+    // 사용자가 받아야 하는 안내가 같다 (받는 key 목록).
+    const resolved = key orelse return .unknown_key;
     // Bare 문자/숫자/Space/Tab/grave나 Shift-only 조합을 전역 단축키로
     // 등록하면 일상 입력을 OS 전체에서 가로챈다. modifier 없이 안전하게
     // 허용하는 키는 F1~F12뿐 — capturedHotkeyText 와 동일 규칙.
@@ -156,8 +186,8 @@ fn parseHotkeyString(s: []const u8) ?ParsedHotkey {
         },
         .char => false,
     };
-    if (!(ctrl or alt or super) and !is_function_key) return null;
-    return .{ .ctrl = ctrl, .shift = shift, .alt = alt, .super = super, .key = resolved };
+    if (!(ctrl or alt or super) and !is_function_key) return .modifier_required;
+    return .{ .ok = .{ .ctrl = ctrl, .shift = shift, .alt = alt, .super = super, .key = resolved } };
 }
 
 /// 키 이름 토큰 → 정규화된 key. 두 표기 모두 받음 (사용자 친화):
@@ -294,7 +324,10 @@ const LinuxHotkey = struct {
     pub const MOD_SUPER: u32 = 0x8; // Win key / Super / `cmd` 토큰.
 
     pub fn fromString(s: []const u8) ?LinuxHotkey {
-        const parsed = parseHotkeyString(s) orelse return null;
+        const parsed = switch (parseHotkeyString(s)) {
+            .ok => |p| p,
+            else => return null,
+        };
         var modifiers: u32 = 0;
         if (parsed.alt) modifiers |= MOD_ALT;
         if (parsed.ctrl) modifiers |= MOD_CTRL;
@@ -414,6 +447,42 @@ test "config parser rejects unsafe global hotkeys" {
     }
 }
 
+test "hotkey rejection reports the cause, not one blanket message" {
+    // #484 — 원인이 둘인데 메시지가 하나여서 `ctrl+twosuperior` 처럼 **이미 modifier 가
+    // 있는** 값에도 "modifier 를 달라" 고 안내했다. 신고자는 modifier 를 더해 보고도
+    // 같은 안내를 다시 받아 실제 원인을 알 수 없었다.
+
+    // 모르는 key 이름 — modifier 유무와 무관하게 `unknown_key` 다.
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("twosuperior").?);
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("ctrl+twosuperior").?);
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("ctrl+minus").?);
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("ctrl+shift+f13").?);
+    // key 토큰이 아예 없는 경우도 같은 안내를 받아야 한다 (받는 key 목록).
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("ctrl").?);
+    try std.testing.expectEqual(HotkeyFailure.unknown_key, hotkeyFailure("ctrl+shift").?);
+
+    // key 는 유효하지만 modifier 없이 전역 등록할 수 없는 경우 — 기존 안내가 맞다.
+    try std.testing.expectEqual(HotkeyFailure.modifier_required, hotkeyFailure("t").?);
+    try std.testing.expectEqual(HotkeyFailure.modifier_required, hotkeyFailure("shift+t").?);
+    try std.testing.expectEqual(HotkeyFailure.modifier_required, hotkeyFailure("space").?);
+    try std.testing.expectEqual(HotkeyFailure.modifier_required, hotkeyFailure("grave").?);
+    try std.testing.expectEqual(HotkeyFailure.modifier_required, hotkeyFailure("5").?);
+
+    // 통과하는 값은 실패 이유가 없다 — `fromString` 과 판정이 갈리지 않는지 함께 본다.
+    const accepted = [_][]const u8{ "f1", "f12", "ctrl+space", "shift+cmd+t", "super+grave", "alt+3" };
+    for (accepted) |text| {
+        try std.testing.expect(hotkeyFailure(text) == null);
+        try std.testing.expect(Hotkey.fromString(text) != null);
+    }
+
+    // 거부되는 값은 반드시 이유가 있다 (둘의 판정이 어긋나면 메시지가 사라진다).
+    const rejected = [_][]const u8{ "twosuperior", "ctrl+minus", "t", "shift+t", "ctrl", "" };
+    for (rejected) |text| {
+        try std.testing.expect(Hotkey.fromString(text) == null);
+        try std.testing.expect(hotkeyFailure(text) != null);
+    }
+}
+
 // 파서 3벌은 OS API 비의존 순수 로직이라 어느 테스트 호스트에서도 세 OS 분을
 // 전부 검증할 수 있다 (#294 G1).
 
@@ -485,7 +554,10 @@ const WindowsHotkey = struct {
     modifiers: u32 = 0,
 
     pub fn fromString(s: []const u8) ?WindowsHotkey {
-        const parsed = parseHotkeyString(s) orelse return null;
+        const parsed = switch (parseHotkeyString(s)) {
+            .ok => |p| p,
+            else => return null,
+        };
         var modifiers: u32 = 0;
         if (parsed.alt) modifiers |= 0x1; // MOD_ALT
         if (parsed.ctrl) modifiers |= 0x2; // MOD_CONTROL
@@ -559,7 +631,10 @@ const MacHotkey = struct {
     modifiers: u64 = 0,
 
     pub fn fromString(s: []const u8) ?MacHotkey {
-        const parsed = parseHotkeyString(s) orelse return null;
+        const parsed = switch (parseHotkeyString(s)) {
+            .ok => |p| p,
+            else => return null,
+        };
         var modifiers: u64 = 0;
         if (parsed.shift) modifiers |= 0x00020000; // kCGEventFlagMaskShift
         if (parsed.ctrl) modifiers |= 0x00040000; // kCGEventFlagMaskControl
@@ -1081,12 +1156,16 @@ pub const Config = struct {
             if (Hotkey.fromString(v.string)) |h| {
                 config.hotkey = h;
             } else {
-                var buf: [384]u8 = undefined;
-                const msg = std.fmt.bufPrint(
-                    &buf,
-                    messages.config_hotkey_invalid_format,
-                    .{v.string},
-                ) catch messages.config_hotkey_invalid_fallback_msg;
+                // #484 — 거부 이유별로 다른 안내를 보낸다. 한 메시지로 묶으면
+                // modifier 를 이미 준 사용자에게 "modifier 를 달라" 고 말하게 된다.
+                // `bufPrint` 의 format 은 comptime 이라 분기 안에서 각각 포맷한다.
+                var buf: [512]u8 = undefined;
+                const msg = if (hotkeyFailure(v.string) == .unknown_key)
+                    std.fmt.bufPrint(&buf, messages.config_hotkey_unknown_key_format, .{v.string}) catch
+                        messages.config_hotkey_unknown_key_fallback_msg
+                else
+                    std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
+                        messages.config_hotkey_invalid_fallback_msg;
                 showConfigFatalMsg(rt, config_path, msg);
             }
         }

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -306,6 +306,17 @@ pub const config_field_number_required_format = "Configuration: \"{s}\" must be 
 pub const config_field_range_required_format = "Configuration: \"{s}\" must be in {s}.";
 pub const config_field_integer_range_required_format = "Configuration: \"{s}\" must be an integer in {s}.";
 pub const config_unknown_theme_header_format = "Configuration: unknown theme \"{s}\"\n\nAvailable themes:\n";
+/// #484 — 거부 이유가 둘인데 메시지가 하나였다. `ctrl+twosuperior` 는 이미 modifier 가
+/// 있는데도 "Other keys require Ctrl, Alt, Super, or Cmd" 를 받아, 신고자가 modifier 를
+/// 더해 보고도 같은 안내를 다시 받았다. 실제 원인 (모르는 key 이름) 을 알 방법이 없었다.
+/// 이제 원인별로 갈라 보낸다 — `config.HotkeyFailure` 참고.
+///
+/// key 이름을 못 알아본 경우. **받는 key 목록을 함께 준다** — 안 되는 이유만 알려 주고
+/// 무엇이 되는지 안 알려 주면 사용자가 또 추측해야 한다.
+pub const config_hotkey_unknown_key_format = "Configuration: \"hotkey\" value \"{s}\" uses a key TildaZ does not recognize.\n\nAccepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return, grave (`)\nAccepted modifiers: ctrl, shift, alt, super (also win / cmd / meta)\n\nKeys outside this list are not supported yet, including layout-specific ones.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
+pub const config_hotkey_unknown_key_fallback_msg = "Configuration: hotkey uses an unrecognized key";
+/// key 는 유효하지만 modifier 가 없어 전역 등록이 위험한 경우 (일상 입력을 OS 전체에서
+/// 가로챈다). 이쪽은 기존 안내가 정확했다.
 pub const config_hotkey_invalid_format = "Configuration: failed to parse \"hotkey\" value \"{s}\".\n\nOnly F1-F12 may be used without modifiers. Other keys require Ctrl, Alt, Super, or Cmd.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_invalid_fallback_msg = "Configuration: hotkey invalid";
 /// #431 — 다른 TildaZ 인스턴스가 이미 쓰는 전역 핫키. 뒤에 있는 (index 가 큰) 쪽이 양보하므로

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -257,6 +257,80 @@ test "Hyprland binds JSON keeps the fields needed for cleanup" {
     try std.testing.expectEqualStrings(",F3", managedHyprlandAccel(&buf, parsed.value[0], "/home/test/tildaz").?);
 }
 
+test "COSMIC entries are identified by our own description marker, not the command" {
+    // writer(`appendCosmicEntries`)가 만드는 형태.
+    try std.testing.expect(isTildazCosmicEntry(
+        "    (modifiers: [], key: \"F1\", description: Some(\"TildaZ_0\")): Spawn(\"/usr/bin/tildaz --toggle 0\"),",
+    ));
+
+    // #484 회귀 — 바이너리 **이름**이 `tildaz` 가 아니면 이전 구현은 자기 항목을 못
+    // 알아봤다. `tildaz-dev --toggle 0` 에는 `tildaz --toggle` 이라는 연속 문자열이
+    // 없다 (하이픈이 끼어서). 못 지우고 하나 더 써서 같은 맵 키가 중복되고, 중복 키가
+    // 있는 RON 은 COSMIC 이 파일 전체를 버린다 — 사용자 단축키까지 사라졌다.
+    try std.testing.expect(isTildazCosmicEntry(
+        "    (modifiers: [], key: \"F1\", description: Some(\"TildaZ_0\")): Spawn(\"/opt/bin/tildaz-dev --toggle 0\"),",
+    ));
+    // 경로만 바뀐 경우도 같이 고정한다.
+    try std.testing.expect(isTildazCosmicEntry(
+        "    (modifiers: [Ctrl, Shift], key: \"F2\", description: Some(\"TildaZ_3\")): Spawn(\"/home/u/bin/tz --toggle 3\"),",
+    ));
+    // 여러 자리 index.
+    try std.testing.expect(isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"grave\", description: Some(\"TildaZ_12\")): Spawn(\"/usr/bin/tildaz --toggle 12\"),",
+    ));
+
+    // #484 거울상 — 사용자 항목의 **명령**에 `tildaz --toggle` 이 들어 있으면 이전
+    // 구현은 우리 것으로 착각해 조용히 지웠다. 이제 남의 항목은 건드리지 않는다.
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"t\", description: Some(\"My wrapper\")): Spawn(\"sh -c 'tildaz --toggle 0; notify-send hi'\"),",
+    ));
+
+    // 표식을 흉내낸 남의 이름 — 번호 자리가 정수가 아니면 우리 것이 아니다.
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"b\", description: Some(\"TildaZ_backup\")): Spawn(\"/usr/bin/backup\"),",
+    ));
+    // 번호 자리가 비어 있는 경우.
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"n\", description: Some(\"TildaZ_\")): Spawn(\"/usr/bin/x\"),",
+    ));
+    // 음수는 index 가 아니다 (`u32`).
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"m\", description: Some(\"TildaZ_-1\")): Spawn(\"/usr/bin/x\"),",
+    ));
+
+    // 전혀 무관한 사용자 항목.
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [Super], key: \"e\", description: Some(\"My file manager\")): Spawn(\"nautilus\"),",
+    ));
+    // 맵 경계 줄.
+    try std.testing.expect(!isTildazCosmicEntry("{"));
+    try std.testing.expect(!isTildazCosmicEntry("}"));
+
+    // 죽어 있던 옛 표식(`TildaZ instance `)은 writer 가 쓴 적이 없으므로 인식 대상이
+    // 아니다 — 살릴 것은 그 절의 *의도* 였고 문자열이 아니다.
+    try std.testing.expect(!isTildazCosmicEntry(
+        "    (modifiers: [], key: \"F1\", description: Some(\"TildaZ instance 0\")): Spawn(\"/usr/bin/tildaz --toggle 0\"),",
+    ));
+}
+
+test "COSMIC closing map line is the last one" {
+    // `syncCosmic` 은 이 offset 직전에 자기 항목을 끼워 넣는다.
+    try std.testing.expectEqual(@as(?usize, 2), findClosingMapLine("{\n}\n"));
+    try std.testing.expect(findClosingMapLine("{\n") == null);
+
+    // 중첩된 `}` 가 있으면 **마지막** 것이 맵의 끝이다.
+    const nested =
+        "{\n" ++
+        "    (modifiers: [], key: \"F1\", description: Some(\"TildaZ_0\")): Spawn(\"x\"),\n" ++
+        "}\n";
+    const offset = findClosingMapLine(nested).?;
+    try std.testing.expectEqualStrings("}", nested[offset .. offset + 1]);
+
+    // 들여쓰기 / CR 이 붙어도 닫는 줄로 인정한다 (`trim` 대상).
+    try std.testing.expectEqual(@as(?usize, 2), findClosingMapLine("{\n  }  \n"));
+    try std.testing.expectEqual(@as(?usize, 2), findClosingMapLine("{\n}\r\n"));
+}
+
 test "Hyprland desired lookup distinguishes keep and changed command" {
     const desired = [_]HyprlandDesired{
         .{ .accel = ",F1", .command = "/home/test/tildaz --toggle 0" },
@@ -322,11 +396,41 @@ pub fn findClosingMapLine(content: []const u8) ?usize {
     return found;
 }
 
+/// COSMIC custom shortcut 한 줄이 **우리가 쓴 것**인지 판정한다.
+///
+/// 근거는 `appendCosmicEntries` 가 직접 쓰는 description 표식
+/// (`description: Some("TildaZ_<index>")`) 하나다. 명령 문자열을 보지 않는 이유가
+/// [#484](https://github.com/ensky0/tildaz/issues/484) 다 — 이전 구현은
+/// `Spawn("` + `tildaz --toggle` 부분 일치였고, 명령에는 바이너리 경로와 이름이
+/// 들어가서 **사용자가 바꿀 수 있는 값**을 판정 근거로 삼고 있었다. 양방향으로 틀렸다.
+///
+/// - 이름을 바꾸면 (`tildaz-dev --toggle 0`) `tildaz --toggle` 이라는 연속 문자열이
+///   사라져 자기 항목을 못 알아봤다. 지우지 못한 채 하나 더 쓰니 **같은 맵 키가
+///   중복**되고, 중복 키가 있는 RON 은 깨진 데이터라 COSMIC 이 파일 전체를 버린다 —
+///   사용자 단축키까지 함께 사라진다. 신고된 "cosmic resets all" 의 기전이다.
+/// - 반대로 사용자 항목의 명령에 `tildaz --toggle` 이 들어 있으면 (래퍼 스크립트 등)
+///   우리 것으로 착각해 **조용히 지웠다.**
+///
+/// 표식은 경로 · 이름과 무관하므로 두 방향이 함께 사라진다.
+///
+/// **접두 매칭**인 이유는 `syncCosmic` 이 "자기 항목 전부 삭제 후 현재 config 목록대로
+/// 재작성" 구조라서다 — config 를 지운 인스턴스의 유령 항목도 정리돼야 한다. 단 번호
+/// 자리가 정말 정수인지 확인해 `TildaZ_backup` 같은 남의 이름을 집지 않는다 (Hyprland
+/// 쪽 `managedToggleCommand` 와 같은 엄격함).
 fn isTildazCosmicEntry(line: []const u8) bool {
-    return std.mem.find(u8, line, "description: Some(\"TildaZ instance ") != null or
-        (std.mem.find(u8, line, "Spawn(\"") != null and
-            std.mem.find(u8, line, "tildaz --toggle") != null);
+    const start = std.mem.find(u8, line, cosmic_entry_marker) orelse return false;
+    const rest = line[start + cosmic_entry_marker.len ..];
+    // 표식 뒤는 `<index>")` 형태다. 닫는 큰따옴표까지가 index 자리.
+    const end = std.mem.findScalar(u8, rest, '"') orelse return false;
+    _ = std.fmt.parseInt(u32, rest[0..end], 10) catch return false;
+    return true;
 }
+
+/// `appendCosmicEntries` 의 writer 와 `isTildazCosmicEntry` 의 matcher 가 **같은**
+/// 표식을 쓰게 묶어 둔다. 이 둘이 갈라진 게 #484 의 원인이었다 — matcher 는
+/// `TildaZ instance ` 를 찾는데 writer 는 `TildaZ_<index>` 를 써서 그 절이 죽어 있었고,
+/// 그래서 명령 문자열 매칭으로 떨어졌다.
+const cosmic_entry_marker = "description: Some(\"TildaZ_";
 
 fn appendCosmicEntries(rt: Runtime, output: *std.ArrayList(u8), allocator: std.mem.Allocator, indices: []const u32) !void {
     var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
@@ -353,7 +457,9 @@ fn appendCosmicEntries(rt: Runtime, output: *std.ArrayList(u8), allocator: std.m
         }
         try output.appendSlice(allocator, "], key: \"");
         try output.appendSlice(allocator, config.linuxKeysymName(hotkey.keysym) orelse return error.InvalidConfig);
-        const description = try std.fmt.allocPrint(allocator, "\", description: Some(\"TildaZ_{d}\")): Spawn(\"", .{index});
+        // 표식은 `cosmic_entry_marker` 를 그대로 쓴다 — matcher 와 문자열이 갈라지면
+        // 자기 항목을 못 알아본다 (#484 의 원인이 정확히 그것이었다).
+        const description = try std.fmt.allocPrint(allocator, "\", " ++ cosmic_entry_marker ++ "{d}\")): Spawn(\"", .{index});
         defer allocator.free(description);
         try output.appendSlice(allocator, description);
         try appendRonString(output, allocator, exe);


### PR DESCRIPTION
Closes #484

커밋 2 개. 둘 다 #484 에서 나왔고 신고자 @squalou 에게 약속한 순서다.

---

## ① `23f9099` COSMIC 항목을 명령이 아니라 우리 표식으로 판정

`isTildazCosmicEntry` 가 자기 항목을 **명령 문자열의 부분 일치** (`Spawn(\"` + `tildaz --toggle`) 로 찾고 있었다. 명령에는 바이너리 경로와 이름이 들어간다 — **사용자가 바꿀 수 있는 값**이라 판정 근거가 될 수 없다. 양방향으로 틀렸다.

| | 이전 |
|---|---|
| 이름이 `tildaz` 가 아닐 때 (`tildaz-dev --toggle 0`) | `tildaz --toggle` 연속 문자열이 없어 **자기 항목을 못 알아봄** → 못 지우고 하나 더 씀 → **같은 맵 키 중복** → RON 이 깨져 COSMIC 이 파일 전체를 버림 → **사용자 단축키까지 사라짐**. 신고된 "cosmic resets all" 의 기전 |
| 사용자 항목 명령에 `tildaz --toggle` 이 있을 때 (래퍼 스크립트) | 우리 것으로 착각해 **조용히 삭제** — 이슈 제목의 "risk of breaking existing" |

`appendCosmicEntries` 가 **이미 자기 표식을 쓰고 있었다** (`description: Some(\"TildaZ_<index>\")`). 그것만으로 판정한다. 죽어 있던 첫 절 (`TildaZ instance ` — writer 가 쓰지 않는 문자열) 도 정리했다. **이 수정은 새 설계가 아니라 그 절의 원래 의도를 복구하는 것이다.** 다시 갈라지지 않게 writer 와 matcher 가 `cosmic_entry_marker` 상수 하나를 공유한다.

접두 매칭인 이유는 `syncCosmic` 이 "자기 항목 전부 삭제 후 재작성" 구조라서다 — 지운 인스턴스의 유령 항목도 정리돼야 한다. 번호가 정수인지 `parseInt` 로 확인해 `TildaZ_backup` 같은 남의 이름은 안 집는다.

**실환경 검증**: 가짜 HOME + `XDG_CURRENT_DESKTOP=COSMIC`, 이름 3 종 (`tildaz` / `tildaz-dev` / `tz`) 을 섞어 4 회 실행 → TildaZ 항목 **1 개 유지** (이전엔 3 개 누적), `tildaz --toggle` 이 든 사용자 wrapper **보존**.

---

## ② `f2de8c6` hotkey 거부 이유를 원인별로 안내

**거부 이유가 둘인데 메시지가 하나였다.** `ctrl+twosuperior` 는 이미 modifier 가 있는데도 "Other keys require Ctrl, Alt, Super, or Cmd" 를 받았다. 신고자는 안내대로 modifier 를 더해 보고도 같은 메시지를 다시 받아 실제 원인 (모르는 key 이름) 을 알 수 없었다. **침묵보다 나쁘다 — 막다른 길로 안내한다.**

`parseHotkeyString` 이 `HotkeyParse` union 으로 이유까지 반환한다. `Hotkey.fromString` (Linux · macOS · Windows **3 곳**) 은 `.ok` 만 받아 기존 시그니처를 유지하고, 새 `hotkeyFailure` 도 **같은 함수**를 쓴다 — 규칙을 복제하면 갈라진다. ① 의 근본 원인이 정확히 그것이었다.

`unknown_key` 메시지는 **받는 key 목록을 함께 준다.** 안 되는 이유만 주고 무엇이 되는지 안 주면 사용자가 또 추측한다.

**수용 집합 자체는 넓히지 않는다.** 좁은 것은 의도된 설계다 (#208 — 이전엔 silent `F1` fallback 이었다). `²` 는 Linux 만 쉽고 (keysym 이름 전달) Windows (VK) · macOS (물리 keycode) 는 layout 종속이라 검증이 필요하다. Linux 만 받으면 config schema parity 가 깨진다. **#482 (AZERTY 키바인딩) 로 넘겼다** — layout 문제 자체가 그쪽 주제고, 거기 설정 UI 방향이 같은 해법을 공유한다.

---

## 테스트 — 두 경로 모두 0 개였다

`shortcut_sync/linux.zig` 의 기존 테스트 3 개는 **전부 Hyprland** 였다. COSMIC 은 하나도 없었고, 그래서 ① 이 살아남았다.

**두 수정 모두 음성 테스트로 검증했다** — 새 테스트가 실제로 회귀를 잡는지 확인:

| | 되돌린 것 | 실패 지점 |
|---|---|---|
| ① | matcher 를 옛 구현으로 | `shortcut_sync/linux.zig:270` (이름 바뀐 바이너리) |
| ② | 원인 구분 제거 (`unknown_key` → `modifier_required`) | `config.zig:456` |

②는 `fromString` 과 `hotkeyFailure` 의 판정이 어긋나지 않는지 **양방향**으로도 본다 — 통과하는 값에 실패 이유가 없고, 거부되는 값에 반드시 이유가 있다.

---

## 문서

- `SPEC.md` COSMIC 절 — "TildaZ 전용 항목" 이라고만 적고 *어떻게 식별하는지* 가 없었다. 그 공백이 ① 의 자리였다. 판정 근거를 durable 결정으로 기록.
- `CONFIG.md` "Hotkey syntax" — key 목록이 **실제보다 좁았다.** `Tab` · `Escape` · `Return` 과 `Grave` / `Backquote` 이름 형태가 빠져 있었다. 전체를 열거하고 `²` 가 안 되는 이유를 이름까지 적었다.

## 남은 것

- #482 — hotkey 수용 key 집합 확대 (layout 문제)
- #489 — `--toggle` exit code 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)