### PR TITLE
fix(config): 오류 다이얼로그의 경로를 첫 줄로 올리고 형식을 하나로 (#495)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1119,6 +1119,20 @@ env var expansion (`~`, `%APPDATA%`) 안 쓰고 펼친 절대 경로. 사용자�
 
 잘못된 config 값 발견 시 `dialog.showFatal` 본문에 *실제로 연 config 파일 절대경로*를 정확히 한 번 명시해 사용자가 어디를 고쳐야 할지 즉시 알게 한다 ([#316](https://github.com/ensky0/tildaz/issues/316)). `Config.load`가 연 path를 `Config.parse`에 직접 전달하고, TOML parse와 모든 semantic/schema 오류가 동적 message 조립을 사용한다. TOML parse 실패는 파서가 준 줄·열까지 함께 보인다. path 조회를 다시 수행하지 않으므로 instance 번호와 실제 파일이 갈리지 않는다.
 
+**경로는 첫 줄이고 형식이 하나다** ([#495](https://github.com/ensky0/tildaz/issues/495)).
+
+```
+Config: /home/user/.config/tildaz/config_0.toml
+
+Configuration: missing required key "window" in (top-level).
+```
+
+예전에는 두 형식이 있었고 경로 위치가 오류 종류에 따라 달랐다 — 파싱 오류는 본문 셋째 줄 (`Path: {s}`), 의미 오류는 맨 끝 (`Config path:\n  {s}`). 의미 오류가 대부분인데 그쪽이 맨 끝이라, 읽는 순서상 *오류를 읽고 → 고쳐야겠다 판단하고 → 다이얼로그를 닫은 뒤* 경로가 필요해졌다. 위쪽 문구가 명확할수록 (`missing required key "window"`) 더 빨리 닫으므로 더 잘 놓쳤다. 사용자가 실제로 겪었다 (2026-08-22).
+
+조립 지점은 **`configErrorMessageAlloc` 한 곳**이다. 형식이 갈라진 원인이 파싱 오류만 그 함수를 지나지 않고 `dialog.showFatal` 을 직접 부른 것이었으므로, 그 경로도 `showConfigFatalMsg` 를 지나게 했다. 파싱 오류 본문은 경로를 담지 않는다 — 담으면 두 번 나온다.
+
+`allocPrint` 실패 시 fallback 도 **경로 자리를 비우지 않는다** (`Config: (unknown)`). 예전 파싱 쪽 fallback 은 경로를 아예 잃어서, 정작 가장 도움이 필요한 상황에서 가장 적은 정보를 줬다.
+
 Windows는 짧은 본문을 기존 `MessageBoxW`로 표시하고 화면 또는 4096 UTF-16 변환 상한을 넘을 때만 read-only multiline EDIT window로 전환한다. macOS는 NSApplication을 config load 전에 준비해 짧은 본문은 기존 NSAlert, overflow 본문은 NSScrollView/NSTextView로 표시한다. Linux config parse는 Wayland 연결 전에 실행되므로 전체 동적 본문을 stderr + log fallback으로 출력한다. **현재 상태: 구현·자동 검증 완료, Linux · macOS · Windows 묶음 실기 대기 (#316).**
 
 ---

--- a/src/config.zig
+++ b/src/config.zig
@@ -2025,23 +2025,29 @@ pub const Config = struct {
         var parsed = parser.parseString(content) catch |err| {
             // TOML 파서는 구문 오류의 **위치**를 준다 (JSON 은 오류 이름만 줬다).
             // 사용자가 어디를 고쳐야 할지 알 수 있게 line / col 을 함께 보여 준다.
+            //
+            // #495 — 경로는 본문에 넣지 않는다. `showConfigFatalMsg` 가 모든 config
+            // 오류 앞에 한 번 붙이므로 여기서 넣으면 두 번 나온다. 그리고 그 함수를
+            // 지나는 것 자체가 요점이다 — 예전엔 이 경로만 `dialog.showFatal` 을 직접
+            // 불러 형식이 갈라졌다.
+            var buf: [256]u8 = undefined;
             const msg = if (parser.error_info) |info| switch (info) {
-                .parse => |pos| std.fmt.allocPrint(
-                    std.heap.page_allocator,
+                .parse => |pos| std.fmt.bufPrint(
+                    &buf,
                     messages.config_parse_failed_at_format,
-                    .{ config_path, pos.line, pos.pos, @errorName(err) },
+                    .{ pos.line, pos.pos, @errorName(err) },
                 ) catch messages.config_parse_failed_fallback_msg,
-                .struct_mapping => std.fmt.allocPrint(
-                    std.heap.page_allocator,
+                .struct_mapping => std.fmt.bufPrint(
+                    &buf,
                     messages.config_parse_failed_format,
-                    .{ config_path, @errorName(err) },
+                    .{@errorName(err)},
                 ) catch messages.config_parse_failed_fallback_msg,
-            } else std.fmt.allocPrint(
-                std.heap.page_allocator,
+            } else std.fmt.bufPrint(
+                &buf,
                 messages.config_parse_failed_format,
-                .{ config_path, @errorName(err) },
+                .{@errorName(err)},
             ) catch messages.config_parse_failed_fallback_msg;
-            dialog.showFatal(rt, messages.config_error_title, msg);
+            showConfigFatalMsg(rt, config_path, msg);
         };
         defer parsed.deinit();
 
@@ -2442,8 +2448,11 @@ fn parseFloat(v: toml.Value) ?f32 {
     };
 }
 
+/// #495 — 모든 config 오류 메시지의 **단일 조립 지점.** 경로가 첫 줄로 붙는다.
+/// 예전엔 파싱 오류가 이 함수를 지나지 않고 자기 본문에 `Path:` 를 직접 넣어,
+/// 오류 종류에 따라 경로 위치가 달랐다 (파싱은 셋째 줄, 의미 오류는 맨 끝).
 fn configErrorMessageAlloc(allocator: std.mem.Allocator, message: []const u8, config_path: []const u8) ![]u8 {
-    return std.fmt.allocPrint(allocator, messages.config_error_with_path_format, .{ message, config_path });
+    return std.fmt.allocPrint(allocator, messages.config_error_with_path_format, .{ config_path, message });
 }
 
 fn showConfigFatalMsg(rt: Runtime, config_path: []const u8, message: []const u8) noreturn {
@@ -2533,25 +2542,28 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
 
 // --- Tests ---
 
-test "#316 semantic config error appends the actual path exactly once" {
+test "#316 · #495 config 오류는 경로를 첫 줄에 정확히 한 번 담는다" {
     const message = try configErrorMessageAlloc(
         std.testing.allocator,
         messages.config_font_family_empty_msg,
-        "/home/user/.config/tildaz/config_7.json",
+        "/home/user/.config/tildaz/config_7.toml",
     );
     defer std.testing.allocator.free(message);
 
+    // #495 — 경로가 **첫 줄**이다. 사용자가 오류 내용을 읽기 전에 눈에 들어와야 한다.
     try std.testing.expectEqualStrings(
-        "Configuration: \"font.family\" must not be empty.\n\n" ++
-            "Config path:\n  /home/user/.config/tildaz/config_7.json",
+        "Config: /home/user/.config/tildaz/config_7.toml\n\n" ++
+            "Configuration: \"font.family\" must not be empty.",
         message,
     );
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, message, "/home/user/.config/tildaz/config_7.json"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, message, "/home/user/.config/tildaz/config_7.toml"));
 }
 
-test "#316 semantic config error preserves platform and long paths" {
+test "#316 · #495 어떤 오류 종류든 경로가 같은 자리에 온다" {
     const bodies = [_][]const u8{
-        messages.config_top_level_must_be_object_msg,
+        // 파싱 오류도 이제 같은 형식을 지난다 — 예전엔 자기 본문에 `Path:` 를 넣었다.
+        "Failed to parse config file.\n\nLine 12, column 3\nError: UnexpectedToken",
+        "Failed to parse config file.\n\nError: UnexpectedToken",
         "Configuration: failed to parse \"hotkey\" value \"plain-t\".",
         "Configuration: \"window.width_percent\" must be a number.",
         "Configuration: unknown theme \"Missing\"\n\nAvailable themes:\nTilda",
@@ -2559,26 +2571,30 @@ test "#316 semantic config error preserves platform and long paths" {
         "Configuration: unknown key \"extra\" in (top-level).",
     };
     const config_paths = [_][]const u8{
-        "/home/user/.config/tildaz/config_0.json",
-        "/Users/user/.config/tildaz/config_3.json",
-        "C:\\Users\\user\\AppData\\Roaming\\tildaz\\config_12.json",
+        "/home/user/.config/tildaz/config_0.toml",
+        "/Users/user/.config/tildaz/config_3.toml",
+        "C:\\Users\\user\\AppData\\Roaming\\tildaz\\config_12.toml",
     };
 
     for (bodies) |body| {
         for (config_paths) |config_path| {
             const message = try configErrorMessageAlloc(std.testing.allocator, body, config_path);
             defer std.testing.allocator.free(message);
-            try std.testing.expect(std.mem.startsWith(u8, message, body));
-            try std.testing.expect(std.mem.endsWith(u8, message, config_path));
+            // 경로가 앞, 본문이 뒤 — 순서가 뒤집혔다 (#495).
+            try std.testing.expect(std.mem.startsWith(u8, message, "Config: "));
+            try std.testing.expect(std.mem.endsWith(u8, message, body));
             try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, message, config_path));
         }
     }
 
+    // 긴 경로도 잘리지 않는다 — 조립이 `allocPrint` 라 상한이 없다. 경로가 앞으로
+    // 옮겨졌으므로 이제 `startsWith` 로 본다 (#495).
     var long_path: [5000]u8 = undefined;
     @memset(&long_path, 'x');
     const long_message = try configErrorMessageAlloc(std.testing.allocator, messages.config_error_fallback_msg, &long_path);
     defer std.testing.allocator.free(long_message);
-    try std.testing.expect(std.mem.endsWith(u8, long_message, &long_path));
+    try std.testing.expect(std.mem.startsWith(u8, long_message, "Config: " ++ ("x" ** 5000)));
+    try std.testing.expect(std.mem.endsWith(u8, long_message, messages.config_error_fallback_msg));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, long_message, &long_path));
 }
 

--- a/src/host/linux/dialog_layout.zig
+++ b/src/host/linux/dialog_layout.zig
@@ -399,16 +399,20 @@ test "current Linux dialog messages fit the 640x480 logical minimum" {
         "0.6.1",
         "/home/example/.local/bin/tildaz",
         123456,
-        "/home/example/.config/tildaz/config_0.json",
+        "/home/example/.config/tildaz/config_0.toml",
         "/home/example/.local/state/tildaz/tildaz0.log",
         "Ctrl+Shift+P",
         "Ctrl+Shift+L",
     });
 
+    // #495 — 경로는 이 본문에 없다. `showConfigFatalMsg` 가 모든 config 오류 앞에
+    // 한 번 붙이므로, 레이아웃 검사도 그 조립 결과를 흉내내야 실제와 같은 높이가 된다.
     var parse_buf: [512]u8 = undefined;
-    const parse_msg = try std.fmt.bufPrint(&parse_buf, messages.config_parse_failed_format, .{
-        "/home/example/.config/tildaz/config_0.json",
-        "SyntaxError",
+    const parse_body = try std.fmt.bufPrint(&parse_buf, messages.config_parse_failed_format, .{"SyntaxError"});
+    var parse_full_buf: [640]u8 = undefined;
+    const parse_msg = try std.fmt.bufPrint(&parse_full_buf, messages.config_error_with_path_format, .{
+        "/home/example/.config/tildaz/config_0.toml",
+        parse_body,
     });
 
     var hotkey_invalid_buf: [384]u8 = undefined;

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -267,6 +267,14 @@ pub const font_family_must_be_string_msg = "Invalid config: font.family must be 
 /// 라인을 붙여 표시.
 pub const font_glyph_fallback_must_be_list_msg = "Invalid config: font.glyph_fallback must be a list of strings (fallback font names).";
 
+// #495 에서 확인 — 아래 셋은 **배선된 적이 없다.** `Config.createDefault` 가 세 실패를
+// 모두 삼키고 (`catch return` · `catch {}`) `Config.load` 의 읽기 실패도 조용히 기본값
+// 으로 떨어진다. 그래서 첫 실행에서 config 를 못 만들면 사용자는 아무 안내도 못 받고
+// 기본값으로 도는 인스턴스를 얻는다.
+//
+// 지우지 않고 남긴다 — 이 문안이 그 경로에 필요한 것이고, 지우면 나중에 다시 써야
+// 한다. 배선 자체는 결정이 필요해서 (읽기 전용 디렉터리에서 시작을 거부할 것인가,
+// 기본값으로 돌 것인가) 별 이슈로 뺐다 — #501.
 pub const config_dir_create_failed_format =
     \\Failed to create config directory.
     \\
@@ -288,10 +296,12 @@ pub const config_read_failed_format =
     \\Error: {s}
 ;
 
+/// #495 — **경로를 담지 않는다.** `showConfigFatalMsg` 가 모든 config 오류 앞에 한
+/// 번 붙인다. 예전엔 파싱 오류만 본문 셋째 줄에 `Path:` 를 넣고 의미 오류는 맨 끝에
+/// 넣어, 같은 다이얼로그에서 경로 위치가 오류 종류에 따라 달랐다.
 pub const config_parse_failed_format =
     \\Failed to parse config file.
     \\
-    \\Path: {s}
     \\Error: {s}
 ;
 /// #493 — TOML 파서는 구문 오류의 **위치**를 준다 (JSON 은 오류 이름만 줬다).
@@ -299,16 +309,24 @@ pub const config_parse_failed_format =
 pub const config_parse_failed_at_format =
     \\Failed to parse config file.
     \\
-    \\Path: {s}
     \\Line {d}, column {d}
     \\Error: {s}
 ;
 pub const config_parse_failed_fallback_msg = "Failed to parse config file.";
 
 pub const config_error_fallback_msg = "Configuration is invalid.";
-pub const config_error_with_path_format = "{s}\n\nConfig path:\n  {s}";
-pub const config_error_with_path_fallback_msg = "Configuration is invalid.\n\nConfig path:\n  (unknown)";
-pub const config_top_level_must_be_object_msg = "Configuration: top-level must be a JSON object.";
+/// #495 — **경로가 첫 줄이다.** 사용자가 오류 내용을 읽기 *전에* 눈에 들어와야 한다.
+/// 예전엔 맨 끝이었고, 읽는 순서상 "오류를 읽고 → 고쳐야겠다 판단하고 → 다이얼로그를
+/// 닫은 뒤" 경로가 필요해졌다. 위쪽 문구가 명확할수록 (`missing required key
+/// "window"`) 더 빨리 닫으므로 더 잘 놓쳤다. 실제로 사용자가 겪었다 (2026-08-22).
+///
+/// 그리고 **모든 config 오류가 이 한 형식을 지난다** — 파싱 오류든 의미 오류든.
+/// 형식이 두 갈래였던 것이 위치 불일치의 원인이었다.
+pub const config_error_with_path_format = "Config: {s}\n\n{s}";
+/// `allocPrint` 실패 시. **경로 자리를 비우지 않는다** — 예전 파싱 쪽 fallback 은
+/// 경로를 아예 잃어서 (`"Failed to parse config JSON."`) 정작 가장 도움이 필요한
+/// 상황에서 가장 적은 정보를 줬다.
+pub const config_error_with_path_fallback_msg = "Config: (unknown)\n\nConfiguration is invalid.";
 pub const config_dock_position_invalid_format = "Configuration: unknown \"window.dock_position\" value \"{s}\".\n\nAllowed: top, bottom, left, right";
 pub const config_dock_position_invalid_fallback_msg = "Configuration: window.dock_position invalid";
 pub const config_field_number_required_format = "Configuration: \"{s}\" must be a number.";


### PR DESCRIPTION
Closes #495.

경로가 다이얼로그에 **들어 있었는데 눈에 안 들어왔다.** 사용자가 실제로 겪었다 (2026-08-22) — 포맷이 틀린 config 로 다이얼로그를 받았는데 파일 위치를 못 찾아 한참 헤맸다.

## 원인은 렌더링이 아니라 위치와 형식 불일치였다

`dialog_layout` 은 본문 자연 높이를 먼저 쓰고 화면을 넘을 때만 viewport 를 만든다 — 우리 메시지는 6~10 줄이라 잘리지 않았다. 실제 문제:

| 오류 종류 | 예전 경로 위치 |
|---|---|
| 파싱 오류 | 본문 **셋째 줄** (`Path: {s}`) |
| 의미 오류 | **맨 끝** (`Config path:\n  {s}`) |

의미 오류(키 없음 · 값 범위 · hotkey 파싱 실패)가 대부분인데 그쪽이 맨 끝이었다. 읽는 순서상 *오류를 읽고 → 고쳐야겠다 판단하고 → 다이얼로그를 닫은 뒤* 경로가 필요해진다. 위쪽 문구가 명확할수록 (`missing required key "window"`) 더 빨리 닫으므로 **더 잘 놓쳤다.**

## 이제 둘이 같다

```
Config: /home/user/.config/tildaz/config_0.toml

Failed to parse config file.

Line 12, column 3
Error: UnexpectedToken
```

```
Config: /home/user/.config/tildaz/config_0.toml

Configuration: missing required key "window" in (top-level).
```

## 형식이 갈라진 원인을 없앴다

**파싱 오류만 `configErrorMessageAlloc` 을 지나지 않고 `dialog.showFatal` 을 직접 불렀다.** 그것이 두 형식이 생긴 이유다. 그 경로도 `showConfigFatalMsg` 를 지나게 했고 파싱 본문에서 `Path:` 줄을 뺐다 — 공통 머리가 주므로 남기면 두 번 나온다. 조립 지점이 한 곳이 됐다.

fallback 도 맞췄다. 예전 파싱 쪽은 경로 없는 문장으로 떨어져 **경로를 아예 잃었다** — 정작 가장 도움이 필요한 상황에서 가장 적은 정보를 줬다. 이제 `Config: (unknown)` 을 유지한다.

## 함께 정리한 것

- **`config_top_level_must_be_object_msg` 삭제.** TOML 의 최상위는 항상 테이블이라 그 검사가 **구조적으로 불가능**하다 (파서가 문법으로 보장한다). 문안도 "JSON object" 라고 적고 있었다. 프로덕션에서는 이미 안 쓰였고 테스트의 표본 본문으로만 남아 있었다.
- **`dialog_layout` 의 레이아웃 검사가 인자 2 개를 넘기고 있었다** — 형식이 바뀌며 컴파일 오류로 잡혔다. 이제 실제 조립 결과를 흉내내 같은 높이를 재고, 그 테스트에 남아 있던 `.json` 경로도 `.toml` 로 바꿨다.

## 파생 이슈 — #501

**배선되지 않은 메시지 셋**이 나왔다: `config_dir_create_failed_format` · `config_default_write_failed_format` · `config_read_failed_format`. `Config.createDefault` 가 세 실패를 다 삼키고 (`catch return` · `catch {}`) `Config.load` 의 읽기 실패도 조용히 기본값으로 떨어진다. 첫 실행에서 config 를 못 만들면 **사용자는 아무 안내도 못 받고** 기본값으로 도는 인스턴스를 얻는다.

이 PR 에서는 **지우지 않고 표시만 했다** — 문안이 그 경로에 필요한 것이고 지우면 나중에 다시 써야 한다. 배선에는 결정이 필요하다 (읽기 전용 디렉터리에서 시작을 거부할 것인가, 기본값으로 돌 것인가). #501 에 선택지를 정리했다.

## 검증

로컬에서 `zig build check` (6 타깃) · `test` · `-Dsimd=true` 통과. 그리고 **이 PR 이 `#500` 의 새 CI 를 처음으로 통과하는 변경**이다.

실제 조립 결과를 출력해 눈으로 확인했다 (위 두 블록이 그 출력이다). 다이얼로그 표시 자체는 세 platform 실기 확인이 남아 있다 — `#316` 이 이미 그 상태로 열려 있던 항목이다.