### PR TITLE
AZERTY 에서 탭 전환이 되게 한다 — Alt+숫자 완화 + PgUp/PgDn 추가 (#482 ①)

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -10,8 +10,8 @@ Cross-platform shortcut convention: each platform follows its native modifier (A
 | New tab | Ctrl+Shift+T | Cmd+T | Ctrl+Shift+T |
 | Close active tab | Ctrl+Shift+W | Cmd+W | Ctrl+Shift+W |
 | Switch tab by index | Alt+1–9 | Cmd+1–9 | Alt+1–9 |
-| Previous tab | Ctrl+Shift+[ | Shift+Cmd+[ | Ctrl+Shift+[ |
-| Next tab | Ctrl+Shift+] | Shift+Cmd+] | Ctrl+Shift+] |
+| Previous tab | Ctrl+Shift+[ *or* Ctrl+PgUp | Shift+Cmd+[ *or* Cmd+PgUp | Ctrl+Shift+[ *or* Ctrl+PgUp |
+| Next tab | Ctrl+Shift+] *or* Ctrl+PgDn | Shift+Cmd+] *or* Cmd+PgDn | Ctrl+Shift+] *or* Ctrl+PgDn |
 | Copy selection (explicit) | Ctrl+Shift+C | Cmd+C | Ctrl+Shift+C |
 | Paste from clipboard | Ctrl+Shift+V | Cmd+V | Ctrl+Shift+V |
 | Reset terminal | Ctrl+Shift+R | Shift+Cmd+R | Ctrl+Shift+R |
@@ -41,6 +41,27 @@ platforms.
 ## Quit confirmation
 
 Alt+F4 (Linux and Windows) and Cmd+Q (macOS) show a confirmation dialog with the open tab count. Enter confirms (Quit); Esc cancels. Closing the last tab via Cmd+W / Ctrl+Shift+W keeps its existing instant behavior — that path is an explicit "close this tab" intent.
+
+## Keyboard layouts
+
+The bracket bindings follow the US layout. On layouts where `[` and `]` need
+AltGr — French AZERTY, for instance, where `[` is AltGr+5 — `Ctrl+Shift+[` would
+mean pressing Ctrl+Shift+AltGr+5, which is not usable. **`Ctrl+PgUp` / `Ctrl+PgDn`
+(`Cmd+PgUp` / `Cmd+PgDn` on macOS) do the same thing and work on every layout**,
+since PgUp and PgDn are single physical keys everywhere. They match what GNOME
+Terminal, Konsole, and Windows Terminal use.
+
+Switching tabs by index also used to fail on AZERTY: the digit row needs Shift
+there, so `Alt+1` is physically Alt+Shift+the `&1` key, and TildaZ was requiring
+Shift *not* to be held. It now accepts either, on every layout.
+
+Mac laptops have no dedicated PgUp / PgDn keys — they are Fn+Up / Fn+Down. The
+existing `Shift+Cmd+[` / `]` and `Cmd+1`–`9` bindings are unchanged, so nothing is
+lost; `Cmd+PgUp` / `Cmd+PgDn` is an addition for people who use the same reflex
+on more than one OS.
+
+`Shift+PgUp` / `Shift+PgDn` still scroll the scrollback, and unmodified PgUp /
+PgDn still go to the program running in the terminal.
 
 ## Tab bar controls
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -297,8 +297,24 @@ minimize/restore.
 | 새 탭 | Ctrl+Shift+T | Cmd+T | Ctrl+Shift+T (L12-β) | ✅ | ✅ | ✅ |
 | 활성 탭 닫기 | Ctrl+Shift+W | Cmd+W | Ctrl+Shift+W (L12-β) | ✅ | ✅ | ✅ |
 | 인덱스 점프 (1..9) | Alt+1..9 ([`Window.wndProc`의 `WM_SYSKEYDOWN`](src/window.zig)) | Cmd+1..9 | Alt+1..9 ([a60fb8e](https://github.com/ensky0/tildaz/commit/a60fb8e)) | ✅ | ✅ | ✅ |
-| 이전 탭 | Ctrl+Shift+[ | Shift+Cmd+[ | Ctrl+Shift+[ (L12-β) | ✅ | ✅ | ✅ |
-| 다음 탭 | Ctrl+Shift+] | Shift+Cmd+] | Ctrl+Shift+] (L12-β) | ✅ | ✅ | ✅ |
+| 이전 탭 | Ctrl+Shift+[ **또는 Ctrl+PgUp** | Shift+Cmd+[ **또는 Cmd+PgUp** | Ctrl+Shift+[ (L12-β) **또는 Ctrl+PgUp** | ✅ | ✅ | ✅ |
+| 다음 탭 | Ctrl+Shift+] **또는 Ctrl+PgDn** | Shift+Cmd+] **또는 Cmd+PgDn** | Ctrl+Shift+] (L12-β) **또는 Ctrl+PgDn** | ✅ | ✅ | ✅ |
+
+**keyboard layout 독립성** ([#482](https://github.com/ensky0/tildaz/issues/482)). 세 platform 이
+단축키를 매칭하는 대상이 다르다 — Windows 는 virtual-key (`VK_1`, `VK_OEM_4`), macOS 는
+`kVK_ANSI_*` 로 **물리 위치**를 보고, Linux 는 **xkb keysym** 으로 *눌러서 나오는 문자*를 본다.
+그래서 layout 종속 결함은 Linux 에만 생긴다.
+
+- **인덱스 점프**는 Linux 에서 `!shift` 를 요구하지 않는다. AZERTY (fr) 등은 숫자열에 Shift 가
+  필요해 keysym `1`~`9` 가 **항상 Shift 와 함께** 도착하고, 예전 조건이 그것을 전부 걸러 그
+  layout 에서 인덱스 전환이 아예 동작하지 않았다. QWERTY 에는 영향이 없다 — Shift 가 keysym 을
+  `exclam` 으로 바꿔 애초에 매칭되지 않는다.
+- **PgUp / PgDn 조합**은 `[` / `]` 가 AltGr 를 요구하는 layout (AZERTY 는 `[` = AltGr+5 →
+  조합이 Ctrl+Shift+AltGr+5) 을 위한 layout 무관 대안이다. 기존 bracket 조합을 **대체하지 않고
+  추가**한다. `Ctrl+Tab` 은 쓰지 않는다 — kitty / CSI-u 에서 구별 가능한 시퀀스라 TUI 앱이
+  정당하게 바인딩하는데 터미널이 삼키면 통과시킬 방법이 없다. PgUp / PgDn 은 GNOME Terminal ·
+  Konsole · Windows Terminal 이 탭 전환에 쓰는, 터미널이 관습적으로 소유하는 조합이다.
+- **기존 PgUp / PgDn 경로는 그대로다** — Shift 동반은 scrollback (§2.5), 맨 키는 PTY.
 
 ### 2.3 클립보드
 
@@ -418,7 +434,7 @@ TildaZ icon을 사용한다([Apple `NSCriticalAlertStyle`](https://developer.app
 > **`<` / `>` 화살표 vs 활성 탭 — Firefox 패턴 (#117):**
 >
 > 1. `<` / `>` 클릭은 *viewport 스크롤 전용* — 활성 탭은 절대 안 바뀜. 사용자가 "다른 탭 *목록* 을 보러 왔다" 는 명시 의도이지 활성 전환 의도 아님.
-> 2. 활성 변경 트리거는 **탭 클릭 / Alt+숫자 / Ctrl+Shift+[ / Ctrl+Shift+] (Win) / Cmd+숫자 / Shift+Cmd+[ / Shift+Cmd+] (mac) / `+` (새 탭)** 만.
+> 2. 활성 변경 트리거는 **탭 클릭 / Alt+숫자 / Ctrl+Shift+[ / Ctrl+Shift+] / Ctrl+PgUp / Ctrl+PgDn (Win · Linux) / Cmd+숫자 / Shift+Cmd+[ / Shift+Cmd+] / Cmd+PgUp / Cmd+PgDn (mac) / `+` (새 탭)** 만.
 > 3. `<` / `>` 누르는 순간 `tab_scroll_user_override = true` set → 매 frame `ensureActiveTabVisible` skip → 활성 탭이 viewport 밖이어도 그대로. 활성 변경 / 새 탭 / drag reorder 끝나는 시점에 false 로 reset 되어 ensure 재가동.
 > 4. 활성 변경 시 viewport 동작: 활성 탭이 이미 보이면 그대로 (색깔만 변경), 안 보이면 보이는 가장 가까운 위치로 *minimum* 이동 (Chrome / Firefox 동등).
 >

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -359,6 +359,9 @@ const xkb_key_w_lower: u32 = 0x77;
 const xkb_key_w_upper: u32 = 0x57;
 // `[` 과 Shift 의 `{` 가 keymap 별로 다른 keysym — 둘 다 매치. `]` / `}` 도
 // 동일.
+// #482 — QWERTY 에서 Alt+Shift+1 이 내는 keysym. Shift 가 keysym 자체를 바꾸므로
+// 숫자 완화가 그 layout 에서 새 조합을 잡지 않음을 테스트로 고정하는 데 쓴다.
+const xkb_key_exclam: u32 = 0x21;
 const xkb_key_bracketleft: u32 = 0x5b;
 const xkb_key_braceleft: u32 = 0x7b;
 // SPEC §2.2 — Alt+1..9 탭 인덱스 점프. xkb keysym = ASCII '1'..'9'.
@@ -692,6 +695,21 @@ fn classifyInput(sym: u32, ctrl: bool, shift: bool, alt: bool) ?input_policy.Inp
             else => null,
         };
     }
+    // #482 — Ctrl+PgUp / Ctrl+PgDn 으로 이전 / 다음 탭. `Ctrl+Shift+[` / `]` 가
+    // AZERTY 에서 쓸 수 없어 추가한 **layout 무관** 대안이다: 그 layout 에서 `[` 는
+    // AltGr+5 라서 조합이 Ctrl+Shift+AltGr+5 가 된다 (손가락 네 개). PgUp / PgDn 은
+    // 어느 layout 에나 있는 단일 물리 키다.
+    //
+    // `Ctrl+Tab` 을 쓰지 않은 이유: 현대 키보드 프로토콜 (kitty / CSI-u) 에서 그건
+    // 구별 가능한 시퀀스라 TUI 앱이 정당하게 바인딩한다. 터미널이 삼키면 사용자가
+    // 통과시킬 방법이 없다. 반면 Ctrl+PgUp / PgDn 은 GNOME Terminal · Konsole ·
+    // Windows Terminal 이 탭 전환에 쓰는 — 터미널이 관습적으로 소유하는 — 조합이다.
+    //
+    // 아래 Shift+PgUp / PgDn (scrollback) 과 맨 PgUp / PgDn (PTY) 은 그대로다.
+    if (ctrl and !shift and !alt) {
+        if (sym == xkb_key_page_up) return .{ .shortcut = .prev_tab };
+        if (sym == xkb_key_page_down) return .{ .shortcut = .next_tab };
+    }
     // Ctrl+C (Shift 없음) — SIGINT(line abort). preedit 자모 discard 는 best-effort:
     // fcitx5 는 Ctrl+C 에서 자모를 먼저 확정해 `가^C`(취소된 줄이라 무해, §5.1).
     if (ctrl and !shift and !alt and (sym == xkb_key_c_lower or sym == xkb_key_c_upper)) return .interrupt;
@@ -699,7 +717,18 @@ fn classifyInput(sym: u32, ctrl: bool, shift: bool, alt: bool) ?input_policy.Inp
     if (alt and !ctrl) {
         if (sym == xkb_key_return) return .{ .shortcut = .fullscreen };
         if (!shift and sym == xkb_key_f4) return .{ .shortcut = .quit };
-        if (!shift and sym >= xkb_key_1 and sym <= xkb_key_9) return .{ .shortcut = .switch_tab };
+        // #482 — `!shift` 를 요구하지 않는다. AZERTY (fr) 등에서 숫자열은 **Shift 를
+        // 눌러야 숫자가 나온다** (무시프트는 `&é"'(-è_çà`). 그래서 keysym `1`~`9` 가
+        // 항상 Shift 와 함께 도착해 `!shift` 가 전부 걸러 냈다 — 인덱스 탭 전환이
+        // 그 layout 에서 아예 동작하지 않았다.
+        //
+        // QWERTY 에는 영향이 없다: Shift 가 keysym 자체를 바꿔서 Alt+Shift+1 은
+        // `exclam` (0x21) 로 도착하고 `xkb_key_1` 과 매칭되지 않는다. 즉 이 조건을
+        // 풀어도 QWERTY 에서 새로 잡히는 조합이 없다.
+        //
+        // Windows (`VK_1`) 와 macOS (`kVK_ANSI_1`) 는 **물리 위치**로 매칭해서 애초에
+        // 이 문제가 없다. keysym 으로 매칭하는 Linux 만의 결함이었다.
+        if (sym >= xkb_key_1 and sym <= xkb_key_9) return .{ .shortcut = .switch_tab };
     }
     // 그 외는 정책 대상 아님(일반 문자 / 터미널 control char / preedit-Ctrl
     // commit / scroll) → 기존 PTY 경로.
@@ -728,6 +757,27 @@ test "#296 classifyInput — native xkb → 공통 Input 분류" {
     try T.expectEqual(@as(?I, .{ .shortcut = .quit }), C(xkb_key_f4, false, false, true));
     try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_1, false, false, true));
     try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_9, false, false, true));
+    // #482 — AZERTY (fr) 는 숫자열에 Shift 가 필요해 keysym `1`~`9` 가 **항상 Shift 와
+    // 함께** 도착한다. 예전 `!shift` 조건이 그것을 전부 걸러 인덱스 탭 전환이 그 layout
+    // 에서 아예 동작하지 않았다.
+    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_1, false, true, true));
+    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_9, false, true, true));
+    // QWERTY 에서는 Alt+Shift+1 이 `exclam` 으로 도착하므로 위 완화가 새로 잡는 조합이
+    // 없다 — 이 keysym 은 정책 대상이 아니다.
+    try T.expectEqual(@as(?I, null), C(xkb_key_exclam, false, true, true));
+    // Ctrl 동반은 여전히 Alt 계열이 아니다 (첫 블록의 Ctrl+Shift 와 충돌 방지).
+    try T.expectEqual(@as(?I, null), C(xkb_key_1, true, false, true));
+
+    // #482 — Ctrl+PgUp / PgDn 으로 이전 / 다음 탭 (layout 무관 대안).
+    try T.expectEqual(@as(?I, .{ .shortcut = .prev_tab }), C(xkb_key_page_up, true, false, false));
+    try T.expectEqual(@as(?I, .{ .shortcut = .next_tab }), C(xkb_key_page_down, true, false, false));
+    // Shift+PgUp / PgDn 은 scrollback 이라 정책 대상이 아니고, Ctrl+Shift 조합도
+    // 탭 전환으로 잡지 않는다 — 기존 동작을 건드리지 않았음을 고정한다.
+    try T.expectEqual(@as(?I, null), C(xkb_key_page_down, false, true, false));
+    try T.expectEqual(@as(?I, null), C(xkb_key_page_up, true, true, false));
+    // 맨 PgUp / PgDn 은 PTY 로 간다.
+    try T.expectEqual(@as(?I, null), C(xkb_key_page_up, false, false, false));
+    try T.expectEqual(@as(?I, null), C(xkb_key_page_down, false, false, false));
     // Ctrl+C (Shift 없음) → interrupt
     try T.expectEqual(@as(?I, .interrupt), C(xkb_key_c_lower, true, false, false));
     // 미분류(null → 기존 PTY 경로):
