### PR TITLE
feat(config): config 를 TOML 로 옮기고 단축키를 설정 가능하게 한다 + 비라틴 layout 버그 (#493 · #496)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@ policy, while each host owns the OS event loop and native APIs.
 | Session core | Yes | `src/session_core.zig` | Tabs, active index, scrollback, VT draining, PTY queues |
 | Tab behavior | Yes | `src/tab_actions.zig`, `src/tab_interaction.zig`, `src/tab_layout.zig` | Tab switching, close paths, drag, hit testing |
 | Selection | Yes | `src/terminal_interaction.zig` | Drag selection, word selection, wide-cell handling |
-| Config | Yes | `src/config.zig`, `src/paths.zig` | Strict schema, defaults, `_` comment keys, current `config_N.json` / `tildaz_N.log` paths |
+| Config | Yes | `src/config.zig`, `src/paths.zig` | Strict schema, defaults, TOML parse via `sam701/zig-toml`, current `config_N.toml` / `tildaz_N.log` paths |
 | Dialog/messages | Yes wrapper | `src/dialog.zig`, `src/messages.zig` | Single entry point for user-visible text and dialogs |
 | PTY | Wrapper | `src/terminal.zig`, `src/terminal/windows/pty.zig`, `src/terminal/posix/pty.zig` (Linux · macOS shared) | ConPTY or POSIX PTY behind the same external API |
 | Renderer (GPU wrapper) | Wrapper (Windows/macOS only) | `src/renderer.zig`, `src/renderer/windows.zig`, `src/renderer/macos.zig` | Tab bar + terminal drawing with a shared call shape. Linux deliberately has no wrapper implementation (see `src/renderer.zig` comment) |
@@ -161,9 +161,10 @@ selection behavior, config schema, dialogs, and child shell environment. OS
 conventions remain native: Windows uses Ctrl/Alt patterns; macOS uses Cmd/Shift
 Cmd patterns and AppKit input callbacks.
 
-**Strict config.** `src/config.zig` is the source of truth for the JSON schema
-and defaults. Unknown keys are fatal except `_`-prefixed comment keys. Numeric
-fields include their units (`_percent`, `_point`, `_ratio`).
+**Strict config.** `src/config.zig` is the source of truth for the TOML schema
+and defaults. Every key is required and unknown keys are fatal, with no
+exception -- TOML has real `#` comments, so there is no need for comment-shaped
+keys. Numeric fields include their units (`_percent`, `_point`, `_ratio`).
 
 **Wayland-only on Linux.** Wayland is where modern Linux desktops are heading,
 which matches the goal of behaving well on current desktop managers. X11 is not

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -4,22 +4,24 @@ Config file path (per OS standard):
 
 | OS | Path |
 |---|---|
-| Linux | `~/.config/tildaz/config_N.json` (XDG) |
-| macOS | `~/.config/tildaz/config_N.json` (XDG, Ghostty / Alacritty pattern) |
-| Windows | `%APPDATA%\tildaz\config_N.json` |
+| Linux | `~/.config/tildaz/config_N.toml` (XDG) |
+| macOS | `~/.config/tildaz/config_N.toml` (XDG, Ghostty / Alacritty pattern) |
+| Windows | `%APPDATA%\tildaz\config_N.toml` |
 
-The first launch creates `config_0.json` with defaults. Launching TildaZ while
+The first launch creates `config_0.toml` with defaults. Launching TildaZ while
 all configured instances are already running shows the resulting instance count
 and a hotkey capture dialog before writing the next numbered file. Press the
 desired key combination; **Create** remains disabled until a valid, unused
-hotkey is captured. Each `config_N.json` owns one TildaZ process. A legacy
-`config.json` is not loaded, converted, or deleted. Linux and macOS insert the
+hotkey is captured. Each `config_N.toml` owns one TildaZ process. A legacy
+`config.json` is not loaded, converted, or deleted. Neither is a `config_N.json` left over from before TildaZ used TOML — it stays on disk, unread. Linux and macOS insert the
 user's `$SHELL` env (or
 `/bin/bash`) into newly created configs.
 
 > **Strict schema validation** — every key is required, unknown keys are rejected, type mismatches are fatal. The `defaultConfigJson` function in [`src/config.zig`](src/config.zig) is the single source of truth (used both for first-run file creation and for validating user config). Linux, macOS, and Windows apply the same policy.
 >
-> **Comment keys** — any key starting with `_` (e.g. `_note`, `_disabled_test_font`) is treated as a user comment and skipped from schema validation. Use this to annotate your config or temporarily disable a field by renaming it (e.g. `"shell": "/bin/zsh"` → `"_shell": "/bin/zsh"`). The `_` prefix convention is not part of JSON itself but is convenient here since the official schema never uses it.
+> **Comments** — TOML has real comments: anything after `#` on a line is ignored, either on its own line or after a value. Use them to annotate your config.
+>
+> Note that commenting a field **out** is not the same as leaving it at its default: every field listed in the table above is required, so removing one is an error rather than a fallback. To go back to a default, set the value explicitly.
 
 ## Linux example
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -17,91 +17,100 @@ hotkey is captured. Each `config_N.toml` owns one TildaZ process. A legacy
 user's `$SHELL` env (or
 `/bin/bash`) into newly created configs.
 
-> **Strict schema validation** — every key is required, unknown keys are rejected, type mismatches are fatal. The `defaultConfigJson` function in [`src/config.zig`](src/config.zig) is the single source of truth (used both for first-run file creation and for validating user config). Linux, macOS, and Windows apply the same policy.
+> **Strict schema validation** — every key is required, unknown keys are rejected, type mismatches are fatal. The `defaultConfigToml` function in [`src/config.zig`](src/config.zig) is the single source of truth (used both for first-run file creation and for validating user config). Linux, macOS, and Windows apply the same policy.
 >
 > **Comments** — TOML has real comments: anything after `#` on a line is ignored, either on its own line or after a value. Use them to annotate your config.
 >
 > Note that commenting a field **out** is not the same as leaving it at its default: every field listed in the table above is required, so removing one is an error rather than a fallback. To go back to a default, set the value explicitly.
 
-## Linux example
+## Examples
 
-```json
-{
-  "window": {
-    "dock_position": "top",
-    "width_percent": 50.0,
-    "height_percent": 100.0,
-    "offset_percent": 100.0,
-    "opacity_percent": 100.0
-  },
-  "font": {
-    "family": "DejaVu Sans Mono",
-    "glyph_fallback": ["Noto Sans CJK KR", "Noto Color Emoji"],
-    "size_point": 15,
-    "cell_width_ratio": 1.0,
-    "line_height_ratio": 1.1
-  },
-  "theme": "Tilda",
-  "shell": "/bin/bash",
-  "hotkey": "F1",
-  "auto_start": true,
-  "hidden_start": false,
-  "max_scroll_lines": 10000
-}
+Every field below is required, so a real config also carries the `[keys]`
+table -- see [Keyboard shortcuts](#keyboard-shortcuts). The examples omit it
+only to stay readable; TildaZ writes the whole file for you on first launch.
+
+### Linux
+
+```toml
+hotkey           = "F1"
+
+shell            = "/bin/bash"
+
+auto_start       = true
+hidden_start     = false
+
+theme            = "Tilda"
+max_scroll_lines = 10000
+
+[window]
+dock_position   = "top"   # top | bottom | left | right
+width_percent   = 50.0
+height_percent  = 100.0
+offset_percent  = 100.0
+opacity_percent = 100.0
+
+[font]
+family            = "DejaVu Sans Mono"
+glyph_fallback    = ["Noto Sans CJK KR", "Noto Color Emoji"]
+size_point        = 15
+cell_width_ratio  = 1.0
+line_height_ratio = 1.1
 ```
 
-## macOS example
+### macOS
 
-```json
-{
-  "window": {
-    "dock_position": "top",
-    "width_percent": 50.0,
-    "height_percent": 100.0,
-    "offset_percent": 100.0,
-    "opacity_percent": 100.0
-  },
-  "font": {
-    "family": "Menlo",
-    "glyph_fallback": ["Apple SD Gothic Neo", "Apple Color Emoji", "Apple Symbols"],
-    "size_point": 15,
-    "cell_width_ratio": 1.0,
-    "line_height_ratio": 1.1
-  },
-  "theme": "Tilda",
-  "shell": "/bin/zsh",
-  "hotkey": "F1",
-  "auto_start": true,
-  "hidden_start": false,
-  "max_scroll_lines": 10000
-}
+```toml
+hotkey           = "F1"
+
+shell            = "/bin/zsh"
+
+auto_start       = true
+hidden_start     = false
+
+theme            = "Tilda"
+max_scroll_lines = 10000
+
+[window]
+dock_position   = "top"   # top | bottom | left | right
+width_percent   = 50.0
+height_percent  = 100.0
+offset_percent  = 100.0
+opacity_percent = 100.0
+
+[font]
+family            = "Menlo"
+glyph_fallback    = ["Apple SD Gothic Neo", "Apple Color Emoji", "Apple Symbols"]
+size_point        = 15
+cell_width_ratio  = 1.0
+line_height_ratio = 1.1
 ```
 
-## Windows example
+### Windows
 
-```json
-{
-  "window": {
-    "dock_position": "top",
-    "width_percent": 50.0,
-    "height_percent": 100.0,
-    "offset_percent": 100.0,
-    "opacity_percent": 100.0
-  },
-  "font": {
-    "family": "Cascadia Code",
-    "glyph_fallback": ["Malgun Gothic", "Segoe UI Emoji", "Segoe UI Symbol"],
-    "size_point": 15,
-    "cell_width_ratio": 1.0,
-    "line_height_ratio": 1.1
-  },
-  "theme": "Tilda",
-  "shell": "cmd.exe",
-  "hotkey": "F1",
-  "auto_start": true,
-  "hidden_start": false,
-  "max_scroll_lines": 10000
-}
+```toml
+hotkey           = "F1"
+
+shell            = "cmd.exe"
+
+auto_start       = true
+hidden_start     = false
+
+theme            = "Tilda"
+max_scroll_lines = 10000
+
+[window]
+dock_position   = "top"   # top | bottom | left | right
+width_percent   = 50.0
+height_percent  = 100.0
+offset_percent  = 100.0
+opacity_percent = 100.0
+
+[font]
+family            = "Cascadia Code"
+glyph_fallback    = ["Malgun Gothic", "Segoe UI Emoji", "Segoe UI Symbol"]
+size_point        = 15
+cell_width_ratio  = 1.0
+line_height_ratio = 1.1
 ```
 
 ## Field reference

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -203,7 +203,38 @@ sudo rm /etc/fonts/conf.d/75-twemoji.conf && fc-cache -f
 Startup only fails when the name matches **no** installed font at all — a typo, or a font that is
 not installed.
 
-### Hotkey syntax
+### Keyboard shortcuts
+
+The `[keys]` table binds an action to one or more key combinations. Every action
+appears in the file, so you can see the whole set without consulting the docs.
+
+```toml
+[keys]
+new_tab  = ["ctrl+shift+t"]
+prev_tab = ["ctrl+shift+[", "ctrl+pageup"]
+quit     = []
+```
+
+- **A list, not a single value** — an action can have several keys. `prev_tab`
+  ships with two because the bracket form is unusable on some layouts (see
+  KEYBINDINGS.md).
+- **An empty list unbinds the action.** That is the only way to express "no
+  key"; the entry itself always stays in the file.
+- **Every key may trigger only one action.** Binding the same combination twice
+  is an error at startup, and the message names both actions.
+- `cmd` resolves per platform (Super on Linux, Win on Windows, Command on
+  macOS), so one file works on all three.
+
+**Scrolling is not in `[keys]`.** `Shift+PgUp` / `Shift+PgDn` scroll the
+scrollback, and scrolling is not a shortcut — it is the same action as the mouse
+wheel, just driven from the keyboard. TildaZ does not let you rebind the mouse
+wheel either. Those two combinations are fixed.
+
+The global `hotkey` is also separate, and for a different reason: it is
+registered with the operating system rather than handled inside TildaZ, so it
+lives at the top level and takes a single value.
+
+## Hotkey syntax
 
 `hotkey` accepts a single key optionally combined with modifiers, joined by `+`
 (e.g. `"F1"`, `"Ctrl+Space"`, `"Shift+Cmd+T"`). Rules (validated at startup — an

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -219,29 +219,128 @@ appears in the file, so you can see the whole set without consulting the docs.
 
 ```toml
 [keys]
-new_tab  = ["ctrl+shift+t"]
-prev_tab = ["ctrl+shift+[", "ctrl+pageup"]
-quit     = []
+new_tab   = ["ctrl+shift+t"]
+prev_tab  = ["ctrl+shift+[", "ctrl+pageup"]
+close_tab = ["ctrl+shift+[KeyW]"]
+quit      = []
 ```
 
-- **A list, not a single value** — an action can have several keys. `prev_tab`
-  ships with two because the bracket form is unusable on some layouts (see
-  KEYBINDINGS.md).
+- **A list, not a single value** — an action can have several keys.
 - **An empty list unbinds the action.** That is the only way to express "no
   key"; the entry itself always stays in the file.
 - **Every key may trigger only one action.** Binding the same combination twice
   is an error at startup, and the message names both actions.
+- **The defaults are not the same on every OS.** macOS follows Apple's
+  convention (`Cmd+T`, `Shift+Cmd+[`), Linux and Windows use `Ctrl+Shift+T`.
+  A modifier swap is not enough to express that, so the two default tables are
+  separate. See KEYBINDINGS.md for the full list.
 - `cmd` resolves per platform (Super on Linux, Win on Windows, Command on
-  macOS), so one file works on all three.
+  macOS), so a combination you write yourself works on all three.
 
-**Scrolling is not in `[keys]`.** `Shift+PgUp` / `Shift+PgDn` scroll the
-scrollback, and scrolling is not a shortcut — it is the same action as the mouse
-wheel, just driven from the keyboard. TildaZ does not let you rebind the mouse
-wheel either. Those two combinations are fixed.
+#### Two ways to name a key
 
-The global `hotkey` is also separate, and for a different reason: it is
-registered with the operating system rather than handled inside TildaZ, so it
-lives at the top level and takes a single value.
+```toml
+close_tab = ["ctrl+shift+w"]         # by label   -- the letter printed on the key
+close_tab = ["ctrl+shift+[KeyW]"]    # by position -- the physical spot, any layout
+```
+
+**A label is what the key types.** It is the natural way to write a shortcut and
+it is what the defaults use. It only works if your layout can actually produce
+that character: on a Cyrillic or Greek layout no key produces `w`, so
+`ctrl+shift+w` can never fire.
+
+**A position is a physical spot on the keyboard**, independent of layout. The
+names are [W3C `KeyboardEvent.code` values][w3c] — the same vocabulary browsers
+use, and the same notation VS Code uses in its keybindings. `[KeyW]` means "the
+key where a US QWERTY keyboard has `w`", whatever that key prints on your
+layout.
+
+[w3c]: https://www.w3.org/TR/uievents-code/
+
+Use a position when a label cannot reach the key you want:
+
+| Situation | Why the label fails | Position form |
+|---|---|---|
+| Cyrillic, Greek, Arabic, Hebrew… | no key produces a Latin letter | `ctrl+shift+[KeyW]` |
+| French AZERTY brackets | `[` is AltGr+5, so the label needs four fingers | `ctrl+shift+[BracketLeft]` |
+| Keys outside the label set | `-` `=` `\` `;` `'` `,` `.` `/`, numpad, arrows | `ctrl+[Minus]` |
+
+Positions and labels can be mixed freely, including within one action's list.
+
+#### Accepted keys
+
+**By label**: `F1`–`F12`, `A`–`Z`, `0`–`9`, `Space`, `Tab`, `Escape` (`Esc`),
+`Return` (`Enter`), `PageUp` (`PgUp`), `PageDown` (`PgDn`), `` ` `` (also
+`Grave` / `Backquote`), `[` (also `BracketLeft`), `]` (also `BracketRight`).
+Case does not matter. Anything else is an error at startup — including
+layout-specific characters such as `²` on French AZERTY.
+
+The label set is deliberately narrow. Widening it would mean giving `-` a value,
+and the only fixed values available (`VK_OEM_MINUS`, `kVK_ANSI_Minus`) are not
+labels at all — they are "the spot where US QWERTY has `-`". Calling that a
+label would make the same config mean different keys on different platforms.
+Positions are honest about being positions, so that is where the extra keys
+live.
+
+**By position**: every key a keyboard can send, in square brackets.
+
+| Group | Names |
+|---|---|
+| Function | `[F1]`–`[F24]` |
+| Letters | `[KeyA]`–`[KeyZ]` |
+| Digit row | `[Digit0]`–`[Digit9]` |
+| Symbols | `[Backquote]` `[Minus]` `[Equal]` `[BracketLeft]` `[BracketRight]` `[Backslash]` `[Semicolon]` `[Quote]` `[Comma]` `[Period]` `[Slash]` |
+| Non-US keys | `[IntlBackslash]` (the extra key on ISO keyboards — `<>` on AZERTY), `[IntlYen]`, `[IntlRo]` |
+| Editing | `[Space]` `[Tab]` `[Escape]` `[Enter]` `[Backspace]` `[Insert]` `[Delete]` `[Home]` `[End]` `[PageUp]` `[PageDown]` |
+| Arrows | `[ArrowUp]` `[ArrowDown]` `[ArrowLeft]` `[ArrowRight]` |
+| Numpad | `[NumLock]` `[Numpad0]`–`[Numpad9]` `[NumpadDivide]` `[NumpadMultiply]` `[NumpadSubtract]` `[NumpadAdd]` `[NumpadEnter]` `[NumpadDecimal]` `[NumpadEqual]` |
+| Other | `[CapsLock]` `[PrintScreen]` `[ScrollLock]` `[Pause]` `[ContextMenu]` `[Lang1]` `[Lang2]` `[Convert]` `[NonConvert]` `[KanaMode]` |
+
+Modifier keys themselves (`[ShiftLeft]`, `[ControlLeft]`, …) are not accepted:
+in this syntax a modifier is a prefix, not a key.
+
+**A few positions do not exist on macOS.** `[PrintScreen]`, `[ScrollLock]` and
+`[Pause]` arrive there as `[F13]`, `[F14]` and `[F15]` — Apple's extended
+keyboard puts those function keys in the same spots, so use those names instead.
+`[F21]`–`[F24]`, `[Convert]`, `[NonConvert]` and `[KanaMode]` have no macOS
+equivalent at all. TildaZ reports this at startup rather than leaving the
+binding quietly dead, and only on macOS: the same config is fine on Linux and
+Windows.
+
+#### Modifiers
+
+`Ctrl`, `Alt` (also `Option` / `Opt`), `Shift`, and the platform key written as
+`Cmd` (also `Command` / `Super` / `Win` / `Meta` / `Logo`).
+
+**A key that types text needs `Ctrl`, `Alt`, or `Cmd`** — binding it with no
+modifier, or with `Shift` alone, would make that character impossible to type in
+the terminal. Keys that type nothing may be bound bare: `F1`–`F24`, `PageUp`,
+`PageDown`, `Escape`, `NumLock`, `CapsLock`. Arrow and editing keys count as
+typing keys even though they produce no character, because they send escape
+sequences that programs in the terminal expect to receive.
+
+**Digit bindings ignore Shift.** On layouts where the digit row needs Shift —
+French AZERTY, where the unshifted row is `&é"'(-è_çà` — `Alt+1` physically
+arrives as Alt+Shift+the `&1` key. Without this exception, switching tabs by
+index would be dead on those layouts. It applies to digits only: `Shift+Alt+F4`
+still does not trigger a binding on `Alt+F4`.
+
+#### Two things are not in `[keys]`
+
+**Scrolling.** `Shift+PgUp` / `Shift+PgDn` scroll the scrollback, and scrolling
+is not a shortcut — it is the same action as the mouse wheel, driven from the
+keyboard. TildaZ does not let you rebind the wheel either. Those two
+combinations are fixed.
+
+**`Ctrl+C`.** It sends SIGINT to the program in the terminal. Letting a config
+file shadow it would mean one typo costs you the ability to interrupt a command.
+
+The global `hotkey` is separate for a different reason: it is registered with the
+operating system rather than handled inside TildaZ, so it lives at the top level
+and takes a single value. It does **not** accept the position form — every path
+TildaZ registers it through (sway, Hyprland, COSMIC, KDE) accepts only a
+character. A function key is the safest choice there, being identical on every
+layout.
 
 ## Hotkey syntax
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -217,8 +217,9 @@ invalid value shows an error dialog and exits):
 - **`Shift` alone is not a valid trigger modifier** — combine it with
   `Ctrl` / `Alt` / `Cmd` (e.g. `Shift+Cmd+T` is fine, `Shift+T` is not).
 - **Accepted keys**, in full: `F1`–`F12`, `A`–`Z`, `0`–`9`, `Space`, `Tab`,
-  `Escape` (`Esc`), `Return` (`Enter`), and `` ` `` — writable as `` ` ``,
-  `Grave`, or `Backquote`. Letter case does not matter.
+  `Escape` (`Esc`), `Return` (`Enter`), `PageUp` (`PgUp`), `PageDown` (`PgDn`),
+  `` ` `` (also `Grave` / `Backquote`), `[` (also `BracketLeft`), and `]` (also
+  `BracketRight`). Letter case does not matter.
 - **Any other key is rejected**, and that includes layout-specific keys such as
   `²` (`twosuperior`) on French AZERTY. The accepted set is deliberately narrow:
   it is the set every platform's native hotkey backend is known to map the same

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -2,6 +2,11 @@
 
 Cross-platform shortcut convention: each platform follows its native modifier (Apple HIG order Shift+Cmd on macOS; Ctrl+Shift on Linux and Windows).
 
+These are the **defaults**. Every row except the scrollback pair can be changed in
+the `[keys]` table of your config — see [CONFIG.md](CONFIG.md#keyboard-shortcuts)
+for the syntax, and [Keyboard layouts](#keyboard-layouts) below if your keyboard
+is not US QWERTY.
+
 | Action | Linux | macOS | Windows |
 |--------|-------|-------|---------|
 | Toggle terminal show/hide | F1 (configurable) | F1 (configurable) | F1 (configurable) |
@@ -49,24 +54,91 @@ action as the mouse wheel, which is also not rebindable.
 
 ## Keyboard layouts
 
-The bracket bindings follow the US layout. On layouts where `[` and `]` need
-AltGr — French AZERTY, for instance, where `[` is AltGr+5 — `Ctrl+Shift+[` would
-mean pressing Ctrl+Shift+AltGr+5, which is not usable. **`Ctrl+PgUp` / `Ctrl+PgDn`
-(`Cmd+PgUp` / `Cmd+PgDn` on macOS) do the same thing and work on every layout**,
-since PgUp and PgDn are single physical keys everywhere. They match what GNOME
-Terminal, Konsole, and Windows Terminal use.
+Every binding above can be changed in `[keys]` (see CONFIG.md). This section is
+about the cases where the *default* bindings cannot be typed at all, and what to
+write instead.
 
-Switching tabs by index also used to fail on AZERTY: the digit row needs Shift
-there, so `Alt+1` is physically Alt+Shift+the `&1` key, and TildaZ was requiring
-Shift *not* to be held. It now accepts either, on every layout.
+### Non-Latin layouts: letter shortcuts cannot work by label
 
-Mac laptops have no dedicated PgUp / PgDn keys — they are Fn+Up / Fn+Down. The
-existing `Shift+Cmd+[` / `]` and `Cmd+1`–`9` bindings are unchanged, so nothing is
-lost; `Cmd+PgUp` / `Cmd+PgDn` is an addition for people who use the same reflex
-on more than one OS.
+On a Cyrillic, Greek, Arabic, or Hebrew layout, **no key produces a Latin
+letter**. `Ctrl+Shift+W` is therefore unreachable — not awkward, unreachable.
+The keyboard has no `w` to press:
 
-`Shift+PgUp` / `Shift+PgDn` still scroll the scrollback, and unmodified PgUp /
-PgDn still go to the program running in the terminal.
+```
+$ xkbcli how-to-type --layout ru 'w'
+(nothing)
+```
+
+Rebinding to another letter does not help, because the problem is the whole
+Latin alphabet. The fix is to name the key by **position** instead of by label:
+
+```toml
+[keys]
+new_tab        = ["ctrl+shift+[KeyT]"]
+close_tab      = ["ctrl+shift+[KeyW]"]
+copy_selection = ["ctrl+shift+[KeyC]"]
+paste          = ["ctrl+shift+[KeyV]"]
+prev_tab       = ["ctrl+shift+[BracketLeft]", "ctrl+pageup"]
+next_tab       = ["ctrl+shift+[BracketRight]", "ctrl+pagedown"]
+```
+
+`[KeyW]` means "the key where a US QWERTY keyboard has `w`". You press the same
+physical key a US user presses; what it prints does not matter. The names are
+W3C `KeyboardEvent.code` values — the full list is in CONFIG.md.
+
+### French AZERTY
+
+Letters are fine on AZERTY (it is a Latin layout), but two of the defaults are
+not.
+
+**Brackets.** `[` is AltGr+5, so `Ctrl+Shift+[` means Ctrl+Shift+AltGr+5 — four
+fingers. Two ways out, and the second is already bound by default:
+
+```toml
+prev_tab = ["ctrl+shift+[BracketLeft]", "ctrl+pageup"]
+```
+
+`[BracketLeft]` is the physical spot, which on AZERTY is the `^` key next to
+`P` — reachable with no AltGr. And **`Ctrl+PgUp` / `Ctrl+PgDn` work on every
+layout** because PgUp and PgDn are single physical keys everywhere; they match
+what GNOME Terminal, Konsole, and Windows Terminal use.
+
+**The digit row.** AZERTY needs Shift for digits (unshifted it is `&é"'(-è_çà`),
+so `Alt+1` physically arrives as Alt+Shift+the `&1` key. TildaZ accepts that:
+digit bindings ignore Shift, on every layout. Nothing to change.
+
+**The extra ISO key.** AZERTY has a `<>` key that US keyboards do not have. It
+is `[IntlBackslash]` if you want to bind it.
+
+### macOS
+
+macOS reports the physical key, so a shortcut lands on the same *spot* on every
+layout. That is Apple's convention and it cuts both ways: an AZERTY user's
+`Cmd+W` is the key printed `Z`, because that spot is where US QWERTY has `w`.
+Nothing to configure — but worth knowing if the letter in the menu does not
+match the key you press.
+
+Mac laptops have no dedicated PgUp / PgDn keys; they are Fn+Up / Fn+Down. The
+`Shift+Cmd+[` / `]` and `Cmd+1`–`9` defaults are unchanged, so nothing is lost.
+`Cmd+PgUp` / `Cmd+PgDn` is an addition for people who use the same reflex on more
+than one OS.
+
+A few positions do not exist on macOS — `[PrintScreen]`, `[ScrollLock]` and
+`[Pause]` arrive as `[F13]`, `[F14]`, `[F15]`. CONFIG.md has the details.
+
+### The global hotkey is different
+
+`hotkey` is registered with the desktop rather than handled inside TildaZ, and
+every path TildaZ uses for that (sway, Hyprland, COSMIC, KDE) accepts only a
+character — so it does **not** take the position form. A function key is the
+safest choice: `F1`–`F12` are identical on every layout.
+
+### What stays fixed
+
+`Shift+PgUp` / `Shift+PgDn` scroll the scrollback and cannot be rebound —
+scrolling is the mouse wheel's action driven from the keyboard, and the wheel is
+not rebindable either. Unmodified PgUp / PgDn go to the program running in the
+terminal. `Ctrl+C` always sends SIGINT.
 
 ## Tab bar controls
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -20,7 +20,7 @@ Cross-platform shortcut convention: each platform follows its native modifier (A
 | Open log in editor | Ctrl+Shift+L | Shift+Cmd+L | Ctrl+Shift+L |
 | Perf snapshot to log | Ctrl+Shift+F12 | Shift+Cmd+F12 | Ctrl+Shift+F12 |
 | Quit | Alt+F4 (or close last tab) | Cmd+Q | Alt+F4 (or close last tab) |
-| Scrollback page up / down | Shift+PgUp / PgDn | Shift+PgUp / PgDn | Shift+PgUp / PgDn |
+| Scrollback page up / down *(fixed)* | Shift+PgUp / PgDn | Shift+PgUp / PgDn | Shift+PgUp / PgDn |
 
 On Linux the drop-down is normally sized from config (`dock_position` /
 `width_percent` / `height_percent`). Fullscreen is delegated to the compositor:
@@ -41,6 +41,11 @@ platforms.
 ## Quit confirmation
 
 Alt+F4 (Linux and Windows) and Cmd+Q (macOS) show a confirmation dialog with the open tab count. Enter confirms (Quit); Esc cancels. Closing the last tab via Cmd+W / Ctrl+Shift+W keeps its existing instant behavior — that path is an explicit "close this tab" intent.
+
+Everything in the table above except the scrollback row can be rebound in
+`config_N.toml` — see the `[keys]` section in [CONFIG.md](CONFIG.md). Scrolling
+the scrollback is fixed, because it is scrolling rather than a shortcut: the same
+action as the mouse wheel, which is also not rebindable.
 
 ## Keyboard layouts
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ you do not.
 - **You need a Wayland drop-down terminal.** TildaZ has real drop-down and global
   hotkey paths across KDE Plasma, GNOME, Cinnamon, COSMIC, Hyprland, and sway.
 - **You want familiar config everywhere.** Config paths differ by platform, but
-  the JSON schema, themes, hotkey, font, shell, opacity, and geometry settings
+  the TOML schema, themes, hotkey, font, shell, opacity, and geometry settings
   stay familiar.
 
 ## Why TildaZ
 
 - **One key between thought and shell.** Drop the terminal over your current workspace, run the command, and hide it again before your flow cools off.
-- **Same reflex, every OS.** The same drop-down terminal on Linux, macOS, and Windows — one JSON config shape, one muscle memory.
+- **Same reflex, every OS.** The same drop-down terminal on Linux, macOS, and Windows — one TOML config shape, one muscle memory.
 - **Familiar config everywhere.** Config paths differ by platform, but the schema, themes, hotkey, font, shell, opacity, and geometry settings stay familiar.
 - **Wayland coverage that matters.** KDE Plasma, GNOME, Cinnamon, COSMIC, Hyprland, and sway all get a real drop-down and global hotkey path.
 - **Native where it counts.** No Electron, no GTK or Qt runtime dependency — direct Wayland on Linux, GPU rendering on all three, and the fast `libghostty-vt` core.
@@ -77,9 +77,9 @@ First launch creates the default config:
 
 | Platform | Config | Log |
 |---|---|---|
-| Linux | `$XDG_CONFIG_HOME/tildaz/config_0.json` | `$XDG_STATE_HOME/tildaz/tildaz_0.log` |
-| macOS | `$XDG_CONFIG_HOME/tildaz/config_0.json` | `~/Library/Logs/tildaz_0.log` |
-| Windows | `%APPDATA%\tildaz\config_0.json` | `%APPDATA%\tildaz\tildaz_0.log` |
+| Linux | `$XDG_CONFIG_HOME/tildaz/config_0.toml` | `$XDG_STATE_HOME/tildaz/tildaz_0.log` |
+| macOS | `$XDG_CONFIG_HOME/tildaz/config_0.toml` | `~/Library/Logs/tildaz_0.log` |
+| Windows | `%APPDATA%\tildaz\config_0.toml` | `%APPDATA%\tildaz\tildaz_0.log` |
 
 On Linux and macOS, `XDG_CONFIG_HOME` defaults to `~/.config`. On Linux,
 `XDG_STATE_HOME` defaults to `~/.local/state`. Empty or relative XDG values use
@@ -99,11 +99,12 @@ window control shortcuts.
 
 ## Configure
 
-Edit `config_0.json`; the schema is documented in [CONFIG.md](CONFIG.md). Launch
+Edit `config_0.toml`; the schema is documented in [CONFIG.md](CONFIG.md). Launch
 TildaZ again while every configured instance is running to create another one.
-Press its global hotkey and choose **Create**; TildaZ writes `config_1.json`,
-`config_2.json`, and so on. Each config owns one process, hotkey, and log file.
-Legacy `config.json` files are left untouched and are not loaded.
+Press its global hotkey and choose **Create**; TildaZ writes `config_1.toml`,
+`config_2.toml`, and so on. Each config owns one process, hotkey, and log file.
+Legacy `config.json` files, and any `config_N.json` from before TildaZ used TOML,
+are left untouched and are not loaded.
 
 Common fields:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -300,21 +300,68 @@ minimize/restore.
 | 이전 탭 | Ctrl+Shift+[ **또는 Ctrl+PgUp** | Shift+Cmd+[ **또는 Cmd+PgUp** | Ctrl+Shift+[ (L12-β) **또는 Ctrl+PgUp** | ✅ | ✅ | ✅ |
 | 다음 탭 | Ctrl+Shift+] **또는 Ctrl+PgDn** | Shift+Cmd+] **또는 Cmd+PgDn** | Ctrl+Shift+] (L12-β) **또는 Ctrl+PgDn** | ✅ | ✅ | ✅ |
 
-**keyboard layout 독립성** ([#482](https://github.com/ensky0/tildaz/issues/482)). 세 platform 이
-단축키를 매칭하는 대상이 다르다 — Windows 는 virtual-key (`VK_1`, `VK_OEM_4`), macOS 는
-`kVK_ANSI_*` 로 **물리 위치**를 보고, Linux 는 **xkb keysym** 으로 *눌러서 나오는 문자*를 본다.
-그래서 layout 종속 결함은 Linux 에만 생긴다.
+**이 표는 기본값이다** ([#493](https://github.com/ensky0/tildaz/issues/493) 3-c 이후).
+scrollback 쌍과 `Ctrl+C` 를 뺀 모든 조합은 config 의 `[keys]` 로 바꿀 수 있고, 세 platform 의
+판정이 `config.lookupAction` 한 곳에서 일어난다. 그 전에는 host 마다 하드코딩된 키 표가 있었고
+**분류부와 실행부에 같은 표가 두 번** 적혀 있었다 — 그 이중 기술이 갈라지는 것이
+[#484](https://github.com/ensky0/tildaz/issues/484) 의 원인이었다.
 
-- **인덱스 점프**는 Linux 에서 `!shift` 를 요구하지 않는다. AZERTY (fr) 등은 숫자열에 Shift 가
-  필요해 keysym `1`~`9` 가 **항상 Shift 와 함께** 도착하고, 예전 조건이 그것을 전부 걸러 그
-  layout 에서 인덱스 전환이 아예 동작하지 않았다. QWERTY 에는 영향이 없다 — Shift 가 keysym 을
-  `exclam` 으로 바꿔 애초에 매칭되지 않는다.
+기본값 표는 **platform 별로 둘이다** (`macDefaultBindings` / `pcDefaultBindings`). `cmd` 토큰이
+modifier 차이를 흡수하지만 macOS 는 **Shift 의 유무까지 다르다** — PC 쪽 `Ctrl+Shift+T` 에
+대응하는 Apple HIG 관습이 `Cmd+T` 다. 한 표로 덮으면 macOS 사용자의 모든 단축키가
+`Control+Shift+*` 가 된다.
+
+**keyboard layout 독립성** ([#482](https://github.com/ensky0/tildaz/issues/482) ·
+[#496](https://github.com/ensky0/tildaz/issues/496)). 세 platform 이 단축키를 매칭하는 대상이
+다르다 — Windows 는 virtual-key (`VK_1`, `VK_OEM_4`), macOS 는 `kVK_ANSI_*` 로 **물리 위치**를
+보고, Linux 는 **xkb keysym** 으로 *눌러서 나오는 문자*를 본다. 그래서 layout 종속 결함의 모양이
+platform 마다 다르다.
+
+- **비라틴 layout (키릴 · 그리스 · 아랍 ...) 에서는 글자 단축키를 라벨로 적을 수 없다.**
+  `xkbcli how-to-type --layout ru 'w'` 가 빈 결과다 — 그 자판의 어느 키도 `w` 를 내지 않으므로
+  `ctrl+shift+w` 는 영원히 발동하지 않고, **다른 글자로 재바인딩해도 해결되지 않는다** (라틴
+  알파벳 전체가 없다). 그래서 키를 **물리 위치**로도 적을 수 있게 했다 — `"ctrl+shift+[KeyW]"`.
+  이름은 [W3C `KeyboardEvent.code`](https://www.w3.org/TR/uievents-code/) 값이고 (2025 년
+  Recommendation) 표기는 VS Code 와 같은 대괄호다. 세 platform 값의 단일 출처는
+  `src/physical_key.zig` 다.
+- **수용 집합은 라벨 쪽이 좁고 위치 쪽이 넓다.** 의도한 비대칭이다. 라벨을 넓히려면 `-` 에
+  값을 줘야 하는데 쓸 수 있는 고정값 (`VK_OEM_MINUS` · `kVK_ANSI_Minus`) 은 라벨이 아니라 "US
+  자판에서 `-` 가 있는 자리" 다. 그것을 라벨이라 부르면 같은 config 가 platform 마다 다른 키를
+  뜻한다. 위치는 처음부터 자리이므로 그 문제가 없어 자판이 낼 수 있는 키를 다 담는다.
+  라벨을 정직하게 넓히는 것은 live layout 조회 (macOS `UCKeyTranslate` · Windows
+  `VkKeyScanExW`) 가 전제다.
+- **Linux 는 라벨 매칭이라 Shift 가 바꾼 키 값을 되돌린다** (`normalizeLinuxKeysym`).
+  `ctrl+shift+c` binding 은 keysym `c` 로 저장되는데 실제로는 `C` 가 도착하고, `ctrl+shift+[` 는
+  `{` 로 도착한다. 예전 매처가 두 값을 나란히 적어 (`xkb_key_c_lower, xkb_key_c_upper`) 풀던
+  자리다. **Shift 비트는 건드리지 않는다** — 값만 되돌리므로 `ctrl+shift+c` 와 `ctrl+c` 는 여전히
+  다른 조합이다. 숫자는 일부러 제외한다: `exclam` → `1` 로 되돌리면 QWERTY 에서 `Alt+Shift+1` 이
+  탭 전환이 되어 동작이 넓어진다.
+- **인덱스 점프는 숫자 binding 에서 Shift 를 무시한다** (`isDigitBinding`). AZERTY (fr) 등은
+  숫자열에 Shift 가 필요해 keysym / VK `1`~`9` 가 **항상 Shift 와 함께** 도착한다. 확대가 아니라
+  현행 유지다 — 3-c 이전의 세 host 가 모두 Shift 를 보지 않았다 (Windows
+  `wParam >= 0x31 and wParam <= 0x39`, macOS `keycodeToTabIndex(kc) != null`, Linux 는 #482 에서
+  `!shift` 요구 제거). 예외는 **숫자에서 멈춘다** — `shift+alt+f4` 는 `alt+f4` 를 발동시키지
+  않는다. QWERTY 에는 영향이 없다: Shift 가 keysym 을 `exclam` 으로 바꿔 애초에 매칭되지 않는다.
 - **PgUp / PgDn 조합**은 `[` / `]` 가 AltGr 를 요구하는 layout (AZERTY 는 `[` = AltGr+5 →
   조합이 Ctrl+Shift+AltGr+5) 을 위한 layout 무관 대안이다. 기존 bracket 조합을 **대체하지 않고
   추가**한다. `Ctrl+Tab` 은 쓰지 않는다 — kitty / CSI-u 에서 구별 가능한 시퀀스라 TUI 앱이
   정당하게 바인딩하는데 터미널이 삼키면 통과시킬 방법이 없다. PgUp / PgDn 은 GNOME Terminal ·
   Konsole · Windows Terminal 이 탭 전환에 쓰는, 터미널이 관습적으로 소유하는 조합이다.
 - **기존 PgUp / PgDn 경로는 그대로다** — Shift 동반은 scrollback (§2.5), 맨 키는 PTY.
+- **전역 `hotkey` 는 위치 표기를 받지 않는다.** OS / compositor 에 *등록* 해야 하고 그 4 경로가
+  모두 문자 기반이다 (sway `bindsym` · Hyprland keysym · COSMIC RON `key:` · KGlobalAccel
+  `qtKey`). 조용히 keysym 0 을 등록하는 대신 원인이 분명한 실패를 낸다 —
+  [#496](https://github.com/ensky0/tildaz/issues/496) 1-b 가 그 제약을 다룬다.
+- **macOS 에 없는 위치가 있다.** `PrintScreen` · `ScrollLock` · `Pause` 는 **없는 것이 아니라
+  `F13` · `F14` · `F15` 로 보고된다** (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). `F21`~`F24`
+  와 JIS 입력 전환 키 3 개는 정말 없다. 두 경우의 안내가 다르다 — 앞쪽은 "그 이름을 쓰라",
+  뒤쪽은 "이 platform 에 없다". 어느 쪽이든 **파싱 단계에서 거부한다**: 조용히 미동작으로 두면
+  [#208](https://github.com/ensky0/tildaz/issues/208) 이 막던 silent failure 로 되돌아간다.
+
+**재바인딩할 수 없는 것 둘.** `Shift+PgUp` / `Shift+PgDn` 은 단축키가 아니라 **스크롤**이고
+(`app_event` 에서도 `scroll` 범주로, 마우스 휠과 같은 자리다) `Ctrl+C` 는 SIGINT 다. 둘 다
+config 로 가릴 수 있게 하면 실수 한 번으로 터미널의 기본 기능을 잃는다. 그래서 `Ctrl+C` 는
+config 조회보다 **먼저** 판정한다.
 
 ### 2.3 클립보드
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -644,22 +644,23 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 
 같은 nested schema, default 만 OS-specific. *Single source of truth* 패턴 — [`src/config.zig`](src/config.zig) 의 `Defaults` struct (Win/Mac 분기, 같은 필드 순서로 나란히) 한 곳에 모든 default 값. 이로부터:
 
-1. **`defaultConfigJson(allocator, shell_resolved)`** 이 runtime `allocPrint` 로 default JSON 을 생성 (shell 은 host 가 runtime 에 결정한 값이라 comptime 생성 불가 — 과거 `DEFAULT_CONFIG_JSON` + `comptimePrint` 에서 전환) — 첫 실행 시 디스크의 `config_0.json`에 저장 + parse() 의 `validateStructure` 검증 ground truth.
+1. **`defaultConfigToml(allocator, shell_resolved)`** 이 runtime `allocPrint` 로 default TOML 을 생성 (shell 은 host 가 runtime 에 결정한 값이라 comptime 생성 불가 — 과거 `DEFAULT_CONFIG_JSON` + `comptimePrint` 에서 전환) — 첫 실행 시 디스크의 `config_0.toml`에 저장 + parse() 의 `validateStructure` 검증 ground truth.
 2. **`Config` struct field initializer** 가 참조하는 `default_*` const 모두 같은 `Defaults` 에서 derive — 디스크 default 와 메모리 fallback 자동 sync.
 
-이전엔 default 값이 6+ 곳 (JSON literal + 별도 const 들 + Config struct hardcoded literal) 에 흩어져 있어 한쪽만 고치면 어긋남 — 시연 중 발견 (#135). 이제 `Defaults` 한 곳만 고치면 양쪽 자동 sync.
+이전엔 default 값이 6+ 곳 (config literal + 별도 const 들 + Config struct hardcoded literal) 에 흩어져 있어 한쪽만 고치면 어긋남 — 시연 중 발견 (#135). 이제 `Defaults` 한 곳만 고치면 양쪽 자동 sync.
 
 ### 7.1 번호별 config / process 정책 (#267)
 
-- 활성 설정은 `config_0.json`, `config_1.json`, ... 형식만 인식한다. 기존
-  `config.json`은 읽기·변환·수정·삭제하지 않는다.
-- `config_N.json` 하나가 worker process 하나, global hotkey 하나, `tildaz_N.log`
+- 활성 설정은 `config_0.toml`, `config_1.toml`, ... 형식만 인식한다. 기존
+  `config.json` 도, TOML 전환 전의 `config_N.json` 도 읽기·변환·수정·삭제하지
+  않는다 — 디스크에 그대로 남고 읽지 않는다 (#493).
+- `config_N.toml` 하나가 worker process 하나, global hotkey 하나, `tildaz_N.log`
   하나를 소유한다. worker는 `--instance N`으로 시작하며 번호별 advisory file lock으로
   중복 실행을 막는다.
 - 일반 실행은 config index별 실행 상태를 확인하고 빠진 TildaZ worker를 한 번에 모두
-  복구한 뒤 launcher가 종료한다. `config_0.json`이 없으면 다른 번호의 config 존재
+  복구한 뒤 launcher가 종료한다. `config_0.toml`이 없으면 다른 번호의 config 존재
   여부와 무관하게 default/F1으로 먼저 생성한다. 단순 process 수가 아니라
-  `config_<N>.json` ↔ worker N 대응으로 판정한다.
+  `config_<N>.toml` ↔ worker N 대응으로 판정한다.
 - 모든 configured TildaZ worker가 이미 실행 중일 때만 총 실행 개수와 hotkey capture 영역을
   한 다이얼로그에 표시한다. prompt 전에 worker 0을 show/restore/activate하며, 표시가
   반영된 뒤 alert를 연다. 실제 key 조합을 캡처하기 전에는 **Create**가 비활성이다.
@@ -711,7 +712,7 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
   config transaction을 위해 다시 획득한다. launcher가 lock을 쥔 채 worker의 처리를
   기다리는 순환 대기는 허용하지 않는다.
 
-> Zig 의 `std.json` 이 comptime allocator 를 지원 안 해 (0.15.2 에서 확인 — 0.16 에서 재확인하지 않았다) (FixedBufferAllocator 의 `@intFromPtr` runtime-only) JSON → Zig 방향 derive 는 불가. 반대로 Zig `Defaults` struct → JSON 방향 생성이 우리 패턴 — shell 이 runtime 결정값(`resolveShell`)이 되면서 `comptimePrint` 대신 `defaultConfigJson` 의 runtime `allocPrint` 로 생성한다.
+> 방향은 **Zig `Defaults` struct → TOML** 이고 그 반대가 아니다. shell 이 runtime 결정값(`resolveShell`)이라 comptime 생성이 불가능하므로 `comptimePrint` 대신 `defaultConfigToml` 의 runtime `allocPrint` 로 만든다. 파싱은 `sam701/zig-toml` 의 value tree (`toml.Table` / `toml.Value`) 를 쓰고 struct 매핑은 쓰지 않는다 — `validateStructure` 가 default 문서와 user 문서를 같은 표현으로 비교해야 하기 때문이다.
 
 | 필드 | 의미 | Windows default | macOS default | Linux default / 구현 | Win | Mac | Linux |
 |---|---|---|---|---|---|---|---|
@@ -753,13 +754,13 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 
 > **schema strict 검증** (Windows + macOS 동일, v0.4.1 통일 — #118 후속):
 > - 모든 키 (`window.*`, `font.*`, `theme`, `shell`, `hotkey`, `auto_start`, `hidden_start`, `max_scroll_lines`) 가 *required*. 한 개라도 missing 이면 fatal `missing required key "..."` (사용자 의도하는 위치에 적었는데 silently 무시되는 사고 방지).
-> - 알 수 없는 키 (오타 / 잘못된 위치) 면 fatal `unknown key "..."`. 단 `_` prefix key (예: `_note`, `_disabled_*`) 는 *사용자 주석* 으로 인정 — schema 검사 skip (#173). JSON 표준에 주석 없지만 정식 key 는 `_` 안 붙으니 충돌 없는 convention.
+> - 알 수 없는 키 (오타 / 잘못된 위치) 면 fatal `unknown key "..."`. 예외는 없다 — TOML 은 `#` 주석을 지원하므로 주석 용도의 key 를 인정할 이유가 없다 (JSON 시절의 `_` prefix convention 은 #493 에서 걷어냈다).
 > - Type mismatch (예: `width_percent` 에 string) 면 fatal `type mismatch at "..."`. `font.family` / `font.glyph_fallback` 의 type 위반은 더 친절한 별도 메시지 (`font_validate` 의 helper).
-> - 위 검증 모두 `validateStructure(user, default, ctx)` 한 함수가 재귀로 처리 — `defaultConfigJson(allocator, shell_resolved)` 결과와 user config 를 비교.
+> - 위 검증 모두 `validateStructure(user, default, ctx)` 한 함수가 재귀로 처리 — `defaultConfigToml(allocator, shell_resolved)` 결과와 user config 를 비교.
 
 ### 7.1 hotkey 상세
 
-**Schema**: `string`. `config_0.json` 기본값: `"F1"`. 각 config = 해당 worker hotkey의 source of truth (cross-platform parity). Windows는 `RegisterHotKey`, macOS는 `CGEventTap`, Linux는 desktop별 native backend를 쓴다. KDE Plasma는 direct KGlobalAccel D-Bus, GNOME/Cinnamon은 GSettings·Shell extension, COSMIC/Hyprland/sway는 compositor binding→`tildaz --toggle N` Unix socket IPC(#198)다. 미인식 desktop은 자동 fallback을 만들지 않으며 사용자가 `tildaz --toggle N`을 수동 binding할 수 있다.
+**Schema**: `string`. `config_0.toml` 기본값: `"F1"`. 각 config = 해당 worker hotkey의 source of truth (cross-platform parity). Windows는 `RegisterHotKey`, macOS는 `CGEventTap`, Linux는 desktop별 native backend를 쓴다. KDE Plasma는 direct KGlobalAccel D-Bus, GNOME/Cinnamon은 GSettings·Shell extension, COSMIC/Hyprland/sway는 compositor binding→`tildaz --toggle N` Unix socket IPC(#198)다. 미인식 desktop은 자동 fallback을 만들지 않으며 사용자가 `tildaz --toggle N`을 수동 binding할 수 있다.
 
 **잘못된 hotkey 처리**: `Hotkey.fromString` 이 *null* 이면 `dialog.showFatal(config_error_title, config_hotkey_invalid_format)` 후 process exit ([src/config.zig:962-974](src/config.zig#L962-L974), mac/win/linux 동일). 즉 *parse-pass = 등록 가능 보장* 이 아니라 *parse-pass = format 문법 합격*. Linux native backend 변환 가능 여부는 아래 *Key 토큰 표*를 따른다.
 
@@ -767,15 +768,15 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 
 **예제** (모든 platform 동일 문법):
 
-```json
-"hotkey": "F1"                  // 기본
-"hotkey": "ctrl+space"          // 흔한 toggle
-"hotkey": "ctrl+shift+t"        // ✅ KDE 테스트 통과
-"hotkey": "alt+f12"             // ✅ KDE 테스트 통과
-"hotkey": "super+a"             // ✅ KDE — plasmashell next activity 충돌 → takeover dialog
-"hotkey": "ctrl+f7"             // ✅ KDE — kwin ExposeClass 충돌 → takeover dialog
-"hotkey": "shift+cmd+t"         // mac 친숙 표기 (`cmd` = `super` = `meta` 모두 동일 키)
-"hotkey": "ctrl+grave"          // backtick — `grave` 또는 `` ` `` 둘 다 가능
+```toml
+hotkey = "F1"                   # 기본
+hotkey = "ctrl+space"           # 흔한 toggle
+hotkey = "ctrl+shift+t"         # ✅ KDE 테스트 통과
+hotkey = "alt+f12"              # ✅ KDE 테스트 통과
+hotkey = "super+a"              # ✅ KDE — plasmashell next activity 충돌 → takeover dialog
+hotkey = "ctrl+f7"              # ✅ KDE — kwin ExposeClass 충돌 → takeover dialog
+hotkey = "shift+cmd+t"          # mac 친숙 표기 (`cmd` = `super` = `meta` 모두 동일 키)
+hotkey = "ctrl+grave"           # backtick — `grave` 또는 `` ` `` 둘 다 가능
 ```
 
 **Modifier 토큰** (대소문자 무관, `+` 분리, 임의 개수 결합):
@@ -795,8 +796,10 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 | Latin letter | `a` ~ `z` (또는 `A` ~ `Z`) | ✅ |
 | Digit | `0` ~ `9` | ✅ |
 | Named special | `space`, `tab`, `escape` / `esc`, `return` / `enter` | ✅ |
+| Page key | `pageup` / `pgup`, `pagedown` / `pgdn` | ✅ — 어느 layout 에나 있는 단일 물리 키 ([#482](https://github.com/ensky0/tildaz/issues/482)) |
+| Bracket | `bracketleft` / `[`, `bracketright` / `]` | ✅ — `[keys]` 의 `prev_tab` / `next_tab` 기본값이 쓴다 ([#493](https://github.com/ensky0/tildaz/issues/493)) |
 | Backtick | `grave` / `backquote` (이름) 또는 `` ` `` (글자) | ✅ |
-| 기타 literal ASCII symbol | `~` `!` `@` `#` `$` `%` `^` `&` `*` `(` `)` `-` `_` `=` `+` `[` `]` `{` `}` `;` `:` `'` `"` `,` `.` `<` `>` `/` `?` `\` `|` | ❌ — `LinuxHotkey.fromString`이 명시 reject(#208). caller가 `dialog.showFatal(config_error_title, config_hotkey_invalid_format)`로 즉시 알린다. 수용 범위 확대는 모든 native backend의 실제 key-code mapping 검증 후 별도 진행한다. |
+| 기타 literal ASCII symbol | `~` `!` `@` `#` `$` `%` `^` `&` `*` `(` `)` `-` `_` `=` `+` `{` `}` `;` `:` `'` `"` `,` `.` `<` `>` `/` `?` `\` `|` | ❌ — `LinuxHotkey.fromString`이 명시 reject(#208). caller가 `dialog.showFatal(config_error_title, config_hotkey_invalid_format)`로 즉시 알린다. 수용 범위 확대는 모든 native backend의 실제 key-code mapping 검증 후 별도 진행한다. |
 
 **KDE Plasma direct KGlobalAccel** (`kglobalaccel.Client`, #244):
 
@@ -838,7 +841,7 @@ binding은 같은 accelerator를 재사용하면 새 TildaZ command로 덮이고
 
 **Wayland hotkey capture inhibitor**: Linux prompt surface가 focus를 가진 동안 compositor가 `zwp_keyboard_shortcuts_inhibit_manager_v1`을 client에게 노출하면 `zwp_keyboard_shortcuts_inhibitor_v1`을 생성한다. 따라서 기존 compositor binding이 있는 F-key도 prompt가 직접 받는다. Create / Cancel / Esc / surface 종료 시 inhibitor를 surface보다 먼저 파괴해 일반 shortcut routing을 즉시 복구한다. protocol을 노출하지 않는 compositor는 기존 입력 경로를 유지한다. sway에서 `--inhibited`로 등록한 특수 binding은 compositor 정책상 예외로 계속 실행될 수 있다([Wayland protocol](https://wayland.app/protocols/keyboard-shortcuts-inhibit-unstable-v1), [sway inhibitor 동작](https://man.archlinux.org/man/sway.5.en)).
 
-**Hyprland — runtime binding 증분 동기화**: launcher lock 안에서 `hyprctl -j binds` JSON actual 과 `config_N.json` desired 를 비교한다. accelerator와 현재 TildaZ 실행 파일의 `--toggle N` command가 모두 같은 binding은 유지하고, TildaZ가 소유한 stale binding만 `unbind`, 누락 binding만 `bind`한다. 따라서 config 삭제나 hotkey 변경 뒤 과거 F3/F4 등이 세션에 남아 prompt 입력을 가로채지 않는다. 다른 실행 파일이나 dispatcher의 사용자 binding은 식별 대상이 아니다.
+**Hyprland — runtime binding 증분 동기화**: launcher lock 안에서 `hyprctl -j binds` JSON actual 과 `config_N.toml` desired 를 비교한다. accelerator와 현재 TildaZ 실행 파일의 `--toggle N` command가 모두 같은 binding은 유지하고, TildaZ가 소유한 stale binding만 `unbind`, 누락 binding만 `bind`한다. 따라서 config 삭제나 hotkey 변경 뒤 과거 F3/F4 등이 세션에 남아 prompt 입력을 가로채지 않는다. 다른 실행 파일이나 dispatcher의 사용자 binding은 식별 대상이 아니다.
 
 **KDE Plasma / GNOME / Cinnamon — persistent binding 증분 정리**: launcher는 KDE Plasma에서 KGlobalAccel `allComponents()`와 Component `uniqueName`을 조회해 config에서 사라진 `tildaz.instanceN`의 `toggle-N`만 `unregister`한다([KGlobalAccel D-Bus interface](https://github.com/KDE/kglobalaccel/blob/master/src/org.kde.KGlobalAccel.xml), [Component interface](https://github.com/KDE/kglobalaccel/blob/master/src/org.kde.kglobalaccel.Component.xml)). GNOME/Cinnamon의 GSettings fallback도 custom keybinding 목록에서 TildaZ numbered entry만 식별해 사라진 번호를 제거하며 사용자 항목은 보존한다. GNOME/Cinnamon Shell extension은 config directory monitor로 변경을 받고 동일 index/accelerator는 유지한다.
 
@@ -971,7 +974,7 @@ binding은 같은 accelerator를 재사용하면 새 TildaZ command로 덮이고
 
 | 항목 | Windows | macOS | Linux |
 |---|---|---|---|
-| **config** | `%APPDATA%\tildaz\config_N.json` (Microsoft 표준) | `$XDG_CONFIG_HOME/tildaz/config_N.json` (fallback `~/.config`; ghostty/alacritty 패턴) | `$XDG_CONFIG_HOME/tildaz/config_N.json` (fallback `~/.config`) |
+| **config** | `%APPDATA%\tildaz\config_N.toml` (Microsoft 표준) | `$XDG_CONFIG_HOME/tildaz/config_N.toml` (fallback `~/.config`; ghostty/alacritty 패턴) | `$XDG_CONFIG_HOME/tildaz/config_N.toml` (fallback `~/.config`) |
 | **log** | `%APPDATA%\tildaz\tildaz_N.log` (Microsoft 표준) | `~/Library/Logs/tildaz_N.log` (Apple HIG — Console.app 자동 인덱싱) | `$XDG_STATE_HOME/tildaz/tildaz_N.log` (fallback `~/.local/state`) |
 | **process / endpoint state** | `%LOCALAPPDATA%\tildaz\run\launcher.lock`, `instanceN.lock`, `instanceN.endpoint` | `~/Library/Caches/TildaZ/launcher.lock`, `instanceN.lock`, `instanceN.endpoint` | `$XDG_RUNTIME_DIR/tildaz/launcher.lock`, `instanceN.lock`, `instanceN.endpoint`; `XDG_RUNTIME_DIR`가 없으면 `${XDG_CACHE_HOME:-~/.cache}/tildaz/run/` |
 
@@ -1019,7 +1022,7 @@ onrender 진단 수치에만 적용한다. instance timeout이나 Linux startup/
 [Windows unbiased interrupt time](https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttimeprecise)).
 
 **메커니즘:**
-- Windows: `ShellExecuteW(NULL, "open", path, ...)` — 사용자 default editor (`.json` / `.log` 의 file association). **연결이 없으면 `notepad.exe` 로 연다** ([#456](https://github.com/ensky0/tildaz/issues/456)). 확장자에 기본 앱이 없으면 Windows 는 아무 것도 열지 않으면서 `ShellExecuteW` 는 성공을 반환해서 (실측: 연결 있는 `.log` 과 연결 없는 `.json` 이 **둘 다 42**, 창은 한쪽만 뜸) 호출 결과로는 성패를 알 수 없다. 그래서 열기 **전에** 연결을 조회한다 — `UserChoice` → `HKCR\<ext>` 기본값 → 그 ProgId 의 `shell\open\command` 순. `AssocQueryString` 계열은 `OpenWithProgids` 후보까지 답해서 이 판정에 쓸 수 없다. 확실히 없을 때만 fallback 하고, 조회가 불확실하면 OS 에 맡긴다.
+- Windows: `ShellExecuteW(NULL, "open", path, ...)` — 사용자 default editor (`.toml` / `.log` 의 file association). **연결이 없으면 `notepad.exe` 로 연다** ([#456](https://github.com/ensky0/tildaz/issues/456)). 확장자에 기본 앱이 없으면 Windows 는 아무 것도 열지 않으면서 `ShellExecuteW` 는 성공을 반환해서 (실측: 연결 있는 `.log` 과 연결 없는 `.json` 이 **둘 다 42**, 창은 한쪽만 뜸 — config 가 JSON 이던 시절의 측정이고, `.toml` 도 연결 없는 확장자라 상황은 같다) 호출 결과로는 성패를 알 수 없다. 그래서 열기 **전에** 연결을 조회한다 — `UserChoice` → `HKCR\<ext>` 기본값 → 그 ProgId 의 `shell\open\command` 순. `AssocQueryString` 계열은 `OpenWithProgids` 후보까지 답해서 이 판정에 쓸 수 없다. 확실히 없을 때만 fallback 하고, 조회가 불확실하면 OS 에 맡긴다.
 - macOS: `/usr/bin/open <path>` 를 자식 process 로 — Finder 가 file extension 따라 default app.
 - Linux: `xdg-open <path>` 를 자식 process 로 — XDG MIME database.
 
@@ -1045,8 +1048,8 @@ TildaZ v0.3.0
 exe   : /Applications/TildaZ.app/Contents/MacOS/tildaz   (mac)
         C:\Users\<u>\...\tildaz.exe                       (win)
 pid   : 12345
-config: /Users/<u>/.config/tildaz/config_0.json            (mac)
-        C:\Users\<u>\AppData\Roaming\tildaz\config_0.json   (win)
+config: /Users/<u>/.config/tildaz/config_0.toml            (mac)
+        C:\Users\<u>\AppData\Roaming\tildaz\config_0.toml   (win)
 log   : /Users/<u>/Library/Logs/tildaz_0.log               (mac)
         C:\Users\<u>\AppData\Roaming\tildaz\tildaz_0.log    (win)
 
@@ -1067,7 +1070,7 @@ env var expansion (`~`, `%APPDATA%`) 안 쓰고 펼친 절대 경로. 사용자�
 
 ### 11.4 config error 시 dialog 경로 안내
 
-잘못된 config 값 발견 시 `dialog.showFatal` 본문에 *실제로 연 config 파일 절대경로*를 정확히 한 번 명시해 사용자가 어디를 고쳐야 할지 즉시 알게 한다 ([#316](https://github.com/ensky0/tildaz/issues/316)). `Config.load`가 연 path를 `Config.parse`에 직접 전달하고, JSON parse와 모든 semantic/schema 오류가 동적 message 조립을 사용한다. path 조회를 다시 수행하지 않으므로 instance 번호와 실제 파일이 갈리지 않는다.
+잘못된 config 값 발견 시 `dialog.showFatal` 본문에 *실제로 연 config 파일 절대경로*를 정확히 한 번 명시해 사용자가 어디를 고쳐야 할지 즉시 알게 한다 ([#316](https://github.com/ensky0/tildaz/issues/316)). `Config.load`가 연 path를 `Config.parse`에 직접 전달하고, TOML parse와 모든 semantic/schema 오류가 동적 message 조립을 사용한다. TOML parse 실패는 파서가 준 줄·열까지 함께 보인다. path 조회를 다시 수행하지 않으므로 instance 번호와 실제 파일이 갈리지 않는다.
 
 Windows는 짧은 본문을 기존 `MessageBoxW`로 표시하고 화면 또는 4096 UTF-16 변환 상한을 넘을 때만 read-only multiline EDIT window로 전환한다. macOS는 NSApplication을 config load 전에 준비해 짧은 본문은 기존 NSAlert, overflow 본문은 NSScrollView/NSTextView로 표시한다. Linux config parse는 Wayland 연결 전에 실행되므로 전체 동적 본문을 stderr + log fallback으로 출력한다. **현재 상태: 구현·자동 검증 완료, Linux · macOS · Windows 묶음 실기 대기 (#316).**
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -14,6 +14,7 @@ dependency, `ghostty`; the rest arrive transitively through it.
 |---|---|---|
 | `libghostty-vt` (Ghostty) | MIT | Always |
 | `uucode` | MIT | Always — Ghostty's VT module uses it for grapheme break support |
+| `zig-toml` | MIT | Always — parses the TOML config file |
 | Highway | Apache-2.0 (also available under BSD-3-Clause) | Builds with `-Dsimd=true`, which official releases use |
 | `OpenConsole.exe` / `conpty.dll` (ConPTY) | MIT | Windows builds only — shipped as separate files, not linked |
 
@@ -33,6 +34,12 @@ Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
 
 ```
 Copyright (c) 2026 Jacob Sandlund
+```
+
+**zig-toml** — https://github.com/sam701/zig-toml
+
+```
+Copyright (c) 2022-present Alexei Samokvalov & Contributors
 ```
 
 **Highway** — https://github.com/google/highway
@@ -89,9 +96,9 @@ their names or trademarks.
 
 ## MIT License
 
-Applies to `libghostty-vt`, `uucode`, ConPTY, iTerm2-Color-Schemes, and the
-Campbell palette from `microsoft/terminal`, under the respective copyright
-notices above.
+Applies to `libghostty-vt`, `uucode`, `zig-toml`, ConPTY,
+iTerm2-Color-Schemes, and the Campbell palette from `microsoft/terminal`, under
+the respective copyright notices above.
 
 ```
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/build.zig
+++ b/build.zig
@@ -104,6 +104,13 @@ pub fn build(b: *std.Build) void {
         exe_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
 
+    // TOML config 파서 (#493). ghostty 와 달리 lazy 가 아니다 — config 파싱은
+    // 조건 없이 항상 필요하다 (ghostty 의 `uucode` 와 같은 성격).
+    exe_mod.addImport("toml", b.dependency("toml", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("toml"));
+
     if (is_windows_target) {
         // PE VERSIONINFO 리소스 (Explorer 속성 / Task Manager 에서 버전 표시).
         const windows_resource = b.addConfigHeader(.{
@@ -305,6 +312,11 @@ pub fn build(b: *std.Build) void {
     })) |dep| {
         test_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
+
+    test_mod.addImport("toml", b.dependency("toml", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("toml"));
     if (is_linux_target) test_mod.link_libc = true;
     if (is_macos_target) {
         test_mod.linkSystemLibrary("objc", .{});
@@ -402,6 +414,11 @@ pub fn build(b: *std.Build) void {
     })) |dep| {
         stress_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
+
+    stress_mod.addImport("toml", b.dependency("toml", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("toml"));
     // 하네스는 창을 띄우지 않지만 `config.zig` 를 거쳐 dialog 경로가 그래프에 들어온다
     // (기본 scrollback 값을 앱과 같게 쓰기 위해). 그래서 link spec 은 test_mod 와 같다.
     if (is_linux_target) stress_mod.link_libc = true;
@@ -535,6 +552,11 @@ pub fn build(b: *std.Build) void {
             })) |dep| {
                 check_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
             }
+
+            check_mod.addImport("toml", b.dependency("toml", .{
+                .target = target,
+                .optimize = optimize,
+            }).module("toml"));
             // OS-specific link spec 도 declare. *compile-only* 라 link 안 함이지만
             // host 코드의 일부 `extern` decl 이 module 의 link_libc / framework 마커를
             // 검사하는 케이스 일관성. mac framework / windows resource 는 compile

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -38,6 +38,19 @@
             .url = "https://github.com/ghostty-org/ghostty/archive/94d775fefc21f74d9cc85a46b34c4e1d85318fd0.tar.gz",
             .hash = "ghostty-1.3.2-dev-5UdBCyCSPwV-Pp82UMGLutqeo0gckMrI0GfbUbUY0-Jt",
         },
+        // TOML config 파서 (#493). MIT.
+        //
+        // **`zig-0.16` 브랜치 커밋으로 고정한다.** upstream `main` 은 Zig 0.16 에서
+        // 컴파일이 깨진다 — `struct_mapping.zig` 의 `@fromBackingInt` builtin 이
+        // 0.16 에 없다. 이 브랜치는 `parseFile` 이 `std.Io` 를 받는 등 0.16 의 새
+        // 인터페이스에 맞춰져 있다. upstream 이 main 에 병합하면 그때 옮긴다.
+        //
+        // ghostty 와 같은 이유로 커밋 고정 — 브랜치 tarball 은 움직이면 CI
+        // 프리페치가 해시 불일치로 실패한다.
+        .toml = .{
+            .url = "https://github.com/sam701/zig-toml/archive/8685923e32e8b8a795eb2715684236975a70faed.tar.gz",
+            .hash = "toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/config.zig
+++ b/src/config.zig
@@ -543,6 +543,45 @@ test "#493 [keys] scope accepts what the defaults need, and still guards typing"
     try std.testing.expect(parseHotkeyString("f5", .global_hotkey) == .ok);
 }
 
+test "#493 lookup is exact — no shift-insensitive fallback" {
+    // 이 테스트가 `lookupAction` 을 실제로 호출해 **세 platform 에서 컴파일 검증**
+    // 되게 한다 (Zig 는 호출되지 않는 함수 본문을 분석하지 않는다).
+    var buf: [MAX_KEY_BINDINGS]KeyBinding = undefined;
+    var n: usize = 0;
+    const add = struct {
+        fn f(list: []KeyBinding, count: *usize, text: []const u8, action: KeyAction) !void {
+            const parsed = switch (parseHotkeyString(text, .app_binding)) {
+                .ok => |v| v,
+                else => return error.TestUnexpectedResult,
+            };
+            list[count.*] = .{ .hotkey = Hotkey.fromParsed(parsed), .action = action };
+            count.* += 1;
+        }
+    }.f;
+    try add(&buf, &n, "alt+return", .fullscreen);
+    try add(&buf, &n, "shift+alt+return", .fullscreen_workarea);
+    try add(&buf, &n, "alt+1", .switch_tab1);
+    const bindings = buf[0..n];
+
+    const hk = struct {
+        fn f(text: []const u8) !Hotkey {
+            return switch (parseHotkeyString(text, .app_binding)) {
+                .ok => |v| Hotkey.fromParsed(v),
+                else => error.TestUnexpectedResult,
+            };
+        }
+    }.f;
+
+    try std.testing.expectEqual(KeyAction.fullscreen, lookupAction(bindings, try hk("alt+return")).?);
+    try std.testing.expectEqual(KeyAction.fullscreen_workarea, lookupAction(bindings, try hk("shift+alt+return")).?);
+    try std.testing.expectEqual(KeyAction.switch_tab1, lookupAction(bindings, try hk("alt+1")).?);
+
+    // Shift 가 더 붙은 조합은 **일치하지 않는다.** 완화 조회를 뺀 결과이고 의도된
+    // 동작이다 — `shift+alt+f4` 가 `alt+f4` 를 발동시키는 일이 없다.
+    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+1")) == null);
+    try std.testing.expect(lookupAction(bindings, try hk("ctrl+alt+return")) == null);
+}
+
 test "#493 default [keys] has no conflicting bindings" {
     // 액션 → 키 방향을 택한 대가로 충돌 감지가 우리 몫이다 (키 → 액션이면 TOML 이
     // 중복 키로 잡아 준다). 기본값끼리 충돌하면 첫 실행부터 fatal 이므로 고정한다.
@@ -566,8 +605,8 @@ test "#493 default [keys] has no conflicting bindings" {
             count += 1;
         }
     }
-    // 액션 25 개 + prev_tab / next_tab 이 2 개씩 = 27.
-    try std.testing.expectEqual(@as(usize, 27), count);
+    // 액션 23 개 + prev_tab / next_tab 이 2 개씩 = 25.
+    try std.testing.expectEqual(@as(usize, 25), count);
 }
 
 test "#493 generated config carries every action so none is silently missing" {
@@ -703,12 +742,19 @@ const WindowsHotkey = struct {
         return fromParsed(parsed);
     }
 
+    /// `RegisterHotKey` 의 modifier 비트. #493 3-c 의 `lookupAction` 이 platform 과
+    /// 무관하게 `Hotkey.MOD_SHIFT` 를 참조하므로 세 타입이 같은 이름을 갖는다.
+    pub const MOD_ALT: u32 = 0x1;
+    pub const MOD_CTRL: u32 = 0x2;
+    pub const MOD_SHIFT: u32 = 0x4;
+    pub const MOD_SUPER: u32 = 0x8;
+
     pub fn fromParsed(parsed: ParsedHotkey) WindowsHotkey {
         var modifiers: u32 = 0;
-        if (parsed.alt) modifiers |= 0x1; // MOD_ALT
-        if (parsed.ctrl) modifiers |= 0x2; // MOD_CONTROL
-        if (parsed.shift) modifiers |= 0x4; // MOD_SHIFT
-        if (parsed.super) modifiers |= 0x8; // MOD_WIN
+        if (parsed.alt) modifiers |= MOD_ALT;
+        if (parsed.ctrl) modifiers |= MOD_CTRL;
+        if (parsed.shift) modifiers |= MOD_SHIFT;
+        if (parsed.super) modifiers |= MOD_SUPER;
         return .{ .vkey = vkeyFromKey(parsed.key), .modifiers = modifiers };
     }
 
@@ -790,12 +836,19 @@ const MacHotkey = struct {
         return fromParsed(parsed);
     }
 
+    /// `kCGEventFlagMask*`. #493 3-c 의 `lookupAction` 이 platform 과 무관하게
+    /// `Hotkey.MOD_SHIFT` 를 참조하므로 세 타입이 같은 이름을 갖는다.
+    pub const MOD_SHIFT: u64 = 0x00020000;
+    pub const MOD_CTRL: u64 = 0x00040000;
+    pub const MOD_ALT: u64 = 0x00080000;
+    pub const MOD_SUPER: u64 = 0x00100000;
+
     pub fn fromParsed(parsed: ParsedHotkey) MacHotkey {
         var modifiers: u64 = 0;
-        if (parsed.shift) modifiers |= 0x00020000; // kCGEventFlagMaskShift
-        if (parsed.ctrl) modifiers |= 0x00040000; // kCGEventFlagMaskControl
-        if (parsed.alt) modifiers |= 0x00080000; // kCGEventFlagMaskAlternate
-        if (parsed.super) modifiers |= 0x00100000; // kCGEventFlagMaskCommand
+        if (parsed.shift) modifiers |= MOD_SHIFT;
+        if (parsed.ctrl) modifiers |= MOD_CTRL;
+        if (parsed.alt) modifiers |= MOD_ALT;
+        if (parsed.super) modifiers |= MOD_SUPER;
         return .{ .keycode = keycodeFromKey(parsed.key), .modifiers = modifiers };
     }
 
@@ -1144,7 +1197,12 @@ fn defaultFontFamiliesArray() [MAX_FONT_FAMILIES][]const u8 {
 ///   - `fullscreen_workarea` 는 별 `Shortcut` 이 없다 — 런타임은 `fullscreen` +
 ///     Shift 여부로 갈린다. config 에서는 두 동작이 별 항목이어야 각각 바인딩할 수
 ///     있다.
-///   - `scroll_page_*` 는 `Shortcut` 에 아예 없다 (host 가 직접 처리).
+///
+/// **스크롤백 (`Shift+PgUp` / `Shift+PgDn`) 은 일부러 없다.** 그것은 단축키가 아니라
+/// **스크롤**이다 — `app_event.Event` 에서도 `shortcut` 이 아니라 `scroll` 범주이고,
+/// 마우스 휠과 같은 자리다. 세 platform 모두 매처 밖에서 처리한다 (Linux
+/// `wayland_minimal` · Windows `wndProc` · macOS `tildazKeyDown`). 마우스 스크롤을
+/// 재바인딩하지 않는 것과 같은 이유로 설정 대상이 아니다.
 ///
 /// 그래서 이 enum 이 config 의 단일 출처이고, 런타임 매핑은 3-c 단계에서 붙인다.
 ///
@@ -1178,10 +1236,6 @@ pub fn defaultBindings(action: KeyAction) []const []const u8 {
         .fullscreen => &.{"alt+return"},
         .fullscreen_workarea => &.{"shift+alt+return"},
         .quit => &.{"alt+f4"},
-        // Shift 단독이지만 PageUp / PageDown 은 글자를 내지 않아 타이핑을 훔치지
-        // 않는다 — `HotkeyScope.app_binding` 규칙이 이것을 허용한다.
-        .scroll_page_up => &.{"shift+pageup"},
-        .scroll_page_down => &.{"shift+pagedown"},
         .reset_terminal => &.{"ctrl+shift+r"},
         .show_about => &.{"ctrl+shift+i"},
         .open_config => &.{"ctrl+shift+p"},
@@ -1216,7 +1270,6 @@ fn appendKeysSection(w: *std.Io.Writer) !void {
         .{ .title = null, .actions = &.{ .new_tab, .close_tab, .prev_tab, .next_tab, .switch_tab1, .switch_tab2, .switch_tab3, .switch_tab4, .switch_tab5, .switch_tab6, .switch_tab7, .switch_tab8, .switch_tab9 } },
         .{ .title = "클립보드", .actions = &.{ .copy_selection, .paste } },
         .{ .title = "창", .actions = &.{ .fullscreen, .fullscreen_workarea, .quit } },
-        .{ .title = "스크롤백", .actions = &.{ .scroll_page_up, .scroll_page_down } },
         .{ .title = "도구", .actions = &.{ .reset_terminal, .show_about, .open_config, .open_log, .dump_perf } },
     };
     for (groups) |g| {
@@ -1260,8 +1313,6 @@ pub const KeyAction = enum {
     fullscreen,
     fullscreen_workarea,
     quit,
-    scroll_page_up,
-    scroll_page_down,
     reset_terminal,
     show_about,
     open_config,
@@ -1274,6 +1325,25 @@ pub const KeyAction = enum {
         return @tagName(self);
     }
 };
+
+/// #493 3-c — 키 이벤트에서 만든 `Hotkey` 로 액션을 찾는다. **정확히 일치만** 본다.
+///
+/// Shift 를 무시하는 완화 조회를 두었다가 뺐다. AZERTY 처럼 숫자열에 Shift 가 필요한
+/// layout 에서 `Alt+1` 이 `Alt+Shift+(&1 키)` 로 도착하는 문제를 매칭 쪽에서 풀려고
+/// 했는데, 그러면
+///
+///   - `Shift+Alt+F4` 도 `alt+f4` (quit) 로 잡히는 등 **의도하지 않은 조합이 발동**하고,
+///   - QWERTY 에서 `Shift+[` 는 keysym 이 `{` 라서 정규화 표가 따로 필요해지고,
+///   - 무엇보다 "이 키가 왜 저 동작을 하는가" 를 사용자가 설명할 수 없게 된다.
+///
+/// layout 때문에 특정 조합을 누를 수 없다면 **그 layout 에서 다른 키로 바꾸는 것**이
+/// 답이다 — `[keys]` 를 설정 가능하게 만든 이유가 그것이다.
+pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey) ?KeyAction {
+    for (bindings) |b| {
+        if (std.meta.eql(b.hotkey, hotkey)) return b.action;
+    }
+    return null;
+}
 
 /// 한 액션에 키를 여러 개 줄 수 있다 (결정 3). 런타임 조회 방향은 **키 → 액션**
 /// 이므로 (키 이벤트를 받아 "무슨 액션인가" 를 묻는다) 평면 배열로 보관한다.

--- a/src/config.zig
+++ b/src/config.zig
@@ -145,6 +145,14 @@ pub const HotkeyFailure = enum {
     /// 문자 기반이라 (sway `bindsym` · Hyprland keysym · COSMIC RON · KGlobalAccel
     /// `qtKey`) 위치를 넘길 자리가 없다. 조용히 keysym 0 을 등록하는 대신 거부한다.
     position_in_global_hotkey,
+    /// #496 — macOS 가 이 자리를 **다른 이름으로 보고**한다. `PrintScreen` ·
+    /// `ScrollLock` · `Pause` 를 PC 자판에서 누르면 `F13` · `F14` · `F15` 로 온다
+    /// (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). 키가 없는 것이 아니므로
+    /// 안내가 "쓸 수 없다" 가 아니라 "저 이름을 쓰라" 여야 한다.
+    position_aliased_on_macos,
+    /// #496 — macOS 에 이 자리가 정말로 없다. `F21`~`F24` (Apple 의 `kVK_*` 가 F20
+    /// 에서 멈춘다) 와 JIS 입력 전환 키 (`Convert` · `NonConvert` · `KanaMode`).
+    position_absent_on_macos,
 };
 
 /// `Hotkey.fromString` 이 왜 null 이었는지. **판정을 재현하지 않고** 같은
@@ -156,6 +164,8 @@ pub fn hotkeyFailure(s: []const u8) ?HotkeyFailure {
         .unknown_key => .unknown_key,
         .modifier_required => .modifier_required,
         .position_in_global_hotkey => .position_in_global_hotkey,
+        .position_aliased_on_macos => .position_aliased_on_macos,
+        .position_absent_on_macos => .position_absent_on_macos,
     };
 }
 
@@ -164,6 +174,8 @@ const HotkeyParse = union(enum) {
     unknown_key,
     modifier_required,
     position_in_global_hotkey,
+    position_aliased_on_macos,
+    position_absent_on_macos,
 };
 
 /// 파싱 규칙이 쓰임새에 따라 다르다 (#493). `parseHotkeyString` 참고.
@@ -205,6 +217,14 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
     const resolved = key orelse return .unknown_key;
     // #496 — 위치 표기는 아직 `[keys]` 전용이다 (`HotkeyFailure` 주석 참고).
     if (scope == .global_hotkey and resolved == .code) return .position_in_global_hotkey;
+    // #496 — 이 platform 에서 값이 없는 자리는 거부한다. 조용히 미동작으로 두면
+    // 사용자가 config 를 몇 번이고 다시 읽게 된다 (#208 이 막으려던 것).
+    if (is_macos and resolved == .code and !physical_key.availableOnThisPlatform(resolved.code)) {
+        return if (physical_key.macAlias(resolved.code) != null)
+            .position_aliased_on_macos
+        else
+            .position_absent_on_macos;
+    }
     // Bare 문자/숫자/Space/Tab/grave나 Shift-only 조합을 전역 단축키로
     // 등록하면 일상 입력을 OS 전체에서 가로챈다. modifier 없이 안전하게
     // 허용하는 키는 F1~F12뿐 — capturedHotkeyText 와 동일 규칙.
@@ -245,8 +265,18 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
             },
             // #496 — 위치도 같은 기준이다. 그 *자리* 가 글자를 내는지로 본다: 어떤
             // layout 에서든 `KeyW` 자리는 글자를 내고 `F5` 자리는 내지 않는다.
+            //
+            // 방향키 · `Home` · `End` · `Delete` 등은 글자를 내지 않지만 **터미널로
+            // escape sequence 를 보낸다.** modifier 없이 바인딩하면 그 키를 TUI 앱에
+            // 넘길 방법이 없어지므로 여기서는 "글자를 내는 것" 과 같이 취급한다 —
+            // `else => true` 가 그 뜻이다. 예전부터 맨 `PageUp` / `PageDown` /
+            // `Escape` 를 허용해 온 것은 유지한다 (그 셋은 라벨 쪽 규칙과 짝이다).
             .code => |c| switch (c) {
                 .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12 => false,
+                .f13, .f14, .f15, .f16, .f17, .f18, .f19, .f20 => false,
+                .f21, .f22, .f23, .f24 => false,
+                .print_screen, .scroll_lock, .pause, .context_menu => false,
+                .num_lock, .caps_lock => false,
                 .page_up, .page_down, .escape => false,
                 else => true,
             },
@@ -680,6 +710,40 @@ test "#496 위치 binding 은 라벨과 무관하게 자리로 매칭한다" {
     );
 }
 
+test "#496 macOS 에 값이 없는 자리는 그 platform 에서만 거부한다" {
+    // 거부는 **platform 조건**이다. Linux / Windows 에서 `[PrintScreen]` 은 정상
+    // 이므로, 한 config 를 세 OS 에서 쓰는 사용자는 macOS 에서만 안내를 받는다.
+    if (is_macos) {
+        try std.testing.expectEqual(
+            HotkeyParse.position_aliased_on_macos,
+            parseHotkeyString("ctrl+[PrintScreen]", .app_binding),
+        );
+        try std.testing.expectEqual(
+            HotkeyParse.position_absent_on_macos,
+            parseHotkeyString("ctrl+[F21]", .app_binding),
+        );
+        // 안내가 가리키는 대체 자리는 실제로 받아야 한다 — 그러지 않으면 막다른
+        // 길이 된다 (#484).
+        try std.testing.expect(parseHotkeyString("ctrl+[F13]", .app_binding) == .ok);
+    } else {
+        try std.testing.expect(parseHotkeyString("ctrl+[PrintScreen]", .app_binding) == .ok);
+        try std.testing.expect(parseHotkeyString("ctrl+[F21]", .app_binding) == .ok);
+    }
+    // 메뉴 키는 세 platform 모두 값이 있다 — 한 번 "macOS 에 없다" 고 적었던
+    // 자리이므로 못을 박는다.
+    try std.testing.expect(parseHotkeyString("ctrl+[ContextMenu]", .app_binding) == .ok);
+
+    // 방향키 · 편집 패드는 글자를 내지 않지만 터미널로 escape sequence 를 보낸다.
+    // modifier 없이 바인딩하면 TUI 앱에 그 키를 넘길 방법이 없어지므로 요구한다.
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("[ArrowUp]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("[Home]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("[Numpad5]", .app_binding));
+    try std.testing.expect(parseHotkeyString("ctrl+[ArrowUp]", .app_binding) == .ok);
+    // 기능 키 자리는 modifier 없이도 안전하다 (글자도 sequence 도 아니다).
+    try std.testing.expect(parseHotkeyString("[F13]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("[NumLock]", .app_binding) == .ok);
+}
+
 test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
     // `physical_key.zig` 의 `mac` 열과 `MacHotkey.keycodeFromKey` 는 **같은 US 위치
     // 표** 다. 두 곳에 값을 두는 것은 어쩔 수 없다 (한쪽은 라벨 → 위치, 한쪽은 위치
@@ -693,7 +757,7 @@ test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
         const code = physical_key.fromName(name).?;
         try std.testing.expectEqual(
             MacHotkey.keycodeFromKey(.{ .char = letter }),
-            @as(u32, physical_key.macKeyCode(code)),
+            @as(u32, physical_key.macKeyCode(code).?),
         );
     }
     for ('0'..'9' + 1) |c| {
@@ -702,7 +766,7 @@ test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
         const code = physical_key.fromName(name).?;
         try std.testing.expectEqual(
             MacHotkey.keycodeFromKey(.{ .char = digit }),
-            @as(u32, physical_key.macKeyCode(code)),
+            @as(u32, physical_key.macKeyCode(code).?),
         );
     }
 
@@ -726,7 +790,7 @@ test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
     for (pairs) |pair| {
         try std.testing.expectEqual(
             MacHotkey.keycodeFromKey(.{ .named = pair.named }),
-            @as(u32, physical_key.macKeyCode(pair.code)),
+            @as(u32, physical_key.macKeyCode(pair.code).?),
         );
     }
     // `pairs` 가 named 라벨을 **빠짐없이** 덮어야 한다. 라벨을 하나 더하면 여기서
@@ -1091,7 +1155,10 @@ const MacHotkey = struct {
             // — sentinel 이 필요 없다. 그래서 라벨 `w` 와 `[KeyW]` 가 이 platform 에서
             // 완전히 같은 값을 낸다 (#496 항목 2 의 뿌리이기도 하다: 라벨 쪽이 live
             // layout 을 보지 않고 US 위치를 준다).
-            .code => |c| physical_key.macKeyCode(c),
+            // 파싱이 `availableOnThisPlatform` 으로 이미 거부했으므로 macOS 에서
+            // null 이 여기 도달할 수 없다. 조용히 0 을 쓰면 #208 이 막던 silent
+            // failure 로 되돌아가므로 값을 꾸미지 않는다.
+            .code => |c| physical_key.macKeyCode(c) orelse unreachable,
             .named => |n| switch (n) {
                 .f1 => 0x7A,
                 .f2 => 0x78,
@@ -2055,6 +2122,9 @@ pub const Config = struct {
                         messages.config_hotkey_position_fallback_msg,
                     .modifier_required => std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
                         messages.config_hotkey_invalid_fallback_msg,
+                    // 전역 `hotkey` 는 위치 표기를 아예 안 받으므로 그 전에 걸린다 —
+                    // 이 둘은 `[keys]` 쪽 경로에서만 나온다.
+                    .position_aliased_on_macos, .position_absent_on_macos => unreachable,
                 };
                 showConfigFatalMsg(rt, config_path, msg);
             }
@@ -2222,6 +2292,19 @@ pub const Config = struct {
             // `global_hotkey` 에서만 낸다). exhaustive switch 를 유지하려고 둔다 —
             // scope 별 규칙이 바뀌어 여기 도달하면 조용히 넘기지 말고 멈춰야 한다.
             .position_in_global_hotkey => unreachable,
+            // #496 — macOS 에서만 나온다. 겹침 / 부재를 갈라 다른 안내를 준다.
+            .position_aliased_on_macos => {
+                var buf: [640]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, messages.config_key_position_aliased_format, .{ action.configName(), text }) catch
+                    messages.config_key_position_aliased_fallback_msg;
+                showConfigFatalMsg(rt, config_path, msg);
+            },
+            .position_absent_on_macos => {
+                var buf: [640]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, messages.config_key_position_absent_format, .{ action.configName(), text }) catch
+                    messages.config_key_position_absent_fallback_msg;
+                showConfigFatalMsg(rt, config_path, msg);
+            },
         };
         const hotkey = Hotkey.fromParsed(parsed);
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1837,11 +1837,12 @@ fn modifiersAside(h: Hotkey) u32 {
 /// 에서 항상 `Alt+Shift+1` 로 도착하고, 엄격히 비교하면 인덱스 탭 전환이 그
 /// layout 에서 아예 동작하지 않는다.
 ///
-/// **이것은 동작 확대가 아니다** — 세 platform 이 이미 그렇게 동작한다. Windows 는
-/// `wParam >= 0x31 and wParam <= 0x39` 로 Shift 를 아예 안 보고 (`window.zig`),
-/// macOS 는 `keycodeToTabIndex(kc) != null` 로 역시 안 보며 (`host/macos.zig`),
-/// Linux 도 #482 에서 `!shift` 요구를 걷어냈다. 3-c 가 그 셋을 한 규칙으로 모을 때
-/// 이 예외를 빼면 세 platform 모두 AZERTY 에서 퇴행한다.
+/// **이것은 동작 확대가 아니다** — 3-c 이전의 세 host 가 이미 그렇게 동작했다.
+/// Windows 는 `wParam >= 0x31 and wParam <= 0x39` 로 Shift 를 아예 보지 않았고
+/// (`window.zig`), macOS 는 `keycodeToTabIndex(kc) != null` 로 역시 보지 않았으며
+/// (`host/macos.zig`), Linux 도 #482 에서 `!shift` 요구를 걷어냈다. 그 셋을 한 규칙
+/// (`lookupAction`) 으로 모을 때 이 예외를 빼면 세 platform 모두 AZERTY 에서
+/// 퇴행한다. 세 곳의 하드코딩은 3-c 에서 사라졌고 근거만 여기 남는다.
 ///
 /// QWERTY 에는 영향이 없다: 그쪽에서 `Alt+Shift+1` 은 keysym 이 `exclam` 이라
 /// 라벨 비교 자체가 실패한다. Windows / macOS 는 위치 기반이어서 오늘도 잡히므로

--- a/src/config.zig
+++ b/src/config.zig
@@ -23,6 +23,8 @@ const paths = @import("paths.zig");
 const font_validate = @import("font/validate.zig");
 const font_constants = @import("font/constants.zig");
 const font_spec = @import("font/spec.zig");
+const physical_key = @import("physical_key.zig");
+const PhysicalCode = physical_key.PhysicalCode;
 
 const WCHAR = u16;
 
@@ -115,6 +117,9 @@ const HotkeyKeyToken = union(enum) {
     named: HotkeyNamedKey,
     /// 소문자 latin letter 또는 digit (ASCII).
     char: u8,
+    /// #496 — **물리 위치** (`[KeyW]`). 라벨이 아니므로 layout 을 갈아도 같은 자리다.
+    /// 비라틴 layout 에서 글자 단축키를 쓸 수 있는 유일한 방법이다.
+    code: PhysicalCode,
 };
 
 const ParsedHotkey = struct {
@@ -134,6 +139,11 @@ pub const HotkeyFailure = enum {
     unknown_key,
     /// key 는 유효하지만 modifier 없이 전역 등록할 수 없는 키다 (F1~F12 만 허용).
     modifier_required,
+    /// #496 — 위치 표기 (`[KeyW]`) 를 전역 `hotkey` 에 썼다. 아직 `[keys]` 에서만
+    /// 받는다: 전역 핫키는 OS / compositor 에 *등록* 해야 하고 그 4 경로가 모두
+    /// 문자 기반이라 (sway `bindsym` · Hyprland keysym · COSMIC RON · KGlobalAccel
+    /// `qtKey`) 위치를 넘길 자리가 없다. 조용히 keysym 0 을 등록하는 대신 거부한다.
+    position_in_global_hotkey,
 };
 
 /// `Hotkey.fromString` 이 왜 null 이었는지. **판정을 재현하지 않고** 같은
@@ -144,6 +154,7 @@ pub fn hotkeyFailure(s: []const u8) ?HotkeyFailure {
         .ok => null,
         .unknown_key => .unknown_key,
         .modifier_required => .modifier_required,
+        .position_in_global_hotkey => .position_in_global_hotkey,
     };
 }
 
@@ -151,6 +162,7 @@ const HotkeyParse = union(enum) {
     ok: ParsedHotkey,
     unknown_key,
     modifier_required,
+    position_in_global_hotkey,
 };
 
 /// 파싱 규칙이 쓰임새에 따라 다르다 (#493). `parseHotkeyString` 참고.
@@ -190,6 +202,8 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
     // key 토큰이 아예 없는 경우 (예: `"ctrl"` 하나만) 도 "모르는 key" 로 묶는다 —
     // 사용자가 받아야 하는 안내가 같다 (받는 key 목록).
     const resolved = key orelse return .unknown_key;
+    // #496 — 위치 표기는 아직 `[keys]` 전용이다 (`HotkeyFailure` 주석 참고).
+    if (scope == .global_hotkey and resolved == .code) return .position_in_global_hotkey;
     // Bare 문자/숫자/Space/Tab/grave나 Shift-only 조합을 전역 단축키로
     // 등록하면 일상 입력을 OS 전체에서 가로챈다. modifier 없이 안전하게
     // 허용하는 키는 F1~F12뿐 — capturedHotkeyText 와 동일 규칙.
@@ -199,6 +213,9 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
             else => false,
         },
         .char => false,
+        // `global_hotkey` 는 위 분기에서 이미 돌아갔으므로 여기 오는 위치는
+        // `app_binding` 뿐이고, 그 판정은 아래 `types_text` 가 한다.
+        .code => false,
     };
     if (scope == .global_hotkey) {
         if (!(ctrl or alt or super) and !is_function_key) return .modifier_required;
@@ -224,6 +241,13 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
                 // 글자를 내는 키 — modifier 없이 바인딩하면 터미널에 그 글자를 칠 수
                 // 없게 된다.
                 .grave, .bracket_left, .bracket_right => true,
+            },
+            // #496 — 위치도 같은 기준이다. 그 *자리* 가 글자를 내는지로 본다: 어떤
+            // layout 에서든 `KeyW` 자리는 글자를 내고 `F5` 자리는 내지 않는다.
+            .code => |c| switch (c) {
+                .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12 => false,
+                .page_up, .page_down, .escape => false,
+                else => true,
             },
         };
         if (types_text and !(ctrl or alt or super)) return .modifier_required;
@@ -265,6 +289,17 @@ fn hotkeyKeyFromName(name: []const u8) ?HotkeyKeyToken {
     };
     for (map) |entry| {
         if (eqIc(name, entry.name)) return .{ .named = entry.key };
+    }
+    // #496 — 위치 표기 `[KeyW]`. VS Code 와 같은 대괄호이고 안의 이름은 W3C
+    // `KeyboardEvent.code` 값이다 (`physical_key.zig`).
+    //
+    // `[` 와 `]` 는 **라벨로도** 받는 키라 (`prev_tab` 기본값이 `ctrl+shift+[`)
+    // 표기가 겹쳐 보인다. 구분은 길이로 명확하다 — 1 자 `[` 는 라벨, `[...]` 는
+    // 위치다. VS Code 도 같은 상황을 안고 배포한다 (기본값에 `ctrl+[` 가 있다).
+    // 아래 `name.len == 1` 분기보다 **먼저** 봐야 한다.
+    if (name.len >= 3 and name[0] == '[' and name[name.len - 1] == ']') {
+        const inner = name[1 .. name.len - 1];
+        return .{ .code = physical_key.fromName(inner) orelse return null };
     }
     if (name.len == 1) {
         const c = name[0];
@@ -369,6 +404,12 @@ const LinuxHotkey = struct {
     /// 가 이를 `<Control><Shift>...` 같은 prefix 로 변환.
     modifiers: u32 = 0,
 
+    /// #496 — non-null 이면 이 binding 은 **물리 위치**로 매칭한다 (`[KeyW]`).
+    /// 그때 라벨 쪽 값 (`keysym`) 은 의미가 없다. `lookupAction` 이 이 필드로
+    /// 어느 기준을 볼지 고른다 — 두 기준을 한 값에 눌러 담을 수 없어서 (같은
+    /// event 가 라벨 binding 과 위치 binding 에 동시에 걸려야 한다) 필드를 나눈다.
+    code: ?PhysicalCode = null,
+
     pub const MOD_ALT: u32 = 0x1;
     pub const MOD_CTRL: u32 = 0x2;
     pub const MOD_SHIFT: u32 = 0x4;
@@ -390,7 +431,11 @@ const LinuxHotkey = struct {
         if (parsed.ctrl) modifiers |= MOD_CTRL;
         if (parsed.shift) modifiers |= MOD_SHIFT;
         if (parsed.super) modifiers |= MOD_SUPER;
-        return .{ .keysym = keysymFromKey(parsed.key), .modifiers = modifiers };
+        return .{
+            .keysym = keysymFromKey(parsed.key),
+            .modifiers = modifiers,
+            .code = if (parsed.key == .code) parsed.key.code else null,
+        };
     }
 
     /// 정규화된 key → xkb keysym. `xkbcommon/xkbcommon-keysyms.h` 의
@@ -398,6 +443,9 @@ const LinuxHotkey = struct {
     fn keysymFromKey(key: HotkeyKeyToken) u32 {
         return switch (key) {
             .char => |c| c,
+            // 위치 binding 은 keysym 으로 매칭하지 않는다 — `code` 필드가 기준이다.
+            // 0 은 어떤 실제 keysym 과도 겹치지 않는 sentinel 이다.
+            .code => 0,
             .named => |n| switch (n) {
                 .f1 => 0xffbe,
                 .f2 => 0xffbf,
@@ -572,14 +620,157 @@ test "#493 lookup is exact — no shift-insensitive fallback" {
         }
     }.f;
 
-    try std.testing.expectEqual(KeyAction.fullscreen, lookupAction(bindings, try hk("alt+return")).?);
-    try std.testing.expectEqual(KeyAction.fullscreen_workarea, lookupAction(bindings, try hk("shift+alt+return")).?);
-    try std.testing.expectEqual(KeyAction.switch_tab1, lookupAction(bindings, try hk("alt+1")).?);
+    try std.testing.expectEqual(KeyAction.fullscreen, lookupAction(bindings, try hk("alt+return"), null).?);
+    try std.testing.expectEqual(KeyAction.fullscreen_workarea, lookupAction(bindings, try hk("shift+alt+return"), null).?);
+    try std.testing.expectEqual(KeyAction.switch_tab1, lookupAction(bindings, try hk("alt+1"), null).?);
 
     // Shift 가 더 붙은 조합은 **일치하지 않는다.** 완화 조회를 뺀 결과이고 의도된
     // 동작이다 — `shift+alt+f4` 가 `alt+f4` 를 발동시키는 일이 없다.
-    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+1")) == null);
-    try std.testing.expect(lookupAction(bindings, try hk("ctrl+alt+return")) == null);
+    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+1"), null) == null);
+    try std.testing.expect(lookupAction(bindings, try hk("ctrl+alt+return"), null) == null);
+}
+
+test "#496 위치 binding 은 라벨과 무관하게 자리로 매칭한다" {
+    const parse = struct {
+        fn f(text: []const u8) !Hotkey {
+            return switch (parseHotkeyString(text, .app_binding)) {
+                .ok => |v| Hotkey.fromParsed(v),
+                else => error.TestUnexpectedResult,
+            };
+        }
+    }.f;
+
+    var buf: [MAX_KEY_BINDINGS]KeyBinding = undefined;
+    var n: usize = 0;
+    // 라벨 binding 하나, 위치 binding 하나 — 한 조회가 둘 다 상대한다.
+    buf[n] = .{ .hotkey = try parse("ctrl+shift+t"), .action = .new_tab };
+    n += 1;
+    buf[n] = .{ .hotkey = try parse("ctrl+shift+[KeyW]"), .action = .close_tab };
+    n += 1;
+    const bindings = buf[0..n];
+
+    // 위치 binding 은 라벨을 보지 않는다. 키릴 layout 에서 그 자리를 누르면 라벨은
+    // `ц` 라서 라벨 표현이 무엇이든 상관없이 자리로 잡혀야 한다 — 여기서는 라벨
+    // 표현을 일부러 엉뚱한 것 (`ctrl+shift+f9`) 으로 주고 자리만 맞춘다.
+    try std.testing.expectEqual(
+        KeyAction.close_tab,
+        lookupAction(bindings, try parse("ctrl+shift+f9"), .key_w).?,
+    );
+    // modifier 가 다르면 자리가 맞아도 매칭하지 않는다.
+    try std.testing.expect(lookupAction(bindings, try parse("ctrl+f9"), .key_w) == null);
+    // 자리를 모르는 event (표에 없는 키) 는 위치 binding 을 발동시키지 않는다.
+    try std.testing.expect(lookupAction(bindings, try parse("ctrl+shift+f9"), null) == null);
+    // 라벨 binding 은 자리 정보가 있어도 라벨로 판정한다 — 위치를 엉뚱하게 줘도
+    // 라벨이 맞으면 잡힌다.
+    try std.testing.expectEqual(
+        KeyAction.new_tab,
+        lookupAction(bindings, try parse("ctrl+shift+t"), .key_z).?,
+    );
+}
+
+test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
+    // `physical_key.zig` 의 `mac` 열과 `MacHotkey.keycodeFromKey` 는 **같은 US 위치
+    // 표** 다. 두 곳에 값을 두는 것은 어쩔 수 없다 (한쪽은 라벨 → 위치, 한쪽은 위치
+    // 이름 → 위치) — 그래서 갈라지지 않는다는 것을 여기서 고정한다. 표가 갈라지면
+    // `[KeyW]` 와 라벨 `w` 가 macOS 에서 다른 키가 되고, 그 증상은 조용하다.
+    var name_buf: [16]u8 = undefined;
+
+    for ('a'..'z' + 1) |c| {
+        const letter: u8 = @intCast(c);
+        const name = std.fmt.bufPrint(&name_buf, "Key{c}", .{std.ascii.toUpper(letter)}) catch unreachable;
+        const code = physical_key.fromName(name).?;
+        try std.testing.expectEqual(
+            MacHotkey.keycodeFromKey(.{ .char = letter }),
+            @as(u32, physical_key.macKeyCode(code)),
+        );
+    }
+    for ('0'..'9' + 1) |c| {
+        const digit: u8 = @intCast(c);
+        const name = std.fmt.bufPrint(&name_buf, "Digit{c}", .{digit}) catch unreachable;
+        const code = physical_key.fromName(name).?;
+        try std.testing.expectEqual(
+            MacHotkey.keycodeFromKey(.{ .char = digit }),
+            @as(u32, physical_key.macKeyCode(code)),
+        );
+    }
+
+    const pairs = [_]struct { named: HotkeyNamedKey, code: PhysicalCode }{
+        .{ .named = .f1, .code = .f1 },       .{ .named = .f2, .code = .f2 },
+        .{ .named = .f3, .code = .f3 },       .{ .named = .f4, .code = .f4 },
+        .{ .named = .f5, .code = .f5 },       .{ .named = .f6, .code = .f6 },
+        .{ .named = .f7, .code = .f7 },       .{ .named = .f8, .code = .f8 },
+        .{ .named = .f9, .code = .f9 },       .{ .named = .f10, .code = .f10 },
+        .{ .named = .f11, .code = .f11 },     .{ .named = .f12, .code = .f12 },
+        .{ .named = .space, .code = .space }, .{ .named = .tab, .code = .tab },
+        .{ .named = .escape, .code = .escape },
+        // 라벨은 `return`, W3C 이름은 `Enter` 다 — 같은 키다.
+        .{ .named = .@"return", .code = .enter },
+        .{ .named = .grave, .code = .backquote },
+        .{ .named = .page_up, .code = .page_up },
+        .{ .named = .page_down, .code = .page_down },
+        .{ .named = .bracket_left, .code = .bracket_left },
+        .{ .named = .bracket_right, .code = .bracket_right },
+    };
+    for (pairs) |pair| {
+        try std.testing.expectEqual(
+            MacHotkey.keycodeFromKey(.{ .named = pair.named }),
+            @as(u32, physical_key.macKeyCode(pair.code)),
+        );
+    }
+    // 두 집합의 크기가 맞아야 한다 — 위치 집합은 named 라벨 전부 + 글자 26 + 숫자 10
+    // 이다. 한쪽에만 키를 더하면 위 `pairs` 표가 조용히 불완전해지므로 여기서 막는다.
+    try std.testing.expectEqual(
+        @typeInfo(HotkeyNamedKey).@"enum".fields.len + 26 + 10,
+        @typeInfo(PhysicalCode).@"enum".fields.len,
+    );
+    // 그리고 `pairs` 가 named 라벨을 빠짐없이 덮어야 한다.
+    try std.testing.expectEqual(@typeInfo(HotkeyNamedKey).@"enum".fields.len, pairs.len);
+}
+
+test "#496 위치 표기 파싱" {
+    // 대괄호 안은 W3C `KeyboardEvent.code` 이름이고 대소문자 무관이다.
+    try std.testing.expect(parseHotkeyString("ctrl+shift+[KeyW]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("ctrl+shift+[keyw]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("ctrl+[BracketLeft]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("[F5]", .app_binding) == .ok);
+
+    // 1 자 `[` 는 여전히 **라벨**이다 — 표기가 겹쳐 보이지만 길이로 갈린다.
+    const label = switch (parseHotkeyString("ctrl+shift+[", .app_binding)) {
+        .ok => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(label.key == .named);
+    try std.testing.expectEqual(HotkeyNamedKey.bracket_left, label.key.named);
+
+    const position = switch (parseHotkeyString("ctrl+shift+[BracketLeft]", .app_binding)) {
+        .ok => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(position.key == .code);
+    try std.testing.expectEqual(PhysicalCode.bracket_left, position.key.code);
+
+    // 라벨 집합에 없는 자리는 위치로도 받지 않는다 — 수용 집합이 조용히 넓어지지
+    // 않게 한다 (`physical_key.zig` 의 같은 정책).
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[Minus]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[Slash]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[NotAKey]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[]", .app_binding));
+
+    // 글자를 내는 자리는 modifier 가 필요하고, 내지 않는 자리는 필요 없다 — 라벨과
+    // 같은 기준이다.
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("[KeyW]", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("shift+[KeyW]", .app_binding));
+    try std.testing.expect(parseHotkeyString("[PageUp]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("shift+[PageUp]", .app_binding) == .ok);
+
+    // 전역 `hotkey` 는 아직 위치를 받지 않는다 (1-b 미구현). 조용히 keysym 0 을
+    // 등록하는 대신 원인이 분명한 실패를 낸다.
+    try std.testing.expectEqual(
+        HotkeyParse.position_in_global_hotkey,
+        parseHotkeyString("ctrl+[KeyW]", .global_hotkey),
+    );
+    try std.testing.expectEqual(HotkeyFailure.position_in_global_hotkey, hotkeyFailure("ctrl+[KeyW]").?);
+    try std.testing.expectEqual(@as(?Hotkey, null), Hotkey.fromString("ctrl+[KeyW]"));
 }
 
 test "#493 default [keys] has no conflicting bindings" {
@@ -734,6 +925,12 @@ const WindowsHotkey = struct {
     vkey: u32 = 0x70, // VK_F1
     modifiers: u32 = 0,
 
+    /// #496 — non-null 이면 이 binding 은 **물리 위치**로 매칭한다 (`[KeyW]`).
+    /// 그때 라벨 쪽 값 (`vkey`) 은 의미가 없다. `lookupAction` 이 이 필드로
+    /// 어느 기준을 볼지 고른다 — 두 기준을 한 값에 눌러 담을 수 없어서 (같은
+    /// event 가 라벨 binding 과 위치 binding 에 동시에 걸려야 한다) 필드를 나눈다.
+    code: ?PhysicalCode = null,
+
     pub fn fromString(s: []const u8) ?WindowsHotkey {
         const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
@@ -755,7 +952,11 @@ const WindowsHotkey = struct {
         if (parsed.ctrl) modifiers |= MOD_CTRL;
         if (parsed.shift) modifiers |= MOD_SHIFT;
         if (parsed.super) modifiers |= MOD_SUPER;
-        return .{ .vkey = vkeyFromKey(parsed.key), .modifiers = modifiers };
+        return .{
+            .vkey = vkeyFromKey(parsed.key),
+            .modifiers = modifiers,
+            .code = if (parsed.key == .code) parsed.key.code else null,
+        };
     }
 
     /// 정규화된 key → virtual-key code. letter / digit 은 대문자 ASCII 값
@@ -763,6 +964,9 @@ const WindowsHotkey = struct {
     fn vkeyFromKey(key: HotkeyKeyToken) u32 {
         return switch (key) {
             .char => |c| std.ascii.toUpper(c),
+            // 위치 binding 은 scan code 로 매칭한다 — `code` 필드가 기준이고 vkey 는
+            // 보지 않는다. 0 은 유효한 virtual-key 가 아니라 sentinel 로 안전하다.
+            .code => 0,
             .named => |n| switch (n) {
                 .f1 => 0x70,
                 .f2 => 0x71,
@@ -828,6 +1032,12 @@ const MacHotkey = struct {
     /// CGEventFlags (`kCGEventFlagMask*`). u64 — bit 16..23 사용.
     modifiers: u64 = 0,
 
+    /// #496 — non-null 이면 이 binding 은 **물리 위치**로 매칭한다 (`[KeyW]`).
+    /// 그때 라벨 쪽 값 (`keycode`) 은 의미가 없다. `lookupAction` 이 이 필드로
+    /// 어느 기준을 볼지 고른다 — 두 기준을 한 값에 눌러 담을 수 없어서 (같은
+    /// event 가 라벨 binding 과 위치 binding 에 동시에 걸려야 한다) 필드를 나눈다.
+    code: ?PhysicalCode = null,
+
     pub fn fromString(s: []const u8) ?MacHotkey {
         const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
@@ -849,12 +1059,21 @@ const MacHotkey = struct {
         if (parsed.ctrl) modifiers |= MOD_CTRL;
         if (parsed.alt) modifiers |= MOD_ALT;
         if (parsed.super) modifiers |= MOD_SUPER;
-        return .{ .keycode = keycodeFromKey(parsed.key), .modifiers = modifiers };
+        return .{
+            .keycode = keycodeFromKey(parsed.key),
+            .modifiers = modifiers,
+            .code = if (parsed.key == .code) parsed.key.code else null,
+        };
     }
 
     /// 정규화된 key → `kVK_*` keycode.
     fn keycodeFromKey(key: HotkeyKeyToken) u32 {
         return switch (key) {
+            // macOS 는 `keycode` 자체가 물리 위치라 위치 binding 도 같은 표현이 된다
+            // — sentinel 이 필요 없다. 그래서 라벨 `w` 와 `[KeyW]` 가 이 platform 에서
+            // 완전히 같은 값을 낸다 (#496 항목 2 의 뿌리이기도 하다: 라벨 쪽이 live
+            // layout 을 보지 않고 US 위치를 준다).
+            .code => |c| physical_key.macKeyCode(c),
             .named => |n| switch (n) {
                 .f1 => 0x7A,
                 .f2 => 0x78,
@@ -1341,8 +1560,33 @@ pub const KeyAction = enum {
 ///
 /// layout 때문에 특정 조합을 누를 수 없다면 **그 layout 에서 다른 키로 바꾸는 것**이
 /// 답이다 — `[keys]` 를 설정 가능하게 만든 이유가 그것이다.
-pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey) ?KeyAction {
+///
+/// ## 두 기준
+///
+/// #496 — binding 은 라벨로도 (`ctrl+shift+w`) 위치로도 (`ctrl+shift+[KeyW]`) 적을 수
+/// 있고, 한 event 가 두 종류의 binding 모두와 겨뤄야 한다. 그래서 호출자는 같은
+/// key event 를 **두 표현으로** 넘긴다:
+///
+///   - `hotkey` — 라벨 표현. platform 이 주는 keysym / vkey / keycode 로 만든다.
+///     `hotkey.code` 는 **반드시 null** 이어야 한다 (event 는 binding 이 아니다).
+///   - `code` — 물리 위치. Linux evdev keycode · Windows scan code · macOS keyCode 를
+///     `physical_key.fromEvdev` / `..fromScanCode` / `..fromMacKeyCode` 로 옮긴 값.
+///     표에 없는 키면 null 이고, 그때 위치 binding 은 아무것도 매칭하지 않는다.
+///
+/// binding 쪽 `code` 가 non-null 이면 위치로, null 이면 라벨로 판정한다. 한 binding 이
+/// 두 기준을 동시에 갖지 않으므로 "왜 이 키가 이 동작을 했는가" 가 항상 한 가지로
+/// 설명된다.
+pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey, code: ?PhysicalCode) ?KeyAction {
+    std.debug.assert(hotkey.code == null);
     for (bindings) |b| {
+        if (b.hotkey.code) |want| {
+            // 위치 binding — modifier 는 같아야 하고 자리가 일치해야 한다. 라벨 쪽
+            // 값 (keysym / vkey / keycode) 은 보지 않는다.
+            if (b.hotkey.modifiers != hotkey.modifiers) continue;
+            const got = code orelse continue;
+            if (got == want) return b.action;
+            continue;
+        }
         if (std.meta.eql(b.hotkey, hotkey)) return b.action;
     }
     return null;
@@ -1609,13 +1853,17 @@ pub const Config = struct {
                 // #484 — 거부 이유별로 다른 안내를 보낸다. 한 메시지로 묶으면
                 // modifier 를 이미 준 사용자에게 "modifier 를 달라" 고 말하게 된다.
                 // `bufPrint` 의 format 은 comptime 이라 분기 안에서 각각 포맷한다.
-                var buf: [512]u8 = undefined;
-                const msg = if (hotkeyFailure(v.string) == .unknown_key)
-                    std.fmt.bufPrint(&buf, messages.config_hotkey_unknown_key_format, .{v.string}) catch
-                        messages.config_hotkey_unknown_key_fallback_msg
-                else
-                    std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
-                        messages.config_hotkey_invalid_fallback_msg;
+                var buf: [768]u8 = undefined;
+                const msg = switch (hotkeyFailure(v.string).?) {
+                    .unknown_key => std.fmt.bufPrint(&buf, messages.config_hotkey_unknown_key_format, .{v.string}) catch
+                        messages.config_hotkey_unknown_key_fallback_msg,
+                    // #496 — 원인이 셋이 됐다. 위치 표기를 "modifier 를 달라" 로
+                    // 안내하면 #484 와 같은 막다른 길이 된다.
+                    .position_in_global_hotkey => std.fmt.bufPrint(&buf, messages.config_hotkey_position_format, .{v.string}) catch
+                        messages.config_hotkey_position_fallback_msg,
+                    .modifier_required => std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
+                        messages.config_hotkey_invalid_fallback_msg,
+                };
                 showConfigFatalMsg(rt, config_path, msg);
             }
         }
@@ -1778,6 +2026,10 @@ pub const Config = struct {
                     messages.config_key_needs_modifier_fallback_msg;
                 showConfigFatalMsg(rt, config_path, msg);
             },
+            // `app_binding` scope 는 이 값을 내지 않는다 (`parseHotkeyString` 이
+            // `global_hotkey` 에서만 낸다). exhaustive switch 를 유지하려고 둔다 —
+            // scope 별 규칙이 바뀌어 여기 도달하면 조용히 넘기지 말고 멈춰야 한다.
+            .position_in_global_hotkey => unreachable,
         };
         const hotkey = Hotkey.fromParsed(parsed);
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -25,7 +25,9 @@ const font_constants = @import("font/constants.zig");
 const font_spec = @import("font/spec.zig");
 const physical_key = @import("physical_key.zig");
 const input_policy = @import("input_policy.zig");
-const PhysicalCode = physical_key.PhysicalCode;
+/// #496 — host 가 key event 의 물리 위치를 넘길 때 쓴다 (`lookupAction` 의 3 번째
+/// 인자). config 표면의 타입이므로 여기서 다시 노출한다.
+pub const PhysicalCode = physical_key.PhysicalCode;
 
 const WCHAR = u16;
 
@@ -1743,6 +1745,16 @@ test "#493 3-c — Linux keysym 정규화는 값만 되돌리고 Shift 를 건�
     // 숫자는 건드리지 않는다 — `exclam` 이 `1` 이 되면 동작이 넓어진다.
     try std.testing.expectEqual(@as(u32, 0x21), normalizeLinuxKeysym(0x21)); // ! 그대로
     try std.testing.expectEqual(@as(u32, 0x31), normalizeLinuxKeysym(0x31)); // 1 그대로
+}
+
+/// #493 3-c — `[keys]` 문법의 키 문자열 하나를 `Hotkey` 로. host 의 테스트와 설정
+/// UI 가 쓴다. 실패 원인이 필요하면 `parseHotkeyString` 을 직접 쓴다 — 여기서는
+/// "되면 값, 안 되면 null" 만 준다.
+pub fn appBindingHotkey(text: []const u8) ?Hotkey {
+    return switch (parseHotkeyString(text, .app_binding)) {
+        .ok => |p| Hotkey.fromParsed(p),
+        else => null,
+    };
 }
 
 /// #493 3-c — config 액션을 런타임 입력으로 옮긴다. **세 host 가 이 한 표를 쓴다** —

--- a/src/config.zig
+++ b/src/config.zig
@@ -1455,9 +1455,10 @@ pub fn defaultConfigTomlWithHotkey(
     // `[keys]` 는 액션 수가 많아 별 helper 로 조립한다. **최상위 스칼라 뒤, 테이블
     // 뒤**에 온다 — TOML 은 테이블 헤더 다음의 키를 그 테이블 소속으로 읽으므로
     // 순서를 바꿀 수 없다.
-    // 액션 25 개 × 한 줄 ~60 byte + 그룹 주석. 고정 버퍼로 충분하고 (이 코드베이스의
-    // `Io.Writer.fixed` 패턴) 넘치면 `writeAll` 이 오류를 낸다 — 조용히 잘리지 않는다.
-    var keys_buf: [4096]u8 = undefined;
+    // 액션 23 개 × 한 줄 ~60 byte + 안내 주석 (라벨 / 위치 두 표기 설명이 들어가
+    // 커졌다). 고정 버퍼로 충분하고 (이 코드베이스의 `Io.Writer.fixed` 패턴) 넘치면
+    // `writeAll` 이 오류를 낸다 — 조용히 잘리지 않는다.
+    var keys_buf: [8192]u8 = undefined;
     var keys_fbs: std.Io.Writer = .fixed(&keys_buf);
     try appendKeysSection(&keys_fbs);
     const keys = keys_fbs.buffered();
@@ -1601,13 +1602,29 @@ fn appendKeysSection(w: *std.Io.Writer) !void {
         \\# An action may have several keys. An empty list [] means "no shortcut".
         \\#
         \\# `cmd` resolves per OS -- Super on Linux, Win on Windows, Command on
-        \\# macOS -- so this file works unchanged on all three.
+        \\# macOS -- so a combination you write yourself works on all three.
         \\#
-        \\# Accepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return,
-        \\#                grave(`), pageup, pagedown, [, ]
+        \\# A key can be named two ways:
         \\#
-        \\# See CONFIG.md for the full syntax and KEYBINDINGS.md if your keyboard
-        \\# layout is not US QWERTY.
+        \\#   by label      "ctrl+shift+w"        the letter printed on the key
+        \\#   by position   "ctrl+shift+[KeyW]"   the physical spot, any layout
+        \\#
+        \\# Labels are simpler and are what these defaults use. Use a position when
+        \\# a label cannot reach the key -- on a Cyrillic or Greek layout no key
+        \\# produces `w`, so "ctrl+shift+w" can never fire. Position names are W3C
+        \\# KeyboardEvent.code values: https://www.w3.org/TR/uievents-code/
+        \\#
+        \\# Accepted labels: F1-F12, A-Z, 0-9, space, tab, escape, return,
+        \\#                  grave(`), pageup, pagedown, [, ]
+        \\# Accepted positions: every key a keyboard can send -- letters, digits,
+        \\#                  symbols, numpad, arrows, F13-F24. See CONFIG.md.
+        \\#
+        \\# Scrolling (shift+pageup / shift+pagedown) and ctrl+c are not here: the
+        \\# first is the mouse wheel driven from the keyboard, the second sends
+        \\# SIGINT. Neither can be rebound.
+        \\#
+        \\# CONFIG.md has the full syntax; KEYBINDINGS.md has worked examples for
+        \\# AZERTY and non-Latin keyboards.
         \\# ─────────────────────────────────────────────────────────────────────────
         \\
         \\[keys]

--- a/src/config.zig
+++ b/src/config.zig
@@ -1096,12 +1096,12 @@ pub fn defaultConfigTomlWithHotkey(
     const head = try std.fmt.allocPrint(allocator,
         \\# TildaZ config
         \\#
-        \\# v0.9.0 부터 config 는 TOML 입니다. 이전 JSON 설정을 쓰고 있었다면
-        \\# 같은 폴더의 config_N.json 에 그대로 남아 있습니다 (더는 읽지 않습니다).
+        \\# Since v0.9.0 this file is TOML. If you had a JSON config, it is still
+        \\# next to this file as config_N.json -- TildaZ no longer reads it.
         \\#
-        \\# 값의 의미와 허용 범위: CONFIG.md
+        \\# Field meanings and accepted ranges: CONFIG.md
         \\
-        \\# 전역 핫키 — TildaZ 가 떠 있지 않아도 OS 가 받습니다.
+        \\# Global hotkey -- the OS delivers this even when TildaZ is not focused.
         \\hotkey           = "{s}"
         \\
         \\shell            = "{s}"
@@ -1250,27 +1250,30 @@ fn appendKeysSection(w: *std.Io.Writer) !void {
     try w.writeAll(
         \\
         \\# ─────────────────────────────────────────────────────────────────────────
-        \\# 단축키
+        \\# Keyboard shortcuts
         \\#
-        \\# 액션 하나에 키를 여러 개 줄 수 있습니다. 빈 리스트 [] 는 단축키 없음입니다.
+        \\# An action may have several keys. An empty list [] means "no shortcut".
         \\#
-        \\# `cmd` 는 OS 마다 알맞게 풀립니다 — Linux Super / Windows Win / macOS
-        \\# Command. 그래서 이 파일을 세 OS 에서 그대로 쓸 수 있습니다.
+        \\# `cmd` resolves per OS -- Super on Linux, Win on Windows, Command on
+        \\# macOS -- so this file works unchanged on all three.
         \\#
-        \\# 받는 키: F1-F12, A-Z, 0-9, space, tab, escape, return, grave(`),
-        \\#          pageup, pagedown
+        \\# Accepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return,
+        \\#                grave(`), pageup, pagedown, [, ]
+        \\#
+        \\# See CONFIG.md for the full syntax and KEYBINDINGS.md if your keyboard
+        \\# layout is not US QWERTY.
         \\# ─────────────────────────────────────────────────────────────────────────
         \\
         \\[keys]
         \\
-        \\# 탭
+        \\# Tabs
         \\
     );
     const groups = [_]struct { title: ?[]const u8, actions: []const KeyAction }{
         .{ .title = null, .actions = &.{ .new_tab, .close_tab, .prev_tab, .next_tab, .switch_tab1, .switch_tab2, .switch_tab3, .switch_tab4, .switch_tab5, .switch_tab6, .switch_tab7, .switch_tab8, .switch_tab9 } },
-        .{ .title = "클립보드", .actions = &.{ .copy_selection, .paste } },
-        .{ .title = "창", .actions = &.{ .fullscreen, .fullscreen_workarea, .quit } },
-        .{ .title = "도구", .actions = &.{ .reset_terminal, .show_about, .open_config, .open_log, .dump_perf } },
+        .{ .title = "Clipboard", .actions = &.{ .copy_selection, .paste } },
+        .{ .title = "Window", .actions = &.{ .fullscreen, .fullscreen_workarea, .quit } },
+        .{ .title = "Tools", .actions = &.{ .reset_terminal, .show_about, .open_config, .open_log, .dump_perf } },
     };
     for (groups) |g| {
         if (g.title) |t| {

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,13 +1,14 @@
 // Cross-platform config_N.json schema + parser. Windows + macOS 같은 nested
 // schema, default 만 OS-specific (font.family / font.size / shell / hotkey
-// 등). `Defaults` struct + `defaultConfigJson(alloc, shell_resolved)` 가 schema
+// 등). `Defaults` struct + `defaultConfigToml(alloc, shell_resolved)` 가 schema
 // single source — createDefault 가 그대로 파일에 저장 + parse 시 user config
 // 와 비교 (`validateStructure`) 검증의 ground truth.
 //
-// 새 필드 추가 시 *Defaults + defaultConfigJson 한 곳만* update 하면 required /
+// 새 필드 추가 시 *Defaults + defaultConfigToml 한 곳만* update 하면 required /
 // unknown / type 검증 자동 sync. value range 만 별도 hardcoded.
 
 const std = @import("std");
+const toml = @import("toml");
 const Runtime = @import("runtime.zig").Runtime;
 const builtin = @import("builtin");
 const windows = std.os.windows;
@@ -756,7 +757,7 @@ fn eqIc(a: []const u8, b: []const u8) bool {
 // 나란히 두어서 한눈에 비교 / 편집 가능.
 //
 // 이 한 곳만 고치면:
-//   (a) `defaultConfigJson(alloc, shell_resolved)` — Defaults 값 그대로 JSON
+//   (a) `defaultConfigToml(alloc, shell_resolved)` — Defaults 값 그대로 TOML
 //       템플릿 생성. 첫 실행 시 디스크의 `config_0.json`
 //       에 저장됨 + parse() 의 `validateStructure` 가 schema 검증 ground
 //       truth 로 사용. shell 만 host 가 첫 실행 시점에 resolveShell 로 결정해
@@ -841,14 +842,26 @@ pub const Defaults = struct {
 ///   - macOS: `$SHELL` env 가 있으면 그 값, 없으면 `Defaults.shell` (= `/bin/bash`).
 /// 이렇게 disk 에 명시값으로 적어두면 이후 실행은 disk 그대로 사용 — host 의
 /// runtime fallback 분기 없음 (config 가 단일 source of truth).
-pub fn defaultConfigJson(
+/// 기본 config 문서 (TOML). 두 곳에서 쓴다:
+///   (a) 첫 실행 시 `config_N.toml` 생성
+///   (b) `parse` 의 schema 검증 — 이 문서를 파싱해 key set / 구조 / 타입의 기준으로 삼는다
+///
+/// 그래서 **새 필드를 추가할 때 `Defaults` 와 이 함수 두 곳만** 고치면 required key
+/// 검증까지 따라온다.
+///
+/// 키 순서와 빈 줄 묶음은 의도된 것이다 (#493 결정 10) — **부르는 법 → 안에서 도는 것
+/// → 언제 뜨는가 → 어떻게 보이는가 → 한계**. TOML 은 파싱이 순서와 무관하므로 순전히
+/// 읽는 사람을 위한 배치다.
+///
+/// TOML 제약: **최상위 스칼라는 테이블 헤더보다 먼저** 와야 한다. `[window]` 뒤에
+/// `theme` 을 두면 `window.theme` 으로 해석된다.
+pub fn defaultConfigToml(
     allocator: std.mem.Allocator,
     shell_resolved: []const u8,
 ) ![]const u8 {
-    return defaultConfigJsonWithHotkey(allocator, shell_resolved, Defaults.hotkey);
+    return defaultConfigTomlWithHotkey(allocator, shell_resolved, Defaults.hotkey);
 }
-
-pub fn defaultConfigJsonWithHotkey(
+pub fn defaultConfigTomlWithHotkey(
     allocator: std.mem.Allocator,
     shell_resolved: []const u8,
     hotkey: []const u8,
@@ -862,49 +875,58 @@ pub fn defaultConfigJsonWithHotkey(
         try fw.print("\"{s}\"", .{f});
     }
     try fw.writeAll("]");
-    const glyph_fallback_json = fb_fbs.buffered();
+    const glyph_fallback_toml = fb_fbs.buffered();
 
     return try std.fmt.allocPrint(allocator,
-        \\{{
-        \\  "window": {{
-        \\    "dock_position": "{s}",
-        \\    "width_percent": {d:.1},
-        \\    "height_percent": {d:.1},
-        \\    "offset_percent": {d:.1},
-        \\    "opacity_percent": {d:.1}
-        \\  }},
-        \\  "font": {{
-        \\    "family": "{s}",
-        \\    "glyph_fallback": {s},
-        \\    "size_point": {d},
-        \\    "cell_width_ratio": {d:.1},
-        \\    "line_height_ratio": {d:.1}
-        \\  }},
-        \\  "theme": "{s}",
-        \\  "shell": "{s}",
-        \\  "hotkey": "{s}",
-        \\  "auto_start": {},
-        \\  "hidden_start": {},
-        \\  "max_scroll_lines": {d}
-        \\}}
+        \\# TildaZ config
+        \\#
+        \\# v0.9.0 부터 config 는 TOML 입니다. 이전 JSON 설정을 쓰고 있었다면
+        \\# 같은 폴더의 config_N.json 에 그대로 남아 있습니다 (더는 읽지 않습니다).
+        \\#
+        \\# 값의 의미와 허용 범위: CONFIG.md
+        \\
+        \\# 전역 핫키 — TildaZ 가 떠 있지 않아도 OS 가 받습니다.
+        \\hotkey           = "{s}"
+        \\
+        \\shell            = "{s}"
+        \\
+        \\auto_start       = {}
+        \\hidden_start     = {}
+        \\
+        \\theme            = "{s}"
+        \\max_scroll_lines = {d}
+        \\
+        \\[window]
+        \\dock_position   = "{s}"   # top | bottom | left | right
+        \\width_percent   = {d:.1}
+        \\height_percent  = {d:.1}
+        \\offset_percent  = {d:.1}
+        \\opacity_percent = {d:.1}
+        \\
+        \\[font]
+        \\family            = "{s}"
+        \\glyph_fallback    = {s}
+        \\size_point        = {d}
+        \\cell_width_ratio  = {d:.1}
+        \\line_height_ratio = {d:.1}
         \\
     , .{
+        hotkey,
+        shell_resolved,
+        Defaults.auto_start,
+        Defaults.hidden_start,
+        Defaults.theme,
+        Defaults.max_scroll_lines,
         Defaults.dock_position,
         Defaults.width_percent,
         Defaults.height_percent,
         Defaults.offset_percent,
         Defaults.opacity_percent,
         Defaults.font_family,
-        glyph_fallback_json,
+        glyph_fallback_toml,
         Defaults.font_size_point,
         Defaults.cell_width_ratio,
         Defaults.line_height_ratio,
-        Defaults.theme,
-        shell_resolved,
-        hotkey,
-        Defaults.auto_start,
-        Defaults.hidden_start,
-        Defaults.max_scroll_lines,
     });
 }
 
@@ -1056,8 +1078,26 @@ pub const Config = struct {
 
     fn parse(rt: Runtime, allocator: std.mem.Allocator, content: []const u8, config_path: []const u8) Config {
         var config = Config{};
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch |err| {
-            const msg = std.fmt.allocPrint(
+        // #493 — TOML. `toml.Table` 로 받아 **값 트리**를 직접 훑는다. 구조체 매핑을
+        // 쓰지 않는 이유는 아래 필드별 오류 메시지다 — 매핑에 맡기면 "어느 필드가 왜
+        // 틀렸는지" 가 파서의 일반 오류로 퇴화한다.
+        var parser: toml.Parser(toml.Table) = .init(allocator);
+        defer parser.deinit();
+        var parsed = parser.parseString(content) catch |err| {
+            // TOML 파서는 구문 오류의 **위치**를 준다 (JSON 은 오류 이름만 줬다).
+            // 사용자가 어디를 고쳐야 할지 알 수 있게 line / col 을 함께 보여 준다.
+            const msg = if (parser.error_info) |info| switch (info) {
+                .parse => |pos| std.fmt.allocPrint(
+                    std.heap.page_allocator,
+                    messages.config_parse_failed_at_format,
+                    .{ config_path, pos.line, pos.pos, @errorName(err) },
+                ) catch messages.config_parse_failed_fallback_msg,
+                .struct_mapping => std.fmt.allocPrint(
+                    std.heap.page_allocator,
+                    messages.config_parse_failed_format,
+                    .{ config_path, @errorName(err) },
+                ) catch messages.config_parse_failed_fallback_msg,
+            } else std.fmt.allocPrint(
                 std.heap.page_allocator,
                 messages.config_parse_failed_format,
                 .{ config_path, @errorName(err) },
@@ -1066,19 +1106,20 @@ pub const Config = struct {
         };
         defer parsed.deinit();
 
-        const root = parsed.value;
-        if (root != .object) showConfigFatalMsg(rt, config_path, messages.config_top_level_must_be_object_msg);
+        // TOML 문서의 최상위는 **항상 테이블**이라 JSON 의 "top-level must be object"
+        // 검사가 필요 없다. 그 자리를 파서가 문법으로 보장한다.
+        const root: toml.Value = .{ .table = &parsed.value };
 
         // font.family / font.glyph_fallback 의 type 만 우선 사전 체크 —
         // validateStructure 의 일반 missing-key / type-mismatch 메시지보다 schema
         // 의도 (primary single string + glyph fallback list) 를 명확히 안내.
-        if (root == .object) {
-            if (root.object.get("font")) |fv_pre| {
-                if (fv_pre == .object) {
-                    if (fv_pre.object.get("family")) |fam_v| {
+        if (true) {
+            if (root.table.get("font")) |fv_pre| {
+                if (fv_pre == .table) {
+                    if (fv_pre.table.get("family")) |fam_v| {
                         if (fam_v != .string) font_validate.showFamilyMustBeStringFatal(rt);
                     }
-                    if (fv_pre.object.get("glyph_fallback")) |fb_v| {
+                    if (fv_pre.table.get("glyph_fallback")) |fb_v| {
                         if (fb_v != .array) font_validate.showGlyphFallbackMustBeListFatal(rt);
                         for (fb_v.array.items) |item| {
                             if (item != .string) font_validate.showGlyphFallbackMustBeListFatal(rt);
@@ -1088,17 +1129,20 @@ pub const Config = struct {
             }
         }
 
-        // Schema 검증 — `defaultConfigJson` 과 비교 (key set + nested 구조 + type).
+        // Schema 검증 — `defaultConfigToml` 과 비교 (key set + nested 구조 + type).
         // shell 인자는 schema 검증 시 *값* 무관 — `Defaults.shell` 한 번 사용.
-        const default_json = defaultConfigJson(allocator, Defaults.shell) catch unreachable;
-        defer allocator.free(default_json);
-        var default_parsed = std.json.parseFromSlice(std.json.Value, allocator, default_json, .{}) catch unreachable;
+        const default_doc = defaultConfigToml(allocator, Defaults.shell) catch unreachable;
+        defer allocator.free(default_doc);
+        var default_parser: toml.Parser(toml.Table) = .init(allocator);
+        defer default_parser.deinit();
+        var default_parsed = default_parser.parseString(default_doc) catch unreachable;
         defer default_parsed.deinit();
-        validateStructure(rt, root, default_parsed.value, "(top-level)", config_path);
+        const default_root: toml.Value = .{ .table = &default_parsed.value };
+        validateStructure(rt, root, default_root, "(top-level)", config_path);
 
         // window section
-        if (root.object.get("window")) |wv| {
-            if (wv.object.get("dock_position")) |v| {
+        if (root.table.get("window")) |wv| {
+            if (wv.table.get("dock_position")) |v| {
                 if (DockPosition.fromString(v.string)) |dp| {
                     config.dock_position = dp;
                 } else {
@@ -1111,22 +1155,22 @@ pub const Config = struct {
                     showConfigFatalMsg(rt, config_path, msg);
                 }
             }
-            if (wv.object.get("width_percent")) |v| {
+            if (wv.table.get("width_percent")) |v| {
                 const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.width_percent"});
                 if (f < 1.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.width_percent", "1..100" });
                 config.width_percent = f;
             }
-            if (wv.object.get("height_percent")) |v| {
+            if (wv.table.get("height_percent")) |v| {
                 const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.height_percent"});
                 if (f < 1.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.height_percent", "1..100" });
                 config.height_percent = f;
             }
-            if (wv.object.get("offset_percent")) |v| {
+            if (wv.table.get("offset_percent")) |v| {
                 const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.offset_percent"});
                 if (f < 0.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.offset_percent", "0..100" });
                 config.offset_percent = f;
             }
-            if (wv.object.get("opacity_percent")) |v| {
+            if (wv.table.get("opacity_percent")) |v| {
                 const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.opacity_percent"});
                 if (f < 0.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.opacity_percent", "0..100" });
                 config.opacity_alpha = @round(f * 255.0 / 100.0);
@@ -1134,7 +1178,7 @@ pub const Config = struct {
         }
 
         // theme
-        if (root.object.get("theme")) |v| {
+        if (root.table.get("theme")) |v| {
             if (v.string.len > 0) {
                 config.theme = themes.findTheme(v.string);
                 if (config.theme == null) {
@@ -1152,7 +1196,7 @@ pub const Config = struct {
         }
 
         // hotkey
-        if (root.object.get("hotkey")) |v| {
+        if (root.table.get("hotkey")) |v| {
             if (Hotkey.fromString(v.string)) |h| {
                 config.hotkey = h;
             } else {
@@ -1171,7 +1215,7 @@ pub const Config = struct {
         }
 
         // shell
-        if (root.object.get("shell")) |v| {
+        if (root.table.get("shell")) |v| {
             if (v.string.len > 0) {
                 config.shell = allocator.dupe(u8, v.string) catch v.string;
             } else {
@@ -1180,11 +1224,11 @@ pub const Config = struct {
         }
 
         // auto_start / hidden_start
-        if (root.object.get("auto_start")) |v| config.auto_start = v.bool;
-        if (root.object.get("hidden_start")) |v| config.hidden_start = v.bool;
+        if (root.table.get("auto_start")) |v| config.auto_start = v.boolean;
+        if (root.table.get("hidden_start")) |v| config.hidden_start = v.boolean;
 
         // max_scroll_lines
-        if (root.object.get("max_scroll_lines")) |v| {
+        if (root.table.get("max_scroll_lines")) |v| {
             if (v.integer < 100 or v.integer > 10_000_000) {
                 showConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "max_scroll_lines", "100..10_000_000" });
             }
@@ -1194,19 +1238,19 @@ pub const Config = struct {
         // font section — schema validateStructure 로 family / size_point /
         // cell_width_ratio / line_height_ratio 모두 required + type 검증 끝남.
         // 여기서는 value range + parse.
-        const fv = root.object.get("font").?;
-        if (fv.object.get("size_point")) |v| {
+        const fv = root.table.get("font").?;
+        if (fv.table.get("size_point")) |v| {
             if (v.integer < 8 or v.integer > 72) {
                 showConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "font.size_point", "8..72" });
             }
             config.font_size_point = @intCast(v.integer);
         }
-        if (fv.object.get("cell_width_ratio")) |v| {
+        if (fv.table.get("cell_width_ratio")) |v| {
             const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.cell_width_ratio"});
             if (f < 0.5 or f > 2.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.cell_width_ratio", "0.5..2.0" });
             config.cell_width_ratio = f;
         }
-        if (fv.object.get("line_height_ratio")) |v| {
+        if (fv.table.get("line_height_ratio")) |v| {
             const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.line_height_ratio"});
             if (f < 0.5 or f > 2.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.line_height_ratio", "0.5..2.0" });
             config.line_height_ratio = f;
@@ -1215,7 +1259,7 @@ pub const Config = struct {
         // 보장됨 (위 font_validate.showFamilyMustBeStringFatal). 여기서는 빈
         // 문자열만 reject + chain[0] 에 저장.
         var chain_count: usize = 0;
-        if (fv.object.get("family")) |v| {
+        if (fv.table.get("family")) |v| {
             if (v.string.len == 0) showConfigFatalMsg(rt, config_path, messages.config_font_family_empty_msg);
             config.font_families[0] = allocator.dupe(u8, v.string) catch v.string;
             chain_count = 1;
@@ -1225,7 +1269,7 @@ pub const Config = struct {
         // 체크 보장. 빈 array 는 허용 (system fallback 만 의존). chain[1..] 에
         // 저장. chain 총 길이 (1 + fallback) 가 MAX_FONT_FAMILIES 초과 시 fatal —
         // silent truncate 방지.
-        if (fv.object.get("glyph_fallback")) |v| {
+        if (fv.table.get("glyph_fallback")) |v| {
             for (v.array.items) |item| {
                 if (item.string.len == 0) continue;
                 if (chain_count >= MAX_FONT_FAMILIES) {
@@ -1252,7 +1296,7 @@ pub const Config = struct {
     fn createDefault(rt: Runtime, allocator: std.mem.Allocator, path: []const u8, shell_resolved: []const u8) void {
         const file = std.Io.Dir.createFileAbsolute(rt.io, path, .{}) catch return;
         defer file.close(rt.io);
-        const json_text = defaultConfigJson(allocator, shell_resolved) catch return;
+        const json_text = defaultConfigToml(allocator, shell_resolved) catch return;
         defer allocator.free(json_text);
         file.writeStreamingAll(rt.io, json_text) catch {};
     }
@@ -1323,7 +1367,7 @@ pub const Config = struct {
 
 // --- Helpers ---
 
-fn parseFloat(v: std.json.Value) ?f32 {
+fn parseFloat(v: toml.Value) ?f32 {
     return switch (v) {
         .integer => |i| @floatFromInt(i),
         .float => |f| @floatCast(f),
@@ -1353,7 +1397,10 @@ fn showConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const u
 ///
 /// value range / 의미 검증은 caller (각 필드 별로 hardcoded — default 만으로는
 /// "1..100" 같은 range 표현 불가).
-fn validateStructure(rt: Runtime, user: std.json.Value, def: std.json.Value, ctx: []const u8, config_path: []const u8) void {
+/// #493 — `std.json.Value` 트리 비교에서 `toml.Value` 트리 비교로 옮겼다. 구조는
+/// 그대로다: 사용자 문서와 `defaultConfigToml` 을 파싱한 기준 문서를 같은 자리에서
+/// 비교해 key set · 중첩 · 타입을 검사한다.
+fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []const u8, config_path: []const u8) void {
     const user_tag = std.meta.activeTag(user);
     const def_tag = std.meta.activeTag(def);
     if (user_tag != def_tag) {
@@ -1370,12 +1417,12 @@ fn validateStructure(rt: Runtime, user: std.json.Value, def: std.json.Value, ctx
         }
     }
 
-    if (user_tag != .object) return;
+    if (user_tag != .table) return;
 
-    var def_iter = def.object.iterator();
+    var def_iter = def.table.iterator();
     while (def_iter.next()) |entry| {
         const key = entry.key_ptr.*;
-        if (user.object.get(key) == null) {
+        if (user.table.get(key) == null) {
             var buf: [512]u8 = undefined;
             const msg = std.fmt.bufPrint(
                 &buf,
@@ -1386,10 +1433,10 @@ fn validateStructure(rt: Runtime, user: std.json.Value, def: std.json.Value, ctx
         }
     }
 
-    var user_iter = user.object.iterator();
+    var user_iter = user.table.iterator();
     while (user_iter.next()) |entry| {
         const key = entry.key_ptr.*;
-        if (def.object.get(key) == null) {
+        if (def.table.get(key) == null) {
             // `_` prefix key 는 사용자 주석 — 알 수 없는 key 라도 무시 (#173).
             // JSON 표준 자체엔 주석 없지만 convention. schema 의 정식 key 는
             // 모두 `_` 안 붙으니 기존 검증과 충돌 X. type / 재귀 검사도 모두
@@ -1405,10 +1452,10 @@ fn validateStructure(rt: Runtime, user: std.json.Value, def: std.json.Value, ctx
         }
     }
 
-    var rec_iter = def.object.iterator();
+    var rec_iter = def.table.iterator();
     while (rec_iter.next()) |entry| {
         const key = entry.key_ptr.*;
-        const u_val = user.object.get(key).?;
+        const u_val = user.table.get(key).?;
         var path_buf: [256]u8 = undefined;
         const path = if (std.mem.eql(u8, ctx, "(top-level)"))
             std.fmt.bufPrint(&path_buf, "{s}", .{key}) catch key
@@ -1485,33 +1532,51 @@ test "terminal font defaults use the cross-platform logical size contract" {
     try std.testing.expectEqual(@as(f32, 1.1), spec.line_height_ratio);
 }
 
-test "default config JSON uses the common terminal font defaults" {
+test "default config TOML uses the common terminal font defaults" {
     const allocator = std.testing.allocator;
-    const json_text = try defaultConfigJson(allocator, Defaults.shell);
-    defer allocator.free(json_text);
+    const doc = try defaultConfigToml(allocator, Defaults.shell);
+    defer allocator.free(doc);
 
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_text, .{});
+    var parser: toml.Parser(toml.Table) = .init(allocator);
+    defer parser.deinit();
+    var parsed = try parser.parseString(doc);
     defer parsed.deinit();
 
-    const font = parsed.value.object.get("font").?.object;
+    const font = parsed.value.get("font").?.table;
     try std.testing.expectEqual(@as(i64, 15), font.get("size_point").?.integer);
     try std.testing.expectEqual(@as(f64, 1.1), font.get("line_height_ratio").?.float);
+
+    // #493 — 확정한 키 순서 (결정 10) 를 문서 자체로 고정한다. 순서가 흐트러지면
+    // "부르는 법 → 안에서 도는 것 → 언제 뜨는가 → 어떻게 보이는가 → 한계" 의 의도가
+    // 사라진다. TOML 은 파싱이 순서와 무관하므로 파싱 결과로는 잡히지 않는다.
+    const order = [_][]const u8{
+        "hotkey", "shell", "auto_start", "hidden_start", "theme", "max_scroll_lines",
+        "[window]", "[font]",
+    };
+    var at: usize = 0;
+    for (order) |needle| {
+        const found = std.mem.findPos(u8, doc, at, needle) orelse return error.TestUnexpectedResult;
+        at = found + needle.len;
+    }
+    // 최상위 스칼라가 테이블 헤더보다 뒤에 오면 TOML 이 그 테이블 소속으로 해석한다.
+    const first_header = std.mem.find(u8, doc, "[window]").?;
+    try std.testing.expect(std.mem.find(u8, doc, "max_scroll_lines").? < first_header);
 }
 
 test "explicit line height ratio is preserved when parsing" {
     const allocator = std.testing.allocator;
-    const json_text = @constCast(try defaultConfigJson(allocator, Defaults.shell));
+    const json_text = @constCast(try defaultConfigToml(allocator, Defaults.shell));
     defer allocator.free(json_text);
 
-    const expected = "\"line_height_ratio\": 1.1";
+    const expected = "line_height_ratio = 1.1";
     const offset = std.mem.find(u8, json_text, expected) orelse return error.TestUnexpectedResult;
     const value_offset = offset + expected.len - 3;
     @memcpy(json_text[value_offset .. value_offset + 3], "0.9");
 
-    // #451 — 정상 JSON 이라 `parse` 가 fatal 경로 (config 경로 조회) 로 가지 않는다.
+    // #451 — 정상 문서라 `parse` 가 fatal 경로 (config 경로 조회) 로 가지 않는다.
     // 그래서 `Environ.empty` 로 두어 테스트가 기계의 환경에 안 묶이게 한다.
     const rt: Runtime = .{ .io = std.testing.io, .environ = .empty };
-    const config = Config.parse(rt, allocator, json_text, "/tmp/config_0.json");
+    const config = Config.parse(rt, allocator, json_text, "/tmp/config_0.toml");
     defer config.deinit(allocator);
     try std.testing.expectEqual(@as(f32, 0.9), config.line_height_ratio);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -105,6 +105,10 @@ const HotkeyNamedKey = enum {
     tab,
     escape,
     @"return",
+    page_up,
+    page_down,
+    bracket_left,
+    bracket_right,
 };
 
 const HotkeyKeyToken = union(enum) {
@@ -136,7 +140,7 @@ pub const HotkeyFailure = enum {
 /// `parseHotkeyString` 을 쓴다 — 두 곳에 규칙을 두면 갈라진다 (#484 의 원인이
 /// writer/matcher 가 갈라진 것이었다).
 pub fn hotkeyFailure(s: []const u8) ?HotkeyFailure {
-    return switch (parseHotkeyString(s)) {
+    return switch (parseHotkeyString(s, .global_hotkey)) {
         .ok => null,
         .unknown_key => .unknown_key,
         .modifier_required => .modifier_required,
@@ -149,7 +153,16 @@ const HotkeyParse = union(enum) {
     modifier_required,
 };
 
-fn parseHotkeyString(s: []const u8) HotkeyParse {
+/// 파싱 규칙이 쓰임새에 따라 다르다 (#493). `parseHotkeyString` 참고.
+pub const HotkeyScope = enum {
+    /// `hotkey` — OS 에 등록하는 전역 핫키. modifier 없는 일반 키를 허용하면 OS
+    /// 전체의 타이핑을 가로챈다.
+    global_hotkey,
+    /// `[keys]` — 앱 내부 단축키. 터미널 focus 중에만 유효하므로 위험 범위가 좁다.
+    app_binding,
+};
+
+fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
     var ctrl = false;
     var shift = false;
     var alt = false;
@@ -187,7 +200,34 @@ fn parseHotkeyString(s: []const u8) HotkeyParse {
         },
         .char => false,
     };
-    if (!(ctrl or alt or super) and !is_function_key) return .modifier_required;
+    if (scope == .global_hotkey) {
+        if (!(ctrl or alt or super) and !is_function_key) return .modifier_required;
+    } else {
+        // #493 — `[keys]` (앱 내부 단축키) 는 규칙이 다르다. 전역 핫키의 제약은 *OS
+        // 전체의 입력을 가로채는* 것을 막기 위한 것이고, 앱 내부 단축키는 터미널이
+        // focus 를 가진 동안만 유효하다. 그래서 위험의 성질이 다르다.
+        //
+        // 여기서 막아야 하는 것은 **타이핑을 훔치는 것**이다. `shift+t` 를 허용하면
+        // 터미널에 `T` 를 칠 수 없다. 반면 `shift+pageup` 은 PageUp 이 글자를 내는
+        // 키가 아니라 무해하다 — 그리고 기본 bindings 가 그것을 쓴다.
+        //
+        // 그래서 판정 기준을 "modifier 유무" 가 아니라 **그 키가 글자를 내는가** 로
+        // 둔다. 글자를 내지 않는 키 (F1~F12 · PageUp · PageDown) 는 modifier 없이도
+        // 안전하고, 글자를 내는 키는 ctrl / alt / super 중 하나가 필요하다.
+        const types_text = switch (resolved) {
+            .char => true,
+            .named => |n| switch (n) {
+                .space, .tab, .@"return" => true,
+                .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12 => false,
+                .page_up, .page_down => false,
+                .escape => false,
+                // 글자를 내는 키 — modifier 없이 바인딩하면 터미널에 그 글자를 칠 수
+                // 없게 된다.
+                .grave, .bracket_left, .bracket_right => true,
+            },
+        };
+        if (types_text and !(ctrl or alt or super)) return .modifier_required;
+    }
     return .{ .ok = .{ .ctrl = ctrl, .shift = shift, .alt = alt, .super = super, .key = resolved } };
 }
 
@@ -214,6 +254,14 @@ fn hotkeyKeyFromName(name: []const u8) ?HotkeyKeyToken {
         .{ .name = "backquote", .key = .grave },  .{ .name = "tab", .key = .tab },
         .{ .name = "escape", .key = .escape },    .{ .name = "esc", .key = .escape },
         .{ .name = "return", .key = .@"return" }, .{ .name = "enter", .key = .@"return" },
+        // #493 — `[keys]` 의 기본 bindings 가 쓴다 (scroll_page_up / prev_tab 등).
+        // 어느 layout 에나 있는 단일 물리 키라 layout 종속 문제가 없다 (#482).
+        .{ .name = "pageup", .key = .page_up },   .{ .name = "pgup", .key = .page_up },
+        .{ .name = "pagedown", .key = .page_down }, .{ .name = "pgdn", .key = .page_down },
+        // #493 — 기본 bindings 의 `prev_tab` / `next_tab` 이 쓴다. 세 platform 의 키
+        // 값이 이미 기존 매처에 있어 추측이 아니다 (아래 각 map 의 주석 참고).
+        .{ .name = "bracketleft", .key = .bracket_left },
+        .{ .name = "bracketright", .key = .bracket_right },
     };
     for (map) |entry| {
         if (eqIc(name, entry.name)) return .{ .named = entry.key };
@@ -224,6 +272,8 @@ fn hotkeyKeyFromName(name: []const u8) ?HotkeyKeyToken {
         if (c >= 'a' and c <= 'z') return .{ .char = c };
         if (c >= '0' and c <= '9') return .{ .char = c };
         if (c == '`') return .{ .named = .grave };
+        if (c == '[') return .{ .named = .bracket_left };
+        if (c == ']') return .{ .named = .bracket_right };
     }
     return null;
 }
@@ -325,10 +375,16 @@ const LinuxHotkey = struct {
     pub const MOD_SUPER: u32 = 0x8; // Win key / Super / `cmd` 토큰.
 
     pub fn fromString(s: []const u8) ?LinuxHotkey {
-        const parsed = switch (parseHotkeyString(s)) {
+        const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
             else => return null,
         };
+        return fromParsed(parsed);
+    }
+
+    /// #493 — `[keys]` 파싱이 같은 변환을 쓴다. `fromString` 안에 두면 scope 마다
+    /// 복제해야 하고, 복제하면 갈라진다 (#484 의 교훈).
+    pub fn fromParsed(parsed: ParsedHotkey) LinuxHotkey {
         var modifiers: u32 = 0;
         if (parsed.alt) modifiers |= MOD_ALT;
         if (parsed.ctrl) modifiers |= MOD_CTRL;
@@ -360,6 +416,11 @@ const LinuxHotkey = struct {
                 .tab => 0xff09,
                 .escape => 0xff1b,
                 .@"return" => 0xff0d,
+                .page_up => 0xff55,
+                .page_down => 0xff56,
+                // `wayland_minimal.xkb_key_bracketleft` / `..right` 와 같은 값.
+                .bracket_left => 0x5b,
+                .bracket_right => 0x5d,
             },
         };
     }
@@ -381,6 +442,10 @@ pub fn linuxKeysymName(keysym: u32) ?[]const u8 {
         0xffc7 => "F10",
         0xffc8 => "F11",
         0xffc9 => "F12",
+        0xff55 => "Page_Up",
+        0xff56 => "Page_Down",
+        0x5b => "bracketleft",
+        0x5d => "bracketright",
         0xff09 => "Tab",
         0xff0d => "Return",
         0xff1b => "Escape",
@@ -446,6 +511,82 @@ test "config parser rejects unsafe global hotkeys" {
         try std.testing.expect(Hotkey.fromString("ctrl+t") != null);
         try std.testing.expect(Hotkey.fromString("ctrl+shift+t") != null);
     }
+}
+
+test "#493 [keys] scope accepts what the defaults need, and still guards typing" {
+    // 기본 bindings 가 실제로 파싱되는지 — 이게 깨지면 첫 실행부터 fatal 이다.
+    // (`ctrl+shift+[` 가 수용 집합에 없어 여기서 잡혔던 적이 있다.)
+    for (std.enums.values(KeyAction)) |action| {
+        for (defaultBindings(action)) |text| {
+            const parsed = parseHotkeyString(text, .app_binding);
+            if (parsed != .ok) {
+                std.debug.print("기본 binding 이 파싱 실패: {s} = \"{s}\" ({s})\n", .{ action.configName(), text, @tagName(parsed) });
+                return error.TestUnexpectedResult;
+            }
+        }
+    }
+
+    // `[keys]` 는 글자를 내지 않는 키를 modifier 없이 허용한다 — 기본값이 쓴다.
+    try std.testing.expect(parseHotkeyString("shift+pageup", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("pageup", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("f5", .app_binding) == .ok);
+
+    // 글자를 내는 키는 여전히 modifier 가 필요하다 — 없으면 터미널에 그 글자를
+    // 칠 수 없게 된다.
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("t", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("shift+t", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("[", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("shift+space", .app_binding));
+
+    // 전역 핫키 규칙은 더 엄격하다 — Shift 는 trigger modifier 가 아니다.
+    try std.testing.expectEqual(HotkeyParse.modifier_required, parseHotkeyString("shift+pageup", .global_hotkey));
+    try std.testing.expect(parseHotkeyString("f5", .global_hotkey) == .ok);
+}
+
+test "#493 default [keys] has no conflicting bindings" {
+    // 액션 → 키 방향을 택한 대가로 충돌 감지가 우리 몫이다 (키 → 액션이면 TOML 이
+    // 중복 키로 잡아 준다). 기본값끼리 충돌하면 첫 실행부터 fatal 이므로 고정한다.
+    var seen: [MAX_KEY_BINDINGS]KeyBinding = undefined;
+    var count: usize = 0;
+    for (std.enums.values(KeyAction)) |action| {
+        for (defaultBindings(action)) |text| {
+            const parsed = switch (parseHotkeyString(text, .app_binding)) {
+                .ok => |v| v,
+                else => return error.TestUnexpectedResult,
+            };
+            const hk = Hotkey.fromParsed(parsed);
+            for (seen[0..count]) |prev| {
+                if (std.meta.eql(prev.hotkey, hk)) {
+                    std.debug.print("기본 binding 충돌: \"{s}\" — {s} vs {s}\n", .{ text, prev.action.configName(), action.configName() });
+                    return error.TestUnexpectedResult;
+                }
+            }
+            try std.testing.expect(count < MAX_KEY_BINDINGS);
+            seen[count] = .{ .hotkey = hk, .action = action };
+            count += 1;
+        }
+    }
+    // 액션 25 개 + prev_tab / next_tab 이 2 개씩 = 27.
+    try std.testing.expectEqual(@as(usize, 27), count);
+}
+
+test "#493 generated config carries every action so none is silently missing" {
+    const allocator = std.testing.allocator;
+    const doc = try defaultConfigToml(allocator, Defaults.shell);
+    defer allocator.free(doc);
+
+    // "모든 액션을 항상 파일에 적는다" 가 결정 3 이다. 하나라도 빠지면 사용자가
+    // 읽어서 발견하거나 바꿀 수 없다.
+    for (std.enums.values(KeyAction)) |action| {
+        const name = action.configName();
+        if (std.mem.find(u8, doc, name) == null) {
+            std.debug.print("생성된 config 에 액션이 없음: {s}\n", .{name});
+            return error.TestUnexpectedResult;
+        }
+    }
+    try std.testing.expect(std.mem.find(u8, doc, "[keys]") != null);
+    // `[keys]` 는 테이블이라 최상위 스칼라보다 뒤에 와야 한다.
+    try std.testing.expect(std.mem.find(u8, doc, "max_scroll_lines").? < std.mem.find(u8, doc, "[keys]").?);
 }
 
 test "hotkey rejection reports the cause, not one blanket message" {
@@ -555,10 +696,14 @@ const WindowsHotkey = struct {
     modifiers: u32 = 0,
 
     pub fn fromString(s: []const u8) ?WindowsHotkey {
-        const parsed = switch (parseHotkeyString(s)) {
+        const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
             else => return null,
         };
+        return fromParsed(parsed);
+    }
+
+    pub fn fromParsed(parsed: ParsedHotkey) WindowsHotkey {
         var modifiers: u32 = 0;
         if (parsed.alt) modifiers |= 0x1; // MOD_ALT
         if (parsed.ctrl) modifiers |= 0x2; // MOD_CONTROL
@@ -590,6 +735,12 @@ const WindowsHotkey = struct {
                 .tab => 0x09,
                 .escape => 0x1B,
                 .@"return" => 0x0D,
+                // #493 — `VK_PRIOR` / `VK_NEXT`. #482 의 `wndProc` 이 쓰는 값과 같다.
+                .page_up => 0x21,
+                .page_down => 0x22,
+                // `VK_OEM_4` / `VK_OEM_6`. `window.zig` 의 prev/next tab 이 쓰는 값.
+                .bracket_left => 0xDB,
+                .bracket_right => 0xDD,
             },
         };
     }
@@ -632,10 +783,14 @@ const MacHotkey = struct {
     modifiers: u64 = 0,
 
     pub fn fromString(s: []const u8) ?MacHotkey {
-        const parsed = switch (parseHotkeyString(s)) {
+        const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
             else => return null,
         };
+        return fromParsed(parsed);
+    }
+
+    pub fn fromParsed(parsed: ParsedHotkey) MacHotkey {
         var modifiers: u64 = 0;
         if (parsed.shift) modifiers |= 0x00020000; // kCGEventFlagMaskShift
         if (parsed.ctrl) modifiers |= 0x00040000; // kCGEventFlagMaskControl
@@ -665,6 +820,14 @@ const MacHotkey = struct {
                 .tab => 0x30,
                 .escape => 0x35,
                 .@"return" => 0x24,
+                // #493 — `kVK_PageUp` / `kVK_PageDown`. #482 의 `host/macos.zig` 가
+                // 쓰는 값과 같다 (116 / 121 십진).
+                .page_up => 0x74,
+                .page_down => 0x79,
+                // `kVK_ANSI_LeftBracket` / `..RightBracket`. `host/macos.zig` 의
+                // prev/next tab 이 쓰는 값.
+                .bracket_left => 0x21,
+                .bracket_right => 0x1E,
             },
             // kVK_ANSI_* — parseHotkeyString 의 char 는 소문자 letter / digit 만.
             .char => |c| switch (c) {
@@ -877,7 +1040,7 @@ pub fn defaultConfigTomlWithHotkey(
     try fw.writeAll("]");
     const glyph_fallback_toml = fb_fbs.buffered();
 
-    return try std.fmt.allocPrint(allocator,
+    const head = try std.fmt.allocPrint(allocator,
         \\# TildaZ config
         \\#
         \\# v0.9.0 부터 config 는 TOML 입니다. 이전 JSON 설정을 쓰고 있었다면
@@ -928,6 +1091,22 @@ pub fn defaultConfigTomlWithHotkey(
         Defaults.cell_width_ratio,
         Defaults.line_height_ratio,
     });
+    defer allocator.free(head);
+
+    // `[keys]` 는 액션 수가 많아 별 helper 로 조립한다. **최상위 스칼라 뒤, 테이블
+    // 뒤**에 온다 — TOML 은 테이블 헤더 다음의 키를 그 테이블 소속으로 읽으므로
+    // 순서를 바꿀 수 없다.
+    // 액션 25 개 × 한 줄 ~60 byte + 그룹 주석. 고정 버퍼로 충분하고 (이 코드베이스의
+    // `Io.Writer.fixed` 패턴) 넘치면 `writeAll` 이 오류를 낸다 — 조용히 잘리지 않는다.
+    var keys_buf: [4096]u8 = undefined;
+    var keys_fbs: std.Io.Writer = .fixed(&keys_buf);
+    try appendKeysSection(&keys_fbs);
+    const keys = keys_fbs.buffered();
+
+    const out = try allocator.alloc(u8, head.len + keys.len);
+    @memcpy(out[0..head.len], head);
+    @memcpy(out[head.len..], keys);
+    return out;
 }
 
 // `Defaults` 의 string / float 값을 Config struct 가 보관하는 native type 으로
@@ -954,6 +1133,157 @@ fn defaultFontFamiliesArray() [MAX_FONT_FAMILIES][]const u8 {
     while (i < MAX_FONT_FAMILIES) : (i += 1) arr[i] = "";
     return arr;
 }
+
+/// #493 — `[keys]` 에서 바인딩할 수 있는 액션. **`input_policy.Shortcut` 과 1:1 이
+/// 아니다** — 그쪽은 런타임 dispatch 용이고 이쪽은 config 표면이다. 차이가 셋 있다:
+///
+///   - `switch_tab1`~`9` 는 config 에서 9 개지만 런타임은 `Shortcut.switch_tab`
+///     하나 + 인덱스다. 사람이 읽는 파일에서 "몇 번 탭" 이 이름에 있어야 한다.
+///   - `paste` 는 `Shortcut` 이 아니라 `Input.paste` 다 (preedit commit 정책이 달라
+///     분리돼 있다). config 표면에서는 다른 단축키와 나란히 있어야 자연스럽다.
+///   - `fullscreen_workarea` 는 별 `Shortcut` 이 없다 — 런타임은 `fullscreen` +
+///     Shift 여부로 갈린다. config 에서는 두 동작이 별 항목이어야 각각 바인딩할 수
+///     있다.
+///   - `scroll_page_*` 는 `Shortcut` 에 아예 없다 (host 가 직접 처리).
+///
+/// 그래서 이 enum 이 config 의 단일 출처이고, 런타임 매핑은 3-c 단계에서 붙인다.
+///
+/// 이름을 바꾸면 기존 사용자 config 의 그 키가 "모르는 키" 가 된다 — 결정 8 의
+/// 삭제 대상이 되므로 이름 변경은 비가산적 변경이다.
+/// #493 — 액션별 기본 키. platform 마다 다른 것은 `cmd` 토큰이 흡수한다
+/// (`parseHotkeyString` 이 Linux Super / Windows Win / macOS Cmd 를 같은 값으로
+/// 본다) — 그래서 한 표가 세 platform 을 덮는다.
+///
+/// `KeyAction` 에 variant 를 추가하면 이 표도 채워야 한다. 빠지면
+/// `defaultKeysToml` 이 컴파일 시점에 잡는다 (exhaustive switch).
+pub fn defaultBindings(action: KeyAction) []const []const u8 {
+    return switch (action) {
+        .new_tab => &.{"ctrl+shift+t"},
+        .close_tab => &.{"ctrl+shift+w"},
+        // #482 — bracket 조합은 AZERTY 에서 쓸 수 없어 (`[` = AltGr+5) PgUp / PgDn
+        // 을 layout 무관 대안으로 함께 둔다.
+        .prev_tab => &.{ "ctrl+shift+[", "ctrl+pageup" },
+        .next_tab => &.{ "ctrl+shift+]", "ctrl+pagedown" },
+        .switch_tab1 => &.{"alt+1"},
+        .switch_tab2 => &.{"alt+2"},
+        .switch_tab3 => &.{"alt+3"},
+        .switch_tab4 => &.{"alt+4"},
+        .switch_tab5 => &.{"alt+5"},
+        .switch_tab6 => &.{"alt+6"},
+        .switch_tab7 => &.{"alt+7"},
+        .switch_tab8 => &.{"alt+8"},
+        .switch_tab9 => &.{"alt+9"},
+        .copy_selection => &.{"ctrl+shift+c"},
+        .paste => &.{"ctrl+shift+v"},
+        .fullscreen => &.{"alt+return"},
+        .fullscreen_workarea => &.{"shift+alt+return"},
+        .quit => &.{"alt+f4"},
+        // Shift 단독이지만 PageUp / PageDown 은 글자를 내지 않아 타이핑을 훔치지
+        // 않는다 — `HotkeyScope.app_binding` 규칙이 이것을 허용한다.
+        .scroll_page_up => &.{"shift+pageup"},
+        .scroll_page_down => &.{"shift+pagedown"},
+        .reset_terminal => &.{"ctrl+shift+r"},
+        .show_about => &.{"ctrl+shift+i"},
+        .open_config => &.{"ctrl+shift+p"},
+        .open_log => &.{"ctrl+shift+l"},
+        .dump_perf => &.{"ctrl+shift+f12"},
+    };
+}
+
+/// `[keys]` 섹션 본문. 그룹 주석과 순서는 의도된 것이다 (#493 결정 10) — 파일을
+/// 읽는 사람이 묶음을 알아볼 수 있어야 한다.
+fn appendKeysSection(w: *std.Io.Writer) !void {
+    try w.writeAll(
+        \\
+        \\# ─────────────────────────────────────────────────────────────────────────
+        \\# 단축키
+        \\#
+        \\# 액션 하나에 키를 여러 개 줄 수 있습니다. 빈 리스트 [] 는 단축키 없음입니다.
+        \\#
+        \\# `cmd` 는 OS 마다 알맞게 풀립니다 — Linux Super / Windows Win / macOS
+        \\# Command. 그래서 이 파일을 세 OS 에서 그대로 쓸 수 있습니다.
+        \\#
+        \\# 받는 키: F1-F12, A-Z, 0-9, space, tab, escape, return, grave(`),
+        \\#          pageup, pagedown
+        \\# ─────────────────────────────────────────────────────────────────────────
+        \\
+        \\[keys]
+        \\
+        \\# 탭
+        \\
+    );
+    const groups = [_]struct { title: ?[]const u8, actions: []const KeyAction }{
+        .{ .title = null, .actions = &.{ .new_tab, .close_tab, .prev_tab, .next_tab, .switch_tab1, .switch_tab2, .switch_tab3, .switch_tab4, .switch_tab5, .switch_tab6, .switch_tab7, .switch_tab8, .switch_tab9 } },
+        .{ .title = "클립보드", .actions = &.{ .copy_selection, .paste } },
+        .{ .title = "창", .actions = &.{ .fullscreen, .fullscreen_workarea, .quit } },
+        .{ .title = "스크롤백", .actions = &.{ .scroll_page_up, .scroll_page_down } },
+        .{ .title = "도구", .actions = &.{ .reset_terminal, .show_about, .open_config, .open_log, .dump_perf } },
+    };
+    for (groups) |g| {
+        if (g.title) |t| {
+            try w.writeAll("\n# ");
+            try w.writeAll(t);
+            try w.writeAll("\n");
+        }
+        for (g.actions) |a| {
+            const name = a.configName();
+            try w.writeAll(name);
+            // 값 열을 맞춘다 — 가장 긴 이름 (`fullscreen_workarea`, 19) 기준.
+            var pad: usize = 19 + 1;
+            while (pad > name.len) : (pad -= 1) try w.writeAll(" ");
+            try w.writeAll("= [");
+            for (defaultBindings(a), 0..) |k, i| {
+                if (i > 0) try w.writeAll(", ");
+                try w.print("\"{s}\"", .{k});
+            }
+            try w.writeAll("]\n");
+        }
+    }
+}
+
+pub const KeyAction = enum {
+    new_tab,
+    close_tab,
+    prev_tab,
+    next_tab,
+    switch_tab1,
+    switch_tab2,
+    switch_tab3,
+    switch_tab4,
+    switch_tab5,
+    switch_tab6,
+    switch_tab7,
+    switch_tab8,
+    switch_tab9,
+    copy_selection,
+    paste,
+    fullscreen,
+    fullscreen_workarea,
+    quit,
+    scroll_page_up,
+    scroll_page_down,
+    reset_terminal,
+    show_about,
+    open_config,
+    open_log,
+    dump_perf,
+
+    /// config 파일에 쓰는 이름. enum tag 그대로다 — 파일과 코드가 갈라지지 않게
+    /// 별 문자열 표를 두지 않는다 (#484 의 writer/matcher 교훈).
+    pub fn configName(self: KeyAction) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// 한 액션에 키를 여러 개 줄 수 있다 (결정 3). 런타임 조회 방향은 **키 → 액션**
+/// 이므로 (키 이벤트를 받아 "무슨 액션인가" 를 묻는다) 평면 배열로 보관한다.
+pub const KeyBinding = struct {
+    hotkey: Hotkey,
+    action: KeyAction,
+};
+
+/// 액션 25 개 × 대개 1~2 개. 넉넉히 잡아 할당을 없앤다 (`font_families` 와 같은 방식).
+pub const MAX_KEY_BINDINGS = 64;
 
 pub const Config = struct {
     dock_position: DockPosition = default_dock_position,
@@ -985,6 +1315,9 @@ pub const Config = struct {
     /// chain[1..] 은 glyph fallback 순서. host / renderer 가 한 개의 array 로 받음.
     font_families: [MAX_FONT_FAMILIES][]const u8 = defaultFontFamiliesArray(),
     font_family_count: u8 = DEFAULT_FONT_CHAIN_COUNT,
+    /// #493 — `[keys]` 파싱 결과. 키 → 액션 방향으로 평면 보관한다.
+    key_bindings: [MAX_KEY_BINDINGS]KeyBinding = undefined,
+    key_binding_count: u8 = 0,
 
     pub fn terminalFontSpec(self: *const Config) font_spec.Spec {
         return .{
@@ -1290,7 +1623,111 @@ pub const Config = struct {
         while (i < MAX_FONT_FAMILIES) : (i += 1) config.font_families[i] = "";
         config.font_family_count = @intCast(chain_count);
 
+        parseKeys(rt, root, config_path, &config);
+
         return config;
+    }
+
+    /// #493 — `[keys]` 파싱. 액션 → 키 리스트를 읽어 **키 → 액션** 평면 배열로
+    /// 뒤집는다 (런타임 조회 방향이 그쪽이다).
+    ///
+    /// 액션 → 키 방향을 택한 대가로 **충돌 감지가 우리 몫**이다. 키 → 액션이었다면
+    /// 같은 키가 두 번 나오는 순간 TOML 파서가 중복 키로 잡지만, 이 방향에서는
+    /// `new_tab` 과 `open_config` 에 둘 다 `ctrl+shift+t` 를 적어도 문법상 정상이다.
+    ///
+    /// `[keys]` 자체가 없거나 특정 액션이 빠져 있으면 **기본값으로 채운다** (결정 2).
+    /// 정상 상태에서는 생성기가 모든 액션을 적으므로 이 경로는 버전 업그레이드 뒤의
+    /// 안전망이다.
+    fn parseKeys(rt: Runtime, root: toml.Value, config_path: []const u8, config: *Config) void {
+        const keys_table: ?*toml.Table = if (root.table.get("keys")) |kv|
+            (if (kv == .table) kv.table else null)
+        else
+            null;
+
+        var count: usize = 0;
+        for (std.enums.values(KeyAction)) |action| {
+            const name = action.configName();
+
+            // 이 액션의 키 목록. 파일에 있으면 그것을, 없으면 기본값을 쓴다.
+            var from_file: ?*toml.ValueList = null;
+            if (keys_table) |kt| {
+                if (kt.get(name)) |v| {
+                    if (v != .array) {
+                        var buf: [512]u8 = undefined;
+                        const msg = std.fmt.bufPrint(&buf, messages.config_key_not_list_format, .{ name, name }) catch
+                            messages.config_key_not_list_fallback_msg;
+                        showConfigFatalMsg(rt, config_path, msg);
+                    }
+                    from_file = v.array;
+                }
+            }
+
+            if (from_file) |list| {
+                for (list.items) |item| {
+                    if (item != .string) {
+                        var buf: [512]u8 = undefined;
+                        const msg = std.fmt.bufPrint(&buf, messages.config_key_not_list_format, .{ name, name }) catch
+                            messages.config_key_not_list_fallback_msg;
+                        showConfigFatalMsg(rt, config_path, msg);
+                    }
+                    count = addBinding(rt, config, count, action, item.string, config_path);
+                }
+            } else {
+                for (defaultBindings(action)) |text| {
+                    count = addBinding(rt, config, count, action, text, config_path);
+                }
+            }
+        }
+        config.key_binding_count = @intCast(count);
+    }
+
+    /// 키 문자열 하나를 파싱해 배열에 넣는다. 이미 같은 키가 있으면 **양쪽 액션을
+    /// 짚어** fatal.
+    fn addBinding(
+        rt: Runtime,
+        config: *Config,
+        count: usize,
+        action: KeyAction,
+        text: []const u8,
+        config_path: []const u8,
+    ) usize {
+        const parsed = switch (parseHotkeyString(text, .app_binding)) {
+            .ok => |v| v,
+            .unknown_key => {
+                var buf: [512]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, messages.config_key_invalid_format, .{ action.configName(), text }) catch
+                    messages.config_key_invalid_fallback_msg;
+                showConfigFatalMsg(rt, config_path, msg);
+            },
+            .modifier_required => {
+                var buf: [512]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, messages.config_key_needs_modifier_format, .{ action.configName(), text }) catch
+                    messages.config_key_needs_modifier_fallback_msg;
+                showConfigFatalMsg(rt, config_path, msg);
+            },
+        };
+        const hotkey = Hotkey.fromParsed(parsed);
+
+        for (config.key_bindings[0..count]) |existing| {
+            if (std.meta.eql(existing.hotkey, hotkey)) {
+                var buf: [512]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, messages.config_key_conflict_format, .{
+                    text,
+                    existing.action.configName(),
+                    action.configName(),
+                }) catch messages.config_key_conflict_fallback_msg;
+                showConfigFatalMsg(rt, config_path, msg);
+            }
+        }
+
+        if (count >= MAX_KEY_BINDINGS) {
+            var buf: [256]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, messages.config_key_too_many_format, .{MAX_KEY_BINDINGS}) catch
+                messages.config_key_too_many_fallback_msg;
+            showConfigFatalMsg(rt, config_path, msg);
+        }
+        config.key_bindings[count] = .{ .hotkey = hotkey, .action = action };
+        return count + 1;
     }
 
     fn createDefault(rt: Runtime, allocator: std.mem.Allocator, path: []const u8, shell_resolved: []const u8) void {
@@ -1437,11 +1874,10 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
     while (user_iter.next()) |entry| {
         const key = entry.key_ptr.*;
         if (def.table.get(key) == null) {
-            // `_` prefix key 는 사용자 주석 — 알 수 없는 key 라도 무시 (#173).
-            // JSON 표준 자체엔 주석 없지만 convention. schema 의 정식 key 는
-            // 모두 `_` 안 붙으니 기존 검증과 충돌 X. type / 재귀 검사도 모두
-            // skip — caller 가 자유로운 형식의 주석 사용 가능.
-            if (key.len > 0 and key[0] == '_') continue;
+            // #493 — `_` prefix key 를 주석 대용으로 허용하던 예외를 없앴다 (#173).
+            // JSON 에 주석이 없어서 두었던 우회인데, TOML 은 `#` 으로 진짜 주석을
+            // 쓸 수 있으므로 필요가 사라졌다. 남겨 두면 `_shell` 같은 오타가 조용히
+            // 무시돼 "왜 설정이 안 먹지" 가 된다 — 모르는 key 는 전부 알린다.
             var buf: [512]u8 = undefined;
             const msg = std.fmt.bufPrint(
                 &buf,

--- a/src/config.zig
+++ b/src/config.zig
@@ -729,14 +729,15 @@ test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
             @as(u32, physical_key.macKeyCode(pair.code)),
         );
     }
-    // 두 집합의 크기가 맞아야 한다 — 위치 집합은 named 라벨 전부 + 글자 26 + 숫자 10
-    // 이다. 한쪽에만 키를 더하면 위 `pairs` 표가 조용히 불완전해지므로 여기서 막는다.
-    try std.testing.expectEqual(
-        @typeInfo(HotkeyNamedKey).@"enum".fields.len + 26 + 10,
-        @typeInfo(PhysicalCode).@"enum".fields.len,
-    );
-    // 그리고 `pairs` 가 named 라벨을 빠짐없이 덮어야 한다.
+    // `pairs` 가 named 라벨을 **빠짐없이** 덮어야 한다. 라벨을 하나 더하면 여기서
+    // 걸리고, 그때 위 표에 대응 위치를 적어야 한다.
     try std.testing.expectEqual(@typeInfo(HotkeyNamedKey).@"enum".fields.len, pairs.len);
+    // 방향은 한쪽뿐이다 — **모든 라벨에는 위치가 있지만 그 반대는 아니다.** 위치
+    // 집합이 더 넓다: 라벨이 거부하는 ASCII 기호 자리와 ISO 추가 키를 담는다
+    // (`physical_key.zig` 의 정책 문단 참고). 그래서 등호가 아니라 부등호다.
+    try std.testing.expect(
+        @typeInfo(PhysicalCode).@"enum".fields.len >= pairs.len + 26 + 10,
+    );
 }
 
 test "#496 위치 표기 파싱" {
@@ -761,10 +762,15 @@ test "#496 위치 표기 파싱" {
     try std.testing.expect(position.key == .code);
     try std.testing.expectEqual(PhysicalCode.bracket_left, position.key.code);
 
-    // 라벨 집합에 없는 자리는 위치로도 받지 않는다 — 수용 집합이 조용히 넓어지지
-    // 않게 한다 (`physical_key.zig` 의 같은 정책).
-    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[Minus]", .app_binding));
-    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[Slash]", .app_binding));
+    // 라벨이 거부하는 기호 자리도 **위치로는 받는다** — 자판에 있는 키를 다 쓸 수
+    // 있게 한 결정이다 (`physical_key.zig` 의 정책 문단). 라벨 쪽은 그대로 좁다:
+    // 고정표로 라벨을 넓히면 그건 라벨이 아니라 US 위치가 되기 때문이다.
+    try std.testing.expect(parseHotkeyString("ctrl+[Minus]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("ctrl+[Slash]", .app_binding) == .ok);
+    try std.testing.expect(parseHotkeyString("ctrl+[IntlBackslash]", .app_binding) == .ok);
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+minus", .app_binding));
+    try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+slash", .app_binding));
+    // 표에 없는 이름은 여전히 거부한다.
     try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[NotAKey]", .app_binding));
     try std.testing.expectEqual(HotkeyParse.unknown_key, parseHotkeyString("ctrl+[]", .app_binding));
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -24,6 +24,7 @@ const font_validate = @import("font/validate.zig");
 const font_constants = @import("font/constants.zig");
 const font_spec = @import("font/spec.zig");
 const physical_key = @import("physical_key.zig");
+const input_policy = @import("input_policy.zig");
 const PhysicalCode = physical_key.PhysicalCode;
 
 const WCHAR = u16;
@@ -626,8 +627,19 @@ test "#493 lookup is exact — no shift-insensitive fallback" {
 
     // Shift 가 더 붙은 조합은 **일치하지 않는다.** 완화 조회를 뺀 결과이고 의도된
     // 동작이다 — `shift+alt+f4` 가 `alt+f4` 를 발동시키는 일이 없다.
-    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+1"), null) == null);
     try std.testing.expect(lookupAction(bindings, try hk("ctrl+alt+return"), null) == null);
+    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+return"), null).? == .fullscreen_workarea);
+
+    // **숫자만 예외다** (#482). AZERTY 에서 숫자열은 Shift 를 눌러야 숫자가 나오므로
+    // `Alt+1` 이 항상 `Alt+Shift+1` 로 도착한다. 이 예외가 없으면 세 platform 모두
+    // 그 layout 에서 인덱스 탭 전환이 죽는다 — 세 host 가 이미 Shift 를 안 본다
+    // (`isDigitBinding` 주석 참고). 확대가 아니라 현행 유지다.
+    try std.testing.expect(lookupAction(bindings, try hk("shift+alt+1"), null).? == .switch_tab1);
+    // 예외는 숫자에서 멈춘다 — 다른 키는 여전히 엄격하다.
+    try add(&buf, &n, "alt+f4", .quit);
+    const with_quit = buf[0..n];
+    try std.testing.expect(lookupAction(with_quit, try hk("shift+alt+f4"), null) == null);
+    try std.testing.expect(lookupAction(with_quit, try hk("alt+f4"), null).? == .quit);
 }
 
 test "#496 위치 binding 은 라벨과 무관하게 자리로 매칭한다" {
@@ -1427,13 +1439,53 @@ fn defaultFontFamiliesArray() [MAX_FONT_FAMILIES][]const u8 {
 ///
 /// 이름을 바꾸면 기존 사용자 config 의 그 키가 "모르는 키" 가 된다 — 결정 8 의
 /// 삭제 대상이 되므로 이름 변경은 비가산적 변경이다.
-/// #493 — 액션별 기본 키. platform 마다 다른 것은 `cmd` 토큰이 흡수한다
-/// (`parseHotkeyString` 이 Linux Super / Windows Win / macOS Cmd 를 같은 값으로
-/// 본다) — 그래서 한 표가 세 platform 을 덮는다.
+/// #493 — 액션별 기본 키.
 ///
-/// `KeyAction` 에 variant 를 추가하면 이 표도 채워야 한다. 빠지면
+/// **한 표로 세 platform 을 덮을 수 없다.** 처음엔 `cmd` 토큰이 차이를 흡수한다고
+/// 적었는데 (Linux Super = Windows Win = macOS Command) 그것으로는 부족하다 —
+/// macOS 는 modifier 만 다른 것이 아니라 **Shift 의 유무가 다르다.** Apple HIG 를
+/// 따르는 관습이 `Cmd+T` 인데 PC 쪽은 `Ctrl+Shift+T` 다. `KEYBINDINGS.md` 의 표가
+/// 그 차이를 이미 기록하고 있고, 3-c 배선에서 그 표를 그대로 재현해야 한다.
+/// `cmd` 로만 치환하면 macOS 사용자의 모든 단축키가 `Control+Shift+*` 로 바뀐다.
+///
+/// `KeyAction` 에 variant 를 추가하면 **두 표를 다** 채워야 한다. 빠지면
 /// `defaultKeysToml` 이 컴파일 시점에 잡는다 (exhaustive switch).
 pub fn defaultBindings(action: KeyAction) []const []const u8 {
+    return if (is_macos) macDefaultBindings(action) else pcDefaultBindings(action);
+}
+
+/// macOS 기본 bindings — `KEYBINDINGS.md` 의 macOS 열과 1:1. Apple HIG 순서
+/// (`Shift+Cmd`) 를 따른다.
+fn macDefaultBindings(action: KeyAction) []const []const u8 {
+    return switch (action) {
+        .new_tab => &.{"cmd+t"},
+        .close_tab => &.{"cmd+w"},
+        .prev_tab => &.{ "shift+cmd+[", "cmd+pageup" },
+        .next_tab => &.{ "shift+cmd+]", "cmd+pagedown" },
+        .switch_tab1 => &.{"cmd+1"},
+        .switch_tab2 => &.{"cmd+2"},
+        .switch_tab3 => &.{"cmd+3"},
+        .switch_tab4 => &.{"cmd+4"},
+        .switch_tab5 => &.{"cmd+5"},
+        .switch_tab6 => &.{"cmd+6"},
+        .switch_tab7 => &.{"cmd+7"},
+        .switch_tab8 => &.{"cmd+8"},
+        .switch_tab9 => &.{"cmd+9"},
+        .copy_selection => &.{"cmd+c"},
+        .paste => &.{"cmd+v"},
+        .fullscreen => &.{"cmd+return"},
+        .fullscreen_workarea => &.{"shift+cmd+return"},
+        .quit => &.{"cmd+q"},
+        .reset_terminal => &.{"shift+cmd+r"},
+        .show_about => &.{"shift+cmd+i"},
+        .open_config => &.{"shift+cmd+p"},
+        .open_log => &.{"shift+cmd+l"},
+        .dump_perf => &.{"shift+cmd+f12"},
+    };
+}
+
+/// Linux · Windows 기본 bindings — `KEYBINDINGS.md` 의 두 열과 1:1 (그 둘은 같다).
+fn pcDefaultBindings(action: KeyAction) []const []const u8 {
     return switch (action) {
         .new_tab => &.{"ctrl+shift+t"},
         .close_tab => &.{"ctrl+shift+w"},
@@ -1576,20 +1628,154 @@ pub const KeyAction = enum {
 /// binding 쪽 `code` 가 non-null 이면 위치로, null 이면 라벨로 판정한다. 한 binding 이
 /// 두 기준을 동시에 갖지 않으므로 "왜 이 키가 이 동작을 했는가" 가 항상 한 가지로
 /// 설명된다.
+/// #493 3-c — Linux: 도착한 keysym 을 **binding 쪽 표현**으로 옮긴다.
+///
+/// Linux 는 세 platform 중 유일하게 **라벨 (keysym) 로 매칭한다.** 그래서 Shift 가
+/// keysym 자체를 바꾸는 것이 문제가 된다: binding `ctrl+shift+c` 는 keysym `c`
+/// (0x63) 로 저장되는데 실제로 도착하는 것은 `C` (0x43) 다. 예전 하드코딩 매처가
+/// 두 값을 나란히 적어 (`xkb_key_c_lower, xkb_key_c_upper`) 해결하던 자리이고,
+/// 그것을 규칙 하나로 옮긴 것이 이 함수다.
+///
+/// **Shift 비트는 건드리지 않는다.** 키 값만 무시프트 표현으로 되돌리므로
+/// `ctrl+shift+c` 와 `ctrl+c` 가 여전히 다른 조합이다 — Shift 를 선택적으로 만드는
+/// 완화가 아니다 (그것은 #493 에서 명시적으로 거부했다).
+///
+/// 수용 집합 안에서 Shift 가 값을 바꾸는 키만 다룬다. 숫자는 **일부러 빼 놓았다**:
+/// QWERTY 에서 `Shift+1` 은 `exclam` 인데 그것을 `1` 로 되돌리면 `Alt+Shift+1` 이
+/// 탭 전환이 되어 동작이 넓어진다. AZERTY 의 숫자 문제는 값이 아니라 Shift 비트
+/// 쪽이라 `isDigitBinding` 예외가 담당한다.
+pub fn normalizeLinuxKeysym(sym: u32) u32 {
+    // 대문자 latin → 소문자. binding 은 항상 소문자로 저장된다
+    // (`hotkeyKeyFromName` 이 정규화한다).
+    if (sym >= 'A' and sym <= 'Z') return sym + 0x20;
+    return switch (sym) {
+        0x7b => 0x5b, // braceleft  -> bracketleft
+        0x7d => 0x5d, // braceright -> bracketright
+        0x7e => 0x60, // asciitilde -> grave
+        else => sym,
+    };
+}
+
+test "#493 3-c — Linux keysym 정규화는 값만 되돌리고 Shift 를 건드리지 않는다" {
+    // 대문자 → 소문자. `ctrl+shift+c` binding 이 도착한 `C` 와 만나는 자리다.
+    try std.testing.expectEqual(@as(u32, 0x63), normalizeLinuxKeysym(0x43)); // C -> c
+    try std.testing.expectEqual(@as(u32, 0x77), normalizeLinuxKeysym(0x57)); // W -> w
+    // Shift 가 값을 바꾸는 기호 — 예전 매처가 두 값을 나란히 적던 자리.
+    try std.testing.expectEqual(@as(u32, 0x5b), normalizeLinuxKeysym(0x7b)); // { -> [
+    try std.testing.expectEqual(@as(u32, 0x5d), normalizeLinuxKeysym(0x7d)); // } -> ]
+    try std.testing.expectEqual(@as(u32, 0x60), normalizeLinuxKeysym(0x7e)); // ~ -> `
+    // 이미 무시프트인 값은 그대로.
+    try std.testing.expectEqual(@as(u32, 0x63), normalizeLinuxKeysym(0x63));
+    try std.testing.expectEqual(@as(u32, 0xffbe), normalizeLinuxKeysym(0xffbe)); // F1
+    // 숫자는 건드리지 않는다 — `exclam` 이 `1` 이 되면 동작이 넓어진다.
+    try std.testing.expectEqual(@as(u32, 0x21), normalizeLinuxKeysym(0x21)); // ! 그대로
+    try std.testing.expectEqual(@as(u32, 0x31), normalizeLinuxKeysym(0x31)); // 1 그대로
+}
+
+/// #493 3-c — config 액션을 런타임 입력으로 옮긴다. **세 host 가 이 한 표를 쓴다** —
+/// host 마다 매핑을 두면 갈라진다 (#296 이 정확히 그래서 만들어졌다).
+///
+/// `KeyAction` 과 `input_policy.Shortcut` 이 1:1 이 아니라서 이 표가 필요하다:
+///
+///   - `switch_tab1`~`9` 는 config 에서 9 개, 런타임은 `switch_tab` 하나 + 인덱스다.
+///     **인덱스의 출처가 액션 이름이 된다** — 예전엔 host 마다 native 키 코드에서
+///     뽑았다 (macOS `keycodeToTabIndex`, Linux `sym - xkb_key_1`, Windows
+///     `wParam - 0x31`). 액션을 다 펼쳐 적기로 한 결정의 값을 여기서 돌려받는다.
+///   - `paste` 는 `Shortcut` 이 아니라 `Input.paste` 다 (preedit commit 정책이
+///     다르다).
+pub const ActionInput = struct {
+    input: input_policy.Input,
+    /// `switch_tab` 일 때 0-based 탭 인덱스. 그 외에는 null.
+    tab_index: ?usize = null,
+};
+
+pub fn inputForAction(action: KeyAction) ActionInput {
+    return switch (action) {
+        .new_tab => .{ .input = .{ .shortcut = .new_tab } },
+        .close_tab => .{ .input = .{ .shortcut = .close_tab } },
+        .prev_tab => .{ .input = .{ .shortcut = .prev_tab } },
+        .next_tab => .{ .input = .{ .shortcut = .next_tab } },
+        .switch_tab1 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 0 },
+        .switch_tab2 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 1 },
+        .switch_tab3 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 2 },
+        .switch_tab4 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 3 },
+        .switch_tab5 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 4 },
+        .switch_tab6 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 5 },
+        .switch_tab7 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 6 },
+        .switch_tab8 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 7 },
+        .switch_tab9 => .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 8 },
+        .copy_selection => .{ .input = .{ .shortcut = .copy_selection } },
+        .paste => .{ .input = .paste },
+        .fullscreen => .{ .input = .{ .shortcut = .fullscreen } },
+        .fullscreen_workarea => .{ .input = .{ .shortcut = .fullscreen_workarea } },
+        .quit => .{ .input = .{ .shortcut = .quit } },
+        .reset_terminal => .{ .input = .{ .shortcut = .reset_terminal } },
+        .show_about => .{ .input = .{ .shortcut = .show_about } },
+        .open_config => .{ .input = .{ .shortcut = .open_config } },
+        .open_log => .{ .input = .{ .shortcut = .open_log } },
+        .dump_perf => .{ .input = .{ .shortcut = .dump_perf } },
+    };
+}
+
 pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey, code: ?PhysicalCode) ?KeyAction {
     std.debug.assert(hotkey.code == null);
     for (bindings) |b| {
+        const mods_match = b.hotkey.modifiers == hotkey.modifiers or
+            (isDigitBinding(b.hotkey) and
+                b.hotkey.modifiers == (hotkey.modifiers & ~@as(@TypeOf(hotkey.modifiers), Hotkey.MOD_SHIFT)));
+        if (!mods_match) continue;
         if (b.hotkey.code) |want| {
-            // 위치 binding — modifier 는 같아야 하고 자리가 일치해야 한다. 라벨 쪽
-            // 값 (keysym / vkey / keycode) 은 보지 않는다.
-            if (b.hotkey.modifiers != hotkey.modifiers) continue;
+            // 위치 binding — 자리가 일치해야 한다. 라벨 쪽 값 (keysym / vkey /
+            // keycode) 은 보지 않는다.
             const got = code orelse continue;
             if (got == want) return b.action;
             continue;
         }
-        if (std.meta.eql(b.hotkey, hotkey)) return b.action;
+        if (b.hotkey.code == null and hotkey.code == null and modifiersAside(b.hotkey) == modifiersAside(hotkey)) {
+            return b.action;
+        }
     }
     return null;
+}
+
+/// modifier 를 뺀 라벨 쪽 키 값. `std.meta.eql` 로 통째로 비교하면 Shift 예외를
+/// 표현할 수 없어 (아래) 키 값만 따로 꺼낸다.
+fn modifiersAside(h: Hotkey) u32 {
+    if (is_windows) return h.vkey;
+    if (is_macos) return h.keycode;
+    return h.keysym;
+}
+
+/// #482 — **숫자 binding 은 Shift 를 무시한다.** 일반 규칙이 아니라 숫자에만 두는
+/// 좁은 예외이고, 이유가 layout 에 있다: AZERTY (fr) 등에서 숫자열은 **Shift 를
+/// 눌러야 숫자가 나온다** (무시프트는 `&é"'(-è_çà`). 그래서 `Alt+1` 이 그 layout
+/// 에서 항상 `Alt+Shift+1` 로 도착하고, 엄격히 비교하면 인덱스 탭 전환이 그
+/// layout 에서 아예 동작하지 않는다.
+///
+/// **이것은 동작 확대가 아니다** — 세 platform 이 이미 그렇게 동작한다. Windows 는
+/// `wParam >= 0x31 and wParam <= 0x39` 로 Shift 를 아예 안 보고 (`window.zig`),
+/// macOS 는 `keycodeToTabIndex(kc) != null` 로 역시 안 보며 (`host/macos.zig`),
+/// Linux 도 #482 에서 `!shift` 요구를 걷어냈다. 3-c 가 그 셋을 한 규칙으로 모을 때
+/// 이 예외를 빼면 세 platform 모두 AZERTY 에서 퇴행한다.
+///
+/// QWERTY 에는 영향이 없다: 그쪽에서 `Alt+Shift+1` 은 keysym 이 `exclam` 이라
+/// 라벨 비교 자체가 실패한다. Windows / macOS 는 위치 기반이어서 오늘도 잡히므로
+/// 역시 변화가 없다.
+fn isDigitBinding(h: Hotkey) bool {
+    if (h.code) |c| {
+        return switch (c) {
+            .digit0, .digit1, .digit2, .digit3, .digit4, .digit5, .digit6, .digit7, .digit8, .digit9 => true,
+            else => false,
+        };
+    }
+    // 라벨 쪽은 platform 값에서 되짚는다 — 세 표 모두 숫자를 ASCII 그대로 (Linux
+    // keysym · Windows vkey) 쓰거나 `kVK_ANSI_0`~`9` 로 쓴다.
+    const v = modifiersAside(h);
+    if (is_macos) return physical_key.fromMacKeyCode(v) != null and switch (physical_key.fromMacKeyCode(v).?) {
+        .digit0, .digit1, .digit2, .digit3, .digit4, .digit5, .digit6, .digit7, .digit8, .digit9 => true,
+        else => false,
+    };
+    return v >= '0' and v <= '9';
 }
 
 /// 한 액션에 키를 여러 개 줄 수 있다 (결정 3). 런타임 조회 방향은 **키 → 액션**

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -26,6 +26,7 @@ const log = @import("../../log.zig");
 const messages = @import("../../messages.zig");
 const command_menu = @import("../../command_menu.zig");
 const config_mod = @import("../../config.zig");
+const physical_key = @import("../../physical_key.zig");
 const software_terminal = @import("software_terminal.zig");
 const run_options = @import("../../run_options.zig");
 const dialog_layout = @import("dialog_layout.zig");
@@ -677,125 +678,175 @@ test "#314 dialog drag repaint requests coalesce to the latest row" {
 /// 분류. null = 정책 대상 아님(일반 문자 / 터미널 control char / preedit-Ctrl
 /// commit / scroll 등) → processKeyEvent 의 기존 PTY 경로로. 상태(preedit)에
 /// 따른 "그래서 무엇을 할지" 결정은 여기가 아니라 `input_policy.resolve` 가 한다.
-fn classifyInput(sym: u32, ctrl: bool, shift: bool, alt: bool) ?input_policy.Input {
-    // Ctrl+Shift+* — 클립보드 / 탭 / About / Open Config·Log / reset / perf.
-    if (ctrl and shift and !alt) {
-        return switch (sym) {
-            xkb_key_c_lower, xkb_key_c_upper => .{ .shortcut = .copy_selection },
-            xkb_key_v_lower, xkb_key_v_upper => .paste,
-            xkb_key_t_lower, xkb_key_t_upper => .{ .shortcut = .new_tab },
-            xkb_key_w_lower, xkb_key_w_upper => .{ .shortcut = .close_tab },
-            xkb_key_bracketright, xkb_key_braceright => .{ .shortcut = .next_tab },
-            xkb_key_bracketleft, xkb_key_braceleft => .{ .shortcut = .prev_tab },
-            xkb_key_i_lower, xkb_key_i_upper => .{ .shortcut = .show_about },
-            xkb_key_p_lower, xkb_key_p_upper => .{ .shortcut = .open_config },
-            xkb_key_l_lower, xkb_key_l_upper => .{ .shortcut = .open_log },
-            xkb_key_r_lower, xkb_key_r_upper => .{ .shortcut = .reset_terminal },
-            xkb_key_f12 => .{ .shortcut = .dump_perf },
-            else => null,
-        };
+/// #493 3-c — native 입력을 `[keys]` config 와 맞춰 공통 `Input` 으로 분류한다.
+///
+/// 예전엔 이 함수가 하드코딩된 keysym switch 였다 (`Ctrl+Shift+*` 묶음, `Alt` 묶음,
+/// 숫자 범위 ...). 이제 스스로 판정하는 것은 하나뿐이고 나머지는 config 가 정한다.
+///
+/// **Ctrl+C (interrupt) 는 재바인딩 대상이 아니다.** `[keys]` 로 가릴 수 있게 하면
+/// 사용자가 실수 한 번으로 터미널의 SIGINT 를 잃는다 — scrollback 을 고정으로 둔
+/// 것과 같은 이유다. 그래서 config 조회보다 **먼저** 본다.
+///
+/// Linux 는 세 platform 중 유일하게 라벨 (keysym) 로 매칭하므로 Shift 가 바꿔 놓은
+/// 키 값을 `normalizeLinuxKeysym` 으로 되돌려 넘긴다 (`C`→`c`, `{`→`[`). 예전 매처가
+/// 두 값을 나란히 적던 (`xkb_key_c_lower, xkb_key_c_upper`) 자리다.
+///
+/// `code` 는 같은 event 의 **물리 위치**다 (#496). 위치로 적은 binding
+/// (`ctrl+shift+[KeyW]`) 이 그것으로 매칭된다 — 비라틴 layout 에서 글자 단축키를
+/// 쓸 수 있는 유일한 길이다.
+fn classifyInput(
+    bindings: []const config_mod.KeyBinding,
+    sym: u32,
+    code: ?config_mod.PhysicalCode,
+    ctrl: bool,
+    shift: bool,
+    alt: bool,
+    super: bool,
+) ?config_mod.ActionInput {
+    // Ctrl+C — SIGINT (line abort). preedit 자모 discard 는 best-effort: fcitx5 는
+    // Ctrl+C 에서 자모를 먼저 확정해 `가^C` (취소된 줄이라 무해, §5.1).
+    if (ctrl and !shift and !alt and !super and
+        (sym == xkb_key_c_lower or sym == xkb_key_c_upper))
+    {
+        return .{ .input = .interrupt };
     }
-    // #482 — Ctrl+PgUp / Ctrl+PgDn 으로 이전 / 다음 탭. `Ctrl+Shift+[` / `]` 가
-    // AZERTY 에서 쓸 수 없어 추가한 **layout 무관** 대안이다: 그 layout 에서 `[` 는
-    // AltGr+5 라서 조합이 Ctrl+Shift+AltGr+5 가 된다 (손가락 네 개). PgUp / PgDn 은
-    // 어느 layout 에나 있는 단일 물리 키다.
-    //
-    // `Ctrl+Tab` 을 쓰지 않은 이유: 현대 키보드 프로토콜 (kitty / CSI-u) 에서 그건
-    // 구별 가능한 시퀀스라 TUI 앱이 정당하게 바인딩한다. 터미널이 삼키면 사용자가
-    // 통과시킬 방법이 없다. 반면 Ctrl+PgUp / PgDn 은 GNOME Terminal · Konsole ·
-    // Windows Terminal 이 탭 전환에 쓰는 — 터미널이 관습적으로 소유하는 — 조합이다.
-    //
-    // 아래 Shift+PgUp / PgDn (scrollback) 과 맨 PgUp / PgDn (PTY) 은 그대로다.
-    if (ctrl and !shift and !alt) {
-        if (sym == xkb_key_page_up) return .{ .shortcut = .prev_tab };
-        if (sym == xkb_key_page_down) return .{ .shortcut = .next_tab };
-    }
-    // Ctrl+C (Shift 없음) — SIGINT(line abort). preedit 자모 discard 는 best-effort:
-    // fcitx5 는 Ctrl+C 에서 자모를 먼저 확정해 `가^C`(취소된 줄이라 무해, §5.1).
-    if (ctrl and !shift and !alt and (sym == xkb_key_c_lower or sym == xkb_key_c_upper)) return .interrupt;
-    // Alt+Enter(fullscreen) / Alt+F4(quit) / Alt+1..9(탭 전환). Ctrl 미동반.
-    if (alt and !ctrl) {
-        if (sym == xkb_key_return) return .{ .shortcut = .fullscreen };
-        if (!shift and sym == xkb_key_f4) return .{ .shortcut = .quit };
-        // #482 — `!shift` 를 요구하지 않는다. AZERTY (fr) 등에서 숫자열은 **Shift 를
-        // 눌러야 숫자가 나온다** (무시프트는 `&é"'(-è_çà`). 그래서 keysym `1`~`9` 가
-        // 항상 Shift 와 함께 도착해 `!shift` 가 전부 걸러 냈다 — 인덱스 탭 전환이
-        // 그 layout 에서 아예 동작하지 않았다.
-        //
-        // QWERTY 에는 영향이 없다: Shift 가 keysym 자체를 바꿔서 Alt+Shift+1 은
-        // `exclam` (0x21) 로 도착하고 `xkb_key_1` 과 매칭되지 않는다. 즉 이 조건을
-        // 풀어도 QWERTY 에서 새로 잡히는 조합이 없다.
-        //
-        // Windows (`VK_1`) 와 macOS (`kVK_ANSI_1`) 는 **물리 위치**로 매칭해서 애초에
-        // 이 문제가 없다. keysym 으로 매칭하는 Linux 만의 결함이었다.
-        if (sym >= xkb_key_1 and sym <= xkb_key_9) return .{ .shortcut = .switch_tab };
-    }
-    // 그 외는 정책 대상 아님(일반 문자 / 터미널 control char / preedit-Ctrl
-    // commit / scroll) → 기존 PTY 경로.
-    return null;
+
+    var modifiers: u32 = 0;
+    if (ctrl) modifiers |= config_mod.Hotkey.MOD_CTRL;
+    if (shift) modifiers |= config_mod.Hotkey.MOD_SHIFT;
+    if (alt) modifiers |= config_mod.Hotkey.MOD_ALT;
+    if (super) modifiers |= config_mod.Hotkey.MOD_SUPER;
+    const hotkey: config_mod.Hotkey = .{
+        .keysym = config_mod.normalizeLinuxKeysym(sym),
+        .modifiers = modifiers,
+    };
+    const action = config_mod.lookupAction(bindings, hotkey, code) orelse return null;
+    return config_mod.inputForAction(action);
 }
 
-test "#296 classifyInput — native xkb → 공통 Input 분류" {
+/// 기본 `[keys]` 를 파싱해 테스트용 binding 배열을 만든다. **기본값을 그대로 쓰는
+/// 것이 요점이다** — 하드코딩 매처를 config 로 옮긴 뒤에도 기본 사용자가 보는 동작이
+/// 같아야 하고, 그 동등성을 여기서 검사한다.
+fn testDefaultBindings(buf: []config_mod.KeyBinding) []const config_mod.KeyBinding {
+    var n: usize = 0;
+    for (std.enums.values(config_mod.KeyAction)) |action| {
+        for (config_mod.defaultBindings(action)) |text| {
+            buf[n] = .{ .hotkey = config_mod.appBindingHotkey(text).?, .action = action };
+            n += 1;
+        }
+    }
+    return buf[0..n];
+}
+
+test "#296 · #493 3-c classifyInput — native xkb → config binding → 공통 Input" {
     const T = std.testing;
-    const C = classifyInput;
-    const I = input_policy.Input;
-    // Ctrl+Shift+* → shortcut / paste
-    try T.expectEqual(@as(?I, .{ .shortcut = .copy_selection }), C(xkb_key_c_lower, true, true, false));
-    try T.expectEqual(@as(?I, .paste), C(xkb_key_v_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .new_tab }), C(xkb_key_t_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .close_tab }), C(xkb_key_w_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .next_tab }), C(xkb_key_bracketright, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .prev_tab }), C(xkb_key_bracketleft, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .show_about }), C(xkb_key_i_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .open_config }), C(xkb_key_p_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .open_log }), C(xkb_key_l_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .reset_terminal }), C(xkb_key_r_lower, true, true, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .dump_perf }), C(xkb_key_f12, true, true, false));
-    // Alt 계열 (fullscreen 은 shift 로 cover/avoid — 분류는 동일)
-    try T.expectEqual(@as(?I, .{ .shortcut = .fullscreen }), C(xkb_key_return, false, false, true));
-    try T.expectEqual(@as(?I, .{ .shortcut = .fullscreen }), C(xkb_key_return, false, true, true));
-    try T.expectEqual(@as(?I, .{ .shortcut = .quit }), C(xkb_key_f4, false, false, true));
-    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_1, false, false, true));
-    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_9, false, false, true));
+    var buf: [config_mod.MAX_KEY_BINDINGS]config_mod.KeyBinding = undefined;
+    const b = testDefaultBindings(&buf);
+    const A = config_mod.ActionInput;
+
+    // 위치 인자를 매번 쓰지 않도록 감싼다. 위치 (`code`) 는 이 test 에서 null 이다 —
+    // 기본 binding 이 전부 라벨이기 때문이다 (위치 매칭은 config.zig 쪽 test).
+    const C = struct {
+        fn f(bindings: []const config_mod.KeyBinding, sym: u32, ctrl: bool, shift: bool, alt: bool) ?A {
+            return classifyInput(bindings, sym, null, ctrl, shift, alt, false);
+        }
+    }.f;
+
+    // Ctrl+Shift+* → shortcut / paste. **대문자 keysym 으로도 잡혀야 한다** — Shift 가
+    // 눌려 있으므로 실제로 도착하는 것은 대문자다.
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .copy_selection } }), C(b, xkb_key_c_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .copy_selection } }), C(b, xkb_key_c_upper, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .paste }), C(b, xkb_key_v_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .paste }), C(b, xkb_key_v_upper, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .new_tab } }), C(b, xkb_key_t_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .close_tab } }), C(b, xkb_key_w_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .show_about } }), C(b, xkb_key_i_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .open_config } }), C(b, xkb_key_p_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .open_log } }), C(b, xkb_key_l_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .reset_terminal } }), C(b, xkb_key_r_lower, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .dump_perf } }), C(b, xkb_key_f12, true, true, false));
+
+    // bracket — Shift 로 `{` / `}` 가 되어 도착한다. 예전엔 매처가 네 값을 나란히
+    // 적었고, 지금은 `normalizeLinuxKeysym` 이 되돌린다.
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .prev_tab } }), C(b, xkb_key_bracketleft, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .next_tab } }), C(b, xkb_key_bracketright, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .prev_tab } }), C(b, xkb_key_braceleft, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .next_tab } }), C(b, xkb_key_braceright, true, true, false));
+
+    // Alt 계열. **fullscreen 과 fullscreen_workarea 가 이제 다른 변종이다** (#493 3-c)
+    // — 예전엔 `fullscreen` 하나를 내고 host 가 "Shift 면 workarea" 로 갈랐다. 이제
+    // config 의 두 액션이 각각 잡히므로 그 암묵 규칙이 사라진다.
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .fullscreen } }), C(b, xkb_key_return, false, false, true));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .fullscreen_workarea } }), C(b, xkb_key_return, false, true, true));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .quit } }), C(b, xkb_key_f4, false, false, true));
+
+    // 인덱스 탭 전환 — **인덱스가 액션 이름에서 온다** (`switch_tab1` → 0). 예전엔
+    // host 가 `sym - xkb_key_1` 로 뽑았다.
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 0 }), C(b, xkb_key_1, false, false, true));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 8 }), C(b, xkb_key_9, false, false, true));
     // #482 — AZERTY (fr) 는 숫자열에 Shift 가 필요해 keysym `1`~`9` 가 **항상 Shift 와
-    // 함께** 도착한다. 예전 `!shift` 조건이 그것을 전부 걸러 인덱스 탭 전환이 그 layout
-    // 에서 아예 동작하지 않았다.
-    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_1, false, true, true));
-    try T.expectEqual(@as(?I, .{ .shortcut = .switch_tab }), C(xkb_key_9, false, true, true));
-    // QWERTY 에서는 Alt+Shift+1 이 `exclam` 으로 도착하므로 위 완화가 새로 잡는 조합이
-    // 없다 — 이 keysym 은 정책 대상이 아니다.
-    try T.expectEqual(@as(?I, null), C(xkb_key_exclam, false, true, true));
-    // Ctrl 동반은 여전히 Alt 계열이 아니다 (첫 블록의 Ctrl+Shift 와 충돌 방지).
-    try T.expectEqual(@as(?I, null), C(xkb_key_1, true, false, true));
+    // 함께** 도착한다. `lookupAction` 의 숫자 예외가 그것을 받는다.
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 0 }), C(b, xkb_key_1, false, true, true));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .switch_tab }, .tab_index = 8 }), C(b, xkb_key_9, false, true, true));
+    // QWERTY 에서 Alt+Shift+1 은 `exclam` 으로 도착하므로 위 예외가 새로 잡는 조합이
+    // 없다 — 이 keysym 은 어느 binding 과도 맞지 않는다.
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_exclam, false, true, true));
+    // Ctrl 동반은 숫자 binding 과 맞지 않는다 (`alt+1` 에 Ctrl 이 없다).
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_1, true, false, true));
 
     // #482 — Ctrl+PgUp / PgDn 으로 이전 / 다음 탭 (layout 무관 대안).
-    try T.expectEqual(@as(?I, .{ .shortcut = .prev_tab }), C(xkb_key_page_up, true, false, false));
-    try T.expectEqual(@as(?I, .{ .shortcut = .next_tab }), C(xkb_key_page_down, true, false, false));
-    // Shift+PgUp / PgDn 은 scrollback 이라 정책 대상이 아니고, Ctrl+Shift 조합도
-    // 탭 전환으로 잡지 않는다 — 기존 동작을 건드리지 않았음을 고정한다.
-    try T.expectEqual(@as(?I, null), C(xkb_key_page_down, false, true, false));
-    try T.expectEqual(@as(?I, null), C(xkb_key_page_up, true, true, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .prev_tab } }), C(b, xkb_key_page_up, true, false, false));
+    try T.expectEqual(@as(?A, .{ .input = .{ .shortcut = .next_tab } }), C(b, xkb_key_page_down, true, false, false));
+    // Shift+PgUp / PgDn 은 scrollback 이라 `[keys]` 에 없고, Ctrl+Shift 조합도 탭
+    // 전환으로 잡지 않는다 — 기존 동작을 건드리지 않았음을 고정한다.
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_page_down, false, true, false));
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_page_up, true, true, false));
     // 맨 PgUp / PgDn 은 PTY 로 간다.
-    try T.expectEqual(@as(?I, null), C(xkb_key_page_up, false, false, false));
-    try T.expectEqual(@as(?I, null), C(xkb_key_page_down, false, false, false));
-    // Ctrl+C (Shift 없음) → interrupt
-    try T.expectEqual(@as(?I, .interrupt), C(xkb_key_c_lower, true, false, false));
-    // 미분류(null → 기존 PTY 경로):
-    try T.expectEqual(@as(?I, null), C(xkb_key_t_lower, false, false, false)); // 일반 문자
-    try T.expectEqual(@as(?I, null), C(xkb_key_return, false, false, false)); // Enter
-    try T.expectEqual(@as(?I, null), C(xkb_key_up, false, false, false)); // nav 키
-    try T.expectEqual(@as(?I, null), C(xkb_key_a_lower, true, false, false)); // Ctrl+A = 터미널 \x01
-    try T.expectEqual(@as(?I, null), C(xkb_key_e_lower, true, false, false)); // Ctrl+E = 터미널 \x05
-    try T.expectEqual(@as(?I, null), C(xkb_key_page_up, false, true, false)); // Shift+PgUp = scroll
-    try T.expectEqual(@as(?I, null), C(xkb_key_t_lower, true, false, false)); // Ctrl+T = shell transpose
-    // #482 — 예전엔 여기에 `C(xkb_key_1, false, true, true)` 가 null 로 있었다. 그
-    // 조합 (keysym `1` + Shift) 은 **QWERTY 에서 발생 자체가 불가능하다** — Shift 가
-    // keysym 을 `exclam` 으로 바꾼다. 숫자열에 Shift 가 필요한 layout (AZERTY 등) 에서만
-    // 나오므로, 그 assertion 은 인덱스 탭 전환이 그 layout 에서 안 되는 **버그를 고정**
-    // 하고 있었다. 이제 shortcut 이고 위쪽 Alt 계열 테스트에서 확인한다. QWERTY 쪽
-    // 대응물인 `exclam` 은 계속 정책 대상이 아니다 (바로 위에서 확인).
-    try T.expectEqual(@as(?I, null), C(xkb_key_return, true, false, true)); // Ctrl+Alt+Enter
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_page_up, false, false, false));
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_page_down, false, false, false));
+
+    // Ctrl+C (Shift 없음) → interrupt. **config 조회보다 먼저 본다** — 재바인딩으로
+    // 가릴 수 없다.
+    try T.expectEqual(@as(?A, .{ .input = .interrupt }), C(b, xkb_key_c_lower, true, false, false));
+    try T.expectEqual(@as(?A, .{ .input = .interrupt }), C(b, xkb_key_c_upper, true, false, false));
+
+    // 미분류 (null → 기존 PTY 경로):
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_t_lower, false, false, false)); // 일반 문자
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_return, false, false, false)); // Enter
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_up, false, false, false)); // nav 키
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_a_lower, true, false, false)); // Ctrl+A = 터미널 \x01
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_e_lower, true, false, false)); // Ctrl+E = 터미널 \x05
+    try T.expectEqual(@as(?A, null), C(b, xkb_key_t_lower, true, false, false)); // Ctrl+T = shell transpose
 }
+
+test "#496 위치로 적은 binding 이 라벨과 무관하게 잡힌다 (Linux)" {
+    const T = std.testing;
+    // 키릴 layout 을 흉내낸다: `Ctrl+Shift+`(KeyW 자리) 를 누르면 keysym 은 `Ц`
+    // (U+0426 → xkb Unicode keysym) 로 도착하고 어떤 라벨 binding 과도 맞지 않는다.
+    // 위치로 적은 binding 만 그것을 잡는다.
+    const cyrillic_tse: u32 = 0x01000426;
+    var buf: [4]config_mod.KeyBinding = undefined;
+    buf[0] = .{
+        .hotkey = config_mod.appBindingHotkey("ctrl+shift+w").?,
+        .action = .close_tab,
+    };
+    buf[1] = .{
+        .hotkey = config_mod.appBindingHotkey("ctrl+shift+[KeyT]").?,
+        .action = .new_tab,
+    };
+    const b = buf[0..2];
+
+    // 라벨 binding 은 키릴 keysym 을 못 잡는다 — 이것이 #496 의 버그 자체다.
+    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, cyrillic_tse, .key_w, true, true, false, false));
+    // 위치 binding 은 잡는다. 라벨이 무엇이든 자리가 맞으면 된다.
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, .{ .input = .{ .shortcut = .new_tab } }),
+        classifyInput(b, cyrillic_tse, .key_t, true, true, false, false),
+    );
+    // 자리를 모르는 event (표에 없는 키) 는 위치 binding 을 발동시키지 않는다.
+    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, cyrillic_tse, null, true, true, false, false));
+}
+
 
 fn terminalSequenceForKeysym(sym: u32) ?[]const u8 {
     return switch (sym) {
@@ -5574,15 +5625,21 @@ const Client = struct {
         // 정책 대상이 아니면(일반 문자 / 터미널 control char / preedit-Ctrl
         // commit / scroll) 아래 기존 PTY 경로로 흘린다.
         if (sym_opt) |sym| {
-            if (classifyInput(sym, ctrl, shift, alt)) |input| {
+            // #493 3-c — 분류의 기준이 config 다. #496 — 같은 event 의 물리 위치를
+            // 함께 넘겨 위치로 적은 binding 도 매칭되게 한다. `key` 는 wl_keyboard 가
+            // 준 raw evdev keycode 다 (xkb 는 여기에 8 을 더한 값을 쓴다).
+            const code = physical_key.fromEvdev(key);
+            const super = self.keyboard.superActive();
+            const bindings = self.config.key_bindings[0..self.config.key_binding_count];
+            if (classifyInput(bindings, sym, code, ctrl, shift, alt, super)) |classified| {
                 // #333 — paste 는 우클릭 / command menu 와 공통 semantic helper(requestPaste)
                 // 로 정책을 정확히 한 번 적용한다. generic resolve/switch 보다 먼저 분기해
                 // 이중 commit 을 막는다.
-                if (input == .paste) {
+                if (classified.input == .paste) {
                     self.requestPaste();
                     return;
                 }
-                const disp = input_policy.resolve(input, .{
+                const disp = input_policy.resolve(classified.input, .{
                     .terminal_preedit_active = self.preedit_text.items.len > 0,
                 });
                 switch (disp.pending) {
@@ -5601,7 +5658,9 @@ const Client = struct {
                 }
                 switch (disp.target) {
                     .run_action => {
-                        self.runShortcutForKey(sym, shift);
+                        // `.paste` 는 위에서 돌아갔고 `.interrupt` 의 target 은 `.pty`
+                        // 이므로 여기 오는 것은 `.shortcut` 뿐이다.
+                        self.runShortcut(classified.input.shortcut, classified.tab_index);
                         return;
                     },
                     // interrupt \x03 는 아래 escape / utf8 로. paste 는 위에서 처리.
@@ -5643,39 +5702,48 @@ const Client = struct {
 
     /// #296 — resolve 가 run_action 으로 판정한 전역 단축키 실행. pending
     /// (preedit) commit 은 resolve 의 `.commit` 이 이미 처리하므로 여기선 action 만.
-    fn runShortcutForKey(self: *Client, sym: u32, shift: bool) void {
-        if (sym == xkb_key_c_lower or sym == xkb_key_c_upper) {
-            self.copyActiveSelection();
-        } else if (sym == xkb_key_t_lower or sym == xkb_key_t_upper) {
-            self.handleNewTab();
-        } else if (sym == xkb_key_w_lower or sym == xkb_key_w_upper) {
-            self.handleCloseTab();
-        } else if (sym == xkb_key_bracketright or sym == xkb_key_braceright) {
-            self.handleNextTab();
-        } else if (sym == xkb_key_bracketleft or sym == xkb_key_braceleft) {
-            self.handlePrevTab();
-        } else if (sym == xkb_key_i_lower or sym == xkb_key_i_upper) {
+    ///
+    /// #493 3-c — 예전엔 keysym 으로 다시 분기했다 (`sym == xkb_key_t_lower` ...).
+    /// 즉 어느 키가 어느 동작인지를 **분류와 실행 두 곳**에 적고 있었고, 그 둘이
+    /// 갈라지는 것이 #484 의 원인이기도 했다. 이제 분류가 이미 `Shortcut` 을 줬으므로
+    /// 여기서는 그것만 보고 실행한다.
+    fn runShortcut(self: *Client, shortcut: input_policy.Shortcut, tab_index: ?usize) void {
+        switch (shortcut) {
+            .copy_selection => self.copyActiveSelection(),
+            .new_tab => self.handleNewTab(),
+            .close_tab => self.handleCloseTab(),
+            .next_tab => self.handleNextTab(),
+            .prev_tab => self.handlePrevTab(),
+            // 인덱스는 액션 이름에서 왔다 (`switch_tab3` → 2). 예전엔 여기서
+            // `sym - xkb_key_1` 로 뽑았다.
+            .switch_tab => self.handleSwitchTab(@intCast(tab_index orelse return)),
             // #213 — About 은 reentrancy 밖 drainAboutRequest 가 열도록 flag 만.
-            self.pending_about_request = true;
-        } else if (sym == xkb_key_p_lower or sym == xkb_key_p_upper) {
-            const cfg_path = paths.configPath(self.rt, self.allocator) catch return;
-            defer self.allocator.free(cfg_path);
-            system_open.openInDefaultApp(self.rt, self.allocator, cfg_path);
-        } else if (sym == xkb_key_l_lower or sym == xkb_key_l_upper) {
-            const log_path = log.filePath() orelse return;
-            system_open.openInDefaultApp(self.rt, self.allocator, log_path);
-        } else if (sym == xkb_key_r_lower or sym == xkb_key_r_upper) {
-            if (self.session) |*session| {
-                if (session.resetActive()) self.requestRedraw();
-            }
-        } else if (sym == xkb_key_f12) {
-            perf.dumpAndReset(self.rt, "snapshot");
-        } else if (sym == xkb_key_f4) {
-            self.pending_quit_request = true;
-        } else if (sym == xkb_key_return) {
-            self.toggleFullscreen(if (shift) .avoid else .cover);
-        } else if (sym >= xkb_key_1 and sym <= xkb_key_9) {
-            self.handleSwitchTab(@intCast(sym - xkb_key_1));
+            .show_about => self.pending_about_request = true,
+            .open_config => {
+                const cfg_path = paths.configPath(self.rt, self.allocator) catch return;
+                defer self.allocator.free(cfg_path);
+                system_open.openInDefaultApp(self.rt, self.allocator, cfg_path);
+            },
+            .open_log => {
+                const log_path = log.filePath() orelse return;
+                system_open.openInDefaultApp(self.rt, self.allocator, log_path);
+            },
+            .reset_terminal => {
+                if (self.session) |*session| {
+                    if (session.resetActive()) self.requestRedraw();
+                }
+            },
+            .dump_perf => perf.dumpAndReset(self.rt, "snapshot"),
+            .quit => self.pending_quit_request = true,
+            // #493 3-c — 두 fullscreen 이 이제 별 변종이다. 예전엔 `fullscreen` 하나에
+            // "Shift 가 눌렸으면 avoid" 라는 암묵 규칙이 붙어 있었는데, 사용자가
+            // `fullscreen_workarea` 에 Shift 없는 조합을 줄 수도 있으므로 그 규칙으로는
+            // 안 된다.
+            .fullscreen => self.toggleFullscreen(.cover),
+            .fullscreen_workarea => self.toggleFullscreen(.avoid),
+            // 이 host 의 키 경로가 내지 않는 것들 — command menu 와 toggle 은 다른
+            // 진입점 (마우스 · 전역 핫키) 이 처리한다.
+            .toggle_visibility, .open_command_menu, .open_shortcuts => {},
         }
     }
 

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -21,6 +21,7 @@ const Runtime = @import("../runtime.zig").Runtime;
 const version = @import("../version.zig");
 const objc = @import("../macos_objc.zig");
 const config = @import("../config.zig");
+const physical_key = @import("../physical_key.zig");
 const ghostty = @import("ghostty-vt");
 const display_width = @import("../font/display_width.zig");
 const renderer_module = @import("../renderer.zig");
@@ -873,28 +874,76 @@ fn applyPasteInputPolicy() void {
     }
 }
 
-/// #296 — macOS Cmd+keyCode 를 입력 정책 Shortcut 으로 분류. 인식 못한 조합은
-/// null (→ mainMenu Cmd+Q 등). `tildazKeyDown` 의 dispatch switch 와 정확히 일치.
-fn macCmdShortcut(kc: c_ushort, shift: bool) ?input_policy.Shortcut {
-    if (kc == 8) return .copy_selection; // Cmd+C
-    if (kc == 0x11 and !shift) return .new_tab; // Cmd+T
-    if (kc == 0x0D and !shift) return .close_tab; // Cmd+W
-    if (keycodeToTabIndex(kc) != null) return .switch_tab; // Cmd+1..9
-    if (shift and kc == 0x21) return .prev_tab; // Shift+Cmd+[
-    if (shift and kc == 0x1E) return .next_tab; // Shift+Cmd+]
-    // #482 — Cmd+PgUp / Cmd+PgDn 으로 이전 / 다음 탭. Linux · Windows 의
-    // Ctrl+PgUp / PgDn 에 대응하는 조합이다 (이 프로젝트의 Ctrl→Cmd 매핑).
-    // AZERTY 문제 자체는 macOS 에 없다 — `kVK_ANSI_*` 는 물리 위치라 layout 과
-    // 무관하다. 세 platform 이 같은 반사를 갖게 맞추는 것이 목적이고, 기존
-    // Shift+Cmd+[ / ] 와 Cmd+1..9 는 그대로 남는다 (추가이지 교체가 아니다).
-    // Mac 노트북엔 전용 PgUp / PgDn 키가 없어 Fn+↑ / Fn+↓ 가 되지만, 기존
-    // 바인딩을 그대로 두므로 잃는 것이 없다.
-    if (!shift and kc == 116) return .prev_tab; // Cmd+PageUp
-    if (!shift and kc == 121) return .next_tab; // Cmd+PageDown
-    if (shift and kc == 0x0F) return .reset_terminal; // Shift+Cmd+R
-    if (kc == 0x24) return .fullscreen; // Cmd+Enter / Shift+Cmd+Enter
-    if (shift and kc == 0x6F) return .dump_perf; // Shift+Cmd+F12
-    return null;
+/// #493 3-c — NSEvent 의 keyCode + modifier flags 를 `[keys]` 와 맞춘다. 예전엔
+/// `macCmdShortcut` 이 `kc == 8` 같은 상수 열두 줄로 같은 일을 했다.
+///
+/// macOS 는 `keyCode` 자체가 **물리 위치**다. 그래서 이 platform 은 위치로 적은
+/// binding (`[KeyW]`) 과 라벨 binding (`w`) 이 같은 값을 내고, 둘 다 자연히 잡힌다
+/// — 그 대가로 AZERTY 사용자는 `Z` 라고 새겨진 키를 눌러야 `close_tab` 이 되는
+/// 것이고 (#496 항목 2), 그것은 이 커밋의 범위가 아니다.
+///
+/// modifier 비트가 우연히 같다: `MacHotkey.MOD_*` 는 `kCGEventFlagMask*` 값이고
+/// `NSEventModifierFlag*` 도 같은 비트 자리를 쓴다 (shift 1<<17 · control 1<<18 ·
+/// option 1<<19 · command 1<<20). 그래도 마스크를 명시해 옮긴다 — 두 상수 집합이
+/// 같다는 사실에 조용히 기대지 않는다.
+fn macLookupAction(kc: c_ushort, flags: c_ulong) ?config.KeyAction {
+    const ns_shift: c_ulong = 1 << 17;
+    const ns_control: c_ulong = 1 << 18;
+    const ns_option: c_ulong = 1 << 19;
+    const ns_command: c_ulong = 1 << 20;
+
+    var modifiers: u64 = 0;
+    if ((flags & ns_shift) != 0) modifiers |= config.Hotkey.MOD_SHIFT;
+    if ((flags & ns_control) != 0) modifiers |= config.Hotkey.MOD_CTRL;
+    if ((flags & ns_option) != 0) modifiers |= config.Hotkey.MOD_ALT;
+    if ((flags & ns_command) != 0) modifiers |= config.Hotkey.MOD_SUPER;
+
+    return config.lookupAction(
+        g_config.key_bindings[0..g_config.key_binding_count],
+        .{ .keycode = kc, .modifiers = modifiers },
+        physical_key.fromMacKeyCode(kc),
+    );
+}
+
+/// #493 3-c — 액션 실행. 예전엔 `tildazKeyDown` 의 switch 가 `keyCode` 를 다시 읽어
+/// (`keycodeToTabIndex(kc).?`, `if (shift) .workarea`) 분기했다. 분류와 실행 두 곳에
+/// 같은 키 표가 있었다는 뜻이고, 그 이중 기술이 갈라지는 것이 #484 의 원인이었다.
+///
+/// `true` = 소비했다. `false` 면 호출자가 기존 경로로 흘린다.
+fn runKeyAction(action: config.KeyAction) bool {
+    const mapped = config.inputForAction(action);
+    // #282 A3 / #340 — paste 는 조합을 먼저 확정하고 payload 를 잇는다. pending 적용은
+    // 우클릭과 공통 helper 한 곳이다.
+    if (mapped.input == .paste) {
+        applyPasteInputPolicy();
+        handlePaste();
+        return true;
+    }
+    const shortcut = mapped.input.shortcut;
+    applyShortcutInputPolicy(shortcut);
+    switch (shortcut) {
+        .copy_selection => handleCopy(),
+        .new_tab => handleNewTab(),
+        .close_tab => handleCloseActiveTab(),
+        // 인덱스는 액션 이름에서 왔다 (`switch_tab3` → 2). `keycodeToTabIndex` 가
+        // 하던 일이다.
+        .switch_tab => tab_actions.switchTab(&g_host, mapped.tab_index orelse return false),
+        .prev_tab => tab_actions.prevTab(&g_host),
+        .next_tab => tab_actions.nextTab(&g_host),
+        .reset_terminal => tab_actions.resetActive(&g_host),
+        .dump_perf => perf.dumpAndReset(g_rt, "snapshot"),
+        // #493 3-c — 두 fullscreen 이 별 액션이 됐다. 예전엔 여기서 Shift 를 다시 읽어
+        // 갈랐는데, 사용자가 `fullscreen_workarea` 에 Shift 없는 조합을 줄 수도 있으므로
+        // 그 규칙으로는 안 된다.
+        .fullscreen => toggleFullscreenMode(.monitor),
+        .fullscreen_workarea => toggleFullscreenMode(.workarea),
+        // macOS 는 이 넷을 mainMenu 가 소유한다 (Cmd+Q / About / Config / Log). 메뉴
+        // 항목과 단축키가 둘 다 살아 있으면 어느 쪽이 이겼는지 알 수 없으므로 키
+        // 경로에서는 소비하지 않고 흘린다 — 메뉴가 받는다.
+        .quit, .show_about, .open_config, .open_log => return false,
+        .toggle_visibility, .open_command_menu, .open_shortcuts => return false,
+    }
+    return true;
 }
 
 fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void {
@@ -940,36 +989,20 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
     if (cmd) {
         const get_kc = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) c_ushort);
         const kc = get_kc(event, objc.sel("keyCode"));
-        const NSEventModifierFlagShift: c_ulong = 1 << 17;
-        const shift = (flags & NSEventModifierFlagShift) != 0;
 
-        // #296 — Cmd 단축키의 preedit commit 여부는 입력 정책(input_policy.
-        // resolve) 한 곳에서 결정. copy(Cmd+C)/perf(Shift+Cmd+F12)는 read-only,
-        // 터미널 preedit 은 자모 보존 위해 flush. 그 외 단축키는 commit 후 실행
-        // (SPEC §4.1).
+        // #296 — 단축키의 preedit commit 여부는 입력 정책 (`input_policy.resolve`)
+        // 한 곳에서 결정한다. copy / perf 는 read-only 라 터미널 preedit 을 자모
+        // 보존 위해 flush 하고, 그 외 단축키는 commit 후 실행한다 (SPEC §4.1).
+        // `runKeyAction` 이 그 helper 를 부른다.
         //
-        // #282 A3 / #340 — Cmd+V(paste): 조합을 먼저 확정하고 payload 를 잇는다.
-        // pending 적용은 우클릭과 공통 helper(applyPasteInputPolicy) 한 곳.
-        if (kc == 9) {
-            applyPasteInputPolicy();
-            handlePaste();
-            return;
-        }
-
-        // Cmd+kc → 입력 정책 Shortcut 분류. 인식 못한 Cmd+key 는 mainMenu(Cmd+Q 등).
-        const shortcut = macCmdShortcut(kc, shift) orelse return;
-        applyShortcutInputPolicy(shortcut);
-        switch (shortcut) {
-            .copy_selection => handleCopy(), // Cmd+C (kc 8)
-            .new_tab => handleNewTab(), // Cmd+T
-            .close_tab => handleCloseActiveTab(), // Cmd+W
-            .switch_tab => tab_actions.switchTab(&g_host, keycodeToTabIndex(kc).?), // Cmd+1..9
-            .prev_tab => tab_actions.prevTab(&g_host), // Shift+Cmd+[ / Cmd+PageUp
-            .next_tab => tab_actions.nextTab(&g_host), // Shift+Cmd+] / Cmd+PageDown
-            .reset_terminal => tab_actions.resetActive(&g_host), // Shift+Cmd+R (#162)
-            .fullscreen => toggleFullscreenMode(if (shift) .workarea else .monitor), // Cmd/Shift+Cmd+Enter (#162)
-            .dump_perf => perf.dumpAndReset(g_rt, "snapshot"), // Shift+Cmd+F12 (#160)
-            else => {}, // macOS keyDown 이 안 내는 나머지(show_about/config/log/quit=mainMenu)
+        // #493 3-c — 어느 조합이 어느 액션인지는 `[keys]` 가 정한다. Shift 를 여기서
+        // 따로 읽지 않는다 — 예전엔 `fullscreen` 하나를 놓고 Shift 로 workarea 를
+        // 갈랐지만 이제 두 액션이 별 항목이다.
+        //
+        // 인식 못한 Cmd+key 는 mainMenu (Cmd+Q 등) 로 가야 하므로 소비하지 않고
+        // `return` 한다 — 기존 동작이다.
+        if (macLookupAction(kc, flags)) |action| {
+            if (runKeyAction(action)) return;
         }
         return;
     }
@@ -979,6 +1012,21 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
     const shift = (flags & NSEventModifierFlagShift) != 0;
     const option = (flags & NSEventModifierFlagOption) != 0;
     const get_keycode = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) c_ushort);
+
+    // #493 3-c — Cmd 없는 조합도 `[keys]` 를 본다. 이것이 없으면 사용자가 `[keys]` 에
+    // 적은 `ctrl+shift+t` 같은 binding 이 macOS 에서만 **조용히 무동작**이 된다 —
+    // 세 platform 이 한 config 를 공유하는데 한 곳만 말없이 무시하는 것은 #208 이
+    // 막으려던 종류의 실패다.
+    //
+    // config 가 아래 macOS 고유 경로보다 **앞선다.** 그래서 사용자가 `alt+return` 을
+    // 바인딩하면 Option+Enter 한자 재변환이 가려진다. 의도한 우선순위다 — Linux ·
+    // Windows 도 config 가 먼저이고, 무엇이 이겼는지 설명할 수 있어야 한다.
+    // 기본 macOS config 는 전부 `cmd` 조합이라 기본 사용자에게는 변화가 없다.
+    if (flags & (NSEventModifierFlagShift | NSEventModifierFlagOption | (1 << 18)) != 0) {
+        if (macLookupAction(get_keycode(event, objc.sel("keyCode")), flags)) |action| {
+            if (runKeyAction(action)) return;
+        }
+    }
     const keycode = get_keycode(event, objc.sel("keyCode"));
 
     if (option and keycode == 0x24) {
@@ -2630,23 +2678,6 @@ fn scrollbarScrollToY(mouse_y_px: f32) void {
     }
 }
 
-/// macOS keycode (kVK_ANSI_*) 의 1..9 → 0-base 탭 인덱스. 1 → 0, 2 → 1 식.
-/// 키보드 row 가 keycode 순서가 아니라 매핑이 비균일 (`0x12, 0x13, 0x14,
-/// 0x15, 0x17, 0x16, 0x1A, 0x1C, 0x19`).
-fn keycodeToTabIndex(kc: c_ushort) ?usize {
-    return switch (kc) {
-        0x12 => 0, // 1
-        0x13 => 1, // 2
-        0x14 => 2, // 3
-        0x15 => 3, // 4
-        0x17 => 4, // 5
-        0x16 => 5, // 6
-        0x1A => 6, // 7
-        0x1C => 7, // 8
-        0x19 => 8, // 9
-        else => null,
-    };
-}
 
 /// Cmd+W — 활성 탭을 즉시 정리. PTY 자식이 살아 있어도 deinit 의 SIGHUP +
 /// fd close 로 정상 hangup 후 종료. 마지막 탭이 닫혔는지는 다음 frame 의

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -99,7 +99,9 @@ pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {
     var app = App{
         .rt = rt,
         .session = undefined,
-        .window = .{ .rt = rt },
+        // #493 3-c — `[keys]` 를 window 의 키 경로에 넘긴다. `config` 는 이 함수의
+        // 지역이고 `app` 보다 먼저 선언되므로 slice 가 window 보다 오래 산다.
+        .window = .{ .rt = rt, .key_bindings = config.key_bindings[0..config.key_binding_count] },
         .allocator = alloc,
         .shell = config.shell, // #248 — 런타임 새 탭 재검증용 (config 생존 동안 유효).
     };

--- a/src/input_policy.zig
+++ b/src/input_policy.zig
@@ -48,6 +48,12 @@ pub const Shortcut = enum {
     dump_perf,
     toggle_visibility,
     fullscreen,
+    /// #493 3-c — 패널을 가리지 않는 fullscreen. 예전엔 `fullscreen` 하나에 host 별로
+    /// "Shift 가 눌렸으면 workarea" 라는 암묵 규칙이 붙어 있었다. `[keys]` 가 두
+    /// 동작을 각각 바인딩할 수 있게 되면서 그 규칙을 없애고 variant 를 나눈다 —
+    /// 사용자가 `fullscreen_workarea` 에 Shift 없는 조합을 줄 수도 있으므로 Shift 로
+    /// 갈라서는 안 된다.
+    fullscreen_workarea,
     quit,
     /// `…` 버튼으로 command menu 를 여는 순간 (#329). outside click 과 같은
     /// 상태 변경 — pending 입력(terminal preedit)을 먼저 commit 한다.
@@ -128,7 +134,7 @@ fn expectDisp(input: Input, state: State, pending: Pending, target: Target) !voi
 test "SPEC §4.1 — preedit 중 action 단축키는 commit 후 실행" {
     // 상태를 바꾸는 단축키(탭/reset/about/config/log/fullscreen/quit)는 focus-loss 로
     // preedit 을 확정한 뒤 실행.
-    for ([_]Shortcut{ .new_tab, .close_tab, .next_tab, .prev_tab, .switch_tab, .reset_terminal, .show_about, .open_config, .open_log, .toggle_visibility, .fullscreen, .quit, .open_command_menu, .open_shortcuts }) |sc| {
+    for ([_]Shortcut{ .new_tab, .close_tab, .next_tab, .prev_tab, .switch_tab, .reset_terminal, .show_about, .open_config, .open_log, .toggle_visibility, .fullscreen, .fullscreen_workarea, .quit, .open_command_menu, .open_shortcuts }) |sc| {
         try expectDisp(.{ .shortcut = sc }, preedit, .commit, .run_action);
     }
 }

--- a/src/instances.zig
+++ b/src/instances.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const toml = @import("toml");
 const config = @import("config.zig");
 const paths = @import("paths.zig");
 const runtime = @import("runtime.zig");
@@ -107,8 +108,11 @@ const EndpointProbeResult = enum {
 const endpoint_poll_interval_ns = 10 * std.time.ns_per_ms;
 
 pub fn parseConfigFileName(name: []const u8) ?u32 {
-    if (!std.mem.startsWith(u8, name, "config_") or !std.mem.endsWith(u8, name, ".json")) return null;
-    const digits = name["config_".len .. name.len - ".json".len];
+    // #493 — config 포맷이 TOML 이다. `.json` 은 인식하지 않는다: 남아 있어도 읽지
+    // 않고 인스턴스로 세지도 않는다 (마이그레이션 없음 — 릴리스 노트와 기본 template
+    // 주석으로만 안내한다).
+    if (!std.mem.startsWith(u8, name, "config_") or !std.mem.endsWith(u8, name, ".toml")) return null;
+    const digits = name["config_".len .. name.len - ".toml".len];
     if (digits.len == 0 or (digits.len > 1 and digits[0] == '0')) return null;
     const index = std.fmt.parseInt(u32, digits, 10) catch return null;
     return if (index <= max_config_index) index else null;
@@ -147,7 +151,7 @@ pub fn createDefaultConfig(
 ) !void {
     const path = try paths.configPathFor(rt, allocator, index);
     defer allocator.free(path);
-    const json = try config.defaultConfigJsonWithHotkey(allocator, shell_resolved, hotkey);
+    const json = try config.defaultConfigTomlWithHotkey(allocator, shell_resolved, hotkey);
     defer allocator.free(json);
 
     const file = try std.Io.Dir.createFileAbsolute(rt.io, path, .{ .exclusive = true });
@@ -469,12 +473,16 @@ pub fn configAutoStart(rt: Runtime, allocator: std.mem.Allocator, index: u32) !b
     var file_reader = file.reader(rt.io, &.{});
     const content = try file_reader.interface.allocRemaining(allocator, .limited(64 * 1024));
     defer allocator.free(content);
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
+    // #493 — TOML. 최상위는 문법상 항상 테이블이라 별도 검사가 필요 없다.
+    var parser: toml.Parser(toml.Table) = .init(allocator);
+    defer parser.deinit();
+    // 파싱 오류는 **그대로 전파**한다. `error.InvalidConfig` 로 뭉개면 런처가
+    // 보여 주는 문구가 "InvalidConfig" 하나로 줄어 원인을 못 알린다 (#495).
+    var parsed = try parser.parseString(content);
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidConfig;
-    const value = parsed.value.object.get("auto_start") orelse return error.InvalidConfig;
-    if (value != .bool) return error.InvalidConfig;
-    return value.bool;
+    const value = parsed.value.get("auto_start") orelse return error.InvalidConfig;
+    if (value != .boolean) return error.InvalidConfig;
+    return value.boolean;
 }
 
 pub fn configHotkeyText(rt: Runtime, allocator: std.mem.Allocator, index: u32) ![]u8 {
@@ -486,10 +494,12 @@ pub fn configHotkeyText(rt: Runtime, allocator: std.mem.Allocator, index: u32) !
     var file_reader = file.reader(rt.io, &.{});
     const content = try file_reader.interface.allocRemaining(allocator, .limited(64 * 1024));
     defer allocator.free(content);
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
+    // #493 — TOML. 최상위는 문법상 항상 테이블이라 별도 검사가 필요 없다.
+    var parser: toml.Parser(toml.Table) = .init(allocator);
+    defer parser.deinit();
+    var parsed = try parser.parseString(content);
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidConfig;
-    const value = parsed.value.object.get("hotkey") orelse return error.InvalidConfig;
+    const value = parsed.value.get("hotkey") orelse return error.InvalidConfig;
     if (value != .string) return error.InvalidConfig;
     return allocator.dupe(u8, value.string);
 }
@@ -503,10 +513,12 @@ pub fn hotkeyOwner(rt: Runtime, allocator: std.mem.Allocator, indices: []const u
         var file_reader = file.reader(rt.io, &.{});
         const content = try file_reader.interface.allocRemaining(allocator, .limited(64 * 1024));
         defer allocator.free(content);
-        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
+        // #493 — TOML. 최상위는 문법상 항상 테이블이다.
+        var parser: toml.Parser(toml.Table) = .init(allocator);
+        defer parser.deinit();
+        var parsed = try parser.parseString(content);
         defer parsed.deinit();
-        if (parsed.value != .object) return error.InvalidConfig;
-        const value = parsed.value.object.get("hotkey") orelse return error.InvalidConfig;
+        const value = parsed.value.get("hotkey") orelse return error.InvalidConfig;
         if (value != .string) return error.InvalidConfig;
         const existing = config.Hotkey.fromString(value.string) orelse return error.InvalidConfig;
         if (std.meta.eql(existing, candidate)) return index;
@@ -593,13 +605,18 @@ test "핫키 중복은 뒤에 있는 인스턴스가 양보한다 (#431)" {
 }
 
 test "only canonical numbered config names are accepted" {
-    try std.testing.expectEqual(@as(?u32, 0), parseConfigFileName("config_0.json"));
-    try std.testing.expectEqual(@as(?u32, 42), parseConfigFileName("config_42.json"));
-    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config.json"));
-    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config0.json"));
-    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_01.json"));
-    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config-1.json"));
-    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_1000.json"));
+    try std.testing.expectEqual(@as(?u32, 0), parseConfigFileName("config_0.toml"));
+    try std.testing.expectEqual(@as(?u32, 42), parseConfigFileName("config_42.toml"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config.toml"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config0.toml"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_01.toml"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config-1.toml"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_1000.toml"));
+    // #493 — 남아 있는 `.json` 은 인스턴스로 세지 않는다. 마이그레이션이 없으므로
+    // 옛 파일이 그대로 남는데, 그것을 인스턴스로 오인하면 없는 config 를 띄우려 한다.
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_0.json"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_3.json"));
+    try std.testing.expectEqual(@as(?u32, null), parseConfigFileName("config_0.toml.bak"));
 }
 
 test "next config index follows the greatest existing index" {

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -289,12 +289,21 @@ pub const config_read_failed_format =
 ;
 
 pub const config_parse_failed_format =
-    \\Failed to parse config JSON.
+    \\Failed to parse config file.
     \\
     \\Path: {s}
     \\Error: {s}
 ;
-pub const config_parse_failed_fallback_msg = "Failed to parse config JSON.";
+/// #493 — TOML 파서는 구문 오류의 **위치**를 준다 (JSON 은 오류 이름만 줬다).
+/// 어디를 고쳐야 하는지 알 수 있어야 사용자가 스스로 해결한다.
+pub const config_parse_failed_at_format =
+    \\Failed to parse config file.
+    \\
+    \\Path: {s}
+    \\Line {d}, column {d}
+    \\Error: {s}
+;
+pub const config_parse_failed_fallback_msg = "Failed to parse config file.";
 
 pub const config_error_fallback_msg = "Configuration is invalid.";
 pub const config_error_with_path_format = "{s}\n\nConfig path:\n  {s}";

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -344,6 +344,12 @@ pub const config_hotkey_unknown_key_fallback_msg = "Configuration: hotkey uses a
 /// 가로챈다). 이쪽은 기존 안내가 정확했다.
 pub const config_hotkey_invalid_format = "Configuration: failed to parse \"hotkey\" value \"{s}\".\n\nOnly F1-F12 may be used without modifiers. Other keys require Ctrl, Alt, Super, or Cmd.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_invalid_fallback_msg = "Configuration: hotkey invalid";
+/// #496 — 위치 표기 (`[KeyW]`) 를 전역 `hotkey` 에 쓴 경우. `config_hotkey_invalid`
+/// 로 묶으면 "Only F1-F12 may be used without modifiers" 를 받는데, 사용자는 modifier
+/// 를 이미 줬으므로 #484 와 똑같이 막다른 길이 된다. 무엇이 안 되는지와 **대신 할 수
+/// 있는 것**을 같이 준다.
+pub const config_hotkey_position_format = "Configuration: \"hotkey\" value \"{s}\" uses the position form (in square brackets).\n\nThe position form works in [keys] but not for the global hotkey: TildaZ has to register that one with the desktop, and every path it uses (sway, Hyprland, COSMIC, KDE) accepts only a character.\n\nUse a key name instead -- a function key is the safest choice because it is the same on every keyboard layout.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
+pub const config_hotkey_position_fallback_msg = "Configuration: hotkey cannot use the position form";
 /// #431 — 다른 TildaZ 인스턴스가 이미 쓰는 전역 핫키. 뒤에 있는 (index 가 큰) 쪽이 양보하므로
 /// 이 메시지는 그 인스턴스에만 나온다. **겹친 상대를 번호로 짚어 주는 것이 핵심이다** — 예전엔
 /// Windows 의 `RegisterHotKey` 실패 안내가 "Another app already registered the same combination"

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -322,7 +322,23 @@ pub const config_unknown_theme_header_format = "Configuration: unknown theme \"{
 ///
 /// key 이름을 못 알아본 경우. **받는 key 목록을 함께 준다** — 안 되는 이유만 알려 주고
 /// 무엇이 되는지 안 알려 주면 사용자가 또 추측해야 한다.
-pub const config_hotkey_unknown_key_format = "Configuration: \"hotkey\" value \"{s}\" uses a key TildaZ does not recognize.\n\nAccepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return, grave (`)\nAccepted modifiers: ctrl, shift, alt, super (also win / cmd / meta)\n\nKeys outside this list are not supported yet, including layout-specific ones.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
+/// #493 — `[keys]` 의 같은 키가 두 액션에 걸린 경우. **양쪽 액션을 다 짚는다** —
+/// 한쪽만 알려주면 사용자가 나머지를 찾아 헤맨다 (#484 의 hotkey 메시지 교훈).
+/// 바인딩 총량 상한. 조용히 잘라 버리면 사용자가 적은 단축키가 이유 없이 안 먹는다.
+pub const config_key_too_many_format = "Configuration: too many key bindings in [keys] (limit {d}).";
+pub const config_key_too_many_fallback_msg = "Configuration: too many key bindings in [keys]";
+pub const config_key_conflict_format = "Configuration: \"{s}\" is bound to both \"{s}\" and \"{s}\" in [keys].\n\nEach key may trigger only one action. Remove it from one of them.";
+pub const config_key_conflict_fallback_msg = "Configuration: the same key is bound to two actions in [keys]";
+/// `[keys]` 의 값이 리스트가 아닌 경우.
+pub const config_key_not_list_format = "Configuration: \"keys.{s}\" must be a list of key combinations.\n\nExample: {s} = [\"ctrl+shift+t\"]\nUse an empty list [] to leave the action unbound.";
+pub const config_key_not_list_fallback_msg = "Configuration: a [keys] entry must be a list";
+/// `[keys]` 의 키 문자열을 파싱하지 못한 경우. `hotkey` 와 달리 액션 이름을 함께 짚는다.
+pub const config_key_invalid_format = "Configuration: \"keys.{s}\" contains a key TildaZ does not recognize: \"{s}\".\n\nAccepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return, grave (`), pageup, pagedown, [ , ]\nAccepted modifiers: ctrl, shift, alt, super (also win / cmd / meta)\n\nKeys outside this list are not supported yet, including layout-specific ones.";
+pub const config_key_invalid_fallback_msg = "Configuration: a [keys] entry uses an unrecognized key";
+/// 글자를 내는 키를 modifier 없이 바인딩한 경우 — 그 글자를 터미널에 칠 수 없게 된다.
+pub const config_key_needs_modifier_format = "Configuration: \"keys.{s}\" binds \"{s}\" without Ctrl, Alt, or Cmd.\n\nThat key types text, so binding it alone would make it impossible to type in the terminal. Keys that do not type text (F1-F12, PageUp, PageDown) may be bound without a modifier.";
+pub const config_key_needs_modifier_fallback_msg = "Configuration: a [keys] entry needs a modifier";
+pub const config_hotkey_unknown_key_format = "Configuration: \"hotkey\" value \"{s}\" uses a key TildaZ does not recognize.\n\nAccepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return, grave (`), pageup, pagedown, [ , ]\nAccepted modifiers: ctrl, shift, alt, super (also win / cmd / meta)\n\nKeys outside this list are not supported yet, including layout-specific ones.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_unknown_key_fallback_msg = "Configuration: hotkey uses an unrecognized key";
 /// key 는 유효하지만 modifier 가 없어 전역 등록이 위험한 경우 (일상 입력을 OS 전체에서
 /// 가로챈다). 이쪽은 기존 안내가 정확했다.

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -338,6 +338,14 @@ pub const config_key_invalid_fallback_msg = "Configuration: a [keys] entry uses 
 /// 글자를 내는 키를 modifier 없이 바인딩한 경우 — 그 글자를 터미널에 칠 수 없게 된다.
 pub const config_key_needs_modifier_format = "Configuration: \"keys.{s}\" binds \"{s}\" without Ctrl, Alt, or Cmd.\n\nThat key types text, so binding it alone would make it impossible to type in the terminal. Keys that do not type text (F1-F12, PageUp, PageDown) may be bound without a modifier.";
 pub const config_key_needs_modifier_fallback_msg = "Configuration: a [keys] entry needs a modifier";
+/// #496 — 위치 표기를 macOS 에서 쓸 수 없는 두 경우. 안내가 갈리는 이유는 원인이
+/// 다르기 때문이다 — 하나는 **키가 다른 이름으로 보고되는 것**이고 다른 하나는
+/// **정말 없는 것**이다. 한 메시지로 묶으면 앞쪽 사용자에게 "쓸 수 없다" 고 말하게
+/// 되는데 실제로는 이름만 바꾸면 되는 상황이다 (#484 의 교훈).
+pub const config_key_position_aliased_format = "Configuration: \"keys.{s}\" uses {s}, and macOS reports that key under a different name.\n\nOn a PC keyboard attached to a Mac, PrintScreen, ScrollLock and Pause arrive as F13, F14 and F15 -- Apple's extended keyboard puts those function keys in the same spots.\n\nUse [F13], [F14] or [F15] instead.";
+pub const config_key_position_aliased_fallback_msg = "Configuration: on macOS use [F13] / [F14] / [F15] for PrintScreen / ScrollLock / Pause";
+pub const config_key_position_absent_format = "Configuration: \"keys.{s}\" uses {s}, which macOS does not provide.\n\nApple's key codes stop at F20, and the Japanese input-switching keys (Convert, NonConvert, KanaMode) are handled by the input method rather than delivered as keys.\n\nPick a different key for this action, or leave it unbound with an empty list [].";
+pub const config_key_position_absent_fallback_msg = "Configuration: that key position does not exist on macOS";
 pub const config_hotkey_unknown_key_format = "Configuration: \"hotkey\" value \"{s}\" uses a key TildaZ does not recognize.\n\nAccepted keys: F1-F12, A-Z, 0-9, space, tab, escape, return, grave (`), pageup, pagedown, [ , ]\nAccepted modifiers: ctrl, shift, alt, super (also win / cmd / meta)\n\nKeys outside this list are not supported yet, including layout-specific ones.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_unknown_key_fallback_msg = "Configuration: hotkey uses an unrecognized key";
 /// key 는 유효하지만 modifier 가 없어 전역 등록이 위험한 경우 (일상 입력을 OS 전체에서

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -1,12 +1,12 @@
-// 사용자 데이터 파일 (config_N.json / tildaz_N.log) 의 absolute 절대 경로 — OS
+// 사용자 데이터 파일 (config_N.toml / tildaz_N.log) 의 absolute 절대 경로 — OS
 // 표준 위치를 따른다 (SPEC.md §11.1, AGENTS.md "platform native first").
-// 로그 파일명은 config 파일명 (config_N.json) 과 같은 `이름_번호` 형식.
+// 로그 파일명은 config 파일명 (config_N.toml) 과 같은 `이름_번호` 형식.
 //
-//   Windows: %APPDATA%\tildaz\config_N.json   (Microsoft 표준)
+//   Windows: %APPDATA%\tildaz\config_N.toml   (Microsoft 표준)
 //            %APPDATA%\tildaz\tildaz_N.log
-//   macOS:   $XDG_CONFIG_HOME/tildaz/config_N.json (fallback: $HOME/.config)
+//   macOS:   $XDG_CONFIG_HOME/tildaz/config_N.toml (fallback: $HOME/.config)
 //            $HOME/Library/Logs/tildaz_N.log    (Apple HIG — Console.app 인덱싱)
-//   Linux:   $XDG_CONFIG_HOME/tildaz/config_N.json (fallback: $HOME/.config)
+//   Linux:   $XDG_CONFIG_HOME/tildaz/config_N.toml (fallback: $HOME/.config)
 //            $XDG_STATE_HOME/tildaz/tildaz_N.log (fallback: $HOME/.local/state)
 //
 // 모두 allocator-based — 호출처가 free 책임. 부모 디렉토리는 자동 생성
@@ -31,7 +31,7 @@ pub fn configPathFor(rt: Runtime, allocator: std.mem.Allocator, index: u32) ![]u
     defer allocator.free(dir);
     try ensureDir(rt, dir);
     const sep: u8 = if (builtin.os.tag == .windows) '\\' else '/';
-    return std.fmt.allocPrint(allocator, "{s}{c}config_{d}.json", .{ dir, sep, index });
+    return std.fmt.allocPrint(allocator, "{s}{c}config_{d}.toml", .{ dir, sep, index });
 }
 
 pub fn logPath(rt: Runtime, allocator: std.mem.Allocator) ![]u8 {

--- a/src/physical_key.zig
+++ b/src/physical_key.zig
@@ -1,0 +1,312 @@
+//! #496 — 키의 **물리적 위치**. layout 과 무관하다.
+//!
+//! 라벨 (키에 새겨진 글자) 로만 단축키를 표현하면 비라틴 layout (키릴 · 그리스 ·
+//! 아랍 ...) 에서 글자 단축키가 전부 죽는다. `ctrl+shift+w` 를 등록해도 `ru`
+//! layout 의 어느 키도 `w` 를 내지 않기 때문이다 (`xkbcli how-to-type --layout ru
+//! 'w'` 가 빈 결과다). 그래서 위치로도 적을 수 있어야 한다.
+//!
+//! ## 이름은 W3C 표준을 쓴다
+//!
+//! 이름 집합은 [UI Events KeyboardEvent code Values](https://www.w3.org/TR/uievents-code/)
+//! 다 — 2025 년 W3C Recommendation. 우리가 이름을 발명하지 않는다.
+//!
+//! 표기는 VS Code 와 같은 대괄호다 (`"ctrl+shift+[KeyW]"`). config 문법에는 표준이
+//! 없어 구현마다 다르지만 (`vk(65)` / `sc(30)` — Windows Terminal, `code:25` —
+//! Hyprland, `bindcode 25` — i3 · sway), **숫자를 쓰는 쪽은 `xev` / `wev` 로 값을
+//! 찾아야 한다.** 이름을 쓰는 VS Code 방식만 config 를 읽어서 이해할 수 있다.
+//!
+//! ## 수용 범위는 라벨 집합과 1:1 이다
+//!
+//! 라벨로 쓸 수 있는 키의 **위치만** 담는다 — F1~F12 · A~Z · 0~9 · backquote ·
+//! bracket · space · tab · escape · enter · pageup · pagedown. `-` `=` `\` `;`
+//! `'` `,` `.` `/` 의 위치는 **일부러 없다**: 라벨 쪽이 그것을 거부하는데 (#208)
+//! 위치 쪽만 받으면 수용 집합이 조용히 넓어진다. 확대는 별 결정 사항이다 (#493).
+//!
+//! ## 세 platform 값
+//!
+//! | 열 | 의미 | 출처 |
+//! |---|---|---|
+//! | `evdev` | Linux evdev keycode | `linux/input-event-codes.h` |
+//! | `scan` | Windows scan code (set 1 make code) | `WM_KEYDOWN` lParam bit 16~23 |
+//! | `mac` | macOS hardware keyCode | `Carbon/HIToolbox/Events.h` `kVK_*` |
+//!
+//! evdev 와 set-1 scan code 는 main block 에서 값이 같다 (evdev 가 set 1 에서 왔다).
+//! 그래도 두 열을 따로 적는다 — PageUp / PageDown 처럼 extended 키에서 갈리고
+//! (evdev 104 vs scan 0x49), 같은 값을 우연에 맡기면 나중에 조용히 어긋난다.
+//!
+//! `mac` 열은 `config.zig` 의 `MacHotkey.keycodeFromKey` 와 **값이 같아야 한다** —
+//! 그쪽이 이미 US 위치표이기 때문이다 (그래서 AZERTY macOS 에서 `Z` 라고 새겨진
+//! 키가 `w` 로 잡힌다. #496 항목 2). 두 표가 갈라지면 `[KeyW]` 와 라벨 `w` 가 macOS
+//! 에서 서로 다른 키가 되고 증상이 조용하다. `config.zig` 의
+//! `test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다"` 가 그것을 고정한다.
+
+const std = @import("std");
+
+/// W3C `KeyboardEvent.code` 값 중 TildaZ 가 받는 것.
+pub const PhysicalCode = enum {
+    f1,
+    f2,
+    f3,
+    f4,
+    f5,
+    f6,
+    f7,
+    f8,
+    f9,
+    f10,
+    f11,
+    f12,
+
+    key_a,
+    key_b,
+    key_c,
+    key_d,
+    key_e,
+    key_f,
+    key_g,
+    key_h,
+    key_i,
+    key_j,
+    key_k,
+    key_l,
+    key_m,
+    key_n,
+    key_o,
+    key_p,
+    key_q,
+    key_r,
+    key_s,
+    key_t,
+    key_u,
+    key_v,
+    key_w,
+    key_x,
+    key_y,
+    key_z,
+
+    digit0,
+    digit1,
+    digit2,
+    digit3,
+    digit4,
+    digit5,
+    digit6,
+    digit7,
+    digit8,
+    digit9,
+
+    backquote,
+    bracket_left,
+    bracket_right,
+
+    space,
+    tab,
+    escape,
+    enter,
+    page_up,
+    page_down,
+};
+
+const Entry = struct {
+    code: PhysicalCode,
+    /// W3C 표기 그대로. 대소문자까지 표준이다 — 사용자에게 되돌려 줄 때 이 문자열을
+    /// 쓴다 (`[KeyW]`).
+    name: []const u8,
+    evdev: u16,
+    scan: u16,
+    mac: u16,
+};
+
+/// 단일 출처. 이름 조회 · 값 조회 · 역방향 조회가 모두 이 표를 본다.
+const table = [_]Entry{
+    // Function key — layout 무관이라 위치로 적을 이유는 없지만, 라벨 집합에 있는
+    // 키는 위치로도 적을 수 있어야 한다 (한쪽만 받으면 그 자체가 함정이다).
+    .{ .code = .f1, .name = "F1", .evdev = 59, .scan = 0x3B, .mac = 0x7A },
+    .{ .code = .f2, .name = "F2", .evdev = 60, .scan = 0x3C, .mac = 0x78 },
+    .{ .code = .f3, .name = "F3", .evdev = 61, .scan = 0x3D, .mac = 0x63 },
+    .{ .code = .f4, .name = "F4", .evdev = 62, .scan = 0x3E, .mac = 0x76 },
+    .{ .code = .f5, .name = "F5", .evdev = 63, .scan = 0x3F, .mac = 0x60 },
+    .{ .code = .f6, .name = "F6", .evdev = 64, .scan = 0x40, .mac = 0x61 },
+    .{ .code = .f7, .name = "F7", .evdev = 65, .scan = 0x41, .mac = 0x62 },
+    .{ .code = .f8, .name = "F8", .evdev = 66, .scan = 0x42, .mac = 0x64 },
+    .{ .code = .f9, .name = "F9", .evdev = 67, .scan = 0x43, .mac = 0x65 },
+    .{ .code = .f10, .name = "F10", .evdev = 68, .scan = 0x44, .mac = 0x6D },
+    // F11 / F12 는 F10 다음이 아니다 — set 1 에서 0x57 / 0x58 로 떨어져 있고
+    // evdev 도 그것을 따라 87 / 88 이다.
+    .{ .code = .f11, .name = "F11", .evdev = 87, .scan = 0x57, .mac = 0x67 },
+    .{ .code = .f12, .name = "F12", .evdev = 88, .scan = 0x58, .mac = 0x6F },
+
+    // 글자 — QWERTY 자리 이름이다. `KeyW` 는 "US QWERTY 에서 `w` 가 있는 자리" 이고
+    // 그 자리는 AZERTY 에서 `z` 를, 키릴에서 `ц` 를 낸다.
+    .{ .code = .key_a, .name = "KeyA", .evdev = 30, .scan = 0x1E, .mac = 0x00 },
+    .{ .code = .key_b, .name = "KeyB", .evdev = 48, .scan = 0x30, .mac = 0x0B },
+    .{ .code = .key_c, .name = "KeyC", .evdev = 46, .scan = 0x2E, .mac = 0x08 },
+    .{ .code = .key_d, .name = "KeyD", .evdev = 32, .scan = 0x20, .mac = 0x02 },
+    .{ .code = .key_e, .name = "KeyE", .evdev = 18, .scan = 0x12, .mac = 0x0E },
+    .{ .code = .key_f, .name = "KeyF", .evdev = 33, .scan = 0x21, .mac = 0x03 },
+    .{ .code = .key_g, .name = "KeyG", .evdev = 34, .scan = 0x22, .mac = 0x05 },
+    .{ .code = .key_h, .name = "KeyH", .evdev = 35, .scan = 0x23, .mac = 0x04 },
+    .{ .code = .key_i, .name = "KeyI", .evdev = 23, .scan = 0x17, .mac = 0x22 },
+    .{ .code = .key_j, .name = "KeyJ", .evdev = 36, .scan = 0x24, .mac = 0x26 },
+    .{ .code = .key_k, .name = "KeyK", .evdev = 37, .scan = 0x25, .mac = 0x28 },
+    .{ .code = .key_l, .name = "KeyL", .evdev = 38, .scan = 0x26, .mac = 0x25 },
+    .{ .code = .key_m, .name = "KeyM", .evdev = 50, .scan = 0x32, .mac = 0x2E },
+    .{ .code = .key_n, .name = "KeyN", .evdev = 49, .scan = 0x31, .mac = 0x2D },
+    .{ .code = .key_o, .name = "KeyO", .evdev = 24, .scan = 0x18, .mac = 0x1F },
+    .{ .code = .key_p, .name = "KeyP", .evdev = 25, .scan = 0x19, .mac = 0x23 },
+    .{ .code = .key_q, .name = "KeyQ", .evdev = 16, .scan = 0x10, .mac = 0x0C },
+    .{ .code = .key_r, .name = "KeyR", .evdev = 19, .scan = 0x13, .mac = 0x0F },
+    .{ .code = .key_s, .name = "KeyS", .evdev = 31, .scan = 0x1F, .mac = 0x01 },
+    .{ .code = .key_t, .name = "KeyT", .evdev = 20, .scan = 0x14, .mac = 0x11 },
+    .{ .code = .key_u, .name = "KeyU", .evdev = 22, .scan = 0x16, .mac = 0x20 },
+    .{ .code = .key_v, .name = "KeyV", .evdev = 47, .scan = 0x2F, .mac = 0x09 },
+    .{ .code = .key_w, .name = "KeyW", .evdev = 17, .scan = 0x11, .mac = 0x0D },
+    .{ .code = .key_x, .name = "KeyX", .evdev = 45, .scan = 0x2D, .mac = 0x07 },
+    .{ .code = .key_y, .name = "KeyY", .evdev = 21, .scan = 0x15, .mac = 0x10 },
+    .{ .code = .key_z, .name = "KeyZ", .evdev = 44, .scan = 0x2C, .mac = 0x06 },
+
+    // 숫자열. macOS 값이 순서대로가 아니다 — `kVK_ANSI_6` (0x16) 이 `kVK_ANSI_5`
+    // (0x17) 보다 작다. Apple 헤더의 실제 값이며 오타가 아니다.
+    .{ .code = .digit1, .name = "Digit1", .evdev = 2, .scan = 0x02, .mac = 0x12 },
+    .{ .code = .digit2, .name = "Digit2", .evdev = 3, .scan = 0x03, .mac = 0x13 },
+    .{ .code = .digit3, .name = "Digit3", .evdev = 4, .scan = 0x04, .mac = 0x14 },
+    .{ .code = .digit4, .name = "Digit4", .evdev = 5, .scan = 0x05, .mac = 0x15 },
+    .{ .code = .digit5, .name = "Digit5", .evdev = 6, .scan = 0x06, .mac = 0x17 },
+    .{ .code = .digit6, .name = "Digit6", .evdev = 7, .scan = 0x07, .mac = 0x16 },
+    .{ .code = .digit7, .name = "Digit7", .evdev = 8, .scan = 0x08, .mac = 0x1A },
+    .{ .code = .digit8, .name = "Digit8", .evdev = 9, .scan = 0x09, .mac = 0x1C },
+    .{ .code = .digit9, .name = "Digit9", .evdev = 10, .scan = 0x0A, .mac = 0x19 },
+    // `Digit0` 은 숫자열 맨 오른쪽이라 `Digit9` 다음이다 — 값이 0 부터 시작하지
+    // 않는다.
+    .{ .code = .digit0, .name = "Digit0", .evdev = 11, .scan = 0x0B, .mac = 0x1D },
+
+    .{ .code = .backquote, .name = "Backquote", .evdev = 41, .scan = 0x29, .mac = 0x32 },
+    .{ .code = .bracket_left, .name = "BracketLeft", .evdev = 26, .scan = 0x1A, .mac = 0x21 },
+    .{ .code = .bracket_right, .name = "BracketRight", .evdev = 27, .scan = 0x1B, .mac = 0x1E },
+
+    .{ .code = .space, .name = "Space", .evdev = 57, .scan = 0x39, .mac = 0x31 },
+    .{ .code = .tab, .name = "Tab", .evdev = 15, .scan = 0x0F, .mac = 0x30 },
+    .{ .code = .escape, .name = "Escape", .evdev = 1, .scan = 0x01, .mac = 0x35 },
+    // W3C 는 main block 의 return 키를 `Enter` 라 부른다 (`Return` 이 아니다).
+    .{ .code = .enter, .name = "Enter", .evdev = 28, .scan = 0x1C, .mac = 0x24 },
+    // extended 키 — 여기서 evdev 와 scan 이 갈린다. scan 은 `0xE0` prefix 를 뗀
+    // 값이다 (`WM_KEYDOWN` lParam 의 bit 16~23 에 그 하위 byte 만 온다).
+    .{ .code = .page_up, .name = "PageUp", .evdev = 104, .scan = 0x49, .mac = 0x74 },
+    .{ .code = .page_down, .name = "PageDown", .evdev = 109, .scan = 0x51, .mac = 0x79 },
+};
+
+/// `[...]` 안의 이름 → code. 대소문자 무관 — config 의 다른 토큰이 모두 그렇다.
+pub fn fromName(text: []const u8) ?PhysicalCode {
+    for (table) |e| {
+        if (std.ascii.eqlIgnoreCase(text, e.name)) return e.code;
+    }
+    return null;
+}
+
+/// code → W3C 표기. 사용자에게 되돌려 줄 때 (설정 UI · 오류 메시지) 쓴다.
+pub fn name(code: PhysicalCode) []const u8 {
+    return entry(code).name;
+}
+
+pub fn evdev(code: PhysicalCode) u16 {
+    return entry(code).evdev;
+}
+
+pub fn scanCode(code: PhysicalCode) u16 {
+    return entry(code).scan;
+}
+
+pub fn macKeyCode(code: PhysicalCode) u16 {
+    return entry(code).mac;
+}
+
+pub fn fromEvdev(value: u32) ?PhysicalCode {
+    for (table) |e| {
+        if (e.evdev == value) return e.code;
+    }
+    return null;
+}
+
+pub fn fromScanCode(value: u32) ?PhysicalCode {
+    for (table) |e| {
+        if (e.scan == value) return e.code;
+    }
+    return null;
+}
+
+pub fn fromMacKeyCode(value: u32) ?PhysicalCode {
+    for (table) |e| {
+        if (e.mac == value) return e.code;
+    }
+    return null;
+}
+
+fn entry(code: PhysicalCode) Entry {
+    for (table) |e| {
+        if (e.code == code) return e;
+    }
+    // 아래 test 가 enum 전수를 고정하므로 여기 도달하면 표에 구멍이 난 것이다.
+    unreachable;
+}
+
+test "표가 enum 을 빠짐없이 정확히 한 번씩 덮는다" {
+    const fields = @typeInfo(PhysicalCode).@"enum".fields;
+    try std.testing.expectEqual(fields.len, table.len);
+    inline for (fields) |f| {
+        const code = @field(PhysicalCode, f.name);
+        var seen: usize = 0;
+        for (table) |e| {
+            if (e.code == code) seen += 1;
+        }
+        try std.testing.expectEqual(@as(usize, 1), seen);
+    }
+}
+
+test "세 platform 값이 code 안에서 각각 유일하다" {
+    // 값이 겹치면 역방향 조회 (`fromEvdev` 등) 가 엉뚱한 code 를 준다.
+    for (table, 0..) |a, i| {
+        for (table[i + 1 ..]) |b| {
+            try std.testing.expect(a.evdev != b.evdev);
+            try std.testing.expect(a.scan != b.scan);
+            try std.testing.expect(a.mac != b.mac);
+            try std.testing.expect(!std.ascii.eqlIgnoreCase(a.name, b.name));
+        }
+    }
+}
+
+test "이름 왕복" {
+    for (table) |e| {
+        try std.testing.expectEqual(e.code, fromName(e.name).?);
+        try std.testing.expectEqualStrings(e.name, name(e.code));
+    }
+    // 대소문자 무관.
+    try std.testing.expectEqual(PhysicalCode.key_w, fromName("keyw").?);
+    try std.testing.expectEqual(PhysicalCode.key_w, fromName("KEYW").?);
+    try std.testing.expectEqual(PhysicalCode.bracket_left, fromName("bracketleft").?);
+    // 라벨 집합에 없는 위치는 받지 않는다 — 수용 집합이 조용히 넓어지지 않게.
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Minus"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Slash"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Backslash"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("F13"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName(""));
+}
+
+test "값 왕복" {
+    for (table) |e| {
+        try std.testing.expectEqual(e.code, fromEvdev(e.evdev).?);
+        try std.testing.expectEqual(e.code, fromScanCode(e.scan).?);
+        try std.testing.expectEqual(e.code, fromMacKeyCode(e.mac).?);
+        try std.testing.expectEqual(e.evdev, evdev(e.code));
+        try std.testing.expectEqual(e.scan, scanCode(e.code));
+        try std.testing.expectEqual(e.mac, macKeyCode(e.code));
+    }
+}
+
+test "evdev 와 scan code 가 main block 에서 같고 extended 에서 갈린다" {
+    // 이 성질에 코드가 기대지 않는다는 것을 문서화하는 test 다 — 두 열을 따로
+    // 적는 이유가 여기 있다.
+    try std.testing.expectEqual(evdev(.key_q), scanCode(.key_q));
+    try std.testing.expectEqual(evdev(.f12), scanCode(.f12));
+    try std.testing.expect(evdev(.page_up) != scanCode(.page_up));
+    try std.testing.expect(evdev(.page_down) != scanCode(.page_down));
+}

--- a/src/physical_key.zig
+++ b/src/physical_key.zig
@@ -15,12 +15,23 @@
 //! Hyprland, `bindcode 25` — i3 · sway), **숫자를 쓰는 쪽은 `xev` / `wev` 로 값을
 //! 찾아야 한다.** 이름을 쓰는 VS Code 방식만 config 를 읽어서 이해할 수 있다.
 //!
-//! ## 수용 범위는 라벨 집합과 1:1 이다
+//! ## 수용 범위 — 자판의 모든 키를 담는다
 //!
-//! 라벨로 쓸 수 있는 키의 **위치만** 담는다 — F1~F12 · A~Z · 0~9 · backquote ·
-//! bracket · space · tab · escape · enter · pageup · pagedown. `-` `=` `\` `;`
-//! `'` `,` `.` `/` 의 위치는 **일부러 없다**: 라벨 쪽이 그것을 거부하는데 (#208)
-//! 위치 쪽만 받으면 수용 집합이 조용히 넓어진다. 확대는 별 결정 사항이다 (#493).
+//! 라벨 집합보다 **넓다.** 처음엔 1:1 로 맞췄는데 (라벨이 거부하는 것을 위치만
+//! 받으면 수용 집합이 조용히 넓어지므로) 그 제약을 명시적으로 걷었다.
+//!
+//! 근거는 두 집합의 **의미가 다르다**는 것이다. 라벨을 넓히려면 `-` 에 어떤 값을
+//! 줄지 정해야 하는데, `VK_OEM_MINUS` / `kVK_ANSI_Minus` 는 라벨이 아니라 "US 자판
+//! 에서 `-` 가 있는 자리" 다. 그것을 라벨로 받으면 Linux 는 라벨로, Windows ·
+//! macOS 는 US 위치로 잡아 #496 의 세 갈래 불일치가 더 깊어진다. 라벨을 정직하게
+//! 넓히려면 live layout 조회가 필요하다 (macOS `UCKeyTranslate`, Windows
+//! `VkKeyScanEx`) — #496 항목 2 다.
+//!
+//! 위치 쪽은 그 문제가 없다. `[Minus]` 는 처음부터 "그 자리" 이고 세 platform 에
+//! 고정값이 있다. 그래서 **자판에 있는 키는 위치로 다 쓸 수 있게** 한다.
+//!
+//! 아직 없는 것: numpad · media 키 · JIS 전용 키 (`IntlYen` · `IntlRo`). 값 검증이
+//! 안 됐고 요청도 없었다. 필요하면 표에 행을 더하면 된다.
 //!
 //! ## 세 platform 값
 //!
@@ -98,6 +109,16 @@ pub const PhysicalCode = enum {
     backquote,
     bracket_left,
     bracket_right,
+    minus,
+    equal,
+    semicolon,
+    quote,
+    backslash,
+    comma,
+    period,
+    slash,
+    /// ISO 자판에만 있는 키 (AZERTY 의 `<>`, QWERTZ 의 `<>|`). US ANSI 에는 없다.
+    intl_backslash,
 
     space,
     tab,
@@ -183,6 +204,23 @@ const table = [_]Entry{
     .{ .code = .backquote, .name = "Backquote", .evdev = 41, .scan = 0x29, .mac = 0x32 },
     .{ .code = .bracket_left, .name = "BracketLeft", .evdev = 26, .scan = 0x1A, .mac = 0x21 },
     .{ .code = .bracket_right, .name = "BracketRight", .evdev = 27, .scan = 0x1B, .mac = 0x1E },
+
+    // ASCII 기호 자리. 라벨 집합에는 없지만 (#208) 위치로는 받는다 — 위 정책 문단
+    // 참고. `-` 와 `_` 처럼 Shift 로 갈리는 두 글자가 **한 자리**이므로 이름이
+    // 무시프트 글자 기준이다 (W3C 규칙).
+    .{ .code = .minus, .name = "Minus", .evdev = 12, .scan = 0x0C, .mac = 0x1B },
+    .{ .code = .equal, .name = "Equal", .evdev = 13, .scan = 0x0D, .mac = 0x18 },
+    .{ .code = .semicolon, .name = "Semicolon", .evdev = 39, .scan = 0x27, .mac = 0x29 },
+    .{ .code = .quote, .name = "Quote", .evdev = 40, .scan = 0x28, .mac = 0x27 },
+    .{ .code = .backslash, .name = "Backslash", .evdev = 43, .scan = 0x2B, .mac = 0x2A },
+    .{ .code = .comma, .name = "Comma", .evdev = 51, .scan = 0x33, .mac = 0x2B },
+    .{ .code = .period, .name = "Period", .evdev = 52, .scan = 0x34, .mac = 0x2F },
+    .{ .code = .slash, .name = "Slash", .evdev = 53, .scan = 0x35, .mac = 0x2C },
+    // ISO 자판의 추가 키 — US ANSI 에는 **없다.** AZERTY 의 `<>`, QWERTZ 의 `<>|`
+    // 자리다. `KEY_102ND` / 102-key 자판의 그 키이고, macOS 는 `kVK_ISO_Section`
+    // 이라는 다른 이름을 쓴다. 이 키가 있어야 그 자판 사용자가 "내 키보드의 모든
+    // 키" 를 실제로 다 쓸 수 있다.
+    .{ .code = .intl_backslash, .name = "IntlBackslash", .evdev = 86, .scan = 0x56, .mac = 0x0A },
 
     .{ .code = .space, .name = "Space", .evdev = 57, .scan = 0x39, .mac = 0x31 },
     .{ .code = .tab, .name = "Tab", .evdev = 15, .scan = 0x0F, .mac = 0x30 },
@@ -283,11 +321,15 @@ test "이름 왕복" {
     try std.testing.expectEqual(PhysicalCode.key_w, fromName("keyw").?);
     try std.testing.expectEqual(PhysicalCode.key_w, fromName("KEYW").?);
     try std.testing.expectEqual(PhysicalCode.bracket_left, fromName("bracketleft").?);
-    // 라벨 집합에 없는 위치는 받지 않는다 — 수용 집합이 조용히 넓어지지 않게.
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Minus"));
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Slash"));
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Backslash"));
+    // 라벨 집합에 없는 자리도 위치로는 받는다 — 자판에 있는 키를 다 쓸 수 있게.
+    try std.testing.expectEqual(PhysicalCode.minus, fromName("Minus").?);
+    try std.testing.expectEqual(PhysicalCode.slash, fromName("Slash").?);
+    try std.testing.expectEqual(PhysicalCode.backslash, fromName("Backslash").?);
+    try std.testing.expectEqual(PhysicalCode.intl_backslash, fromName("IntlBackslash").?);
+    // 표에 없는 이름은 여전히 거부한다 — 오타가 조용히 통과하면 안 된다.
     try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("F13"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Numpad0"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("IntlYen"));
     try std.testing.expectEqual(@as(?PhysicalCode, null), fromName(""));
 }
 

--- a/src/physical_key.zig
+++ b/src/physical_key.zig
@@ -15,35 +15,74 @@
 //! Hyprland, `bindcode 25` — i3 · sway), **숫자를 쓰는 쪽은 `xev` / `wev` 로 값을
 //! 찾아야 한다.** 이름을 쓰는 VS Code 방식만 config 를 읽어서 이해할 수 있다.
 //!
-//! ## 수용 범위 — 자판의 모든 키를 담는다
+//! ## 수용 범위 — 자판이 낼 수 있는 키에 제한을 두지 않는다
 //!
 //! 라벨 집합보다 **넓다.** 처음엔 1:1 로 맞췄는데 (라벨이 거부하는 것을 위치만
-//! 받으면 수용 집합이 조용히 넓어지므로) 그 제약을 명시적으로 걷었다.
+//! 받으면 수용 집합이 조용히 넓어지므로) 그 제약을 걷었다.
 //!
 //! 근거는 두 집합의 **의미가 다르다**는 것이다. 라벨을 넓히려면 `-` 에 어떤 값을
 //! 줄지 정해야 하는데, `VK_OEM_MINUS` / `kVK_ANSI_Minus` 는 라벨이 아니라 "US 자판
 //! 에서 `-` 가 있는 자리" 다. 그것을 라벨로 받으면 Linux 는 라벨로, Windows ·
 //! macOS 는 US 위치로 잡아 #496 의 세 갈래 불일치가 더 깊어진다. 라벨을 정직하게
 //! 넓히려면 live layout 조회가 필요하다 (macOS `UCKeyTranslate`, Windows
-//! `VkKeyScanEx`) — #496 항목 2 다.
+//! `VkKeyScanExW`) — #496 항목 2 이고, 그것이 끝나면 라벨 집합은 "위치로 해석할
+//! 이름" 이 되어 이 표에 흡수된다.
 //!
 //! 위치 쪽은 그 문제가 없다. `[Minus]` 는 처음부터 "그 자리" 이고 세 platform 에
-//! 고정값이 있다. 그래서 **자판에 있는 키는 위치로 다 쓸 수 있게** 한다.
+//! 고정값이 있다. 그래서 기호 · numpad · 방향 · 편집 패드 · `F13`~`F24` · ISO / JIS
+//! 추가 키까지 담는다.
 //!
-//! 아직 없는 것: numpad · media 키 · JIS 전용 키 (`IntlYen` · `IntlRo`). 값 검증이
-//! 안 됐고 요청도 없었다. 필요하면 표에 행을 더하면 된다.
+//! `F13`~`F24` 를 담는 이유를 적어 둔다 — 물리 키로 달린 자판은 드물다 (IBM /
+//! Unicomp 122-key 터미널 자판). 실제 쓰임은 **QMK · ZMK · AutoHotkey 로 다른 키를
+//! 그 코드에 매핑**하는 것이다. 아무 앱도 쓰지 않는 코드라서 일부러 그렇게 쓴다.
+//! 그런 사용자에게는 이 행이 있어야 바인딩이 가능하다.
+//!
+//! 담지 않는 것이 둘 있다.
+//!
+//!   - **modifier 자체** (`ShiftLeft` · `ControlLeft` · `MetaLeft` ...). 이 모델에서
+//!     modifier 는 비트이고 키 자리가 아니다. `ctrl+[ShiftLeft]` 는 뜻이 없다.
+//!   - **media / browser 키** (`MediaPlayPause` · `BrowserBack` ...). 자판 위의
+//!     고정 자리가 아니고 (기능 키의 대체 기능이거나 전용 자판에만 있다) macOS 는
+//!     `keyDown` 으로 주지 않는다. 필요해지면 행을 더하면 된다.
 //!
 //! ## 세 platform 값
 //!
 //! | 열 | 의미 | 출처 |
 //! |---|---|---|
 //! | `evdev` | Linux evdev keycode | `linux/input-event-codes.h` |
-//! | `scan` | Windows scan code (set 1 make code) | `WM_KEYDOWN` lParam bit 16~23 |
+//! | `scan` + `extended` | Windows scan code (set 1) | `WM_KEYDOWN` lParam bit 16~23 + bit 24 |
 //! | `mac` | macOS hardware keyCode | `Carbon/HIToolbox/Events.h` `kVK_*` |
 //!
+//! **`extended` 없이는 Windows 열이 틀린다.** control pad 와 numpad 가 같은 하위
+//! 바이트를 쓰고 `0xE0` prefix 로만 갈린다 — `Insert` (`0xE052`) vs `Numpad0`
+//! (`0x52`), `NumpadEnter` (`0xE01C`) vs `Enter` (`0x1C`), `NumpadDivide`
+//! (`0xE035`) vs `Slash` (`0x35`), `PrintScreen` (`0xE037`) vs `NumpadMultiply`
+//! (`0x37`), `Pause` (`0xE045`) vs `NumLock` (`0x45`). lParam bit 24 가 그 prefix
+//! 자리다.
+//!
 //! evdev 와 set-1 scan code 는 main block 에서 값이 같다 (evdev 가 set 1 에서 왔다).
-//! 그래도 두 열을 따로 적는다 — PageUp / PageDown 처럼 extended 키에서 갈리고
-//! (evdev 104 vs scan 0x49), 같은 값을 우연에 맡기면 나중에 조용히 어긋난다.
+//! 그래도 두 열을 따로 적는다 — extended 키에서 갈리고, 같은 값을 우연에 맡기면
+//! 나중에 조용히 어긋난다.
+//!
+//! ## macOS 에 값이 없는 자리 — 두 가지 이유가 섞여 있다
+//!
+//! `mac` 이 optional 이다. 그런데 **이유가 둘이고 사용자에게 줄 안내가 다르다.**
+//!
+//!   - **겹침** — `PrintScreen` · `ScrollLock` · `Pause` 는 macOS 에 키가 없는 것이
+//!     아니다. PC 자판을 Mac 에 꽂으면 그 키가 **`F13` · `F14` · `F15` 로 보고된다**
+//!     (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). 별 `kVK_*` 가 없을 뿐이다.
+//!     그래서 안내가 "쓸 수 없다" 가 아니라 **"macOS 에서는 `[F13]` 으로 잡아라"**
+//!     여야 한다. `mac_alias` 가 그 대체 자리를 담는다.
+//!   - **부재** — `F21`~`F24` 는 Apple 의 `kVK_*` 가 F20 에서 멈춘다. `Convert` ·
+//!     `NonConvert` · `KanaMode` 는 JIS 입력 전환 키로 macOS 가 다르게 처리한다.
+//!     대체 자리가 없다.
+//!
+//! 이 구분은 이전에 `²` 에서 한 번 틀린 것과 같은 종류다 (값이 없다고 적었는데 실은
+//! `grave` 와 값이 같았다). 출처는 Chromium 의 `dom_code_data.inc` mac 열이다.
+//!
+//! 어느 쪽이든 **파싱 단계에서 거부한다** (`config.zig` 의
+//! `position_unavailable_on_platform`) — 조용히 아무 일도 안 하게 두면 #208 이 막던
+//! silent failure 로 되돌아간다.
 //!
 //! `mac` 열은 `config.zig` 의 `MacHotkey.keycodeFromKey` 와 **값이 같아야 한다** —
 //! 그쪽이 이미 US 위치표이기 때문이다 (그래서 AZERTY macOS 에서 `Z` 라고 새겨진
@@ -52,9 +91,11 @@
 //! `test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다"` 가 그것을 고정한다.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// W3C `KeyboardEvent.code` 값 중 TildaZ 가 받는 것.
 pub const PhysicalCode = enum {
+    // ── Function ────────────────────────────────────────────────────────────
     f1,
     f2,
     f3,
@@ -67,7 +108,20 @@ pub const PhysicalCode = enum {
     f10,
     f11,
     f12,
+    f13,
+    f14,
+    f15,
+    f16,
+    f17,
+    f18,
+    f19,
+    f20,
+    f21,
+    f22,
+    f23,
+    f24,
 
+    // ── Writing system — 글자 ───────────────────────────────────────────────
     key_a,
     key_b,
     key_c,
@@ -95,6 +149,7 @@ pub const PhysicalCode = enum {
     key_y,
     key_z,
 
+    // ── Writing system — 숫자열 ─────────────────────────────────────────────
     digit0,
     digit1,
     digit2,
@@ -106,26 +161,77 @@ pub const PhysicalCode = enum {
     digit8,
     digit9,
 
+    // ── Writing system — 기호 ───────────────────────────────────────────────
     backquote,
-    bracket_left,
-    bracket_right,
     minus,
     equal,
+    bracket_left,
+    bracket_right,
+    backslash,
     semicolon,
     quote,
-    backslash,
     comma,
     period,
     slash,
     /// ISO 자판에만 있는 키 (AZERTY 의 `<>`, QWERTZ 의 `<>|`). US ANSI 에는 없다.
     intl_backslash,
+    /// JIS 자판의 `¥`.
+    intl_yen,
+    /// JIS 자판의 `_` / `ろ`.
+    intl_ro,
 
+    // ── Functional ──────────────────────────────────────────────────────────
     space,
     tab,
     escape,
     enter,
+    backspace,
+    caps_lock,
+    print_screen,
+    scroll_lock,
+    pause,
+    context_menu,
+    /// JIS 의 かな, 한글 자판의 한/영 (macOS `kVK_JIS_Kana`).
+    lang1,
+    /// JIS 의 英数, 한글 자판의 한자 (macOS `kVK_JIS_Eisu`).
+    lang2,
+    convert,
+    non_convert,
+    kana_mode,
+
+    // ── Control pad ─────────────────────────────────────────────────────────
+    insert,
+    delete,
+    home,
+    end,
     page_up,
     page_down,
+
+    // ── Arrow pad ───────────────────────────────────────────────────────────
+    arrow_up,
+    arrow_down,
+    arrow_left,
+    arrow_right,
+
+    // ── Numpad ──────────────────────────────────────────────────────────────
+    num_lock,
+    numpad0,
+    numpad1,
+    numpad2,
+    numpad3,
+    numpad4,
+    numpad5,
+    numpad6,
+    numpad7,
+    numpad8,
+    numpad9,
+    numpad_divide,
+    numpad_multiply,
+    numpad_subtract,
+    numpad_add,
+    numpad_enter,
+    numpad_decimal,
+    numpad_equal,
 };
 
 const Entry = struct {
@@ -135,13 +241,18 @@ const Entry = struct {
     name: []const u8,
     evdev: u16,
     scan: u16,
-    mac: u16,
+    /// Windows `0xE0` prefix (lParam bit 24). control pad 와 numpad 를 갈라 준다.
+    extended: bool = false,
+    /// null = macOS 에 별 `kVK_*` 가 없다. 이유는 `mac_alias` 로 갈린다.
+    mac: ?u16 = null,
+    /// `mac` 이 null 인 이유가 **겹침**일 때 그 대체 자리. macOS 는 이 키를 저 자리로
+    /// 보고한다 — 사용자에게 "그 이름을 쓰라" 고 안내할 수 있다.
+    mac_alias: ?PhysicalCode = null,
 };
 
 /// 단일 출처. 이름 조회 · 값 조회 · 역방향 조회가 모두 이 표를 본다.
 const table = [_]Entry{
-    // Function key — layout 무관이라 위치로 적을 이유는 없지만, 라벨 집합에 있는
-    // 키는 위치로도 적을 수 있어야 한다 (한쪽만 받으면 그 자체가 함정이다).
+    // ── Function ────────────────────────────────────────────────────────────
     .{ .code = .f1, .name = "F1", .evdev = 59, .scan = 0x3B, .mac = 0x7A },
     .{ .code = .f2, .name = "F2", .evdev = 60, .scan = 0x3C, .mac = 0x78 },
     .{ .code = .f3, .name = "F3", .evdev = 61, .scan = 0x3D, .mac = 0x63 },
@@ -156,9 +267,25 @@ const table = [_]Entry{
     // evdev 도 그것을 따라 87 / 88 이다.
     .{ .code = .f11, .name = "F11", .evdev = 87, .scan = 0x57, .mac = 0x67 },
     .{ .code = .f12, .name = "F12", .evdev = 88, .scan = 0x58, .mac = 0x6F },
+    // F13~F20 의 macOS 값은 순서대로가 아니다 (Apple 헤더의 실제 값). Apple 확장
+    // 자판이 F13~F15 를 PC 의 PrtSc / ScrLk / Pause 자리에 둔다 — 그래서 그 세 키가
+    // 여기로 겹쳐 들어온다 (아래 `mac_alias`).
+    .{ .code = .f13, .name = "F13", .evdev = 183, .scan = 0x64, .mac = 0x69 },
+    .{ .code = .f14, .name = "F14", .evdev = 184, .scan = 0x65, .mac = 0x6B },
+    .{ .code = .f15, .name = "F15", .evdev = 185, .scan = 0x66, .mac = 0x71 },
+    .{ .code = .f16, .name = "F16", .evdev = 186, .scan = 0x67, .mac = 0x6A },
+    .{ .code = .f17, .name = "F17", .evdev = 187, .scan = 0x68, .mac = 0x40 },
+    .{ .code = .f18, .name = "F18", .evdev = 188, .scan = 0x69, .mac = 0x4F },
+    .{ .code = .f19, .name = "F19", .evdev = 189, .scan = 0x6A, .mac = 0x50 },
+    .{ .code = .f20, .name = "F20", .evdev = 190, .scan = 0x6B, .mac = 0x5A },
+    // F21~F24 는 Apple 의 `kVK_*` 가 F20 에서 멈춰 정말로 없다 (대체 자리도 없다).
+    .{ .code = .f21, .name = "F21", .evdev = 191, .scan = 0x6C },
+    .{ .code = .f22, .name = "F22", .evdev = 192, .scan = 0x6D },
+    .{ .code = .f23, .name = "F23", .evdev = 193, .scan = 0x6E },
+    .{ .code = .f24, .name = "F24", .evdev = 194, .scan = 0x6F },
 
-    // 글자 — QWERTY 자리 이름이다. `KeyW` 는 "US QWERTY 에서 `w` 가 있는 자리" 이고
-    // 그 자리는 AZERTY 에서 `z` 를, 키릴에서 `ц` 를 낸다.
+    // ── 글자 — QWERTY 자리 이름이다. `KeyW` 는 "US QWERTY 에서 `w` 가 있는 자리"
+    // 이고 그 자리는 AZERTY 에서 `z` 를, 키릴에서 `ц` 를 낸다.
     .{ .code = .key_a, .name = "KeyA", .evdev = 30, .scan = 0x1E, .mac = 0x00 },
     .{ .code = .key_b, .name = "KeyB", .evdev = 48, .scan = 0x30, .mac = 0x0B },
     .{ .code = .key_c, .name = "KeyC", .evdev = 46, .scan = 0x2E, .mac = 0x08 },
@@ -186,7 +313,7 @@ const table = [_]Entry{
     .{ .code = .key_y, .name = "KeyY", .evdev = 21, .scan = 0x15, .mac = 0x10 },
     .{ .code = .key_z, .name = "KeyZ", .evdev = 44, .scan = 0x2C, .mac = 0x06 },
 
-    // 숫자열. macOS 값이 순서대로가 아니다 — `kVK_ANSI_6` (0x16) 이 `kVK_ANSI_5`
+    // ── 숫자열. macOS 값이 순서대로가 아니다 — `kVK_ANSI_6` (0x16) 이 `kVK_ANSI_5`
     // (0x17) 보다 작다. Apple 헤더의 실제 값이며 오타가 아니다.
     .{ .code = .digit1, .name = "Digit1", .evdev = 2, .scan = 0x02, .mac = 0x12 },
     .{ .code = .digit2, .name = "Digit2", .evdev = 3, .scan = 0x03, .mac = 0x13 },
@@ -201,36 +328,83 @@ const table = [_]Entry{
     // 않는다.
     .{ .code = .digit0, .name = "Digit0", .evdev = 11, .scan = 0x0B, .mac = 0x1D },
 
+    // ── 기호 자리. `-` 와 `_` 처럼 Shift 로 갈리는 두 글자가 **한 자리**이므로
+    // 이름이 무시프트 글자 기준이다 (W3C 규칙).
     .{ .code = .backquote, .name = "Backquote", .evdev = 41, .scan = 0x29, .mac = 0x32 },
-    .{ .code = .bracket_left, .name = "BracketLeft", .evdev = 26, .scan = 0x1A, .mac = 0x21 },
-    .{ .code = .bracket_right, .name = "BracketRight", .evdev = 27, .scan = 0x1B, .mac = 0x1E },
-
-    // ASCII 기호 자리. 라벨 집합에는 없지만 (#208) 위치로는 받는다 — 위 정책 문단
-    // 참고. `-` 와 `_` 처럼 Shift 로 갈리는 두 글자가 **한 자리**이므로 이름이
-    // 무시프트 글자 기준이다 (W3C 규칙).
     .{ .code = .minus, .name = "Minus", .evdev = 12, .scan = 0x0C, .mac = 0x1B },
     .{ .code = .equal, .name = "Equal", .evdev = 13, .scan = 0x0D, .mac = 0x18 },
+    .{ .code = .bracket_left, .name = "BracketLeft", .evdev = 26, .scan = 0x1A, .mac = 0x21 },
+    .{ .code = .bracket_right, .name = "BracketRight", .evdev = 27, .scan = 0x1B, .mac = 0x1E },
+    .{ .code = .backslash, .name = "Backslash", .evdev = 43, .scan = 0x2B, .mac = 0x2A },
     .{ .code = .semicolon, .name = "Semicolon", .evdev = 39, .scan = 0x27, .mac = 0x29 },
     .{ .code = .quote, .name = "Quote", .evdev = 40, .scan = 0x28, .mac = 0x27 },
-    .{ .code = .backslash, .name = "Backslash", .evdev = 43, .scan = 0x2B, .mac = 0x2A },
     .{ .code = .comma, .name = "Comma", .evdev = 51, .scan = 0x33, .mac = 0x2B },
     .{ .code = .period, .name = "Period", .evdev = 52, .scan = 0x34, .mac = 0x2F },
     .{ .code = .slash, .name = "Slash", .evdev = 53, .scan = 0x35, .mac = 0x2C },
     // ISO 자판의 추가 키 — US ANSI 에는 **없다.** AZERTY 의 `<>`, QWERTZ 의 `<>|`
-    // 자리다. `KEY_102ND` / 102-key 자판의 그 키이고, macOS 는 `kVK_ISO_Section`
-    // 이라는 다른 이름을 쓴다. 이 키가 있어야 그 자판 사용자가 "내 키보드의 모든
-    // 키" 를 실제로 다 쓸 수 있다.
+    // 자리다 (`KEY_102ND`). macOS 는 `kVK_ISO_Section` 이라는 다른 이름을 쓴다.
+    // 이 키가 있어야 그 자판 사용자가 자기 키보드의 모든 키를 쓸 수 있다.
     .{ .code = .intl_backslash, .name = "IntlBackslash", .evdev = 86, .scan = 0x56, .mac = 0x0A },
+    .{ .code = .intl_yen, .name = "IntlYen", .evdev = 124, .scan = 0x7D, .mac = 0x5D },
+    .{ .code = .intl_ro, .name = "IntlRo", .evdev = 89, .scan = 0x73, .mac = 0x5E },
 
+    // ── Functional ──────────────────────────────────────────────────────────
     .{ .code = .space, .name = "Space", .evdev = 57, .scan = 0x39, .mac = 0x31 },
     .{ .code = .tab, .name = "Tab", .evdev = 15, .scan = 0x0F, .mac = 0x30 },
     .{ .code = .escape, .name = "Escape", .evdev = 1, .scan = 0x01, .mac = 0x35 },
     // W3C 는 main block 의 return 키를 `Enter` 라 부른다 (`Return` 이 아니다).
     .{ .code = .enter, .name = "Enter", .evdev = 28, .scan = 0x1C, .mac = 0x24 },
-    // extended 키 — 여기서 evdev 와 scan 이 갈린다. scan 은 `0xE0` prefix 를 뗀
-    // 값이다 (`WM_KEYDOWN` lParam 의 bit 16~23 에 그 하위 byte 만 온다).
-    .{ .code = .page_up, .name = "PageUp", .evdev = 104, .scan = 0x49, .mac = 0x74 },
-    .{ .code = .page_down, .name = "PageDown", .evdev = 109, .scan = 0x51, .mac = 0x79 },
+    .{ .code = .backspace, .name = "Backspace", .evdev = 14, .scan = 0x0E, .mac = 0x33 },
+    .{ .code = .caps_lock, .name = "CapsLock", .evdev = 58, .scan = 0x3A, .mac = 0x39 },
+    // PC 자판을 Mac 에 꽂으면 이 세 키가 F13 / F14 / F15 로 보고된다. 키가 없는 것이
+    // 아니라 별 `kVK_*` 가 없는 것이다 — 그래서 대체 자리를 적어 안내에 쓴다.
+    .{ .code = .print_screen, .name = "PrintScreen", .evdev = 99, .scan = 0x37, .extended = true, .mac_alias = .f13 },
+    .{ .code = .scroll_lock, .name = "ScrollLock", .evdev = 70, .scan = 0x46, .mac_alias = .f14 },
+    .{ .code = .pause, .name = "Pause", .evdev = 119, .scan = 0x45, .extended = true, .mac_alias = .f15 },
+    // 메뉴 키는 macOS 에 값이 있다 (`0x6E`) — 외장 PC 자판에서 동작한다.
+    .{ .code = .context_menu, .name = "ContextMenu", .evdev = 127, .scan = 0x5D, .extended = true, .mac = 0x6E },
+    .{ .code = .lang1, .name = "Lang1", .evdev = 122, .scan = 0xF2, .mac = 0x68 },
+    .{ .code = .lang2, .name = "Lang2", .evdev = 123, .scan = 0xF1, .mac = 0x66 },
+    // JIS 입력 전환 키 — macOS 가 다르게 처리해 `kVK_*` 가 없고 대체 자리도 없다.
+    .{ .code = .convert, .name = "Convert", .evdev = 92, .scan = 0x79 },
+    .{ .code = .non_convert, .name = "NonConvert", .evdev = 94, .scan = 0x7B },
+    .{ .code = .kana_mode, .name = "KanaMode", .evdev = 93, .scan = 0x70 },
+
+    // ── Control pad — Windows 는 전부 extended 다. 그 비트가 없으면 numpad 와
+    // 구분되지 않는다 (모듈 주석의 충돌 표 참고).
+    .{ .code = .insert, .name = "Insert", .evdev = 110, .scan = 0x52, .extended = true, .mac = 0x72 },
+    .{ .code = .delete, .name = "Delete", .evdev = 111, .scan = 0x53, .extended = true, .mac = 0x75 },
+    .{ .code = .home, .name = "Home", .evdev = 102, .scan = 0x47, .extended = true, .mac = 0x73 },
+    .{ .code = .end, .name = "End", .evdev = 107, .scan = 0x4F, .extended = true, .mac = 0x77 },
+    .{ .code = .page_up, .name = "PageUp", .evdev = 104, .scan = 0x49, .extended = true, .mac = 0x74 },
+    .{ .code = .page_down, .name = "PageDown", .evdev = 109, .scan = 0x51, .extended = true, .mac = 0x79 },
+
+    // ── Arrow pad ───────────────────────────────────────────────────────────
+    .{ .code = .arrow_up, .name = "ArrowUp", .evdev = 103, .scan = 0x48, .extended = true, .mac = 0x7E },
+    .{ .code = .arrow_down, .name = "ArrowDown", .evdev = 108, .scan = 0x50, .extended = true, .mac = 0x7D },
+    .{ .code = .arrow_left, .name = "ArrowLeft", .evdev = 105, .scan = 0x4B, .extended = true, .mac = 0x7B },
+    .{ .code = .arrow_right, .name = "ArrowRight", .evdev = 106, .scan = 0x4D, .extended = true, .mac = 0x7C },
+
+    // ── Numpad — Windows 는 `NumpadDivide` / `NumpadEnter` 만 extended 다.
+    // macOS 는 `kVK_ANSI_Keypad*` 이고 `NumLock` 자리가 `kVK_ANSI_KeypadClear` 다.
+    .{ .code = .num_lock, .name = "NumLock", .evdev = 69, .scan = 0x45, .mac = 0x47 },
+    .{ .code = .numpad0, .name = "Numpad0", .evdev = 82, .scan = 0x52, .mac = 0x52 },
+    .{ .code = .numpad1, .name = "Numpad1", .evdev = 79, .scan = 0x4F, .mac = 0x53 },
+    .{ .code = .numpad2, .name = "Numpad2", .evdev = 80, .scan = 0x50, .mac = 0x54 },
+    .{ .code = .numpad3, .name = "Numpad3", .evdev = 81, .scan = 0x51, .mac = 0x55 },
+    .{ .code = .numpad4, .name = "Numpad4", .evdev = 75, .scan = 0x4B, .mac = 0x56 },
+    .{ .code = .numpad5, .name = "Numpad5", .evdev = 76, .scan = 0x4C, .mac = 0x57 },
+    .{ .code = .numpad6, .name = "Numpad6", .evdev = 77, .scan = 0x4D, .mac = 0x58 },
+    .{ .code = .numpad7, .name = "Numpad7", .evdev = 71, .scan = 0x47, .mac = 0x59 },
+    .{ .code = .numpad8, .name = "Numpad8", .evdev = 72, .scan = 0x48, .mac = 0x5B },
+    .{ .code = .numpad9, .name = "Numpad9", .evdev = 73, .scan = 0x49, .mac = 0x5C },
+    .{ .code = .numpad_divide, .name = "NumpadDivide", .evdev = 98, .scan = 0x35, .extended = true, .mac = 0x4B },
+    .{ .code = .numpad_multiply, .name = "NumpadMultiply", .evdev = 55, .scan = 0x37, .mac = 0x43 },
+    .{ .code = .numpad_subtract, .name = "NumpadSubtract", .evdev = 74, .scan = 0x4A, .mac = 0x4E },
+    .{ .code = .numpad_add, .name = "NumpadAdd", .evdev = 78, .scan = 0x4E, .mac = 0x45 },
+    .{ .code = .numpad_enter, .name = "NumpadEnter", .evdev = 96, .scan = 0x1C, .extended = true, .mac = 0x4C },
+    .{ .code = .numpad_decimal, .name = "NumpadDecimal", .evdev = 83, .scan = 0x53, .mac = 0x41 },
+    .{ .code = .numpad_equal, .name = "NumpadEqual", .evdev = 117, .scan = 0x59, .mac = 0x51 },
 };
 
 /// `[...]` 안의 이름 → code. 대소문자 무관 — config 의 다른 토큰이 모두 그렇다.
@@ -250,12 +424,33 @@ pub fn evdev(code: PhysicalCode) u16 {
     return entry(code).evdev;
 }
 
-pub fn scanCode(code: PhysicalCode) u16 {
-    return entry(code).scan;
+pub const ScanCode = struct {
+    value: u16,
+    /// `0xE0` prefix (lParam bit 24).
+    extended: bool,
+};
+
+pub fn scanCode(code: PhysicalCode) ScanCode {
+    const e = entry(code);
+    return .{ .value = e.scan, .extended = e.extended };
 }
 
-pub fn macKeyCode(code: PhysicalCode) u16 {
+/// null = 이 자리는 macOS 에 별 `kVK_*` 가 없다. 이유는 `macAlias` 로 갈린다.
+pub fn macKeyCode(code: PhysicalCode) ?u16 {
     return entry(code).mac;
+}
+
+/// macOS 가 이 키를 **다른 자리로 보고**할 때 그 자리. `PrintScreen` → `F13` 처럼
+/// "쓸 수 없다" 가 아니라 "저 이름으로 쓰라" 고 안내할 수 있게 한다.
+pub fn macAlias(code: PhysicalCode) ?PhysicalCode {
+    return entry(code).mac_alias;
+}
+
+/// 이 platform 에서 쓸 수 있는 자리인가. false 면 config 파싱이 거부해야 한다 —
+/// 조용히 미동작으로 두면 사용자가 이유를 알 수 없다.
+pub fn availableOnThisPlatform(code: PhysicalCode) bool {
+    if (builtin.os.tag == .macos) return entry(code).mac != null;
+    return true;
 }
 
 pub fn fromEvdev(value: u32) ?PhysicalCode {
@@ -265,16 +460,18 @@ pub fn fromEvdev(value: u32) ?PhysicalCode {
     return null;
 }
 
-pub fn fromScanCode(value: u32) ?PhysicalCode {
+pub fn fromScanCode(value: u32, extended: bool) ?PhysicalCode {
     for (table) |e| {
-        if (e.scan == value) return e.code;
+        if (e.scan == value and e.extended == extended) return e.code;
     }
     return null;
 }
 
 pub fn fromMacKeyCode(value: u32) ?PhysicalCode {
     for (table) |e| {
-        if (e.mac == value) return e.code;
+        if (e.mac) |m| {
+            if (m == value) return e.code;
+        }
     }
     return null;
 }
@@ -300,15 +497,49 @@ test "표가 enum 을 빠짐없이 정확히 한 번씩 덮는다" {
     }
 }
 
-test "세 platform 값이 code 안에서 각각 유일하다" {
+test "세 platform 값이 각각 유일하다" {
     // 값이 겹치면 역방향 조회 (`fromEvdev` 등) 가 엉뚱한 code 를 준다.
     for (table, 0..) |a, i| {
         for (table[i + 1 ..]) |b| {
             try std.testing.expect(a.evdev != b.evdev);
-            try std.testing.expect(a.scan != b.scan);
-            try std.testing.expect(a.mac != b.mac);
+            // Windows 는 (scan, extended) 쌍이 열이다 — 하위 바이트만으로는 control
+            // pad 와 numpad 가 겹친다.
+            try std.testing.expect(!(a.scan == b.scan and a.extended == b.extended));
             try std.testing.expect(!std.ascii.eqlIgnoreCase(a.name, b.name));
+            if (a.mac) |am| {
+                if (b.mac) |bm| try std.testing.expect(am != bm);
+            }
         }
+    }
+}
+
+test "extended 비트 없이는 Windows 열이 겹친다" {
+    // 이 test 가 `extended` 열의 존재 이유다. 아래 쌍들은 하위 바이트가 같고
+    // extended 로만 갈린다 — 비트를 빼면 위 유일성 test 가 깨진다.
+    const collisions = [_]struct { a: PhysicalCode, b: PhysicalCode }{
+        .{ .a = .insert, .b = .numpad0 },
+        .{ .a = .delete, .b = .numpad_decimal },
+        .{ .a = .numpad_enter, .b = .enter },
+        .{ .a = .numpad_divide, .b = .slash },
+        .{ .a = .home, .b = .numpad7 },
+        .{ .a = .page_up, .b = .numpad9 },
+        .{ .a = .end, .b = .numpad1 },
+        .{ .a = .page_down, .b = .numpad3 },
+        .{ .a = .arrow_up, .b = .numpad8 },
+        .{ .a = .arrow_down, .b = .numpad2 },
+        .{ .a = .arrow_left, .b = .numpad4 },
+        .{ .a = .arrow_right, .b = .numpad6 },
+        .{ .a = .print_screen, .b = .numpad_multiply },
+        .{ .a = .pause, .b = .num_lock },
+    };
+    for (collisions) |c| {
+        const sa = scanCode(c.a);
+        const sb = scanCode(c.b);
+        try std.testing.expectEqual(sa.value, sb.value);
+        try std.testing.expect(sa.extended != sb.extended);
+        // 그래도 역방향 조회는 갈린다.
+        try std.testing.expectEqual(c.a, fromScanCode(sa.value, sa.extended).?);
+        try std.testing.expectEqual(c.b, fromScanCode(sb.value, sb.extended).?);
     }
 }
 
@@ -321,34 +552,81 @@ test "이름 왕복" {
     try std.testing.expectEqual(PhysicalCode.key_w, fromName("keyw").?);
     try std.testing.expectEqual(PhysicalCode.key_w, fromName("KEYW").?);
     try std.testing.expectEqual(PhysicalCode.bracket_left, fromName("bracketleft").?);
-    // 라벨 집합에 없는 자리도 위치로는 받는다 — 자판에 있는 키를 다 쓸 수 있게.
+    // 라벨 집합에 없는 자리도 위치로는 받는다 — 자판이 낼 수 있는 키에 제한을 두지
+    // 않는다.
     try std.testing.expectEqual(PhysicalCode.minus, fromName("Minus").?);
     try std.testing.expectEqual(PhysicalCode.slash, fromName("Slash").?);
-    try std.testing.expectEqual(PhysicalCode.backslash, fromName("Backslash").?);
     try std.testing.expectEqual(PhysicalCode.intl_backslash, fromName("IntlBackslash").?);
-    // 표에 없는 이름은 여전히 거부한다 — 오타가 조용히 통과하면 안 된다.
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("F13"));
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("Numpad0"));
-    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("IntlYen"));
+    try std.testing.expectEqual(PhysicalCode.numpad7, fromName("Numpad7").?);
+    try std.testing.expectEqual(PhysicalCode.arrow_up, fromName("ArrowUp").?);
+    try std.testing.expectEqual(PhysicalCode.f24, fromName("F24").?);
+    try std.testing.expectEqual(PhysicalCode.intl_yen, fromName("IntlYen").?);
+    try std.testing.expectEqual(PhysicalCode.context_menu, fromName("ContextMenu").?);
+    // 담지 않는 것 — modifier 자체와 media / browser 키. 오타도 여전히 거부한다.
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("ShiftLeft"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("MetaLeft"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("MediaPlayPause"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("F25"));
+    try std.testing.expectEqual(@as(?PhysicalCode, null), fromName("NotAKey"));
     try std.testing.expectEqual(@as(?PhysicalCode, null), fromName(""));
 }
 
 test "값 왕복" {
     for (table) |e| {
         try std.testing.expectEqual(e.code, fromEvdev(e.evdev).?);
-        try std.testing.expectEqual(e.code, fromScanCode(e.scan).?);
-        try std.testing.expectEqual(e.code, fromMacKeyCode(e.mac).?);
+        try std.testing.expectEqual(e.code, fromScanCode(e.scan, e.extended).?);
         try std.testing.expectEqual(e.evdev, evdev(e.code));
-        try std.testing.expectEqual(e.scan, scanCode(e.code));
-        try std.testing.expectEqual(e.mac, macKeyCode(e.code));
+        const sc = scanCode(e.code);
+        try std.testing.expectEqual(e.scan, sc.value);
+        try std.testing.expectEqual(e.extended, sc.extended);
+        if (e.mac) |m| {
+            try std.testing.expectEqual(e.code, fromMacKeyCode(m).?);
+            try std.testing.expectEqual(m, macKeyCode(e.code).?);
+        } else {
+            try std.testing.expectEqual(@as(?u16, null), macKeyCode(e.code));
+        }
     }
+}
+
+test "macOS 에 kVK 가 없는 자리와 그 이유를 고정한다" {
+    // 사용자에게 보이는 동작 (파싱 거부 + 안내 문구) 이므로 우연히 늘거나 줄지 않게
+    // 못을 박는다. **겹침**과 **부재**를 갈라 적는다 — 안내가 다르다.
+    const aliased = [_]struct { code: PhysicalCode, alias: PhysicalCode }{
+        // PC 자판을 Mac 에 꽂으면 이 자리가 F13~F15 로 보고된다. 키가 없는 것이
+        // 아니다 — 이전에 `²` 에서 한 번 틀린 것과 같은 종류의 구분이다.
+        .{ .code = .print_screen, .alias = .f13 },
+        .{ .code = .scroll_lock, .alias = .f14 },
+        .{ .code = .pause, .alias = .f15 },
+    };
+    for (aliased) |a| {
+        try std.testing.expectEqual(@as(?u16, null), macKeyCode(a.code));
+        try std.testing.expectEqual(a.alias, macAlias(a.code).?);
+        // 대체 자리에는 값이 있어야 안내가 성립한다.
+        try std.testing.expect(macKeyCode(a.alias) != null);
+    }
+
+    const absent = [_]PhysicalCode{ .f21, .f22, .f23, .f24, .convert, .non_convert, .kana_mode };
+    for (absent) |c| {
+        try std.testing.expectEqual(@as(?u16, null), macKeyCode(c));
+        // 대체 자리가 없다 — 그래서 안내가 "이 platform 에서는 쓸 수 없다" 가 된다.
+        try std.testing.expectEqual(@as(?PhysicalCode, null), macAlias(c));
+    }
+
+    // 메뉴 키는 값이 **있다.** 한 번 "없다" 고 적었던 자리라 못을 박는다.
+    try std.testing.expectEqual(@as(u16, 0x6E), macKeyCode(.context_menu).?);
+
+    var count: usize = 0;
+    for (table) |e| {
+        if (e.mac == null) count += 1;
+    }
+    try std.testing.expectEqual(aliased.len + absent.len, count);
 }
 
 test "evdev 와 scan code 가 main block 에서 같고 extended 에서 갈린다" {
     // 이 성질에 코드가 기대지 않는다는 것을 문서화하는 test 다 — 두 열을 따로
     // 적는 이유가 여기 있다.
-    try std.testing.expectEqual(evdev(.key_q), scanCode(.key_q));
-    try std.testing.expectEqual(evdev(.f12), scanCode(.f12));
-    try std.testing.expect(evdev(.page_up) != scanCode(.page_up));
-    try std.testing.expect(evdev(.page_down) != scanCode(.page_down));
+    try std.testing.expectEqual(evdev(.key_q), scanCode(.key_q).value);
+    try std.testing.expectEqual(evdev(.f12), scanCode(.f12).value);
+    try std.testing.expect(evdev(.page_up) != scanCode(.page_up).value);
+    try std.testing.expect(evdev(.arrow_up) != scanCode(.arrow_up).value);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,7 +10,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 test "aggregate root imports every common and native-host test module" {
-    // Cross-platform modules (36 files).
+    // Cross-platform modules (37 files).
     _ = @import("about.zig");
     _ = @import("box_drawing.zig");
     _ = @import("chrome_palette.zig");
@@ -29,6 +29,7 @@ test "aggregate root imports every common and native-host test module" {
     _ = @import("messages.zig");
     _ = @import("paths.zig");
     _ = @import("perf.zig");
+    _ = @import("physical_key.zig");
     _ = @import("process_cwd.zig");
     _ = @import("pwd_uri.zig");
     _ = @import("renderer/cell_color.zig");

--- a/src/window.zig
+++ b/src/window.zig
@@ -9,6 +9,8 @@ const paths = @import("paths.zig");
 const perf = @import("perf.zig");
 const dwrite_font = @import("font/windows/font.zig");
 const font_spec = @import("font/spec.zig");
+const config_mod = @import("config.zig");
+const physical_key = @import("physical_key.zig");
 
 const BOOL = windows.BOOL;
 const DWORD = windows.DWORD;
@@ -313,6 +315,8 @@ const VK_CONTROL: c_int = 0x11;
 const VK_SHIFT: c_int = 0x10;
 const VK_MENU: c_int = 0x12; // Alt
 const VK_LBUTTON: c_int = 0x01;
+const VK_LWIN: c_int = 0x5B;
+const VK_RWIN: c_int = 0x5C;
 
 // GDI functions
 extern "gdi32" fn CreateFontW(c_int, c_int, c_int, c_int, c_int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, [*:0]const WCHAR) callconv(.c) HFONT;
@@ -403,6 +407,10 @@ pub const Window = struct {
     /// `getTerminalGridSize` 로 다시 계산했다. 계약에서 격자를 빼면 그 함수와 그 안의
     /// 가짜 fallback 이 함께 사라진다.
     resize_fn: ?*const fn (?*anyopaque) void = null,
+    /// #493 3-c — `[keys]` 의 바인딩. `host/windows.zig` 의 `run()` 이 config 수명
+    /// 동안 유효한 slice 를 넣는다. 비어 있으면 단축키가 하나도 없는 상태이고,
+    /// 그것은 사용자가 `[keys]` 를 전부 `[]` 로 둔 경우와 같다.
+    key_bindings: []const config_mod.KeyBinding = &.{},
     userdata: ?*anyopaque = null,
     write_fn: ?*const fn ([]const u8, ?*anyopaque) void = null,
     app_event_fn: ?*const fn (app_event.Event, ?*anyopaque) bool = null,
@@ -1868,83 +1876,13 @@ pub const Window = struct {
                         return 0;
                     }
                 }
-                // Ctrl+Shift shortcuts
-                if (GetKeyState(VK_CONTROL) < 0 and GetKeyState(VK_SHIFT) < 0) {
-                    // Ctrl+Shift+C: copy current selection (#120)
-                    if (wParam == 0x43) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .copy_selection });
-                        return 0;
-                    }
-                    // Ctrl+Shift+T: new tab
-                    if (wParam == 0x54) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .new_tab });
-                        return 0;
-                    }
-                    // Ctrl+Shift+W: close active tab
-                    if (wParam == 0x57) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .close_active_tab });
-                        return 0;
-                    }
-                    // Ctrl+Shift+V: paste from clipboard
-                    if (wParam == 0x56) {
-                        if (self.write_fn) |write_fn| {
-                            self.pasteClipboard(write_fn);
-                        }
-                        return 0;
-                    }
-                    // Ctrl+Shift+R: reset terminal
-                    if (wParam == 0x52) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .reset_terminal });
-                        return 0;
-                    }
-                    // Ctrl+Shift+P: open config in default editor (#128)
-                    if (wParam == 0x50) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .open_config });
-                        return 0;
-                    }
-                    // Ctrl+Shift+L: open log in default editor (#128)
-                    if (wParam == 0x4C) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .open_log });
-                        return 0;
-                    }
-                    // Ctrl+Shift+F12: dump perf snapshot (dev tool — moved
-                    // from Ctrl+Shift+P which is now Open Config #128)
-                    if (wParam == 0x7B) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .dump_perf });
-                        return 0;
-                    }
-                    // Ctrl+Shift+I: show About dialog
-                    if (wParam == 0x49) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .show_about });
-                        return 0;
-                    }
-                    // Ctrl+Shift+[ (VK_OEM_4) / Ctrl+Shift+] (VK_OEM_6):
-                    // 이전 / 다음 탭 (#125 — macOS Shift+Cmd+[ / ] 와 동등 키 pair).
-                    if (wParam == 0xDB) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .prev_tab });
-                        return 0;
-                    }
-                    if (wParam == 0xDD) {
-                        _ = self.dispatchAppEvent(.{ .shortcut = .next_tab });
-                        return 0;
-                    }
-                }
-                // #482 — Ctrl+PgUp / Ctrl+PgDn 으로 이전 / 다음 탭 (Shift 미동반).
-                // Windows Terminal 과 같은 조합이고, Linux 는 AZERTY 에서 쓸 수 없는
-                // `Ctrl+Shift+[` / `]` 의 layout 무관 대안으로 같은 키를 받는다
-                // (`wayland_minimal.classifyInput`). Windows 는 `VK_OEM_4` 가 물리
-                // 위치라 layout 문제 자체는 없지만, 세 platform 이 같은 반사를 갖게
-                // 맞춘다. Shift+PgUp / PgDn (scrollback) 과 맨 PgUp / PgDn (PTY) 은
-                // 아래 경로 그대로다.
-                if (GetKeyState(VK_CONTROL) < 0 and GetKeyState(VK_SHIFT) >= 0) {
-                    if (wParam == 0x21) { // VK_PRIOR (Page Up)
-                        _ = self.dispatchAppEvent(.{ .shortcut = .prev_tab });
-                        return 0;
-                    }
-                    if (wParam == 0x22) { // VK_NEXT (Page Down)
-                        _ = self.dispatchAppEvent(.{ .shortcut = .next_tab });
-                        return 0;
-                    }
+                // #493 3-c — 여기부터는 `[keys]` 가 정한다. 예전엔 `Ctrl+Shift+*`
+                // 열두 개와 `Ctrl+PgUp` / `Ctrl+PgDn` 이 `wParam` 상수로 하드코딩돼
+                // 있었다. `Ctrl+C` (interrupt) 만 위에서 먼저 보고, 아래 Shift+PgUp
+                // (scrollback) 과 PTY 경로는 config 대상이 아니라 그대로 남는다.
+                if (self.lookupKeyAction(wParam, lParam)) |action| {
+                    self.runKeyAction(action);
+                    return 0;
                 }
 
                 const vk_prior: WPARAM = 0x21; // Page Up
@@ -2136,25 +2074,15 @@ pub const Window = struct {
                 return 0;
             },
             WM_SYSKEYDOWN => {
-                // Alt+Enter => monitor fullscreen.
-                // Shift+Alt+Enter => work-area fullscreen that keeps taskbar visible.
-                // Alt+Enter: fullscreen 토글. `DefWindowProcW` 로 위임하지
-                // 않음 — Windows 기본 경로가 어떤 SC_ 명령을 생성하든 우리가
-                // 정의한 동작 (현재 모니터 `rcWork` ↔ 저장된 dock) 으로 가게.
-                if (wParam == VK_RETURN) {
-                    const workarea = GetAsyncKeyState(VK_SHIFT) < 0;
-                    if (!self.dispatchAppEvent(.{ .shortcut = .{ .fullscreen = workarea } })) {
-                        self.toggleFullscreenMode(if (workarea) .workarea else .monitor);
-                    }
-                    return 0;
-                }
-                // Alt+1 ~ Alt+9: 탭 전환.
-                if (wParam >= 0x31 and wParam <= 0x39) {
-                    _ = self.dispatchAppEvent(.{
-                        .shortcut = .{
-                            .switch_tab = wParam - 0x31,
-                        },
-                    });
+                // #493 3-c — Alt 조합은 Windows 가 `WM_SYSKEYDOWN` 으로 보내므로
+                // 여기서도 같은 `[keys]` 조회를 한다. 예전엔 `VK_RETURN` (fullscreen,
+                // Shift 를 다시 읽어 workarea 판정) 과 `0x31`~`0x39` (탭 전환) 가
+                // 하드코딩돼 있었다.
+                //
+                // `DefWindowProcW` 로 위임하지 않는 것은 그대로다 — Windows 기본
+                // 경로가 어떤 `SC_` 명령을 만들든 우리가 정의한 동작으로 가게 한다.
+                if (self.lookupKeyAction(wParam, lParam)) |action| {
+                    self.runKeyAction(action);
                     return 0;
                 }
                 // #282 A7 — F10 은 Windows 가 메뉴 활성 키로 WM_SYSKEYDOWN 을 보낸다
@@ -2543,6 +2471,88 @@ pub const Window = struct {
         const ok = ImmNotifyIME(himc, NI_COMPOSITIONSTR, CPS_CANCEL, 0).toBool();
         self.preedit_len = 0;
         return ok;
+    }
+
+    /// #493 3-c — `[keys]` 조회. `WM_KEYDOWN` 과 `WM_SYSKEYDOWN` 이 **같은 판정**을
+    /// 쓴다 (Alt 조합만 후자로 오므로 예전엔 두 곳에 따로 적혀 있었다).
+    ///
+    /// Windows 는 문자 키에서 **라벨** 기반이다 — `VK_W` 는 Shift 여부와 무관하게
+    /// 0x57 이고 `VK_OEM_4` 도 그렇다. 그래서 Linux 와 달리 정규화가 필요 없다.
+    ///
+    /// `lParam` 에서 scan code 와 extended 비트를 꺼내 **물리 위치**도 함께 넘긴다
+    /// (#496) — 위치로 적은 binding (`ctrl+shift+[KeyW]`) 이 그것으로 매칭된다.
+    /// extended 비트가 없으면 control pad 와 numpad 가 구분되지 않는다
+    /// (`physical_key.zig` 의 충돌 표).
+    fn lookupKeyAction(self: *Window, wParam: WPARAM, lParam: LPARAM) ?config_mod.KeyAction {
+        var modifiers: u32 = 0;
+        if (GetKeyState(VK_CONTROL) < 0) modifiers |= config_mod.Hotkey.MOD_CTRL;
+        if (GetKeyState(VK_SHIFT) < 0) modifiers |= config_mod.Hotkey.MOD_SHIFT;
+        if (GetKeyState(VK_MENU) < 0) modifiers |= config_mod.Hotkey.MOD_ALT;
+        if (GetKeyState(VK_LWIN) < 0 or GetKeyState(VK_RWIN) < 0) modifiers |= config_mod.Hotkey.MOD_SUPER;
+
+        const bits: usize = @bitCast(lParam);
+        const scan: u32 = @intCast((bits >> 16) & 0xFF);
+        const extended = ((bits >> 24) & 1) != 0;
+        const code = physical_key.fromScanCode(scan, extended);
+
+        return config_mod.lookupAction(
+            self.key_bindings,
+            .{ .vkey = @intCast(wParam), .modifiers = modifiers },
+            code,
+        );
+    }
+
+    /// #493 3-c — 액션 실행. 예전엔 `wParam` 으로 다시 분기했다 (분류와 실행 두 곳에
+    /// 같은 키 표가 있었다는 뜻이고, 그 이중 기술이 갈라지는 것이 #484 의 원인이었다).
+    fn runKeyAction(self: *Window, action: config_mod.KeyAction) void {
+        const mapped = config_mod.inputForAction(action);
+        // `paste` 는 `app_event.Shortcut` 에 없다 — 클립보드 읽기가 host 쪽 일이고
+        // preedit commit 정책도 달라서 (`Input.paste`) 따로 처리한다.
+        if (mapped.input == .paste) {
+            if (self.write_fn) |write_fn| self.pasteClipboard(write_fn);
+            return;
+        }
+        const shortcut: app_event.Shortcut = switch (mapped.input.shortcut) {
+            .new_tab => .new_tab,
+            .close_tab => .close_active_tab,
+            .next_tab => .next_tab,
+            .prev_tab => .prev_tab,
+            // 인덱스는 액션 이름에서 왔다 (`switch_tab3` → 2). 예전엔 여기서
+            // `wParam - 0x31` 로 뽑았다.
+            .switch_tab => .{ .switch_tab = mapped.tab_index orelse return },
+            .reset_terminal => .reset_terminal,
+            .show_about => .show_about,
+            .open_config => .open_config,
+            .open_log => .open_log,
+            .copy_selection => .copy_selection,
+            .dump_perf => .dump_perf,
+            // #493 3-c — 두 fullscreen 이 별 액션이 됐다. 예전엔 `GetAsyncKeyState`
+            // 로 Shift 를 다시 읽어 갈랐는데, 사용자가 `fullscreen_workarea` 에
+            // Shift 없는 조합을 줄 수도 있으므로 그 규칙으로는 안 된다.
+            .fullscreen => .{ .fullscreen = false },
+            .fullscreen_workarea => .{ .fullscreen = true },
+            .quit => {
+                // Alt+F4 는 원래 `DefWindowProcW` 가 `SC_CLOSE` → `WM_CLOSE` 로
+                // 처리했다. 이제 액션으로 잡으므로 같은 메시지를 직접 보낸다 —
+                // `onQuitRequest` 의 확인 다이얼로그 경로가 그대로 이어진다.
+                //
+                // 사용자가 `quit` 을 다른 키로 옮겨도 Alt+F4 자체는 OS 가 계속
+                // 닫는다. 그것을 막으려면 `SC_CLOSE` 를 가로채야 하는데, 시스템
+                // 메뉴의 닫기까지 무력화되므로 하지 않는다.
+                _ = PostMessageW(self.requireHwnd(), WM_CLOSE, 0, 0);
+                return;
+            },
+            // 이 host 의 키 경로가 내지 않는 것들 — toggle 은 전역 핫키가, menu 는
+            // 마우스가 진입점이다.
+            .toggle_visibility, .open_command_menu, .open_shortcuts => return,
+        };
+        if (!self.dispatchAppEvent(.{ .shortcut = shortcut })) {
+            // app 이 소비하지 않은 fullscreen 은 window 가 직접 처리한다 (기존 동작).
+            switch (shortcut) {
+                .fullscreen => |workarea| self.toggleFullscreenMode(if (workarea) .workarea else .monitor),
+                else => {},
+            }
+        }
     }
 
     fn pasteClipboard(self: *Window, write_fn: *const fn ([]const u8, ?*anyopaque) void) void {


### PR DESCRIPTION
config 를 TOML 로 옮기고, 단축키를 사용자가 설정할 수 있게 한다. 그리고 그 과정에서 확인된 버그 하나를 함께 고친다 — **비라틴 layout 에서 글자 단축키가 전부 동작하지 않는다.**

Closes #493. `#496` 은 이 PR 로 절반 (위치 문법) 이 들어가고 나머지는 이어진다.

## 1. config 가 TOML 이 된다

`config_N.json` → `config_N.toml`. 파서는 `sam701/zig-toml` (MIT).

**JSON 마이그레이션 변환기를 만들지 않았다.** 아직 초기이고 사용자가 적어 **고지만** 한다 — 기존 `config_N.json` 은 디스크에 그대로 남고 읽지 않으며, 새로 만들어지는 TOML 머리에 그 사실을 적는다.

TOML 을 고른 이유는 키바인딩이 들어오면 JSON 이 빠르게 장황해지고 **주석을 달 수 없다**는 것이다. `#482` 답변에서 이미 사용자에게 밝힌 방향이다.

## 2. `[keys]` — 단축키를 설정할 수 있다

```toml
[keys]
new_tab   = ["ctrl+shift+t"]
prev_tab  = ["ctrl+shift+[", "ctrl+pageup"]
quit      = []
```

- **액션 → 키** 방향이고 **모든 액션이 파일에 다 적힌다.** 그래서 `#493` 본문이 "진짜 난제" 라고 한 **기본값 병합 / 명시적 해제 문법이 필요 없다** — kitty 의 `no_op` 같은 것 없이 **빈 리스트가 해제**다.
- 한 액션에 키를 여러 개 줄 수 있다. 충돌은 시작 시 fatal 이고 메시지가 **양쪽 액션을 짚는다.**
- **기본값 표가 platform 마다 둘이다** (`macDefaultBindings` / `pcDefaultBindings`). `cmd` 토큰이 modifier 차이를 흡수하지만 macOS 는 **Shift 의 유무까지 다르다** — PC 쪽 `Ctrl+Shift+T` 에 대응하는 Apple HIG 관습은 `Cmd+T` 다. 한 표로 덮으면 macOS 사용자의 모든 단축키가 `Control+Shift+*` 가 된다.

### 세 platform 의 매처가 한 곳으로 모였다

스키마만 넣었을 때는 `[keys]` 를 **아무도 읽지 않았다** — 세 host 가 여전히 하드코딩된 키 표로 판정해서 사용자가 config 를 고쳐도 아무 일이 없었다. 그 배선이 이 PR 의 큰 덩어리다.

배선이 지운 중복 셋:

| 없어진 것 | 무엇이 대신하나 |
|---|---|
| 탭 인덱스 추출 3 벌 (`keycodeToTabIndex` · `wParam - 0x31` · `sym - xkb_key_1`) | **액션 이름** — `switch_tab3` → 2 |
| `fullscreen` + "Shift 면 workarea" 암묵 규칙 3 벌 | 별 액션 `fullscreen_workarea` |
| 분류부 · 실행부에 두 번 적힌 키 표 3 벌 | 분류가 액션을 주고 실행부는 그것만 본다 |

마지막 것이 **#484 의 원인이던 구조**다 — 같은 지식을 두 곳에 적으면 갈라진다.

## 3. #496 — 비라틴 layout 에서 글자 단축키를 쓸 수 있게 된다

②를 파다가 나온 버그다. 키릴 · 그리스 layout 에서는 **그 자판의 어느 키도 라틴 글자를 내지 않는다:**

```
$ xkbcli how-to-type --layout ru 'w'
(비어 있음)
```

그래서 `ctrl+shift+w` 가 영원히 발동하지 않고, **다른 글자로 재바인딩해도 해결되지 않는다.** `#493` 에서 정한 "못 누르는 조합은 재바인딩으로" 가 이 부류에는 성립하지 않는다.

**해법은 키를 물리 위치로도 적을 수 있게 하는 것이다:**

```toml
close_tab = ["ctrl+shift+[KeyW]"]
```

- 이름은 [W3C `KeyboardEvent.code`](https://www.w3.org/TR/uievents-code/) 값이다 (2025 년 Recommendation) — 우리가 이름을 발명하지 않는다.
- 표기는 VS Code 와 같은 대괄호다. config 문법에는 표준이 없어 구현마다 다르지만 (`vk(nnn)` / `sc(nnn)` — Windows Terminal, `code:25` — Hyprland, `bindcode 25` — i3 · sway), **숫자를 쓰는 쪽은 `xev` / `wev` 로 값을 찾아야 한다.** 이름을 쓰는 VS Code 방식만 config 를 읽어서 이해할 수 있다.
- `src/physical_key.zig` 가 세 platform 값의 **단일 출처**다 (evdev · Windows scan code + extended · macOS keyCode).

### 라벨 집합은 좁게 유지하고 위치 집합은 제한을 없앴다 — 의도한 비대칭

라벨을 넓히려면 `-` 에 값을 줘야 하는데, 쓸 수 있는 고정값 (`VK_OEM_MINUS` · `kVK_ANSI_Minus`) 은 **라벨이 아니라 "US 자판에서 `-` 가 있는 자리"** 다. 그것을 라벨이라 부르면 같은 config 가 platform 마다 다른 키를 뜻한다. 라벨을 정직하게 넓히려면 live layout 조회 (macOS `UCKeyTranslate` · Windows `VkKeyScanExW`) 가 전제다.

위치는 처음부터 자리이므로 그 문제가 없다. 그래서 **자판이 낼 수 있는 키를 다 담는다** — 기호 · numpad · 방향 · 편집 패드 · `F13`~`F24` · ISO / JIS 추가 키. 담지 않는 것은 modifier 자체 (`ShiftLeft` 등 — 이 모델에서 modifier 는 비트다) 와 media / browser 키다.

## 검토할 때 봐 주면 좋은 판단들

**① `extended` 열 없이는 Windows 위치표가 틀린다.** control pad 와 numpad 가 같은 하위 바이트를 쓰고 `0xE0` prefix 로만 갈린다 — `Insert`(`0xE052`) vs `Numpad0`(`0x52`) 등 **14 쌍.** `lParam` bit 24 를 열로 넣고 그 쌍들이 실제로 갈리는지 테스트로 고정했다.

**② macOS 의 "값이 없다" 가 두 가지다.** `PrintScreen` · `ScrollLock` · `Pause` 는 없는 것이 아니라 **`F13` · `F14` · `F15` 로 보고된다** (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). `F21`~`F24` 와 JIS 전환 키는 정말 없다. 안내가 달라야 하므로 (`"그 이름을 쓰라"` vs `"이 platform 에 없다"`) 표에 `mac_alias` 열을 뒀다. 처음에 `ContextMenu` 도 없다고 적었는데 **틀렸다** — `0x6E` 로 있다.

**③ 숫자 binding 은 Shift 를 무시한다.** AZERTY 는 숫자열에 Shift 가 필요해 `Alt+1` 이 항상 `Alt+Shift+1` 로 도착한다. **확대가 아니라 현행 유지다** — 배선 이전의 세 host 가 모두 Shift 를 보지 않았다 (Windows `wParam >= 0x31 and wParam <= 0x39`, macOS `keycodeToTabIndex(kc) != null`, Linux 는 #482 에서 `!shift` 제거). 예외는 **숫자에서 멈춘다**: `shift+alt+f4` 는 `alt+f4` 를 발동시키지 않는다.

**④ Linux 만 keysym 정규화가 필요하다.** 세 platform 중 유일하게 라벨로 매칭하므로 `ctrl+shift+c` 가 `C` 로, `ctrl+shift+[` 가 `{` 로 도착한다. 예전 매처가 두 값을 나란히 적어 (`xkb_key_c_lower, xkb_key_c_upper`) 풀던 자리를 규칙 하나로 옮겼다. **Shift 비트는 건드리지 않는다** — 값만 되돌리므로 `ctrl+shift+c` 와 `ctrl+c` 는 여전히 다른 조합이다.

**⑤ 재바인딩할 수 없는 것 둘.** scrollback (`Shift+PgUp` / `PgDn`) 은 단축키가 아니라 **스크롤**이고 (`app_event` 에서도 `scroll` 범주다) `Ctrl+C` 는 SIGINT 다. `Ctrl+C` 는 config 조회보다 **먼저** 판정해 가릴 수 없게 했다.

**⑥ macOS 는 `Cmd` 없는 조합도 조회한다.** 안 하면 `ctrl+shift+t` 같은 binding 이 macOS 에서만 조용히 무동작이 된다. 한 config 를 세 OS 가 공유하는데 한 곳만 말없이 무시하는 것은 `#208` 이 막으려던 종류의 실패다. 대가로 사용자가 `alt+return` 을 바인딩하면 Option+Enter 한자 재변환이 가려진다 — config 우선은 세 platform 공통 규칙이고 기본 macOS config 는 전부 `cmd` 조합이라 기본 사용자에게는 변화가 없다.

**⑦ 전역 `hotkey` 는 위치 표기를 거부한다.** 등록 4 경로가 모두 문자 기반이다 (sway `bindsym` · Hyprland keysym · COSMIC RON `key:` · KGlobalAccel `qtKey`). 조용히 keysym 0 을 등록하는 대신 원인이 분명한 실패를 낸다 — 메시지도 `#484` 교훈대로 "modifier 를 달라" 가 아니라 무엇이 안 되는지와 대신 쓸 수 있는 것을 준다.

## 문서

| 문서 | 담당 |
|---|---|
| `CONFIG.md` | 문법 레퍼런스 — 두 표기, 받는 키 **117 개 전수** (표와 기계적으로 대조했다), 예외 규칙 |
| `KEYBINDINGS.md` | layout 가이드 — 비라틴 · AZERTY · macOS 각각 무엇을 적어야 하는지, 복사해 쓸 `[keys]` 블록 |
| 생성 config 주석 | 두 표기와 그 이유. **영어로 옮겼다** — 사용자가 읽는 파일이다 |
| `SPEC.md` | 내부 계약 — 세 platform 매칭 기준, 비대칭의 이유, 정규화 규칙, 숫자 예외의 근거 |

그 과정에서 TOML 전환이 문서를 따라오지 못한 자리도 전수로 잡았다 — `CONFIG.md` 의 platform 예시 세 개가 아직 JSON 이었고, `SPEC.md` 에 `defaultConfigJson` · `config_N.json` 이 남아 있었고, 코드에 없는 `_` prefix 주석 convention (#173) 을 `SPEC.md` · `ARCHITECTURE.md` 가 아직 약속하고 있었다.

## 검증

`zig build -Dsimd=true` · `zig build test` · `zig build check` (6 타깃) 전부 통과.

세 host 의 분류 테스트를 **기본 `[keys]` 를 그대로 파싱해서** 만든다 — 하드코딩을 config 로 옮긴 뒤에도 기본 사용자가 보는 동작이 같아야 하고, 그 동등성이 검사 대상이다. 대문자 · brace 도착 (`c` `C` `[` `{`), AZERTY 숫자열, 키릴 keysym 에서 위치 binding 만 잡히는 것까지 고정했다.

Linux 실기로 확인했다. **Windows · macOS 는 cross-compile 검증만 했고 실기 확인이 필요하다.**

## 이어지는 것

| | |
|---|---|
| `#496` 1-a | 비라틴 out-of-box (로드 시점 라벨 → 위치 해석). **Linux 전용이다** — Windows 는 비라틴 layout DLL 이 물리 위치에 라틴 VK 를 배정하고 (`KBDRU` scancode 0x11 → `VK_W`) macOS 는 `kVK_ANSI_*` 가 위치라 이미 동작한다 |
| `#496` 1-b | 전역 핫키 4 경로. sway `--to-code` · Hyprland `code:` 는 compositor 가 해석해 주므로 값싸게 고칠 수 있다 |
| `#496` 항목 2 | 라벨을 live layout 으로 해석 → 라벨 집합 제한 소멸. macOS 는 Carbon 을 일부러 링크하지 않아 재검토가 필요하다 |
| `#497` | 설정 UI. **현재 hotkey 캡처가 라벨 기반이라 같은 병을 앓는다** — 캡처가 위치를 기록해야 낫는다 |
