### PR TITLE
ci: PR 에서 빌드 · 테스트 · 6 타깃 check 를 돌린다 (#499)

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,0 +1,73 @@
+# PR 회귀 감지 (#499). 이 workflow 가 생기기 전까지 PR 에서 도는 검사는 CLA 봇
+# 하나뿐이었고, 빌드가 깨진 PR 도 green 으로 보였다.
+#
+# **Linux 러너 하나로 세 platform 을 본다.** `zig build check` 가 cross-compile
+# compile-only 검증이라 러너 매트릭스가 필요 없다 (#201 에서 "Linux dev 머신에서
+# mac compile 에러를 조기 발견" 하려고 만든 step 을 그대로 쓴다).
+#
+# 이 검사가 잡는 것의 실례: #498 에서 `lookupAction` 을 도입할 때 `Hotkey.MOD_SHIFT`
+# 가 Windows / macOS 타입에 없었다. Zig 는 **호출되지 않는 함수 본문을 분석하지
+# 않으므로** 그 함수를 부르는 테스트를 넣기 전까지 native 빌드가 조용히 통과했다.
+# 6 타깃 compile-only 검사만이 그 부류를 잡는다.
+#
+# native Windows / macOS 빌드는 여기 없다 — #266 (ghostty tarball 심볼릭 링크) ·
+# cross-drive zig cache 등 러너별 걸림돌이 있고 `release.yml` 이 그 우회를 담고
+# 있다. step 을 복제하지 않고 재사용할 방법과 함께 별도로 본다 (#499 참고).
+name: pr-verify
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Node.js 20 deprecation (2026-09-16 제거 예정) 회피. `release.yml` ·
+# `macos-signing-check.yml` 과 같은 이유로 둔다 — checkout(@v7) 은 Node 24 native
+# 인데 `mlugg/setup-zig@v2` 와 `actions/cache@v4` 가 아직 Node 20 번들이라 runner 가
+# 강제 Node 24 로 실행하게 한다. upstream 이 Node 24 버전을 내면 제거 (#257).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+# 같은 PR 에 새 커밋이 오면 이전 실행을 취소한다 — 마지막 커밋 결과만 의미가 있다.
+concurrency:
+  group: pr-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # `release.yml` 과 같은 action · 같은 버전을 쓴다. 버전은 `build.zig.zon` 의
+      # `.minimum_zig_version` 과 맞춰야 한다 — 두 곳에 적혀 있으므로 한쪽만 올리면
+      # 갈라진다 (#499 에 한 곳에서 읽는 방법을 남겨 뒀다).
+      - name: Setup Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      # Zig 0.16 은 의존성을 글로벌 캐시가 아니라 build root 옆 `zig-pkg/` 에 푼다.
+      # ghostty tarball 이 커서 이 캐시가 실행 시간을 지배한다. 키는 `build.zig.zon`
+      # 내용이다 — 의존성이 바뀌면 (URL / hash) 자동으로 새로 받는다.
+      - name: Cache fetched dependencies
+        uses: actions/cache@v4
+        with:
+          path: zig-pkg
+          key: zig-pkg-${{ runner.os }}-${{ hashFiles('build.zig.zon') }}
+
+      # 세 platform × 두 arch compile-only. **가장 먼저 돈다** — cross-platform
+      # 회귀가 이 workflow 의 주된 존재 이유이고, native 빌드보다 빠르다.
+      - name: Compile-only verify (6 targets)
+        run: zig build check
+
+      - name: Test
+        run: zig build test
+
+      # 로컬 검증이 이 플래그로 돌므로 CI 도 같은 조합을 본다 — 기본값과 codegen 이
+      # 다르다.
+      - name: Build (simd)
+        run: zig build -Dsimd=true


### PR DESCRIPTION
PR 에서 도는 검사가 **CLA 봇 하나뿐**이었다. 빌드가 깨진 PR 도 green 으로 보였고, "CI 통과" 가 코드에 대해 아무것도 말해 주지 않았다.

Closes #499 의 ①②. native Windows / macOS 빌드 (③) 는 아래 이유로 남긴다.

## Linux 러너 하나로 세 platform 을 본다

`zig build check` 가 cross-compile compile-only 검증이다 — linux · windows · macOS × x86_64 · aarch64 여섯 조합에 app · stress 두 root. 러너 매트릭스가 필요 없다. `#201` 에서 *"Linux dev 머신에서 mac compile 에러를 조기 발견"* 하려고 만든 step 을 그대로 쓴다.

**이 검사가 잡는 것의 실례가 바로 앞 PR 에 있다.** `#498` 에서 `lookupAction` 을 도입할 때 `Hotkey.MOD_SHIFT` 가 Windows · macOS 타입에 없었다. Zig 는 **호출되지 않는 함수 본문을 분석하지 않으므로** (lazy analysis) 그 함수를 부르는 테스트를 넣기 전까지 native 빌드가 조용히 통과했다. 6 타깃 compile-only 검사만이 그 부류를 잡는다.

## step 구성

| 순서 | step | 왜 |
|---|---|---|
| 1 | `zig build check` | cross-platform 회귀가 이 workflow 의 주된 존재 이유이고 native 빌드보다 빠르다 |
| 2 | `zig build test` | |
| 3 | `zig build -Dsimd=true` | 로컬 검증이 이 조합으로 돈다 — 기본값과 codegen 이 다르다 |

- **apt 패키지가 필요 없다.** `linkSystemLibrary` 가 macOS `objc` 뿐이고 xkb / wayland 는 런타임 dlopen 이다.
- **의존성 캐시** — Zig 0.16 은 의존성을 글로벌 캐시가 아니라 build root 옆 `zig-pkg/` 에 푼다. ghostty tarball 이 커서 이 캐시가 실행 시간을 지배한다. 키가 `build.zig.zon` 내용이라 URL / hash 가 바뀌면 자동으로 새로 받는다.
- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** — `release.yml` · `macos-signing-check.yml` 과 같은 이유 (`#257` — `mlugg/setup-zig@v2` 가 아직 Node 20 번들).
- **`concurrency` + `cancel-in-progress`** — 같은 PR 에 새 커밋이 오면 이전 실행을 취소한다.

## native Windows / macOS 빌드를 넣지 않은 이유

러너별 걸림돌이 있고 **`release.yml` 이 그 우회를 이미 담고 있다:**

- **`#266`** — ghostty tarball 이 `CLAUDE.md → AGENTS.md` 심볼릭 링크를 담고 있어 권한 없는 Windows 에서 `zig fetch` unpack 이 `AccessDenied` 로 실패한다.
- **cross-drive zig cache** — checkout 은 `D:\`, 기본 cache 는 `C:\` → `convertPathArg` assert. `release.yml` 이 `ZIG_GLOBAL_CACHE_DIR` 을 `RUNNER_TEMP` 로 옮겨 우회한다.

step 을 복제하면 갈라진다. 지금도 `windows-fetch-check.yml` 이 *"step 구성은 release.yml 의 fetch 이전 단계와 동일하게 유지"* 를 **주석으로만** 약속하고 있는데, 그런 약속은 `#484` 가 보여준 대로 갈라진다. 재사용 방법 (composite action / reusable workflow) 과 함께 별도로 봐야 한다 — `#499` 에 남겼다.

## 검증

로컬에서 세 명령 모두 통과. **그리고 이 PR 자체가 workflow 의 첫 실행이 된다** — 이 PR 의 check 결과가 곧 검증이다.

## 이어지는 것 (`#499` 에 남긴 것)

- native Windows / macOS 빌드 + `release.yml` step 재사용
- zig 버전이 `build.zig.zon` (`.minimum_zig_version`) 과 workflow 두 곳에 적혀 있다 — 한 곳에서 읽는 방법
- branch protection 의 required check 로 걸지