@@ -738,7 +788,12 @@ test "#296 classifyInput — native xkb → 공통 Input 분류" {
     try T.expectEqual(@as(?I, null), C(xkb_key_e_lower, true, false, false)); // Ctrl+E = 터미널 \x05
     try T.expectEqual(@as(?I, null), C(xkb_key_page_up, false, true, false)); // Shift+PgUp = scroll
     try T.expectEqual(@as(?I, null), C(xkb_key_t_lower, true, false, false)); // Ctrl+T = shell transpose
-    try T.expectEqual(@as(?I, null), C(xkb_key_1, false, true, true)); // Alt+Shift+숫자
+    // #482 — 예전엔 여기에 `C(xkb_key_1, false, true, true)` 가 null 로 있었다. 그
+    // 조합 (keysym `1` + Shift) 은 **QWERTY 에서 발생 자체가 불가능하다** — Shift 가
+    // keysym 을 `exclam` 으로 바꾼다. 숫자열에 Shift 가 필요한 layout (AZERTY 등) 에서만
+    // 나오므로, 그 assertion 은 인덱스 탭 전환이 그 layout 에서 안 되는 **버그를 고정**
+    // 하고 있었다. 이제 shortcut 이고 위쪽 Alt 계열 테스트에서 확인한다. QWERTY 쪽
+    // 대응물인 `exclam` 은 계속 정책 대상이 아니다 (바로 위에서 확인).
     try T.expectEqual(@as(?I, null), C(xkb_key_return, true, false, true)); // Ctrl+Alt+Enter
 }
 

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -882,6 +882,15 @@ fn macCmdShortcut(kc: c_ushort, shift: bool) ?input_policy.Shortcut {
     if (keycodeToTabIndex(kc) != null) return .switch_tab; // Cmd+1..9
     if (shift and kc == 0x21) return .prev_tab; // Shift+Cmd+[
     if (shift and kc == 0x1E) return .next_tab; // Shift+Cmd+]
+    // #482 — Cmd+PgUp / Cmd+PgDn 으로 이전 / 다음 탭. Linux · Windows 의
+    // Ctrl+PgUp / PgDn 에 대응하는 조합이다 (이 프로젝트의 Ctrl→Cmd 매핑).
+    // AZERTY 문제 자체는 macOS 에 없다 — `kVK_ANSI_*` 는 물리 위치라 layout 과
+    // 무관하다. 세 platform 이 같은 반사를 갖게 맞추는 것이 목적이고, 기존
+    // Shift+Cmd+[ / ] 와 Cmd+1..9 는 그대로 남는다 (추가이지 교체가 아니다).
+    // Mac 노트북엔 전용 PgUp / PgDn 키가 없어 Fn+↑ / Fn+↓ 가 되지만, 기존
+    // 바인딩을 그대로 두므로 잃는 것이 없다.
+    if (!shift and kc == 116) return .prev_tab; // Cmd+PageUp
+    if (!shift and kc == 121) return .next_tab; // Cmd+PageDown
     if (shift and kc == 0x0F) return .reset_terminal; // Shift+Cmd+R
     if (kc == 0x24) return .fullscreen; // Cmd+Enter / Shift+Cmd+Enter
     if (shift and kc == 0x6F) return .dump_perf; // Shift+Cmd+F12
@@ -955,8 +964,8 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
             .new_tab => handleNewTab(), // Cmd+T
             .close_tab => handleCloseActiveTab(), // Cmd+W
             .switch_tab => tab_actions.switchTab(&g_host, keycodeToTabIndex(kc).?), // Cmd+1..9
-            .prev_tab => tab_actions.prevTab(&g_host), // Shift+Cmd+[
-            .next_tab => tab_actions.nextTab(&g_host), // Shift+Cmd+]
+            .prev_tab => tab_actions.prevTab(&g_host), // Shift+Cmd+[ / Cmd+PageUp
+            .next_tab => tab_actions.nextTab(&g_host), // Shift+Cmd+] / Cmd+PageDown
             .reset_terminal => tab_actions.resetActive(&g_host), // Shift+Cmd+R (#162)
             .fullscreen => toggleFullscreenMode(if (shift) .workarea else .monitor), // Cmd/Shift+Cmd+Enter (#162)
             .dump_perf => perf.dumpAndReset(g_rt, "snapshot"), // Shift+Cmd+F12 (#160)

--- a/src/window.zig
+++ b/src/window.zig
@@ -1929,6 +1929,23 @@ pub const Window = struct {
                         return 0;
                     }
                 }
+                // #482 — Ctrl+PgUp / Ctrl+PgDn 으로 이전 / 다음 탭 (Shift 미동반).
+                // Windows Terminal 과 같은 조합이고, Linux 는 AZERTY 에서 쓸 수 없는
+                // `Ctrl+Shift+[` / `]` 의 layout 무관 대안으로 같은 키를 받는다
+                // (`wayland_minimal.classifyInput`). Windows 는 `VK_OEM_4` 가 물리
+                // 위치라 layout 문제 자체는 없지만, 세 platform 이 같은 반사를 갖게
+                // 맞춘다. Shift+PgUp / PgDn (scrollback) 과 맨 PgUp / PgDn (PTY) 은
+                // 아래 경로 그대로다.
+                if (GetKeyState(VK_CONTROL) < 0 and GetKeyState(VK_SHIFT) >= 0) {
+                    if (wParam == 0x21) { // VK_PRIOR (Page Up)
+                        _ = self.dispatchAppEvent(.{ .shortcut = .prev_tab });
+                        return 0;
+                    }
+                    if (wParam == 0x22) { // VK_NEXT (Page Down)
+                        _ = self.dispatchAppEvent(.{ .shortcut = .next_tab });
+                        return 0;
+                    }
+                }
 
                 const vk_prior: WPARAM = 0x21; // Page Up
                 const vk_next: WPARAM = 0x22; // Page Down


### PR DESCRIPTION
#482 의 **① (기본값이 AZERTY 에서 안 먹음)** 만 다룬다. ② 키바인딩 사용자 설정과 ③ config 포맷 · 설정 UI 는 config 포맷 결정이 선행이라 남는다.

## 근본 원인 — Linux 만 다른 것을 본다

| platform | 매칭 대상 | AZERTY |
|---|---|---|
| Windows | virtual-key (`VK_1`, `VK_OEM_4`) — **물리 위치** | 안 깨짐 |
| macOS | `kVK_ANSI_*` — **물리 위치** | 안 깨짐 |
| **Linux** | **xkb keysym** — 눌러서 *나오는 문자* | **깨짐** |

신고자 @squalou 는 COSMIC 사용자다.

## ①-a 인덱스 점프 (Linux 전용)

`classifyInput` 이 `!shift` 를 요구했다. AZERTY (fr) 는 숫자열에 Shift 가 필요해 (무시프트는 `&é"'(-è_çà`) keysym `1`~`9` 가 **항상 Shift 와 함께** 도착하고, 그 조건이 전부 걸러 냈다.

**QWERTY 에는 no-op 이다**: Shift 가 keysym 자체를 바꿔 Alt+Shift+1 은 `exclam` (0x21) 로 도착하고 `xkb_key_1` 과 매칭되지 않는다. 완화해도 QWERTY 에서 새로 잡는 조합이 없다.

**기존 테스트가 이 버그를 고정하고 있었다.** `C(xkb_key_1, false, true, true) == null` 이 "정책 대상 아님" 목록에 근거 주석 없이 있었는데, 그 조합은 QWERTY 에서 **발생 자체가 불가능**하고 숫자열에 Shift 가 필요한 layout 에서만 나온다. 지운 자리에 왜 지웠는지를 남겼다.

## ①-b PgUp / PgDn (3 platform)

`Ctrl+Shift+[` 는 AZERTY 에서 `[` = AltGr+5 라 **Ctrl+Shift+AltGr+5** 가 된다. 조건을 고쳐도 못 쓴다. layout 무관 대안을 추가한다.

| | 조합 |
|---|---|
| Linux · Windows | `Ctrl+PgUp` / `Ctrl+PgDn` |
| macOS | `Cmd+PgUp` / `Cmd+PgDn` (프로젝트의 Ctrl→Cmd 매핑) |

기존 bracket 조합과 `Cmd+1..9` 를 **대체하지 않고 추가**한다.

**`Ctrl+Tab` 은 쓰지 않았다.** kitty / CSI-u 에서 구별 가능한 시퀀스라 TUI 앱이 정당하게 바인딩하는데, 터미널이 삼키면 통과시킬 방법이 없다. PgUp / PgDn 은 GNOME Terminal · Konsole · Windows Terminal 이 탭 전환에 쓰는 — 터미널이 관습적으로 소유하는 — 조합이다. tildaz 에 이미 같은 철학이 있다: `Shift+PgUp` 은 scrollback (터미널 소유), 맨 `PgUp` 은 PTY.

**기존 PgUp / PgDn 경로는 건드리지 않았다.** 세 platform 모두 Ctrl(Cmd)+PgUp/PgDn 이 비어 있음을 확인했다.

macOS 는 고칠 문제가 없지만 (물리 위치 매칭) 세 platform 이 같은 반사를 갖게 맞춘다 (README 의 "one muscle memory"). Mac 노트북엔 전용 PgUp/PgDn 이 없어 Fn+↑/↓ 지만, 기존 바인딩이 남으므로 잃는 것이 없다.

## 검증

- **음성 테스트** — 두 수정을 되돌려 새 테스트가 실제로 실패하는 것을 확인 (`wayland_minimal.zig:759`). 항상 통과하는 테스트가 아니다.
- 새 테스트가 **건드리지 않은 경로까지 고정**한다: `Shift+PgUp` scrollback, 맨 `PgUp` PTY, `Ctrl+Shift+PgUp`, QWERTY `exclam`.
- `zig build test` 통과, **`zig build check` (6 target — macOS · Windows 코드 포함) 통과**.

## 문서

- `KEYBINDINGS.md` — 표 갱신 + 새 **Keyboard layouts** 절 (왜 bracket 이 AZERTY 에서 안 되는지, Mac 의 Fn 주의사항, 건드리지 않은 PgUp 경로)
- `SPEC.md` — 탭 단축키 표 + layout 독립성 근거 (세 platform 의 매칭 대상 차이) + §활성 변경 트리거 목록

🤖 Generated with [Claude Code](https://claude.com/claude-code)