### PR TITLE
feat(linux): 비라틴 layout 에서 글자 단축키를 살린다 — 라틴 fallback (#496 1-a)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -261,11 +261,18 @@ Use a position when a label cannot reach the key you want:
 
 | Situation | Why the label fails | Position form |
 |---|---|---|
-| Cyrillic, Greek, Arabic, Hebrew… | no key produces a Latin letter | `ctrl+shift+[KeyW]` |
+| Cyrillic, Greek, Arabic, Hebrew… | no key produces a Latin letter — but see below, TildaZ already handles this on Linux | `ctrl+shift+[KeyW]` |
 | French AZERTY brackets | `[` is AltGr+5, so the label needs four fingers | `ctrl+shift+[BracketLeft]` |
 | Keys outside the label set | `-` `=` `\` `;` `'` `,` `.` `/`, numpad, arrows | `ctrl+[Minus]` |
 
 Positions and labels can be mixed freely, including within one action's list.
+
+**On Linux you usually do not need the position form for non-Latin layouts.**
+When TildaZ loads a keymap it checks whether the current layout can produce each
+binding's label at all; if nothing can, it falls back to the physical spot that
+character has on a US keyboard. So the defaults work on a Cyrillic layout
+untouched. The fallback applies only to bindings whose label is unreachable, so a
+`us,ru` setup keeps matching by label. KEYBINDINGS.md has the details.
 
 #### Accepted keys
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -70,7 +70,27 @@ $ xkbcli how-to-type --layout ru 'w'
 ```
 
 Rebinding to another letter does not help, because the problem is the whole
-Latin alphabet. The fix is to name the key by **position** instead of by label:
+Latin alphabet.
+
+**TildaZ handles this for you.** When it loads a keymap it checks, for every
+label binding, whether the current keymap can produce that character at all. If
+nothing can, it matches that binding by the physical spot the character occupies
+on a US keyboard instead. So the defaults work on a Cyrillic layout with no
+config changes: you press the same key a US user presses.
+
+Two details worth knowing:
+
+- **It only kicks in when the label is unreachable.** If you have a Latin layout
+  configured alongside — `us,ru` is the common setup — `w` is reachable, so
+  nothing changes and the label keeps working as usual. That also means the
+  shortcut follows the *label* on that setup, which is what you want.
+- **It is Linux-only, because only Linux needs it.** Windows non-Latin layouts
+  assign Latin virtual keys to the physical spots (`KBDRU` puts `VK_W` on the
+  `w` position), and macOS matches physical key codes to begin with, so letter
+  shortcuts already work there.
+
+You can still name a key by **position** explicitly, which is useful if you want
+a shortcut pinned to a spot regardless of layout:
 
 ```toml
 [keys]

--- a/SPEC.md
+++ b/SPEC.md
@@ -324,6 +324,23 @@ platform 마다 다르다.
   이름은 [W3C `KeyboardEvent.code`](https://www.w3.org/TR/uievents-code/) 값이고 (2025 년
   Recommendation) 표기는 VS Code 와 같은 대괄호다. 세 platform 값의 단일 출처는
   `src/physical_key.zig` 다.
+- **그리고 기본값이 그대로 동작하도록 라틴 fallback 을 둔다** (1-a, Linux 전용).
+  keymap 을 받을 때마다 (`wl_keyboard.keymap` — layout 을 바꿔도 다시 온다) 각 라벨
+  binding 에 대해 **현재 keymap 이 그 문자를 낼 수 있는지** 묻고
+  (`xkb.canProduceKeysym` — layout group × level 전수 조회, modifier 상태를 보지
+  않는다), 낼 수 없으면 그 문자가 US 자판에서 있던 자리로 매칭한다. 실측: `ru` 단독은
+  `w` 를 못 내고 (`us w` 자리가 `0x6c3` `Cyrillic_tse` 를 낸다), `us,ru` 는 낼 수 있다.
+  - **닿지 않을 때만 만든다.** 무조건 2 차 pass 를 돌리면 AZERTY 에서 `Z` 라 인쇄된
+    키 (US `w` 자리) 가 `close_tab` 을 발동시켜 한 동작에 키가 둘 생긴다.
+  - **판정 불가 (`null`) 와 false 를 구분한다.** libxkbcommon 이 keymap 조회 심볼을
+    안 내주면 fallback 을 만들지 않는다 — false 로 읽으면 없어도 되는 fallback 이
+    생긴다. 그 심볼 다섯은 **optional** 이다: 기존 심볼처럼 묶으면 오래된
+    libxkbcommon 에서 키보드가 통째로 죽는데 그것은 이 기능이 감당할 대가가 아니다.
+  - **라벨이 먼저다.** 라벨로 잡히는 event 가 fallback 때문에 다른 액션이 되면
+    사용자가 설명할 수 없다.
+  - GTK 는 같은 문제를 "영어 layout 이 첫 layout 으로 설정돼 있어야 한다" 는 *요구*로
+    푼다. 우리는 요구하지 않고 keymap 을 보고 스스로 판정한다 — `us,ru` 사용자에게는
+    결과가 같고, `ru` 단독 사용자에게는 다르다.
 - **수용 집합은 라벨 쪽이 좁고 위치 쪽이 넓다.** 의도한 비대칭이다. 라벨을 넓히려면 `-` 에
   값을 줘야 하는데 쓸 수 있는 고정값 (`VK_OEM_MINUS` · `kVK_ANSI_Minus`) 은 라벨이 아니라 "US
   자판에서 `-` 가 있는 자리" 다. 그것을 라벨이라 부르면 같은 config 가 platform 마다 다른 키를

--- a/src/config.zig
+++ b/src/config.zig
@@ -1820,6 +1820,89 @@ pub fn inputForAction(action: KeyAction) ActionInput {
     };
 }
 
+/// #496 1-a — 이 binding 이 **라틴 fallback 후보인가.**
+///
+/// 비라틴 layout (키릴 · 그리스 · 아랍 ...) 에서는 그 자판의 어느 키도 라틴 글자를
+/// 내지 않으므로 `ctrl+shift+w` 가 영원히 발동하지 않는다. 그럴 때 **US 자판에서 그
+/// 글자가 있던 자리**로 대신 매칭해 준다 — GTK · i3 · sway · VS Code 가 하는 것과 같다.
+///
+/// 후보 조건은 **layout 에 따라 달라지는 라벨**이라는 것이다:
+///
+///   - 위치로 적은 binding 은 후보가 아니다 (이미 layout 무관하다).
+///   - `F1` · `PageUp` 처럼 layout 과 무관한 named 키는 후보가 아니다 — 어느 자판에나
+///     그 키가 있으므로 라벨 매칭이 실패할 이유가 없다.
+///   - 글자 · 숫자 · `` ` `` · `[` · `]` 만 후보다.
+///
+/// **실제로 fallback 을 만들지는 호출자가 정한다** — 현재 keymap 이 그 글자를 낼 수
+/// 있으면 만들지 않는다. 그것이 중요하다: AZERTY 는 `w` 를 낼 수 있으므로 fallback 이
+/// 생기지 않고, 따라서 `Z` 라 인쇄된 키 (US `w` 자리) 가 `close_tab` 을 발동시키지
+/// **않는다.** 무조건 두 번째 pass 를 돌리면 그 layout 에서 한 동작에 키가 둘 생긴다.
+pub const FallbackCandidate = struct {
+    /// 이 binding 이 기다리는 라벨 keysym. 호출자가 keymap 에 물어볼 값이다.
+    keysym: u32,
+    /// 그 글자가 US 자판에서 있던 자리.
+    code: PhysicalCode,
+};
+
+pub fn fallbackCandidate(hotkey: Hotkey) ?FallbackCandidate {
+    // Linux 만이 라벨 (keysym) 로 매칭한다. Windows 는 비라틴 layout DLL 이 물리
+    // 위치에 라틴 VK 를 배정하고 (`KBDRU` 의 scancode 0x11 → `VK_W`) macOS 는
+    // `kVK_ANSI_*` 가 애초에 위치라, 두 platform 은 키릴에서도 이미 동작한다.
+    if (is_windows or is_macos) return null;
+    if (hotkey.code != null) return null;
+    const code = usPositionForKeysym(hotkey.keysym) orelse return null;
+    return .{ .keysym = hotkey.keysym, .code = code };
+}
+
+/// keysym → US 자판에서 그 글자가 있던 자리. `LinuxHotkey.keysymFromKey` 의 역방향
+/// 이고 **char 계열만** 다룬다 (named 키는 layout 무관이라 fallback 이 필요 없다).
+fn usPositionForKeysym(keysym: u32) ?PhysicalCode {
+    var name_buf: [8]u8 = undefined;
+    if (keysym >= 'a' and keysym <= 'z') {
+        const name = std.fmt.bufPrint(&name_buf, "Key{c}", .{std.ascii.toUpper(@intCast(keysym))}) catch return null;
+        return physical_key.fromName(name);
+    }
+    if (keysym >= '0' and keysym <= '9') {
+        const name = std.fmt.bufPrint(&name_buf, "Digit{c}", .{@as(u8, @intCast(keysym))}) catch return null;
+        return physical_key.fromName(name);
+    }
+    return switch (keysym) {
+        0x60 => .backquote,
+        0x5b => .bracket_left,
+        0x5d => .bracket_right,
+        else => null,
+    };
+}
+
+/// #496 1-a — 라벨 조회가 실패했을 때 **대체 위치**로 한 번 더 본다.
+///
+/// `fallbacks` 는 `bindings` 와 **같은 인덱스**다. non-null 인 항목만 2 차 pass 의
+/// 대상이고, 그것은 호출자가 "이 라벨은 현재 keymap 으로 낼 수 없다" 고 판정한
+/// binding 뿐이다 (`fallbackCandidate` 주석 참고).
+///
+/// 순서가 중요하다 — **라벨이 먼저다.** 라벨로 잡히는 event 가 fallback 때문에 다른
+/// 액션이 되면 사용자가 설명할 수 없다.
+pub fn lookupActionWithFallback(
+    bindings: []const KeyBinding,
+    fallbacks: []const ?PhysicalCode,
+    hotkey: Hotkey,
+    code: ?PhysicalCode,
+) ?KeyAction {
+    if (lookupAction(bindings, hotkey, code)) |action| return action;
+    const got = code orelse return null;
+    for (bindings, 0..) |b, i| {
+        if (i >= fallbacks.len) break;
+        const want = fallbacks[i] orelse continue;
+        if (want != got) continue;
+        // modifier 규칙은 1 차 pass 와 같다 — 숫자 예외까지 포함해서다 (#482).
+        const shift_bit: @TypeOf(hotkey.modifiers) = Hotkey.MOD_SHIFT;
+        const mods_match = b.hotkey.modifiers == hotkey.modifiers or
+            (isDigitBinding(b.hotkey) and b.hotkey.modifiers == (hotkey.modifiers & ~shift_bit));
+        if (mods_match) return b.action;
+    }
+    return null;
+}
+
 pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey, code: ?PhysicalCode) ?KeyAction {
     std.debug.assert(hotkey.code == null);
     for (bindings) |b| {

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -696,6 +696,9 @@ test "#314 dialog drag repaint requests coalesce to the latest row" {
 /// 쓸 수 있는 유일한 길이다.
 fn classifyInput(
     bindings: []const config_mod.KeyBinding,
+    /// #496 1-a — 라벨이 현재 layout 으로 닿지 않는 binding 의 대체 위치. 빈 slice 면
+    /// fallback 없이 라벨 · 위치만 본다.
+    fallbacks: []const ?config_mod.PhysicalCode,
     sym: u32,
     code: ?config_mod.PhysicalCode,
     ctrl: bool,
@@ -720,7 +723,7 @@ fn classifyInput(
         .keysym = config_mod.normalizeLinuxKeysym(sym),
         .modifiers = modifiers,
     };
-    const action = config_mod.lookupAction(bindings, hotkey, code) orelse return null;
+    const action = config_mod.lookupActionWithFallback(bindings, fallbacks, hotkey, code) orelse return null;
     return config_mod.inputForAction(action);
 }
 
@@ -748,7 +751,7 @@ test "#296 · #493 3-c classifyInput — native xkb → config binding → 공�
     // 기본 binding 이 전부 라벨이기 때문이다 (위치 매칭은 config.zig 쪽 test).
     const C = struct {
         fn f(bindings: []const config_mod.KeyBinding, sym: u32, ctrl: bool, shift: bool, alt: bool) ?A {
-            return classifyInput(bindings, sym, null, ctrl, shift, alt, false);
+            return classifyInput(bindings, &.{}, sym, null, ctrl, shift, alt, false);
         }
     }.f;
 
@@ -821,10 +824,11 @@ test "#296 · #493 3-c classifyInput — native xkb → config binding → 공�
 
 test "#496 위치로 적은 binding 이 라벨과 무관하게 잡힌다 (Linux)" {
     const T = std.testing;
-    // 키릴 layout 을 흉내낸다: `Ctrl+Shift+`(KeyW 자리) 를 누르면 keysym 은 `Ц`
-    // (U+0426 → xkb Unicode keysym) 로 도착하고 어떤 라벨 binding 과도 맞지 않는다.
-    // 위치로 적은 binding 만 그것을 잡는다.
-    const cyrillic_tse: u32 = 0x01000426;
+    // 키릴 layout 실측값이다 — `ru` keymap 에서 US `w` 자리 (evdev 17) 가 내는 keysym 이
+    // `0x6c3` (`Cyrillic_tse`) 다. Unicode 형 (`0x01000426`) 이 아니다: xkb 의 `ru` 는
+    // Cyrillic 블록 keysym 을 쓴다 (`xkb.zig` 의 실측 표 참고). 어떤 라벨 binding 과도
+    // 맞지 않고, 위치로 적은 binding 만 이것을 잡는다.
+    const cyrillic_tse: u32 = 0x6c3;
     var buf: [4]config_mod.KeyBinding = undefined;
     buf[0] = .{
         .hotkey = config_mod.appBindingHotkey("ctrl+shift+w").?,
@@ -837,14 +841,59 @@ test "#496 위치로 적은 binding 이 라벨과 무관하게 잡힌다 (Linux)
     const b = buf[0..2];
 
     // 라벨 binding 은 키릴 keysym 을 못 잡는다 — 이것이 #496 의 버그 자체다.
-    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, cyrillic_tse, .key_w, true, true, false, false));
+    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, &.{}, cyrillic_tse, .key_w, true, true, false, false));
     // 위치 binding 은 잡는다. 라벨이 무엇이든 자리가 맞으면 된다.
     try T.expectEqual(
         @as(?config_mod.ActionInput, .{ .input = .{ .shortcut = .new_tab } }),
-        classifyInput(b, cyrillic_tse, .key_t, true, true, false, false),
+        classifyInput(b, &.{}, cyrillic_tse, .key_t, true, true, false, false),
     );
     // 자리를 모르는 event (표에 없는 키) 는 위치 binding 을 발동시키지 않는다.
-    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, cyrillic_tse, null, true, true, false, false));
+    try T.expectEqual(@as(?config_mod.ActionInput, null), classifyInput(b, &.{}, cyrillic_tse, null, true, true, false, false));
+}
+
+test "#496 1-a 라틴 fallback — 라벨이 닿지 않을 때만 자리로 잡는다" {
+    const T = std.testing;
+    var buf: [4]config_mod.KeyBinding = undefined;
+    buf[0] = .{ .hotkey = config_mod.appBindingHotkey("ctrl+shift+w").?, .action = .close_tab };
+    buf[1] = .{ .hotkey = config_mod.appBindingHotkey("ctrl+shift+t").?, .action = .new_tab };
+    const b = buf[0..2];
+
+    // 키릴 layout 실측값 — `ru` 의 US `w` 자리가 내는 keysym (`Cyrillic_tse`).
+    const cyrillic_tse: u32 = 0x6c3;
+
+    // fallback 이 **없으면** 오늘의 버그 그대로다.
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, null),
+        classifyInput(b, &.{}, cyrillic_tse, .key_w, true, true, false, false),
+    );
+
+    // `close_tab` 의 라벨 `w` 가 이 layout 으로 닿지 않는다고 판정된 상태.
+    // `new_tab` 은 후보가 아니다 (닿는다고 가정) — 그래서 null 로 둔다.
+    const fallbacks = [_]?config_mod.PhysicalCode{ .key_w, null };
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, .{ .input = .{ .shortcut = .close_tab } }),
+        classifyInput(b, &fallbacks, cyrillic_tse, .key_w, true, true, false, false),
+    );
+
+    // **fallback 이 있는 binding 만 대상이다.** `KeyT` 자리를 눌러도 `new_tab` 의
+    // fallback 이 null 이므로 잡히지 않는다 — 이것이 AZERTY 에서 한 동작에 키가 둘
+    // 생기지 않게 하는 장치다.
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, null),
+        classifyInput(b, &fallbacks, cyrillic_tse, .key_t, true, true, false, false),
+    );
+
+    // modifier 는 여전히 엄격하다.
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, null),
+        classifyInput(b, &fallbacks, cyrillic_tse, .key_w, true, false, false, false),
+    );
+
+    // **라벨이 먼저다.** 라벨로 잡히는 event 는 fallback 이 있어도 라벨 결과를 낸다.
+    try T.expectEqual(
+        @as(?config_mod.ActionInput, .{ .input = .{ .shortcut = .new_tab } }),
+        classifyInput(b, &fallbacks, xkb_key_t_lower, .key_w, true, true, false, false),
+    );
 }
 
 
@@ -1155,6 +1204,12 @@ const Client = struct {
     /// (`dialog/linux.zig` 참고). 문자열은 `Config` 소유이고 그쪽이 우리보다 오래
     /// 산다. non-null 이면 아직 안 보여준 것이다.
     pending_config_notice: ?[]const u8 = null,
+    /// #496 1-a — 라벨 binding 이 현재 keymap 으로 **닿지 않을 때** 쓸 대체 위치.
+    /// `config.key_bindings` 와 같은 인덱스다. keymap 이 바뀔 때마다 다시 계산한다
+    /// (`wl_keyboard.keymap` 은 layout 을 바꿔도 다시 온다) — layout 종속 판정이라
+    /// 로드 시점에 한 번 굳히면 사용자가 layout 을 바꾼 뒤 틀린다.
+    binding_fallbacks: [config_mod.MAX_KEY_BINDINGS]?config_mod.PhysicalCode =
+        [_]?config_mod.PhysicalCode{null} ** config_mod.MAX_KEY_BINDINGS,
     /// #282 C1 — info/error dialog 도 About 과 같은 deferred. `showInfo` 는
     /// 탭 한도(Ctrl+Shift+T)·shell 소실 알림에서 `handleNewTab`(= processKeyEvent
     /// reentrant) 를 통해 동기 호출되는데, `openInfoDialog` → `createDialogSurface`
@@ -5557,6 +5612,8 @@ const Client = struct {
 
         try self.keyboard.setKeymap(self.allocator, memory);
         log.appendLineVerbose("wayland", "keyboard keymap loaded size={}", .{size});
+        // #496 1-a — layout 이 바뀌면 이 event 가 다시 온다. 그래서 매번 다시 푼다.
+        self.resolveBindingFallbacks();
     }
 
     fn handleKeyboardKey(self: *Client, payload: []const u8) !void {
@@ -5641,7 +5698,8 @@ const Client = struct {
             const code = physical_key.fromEvdev(key);
             const super = self.keyboard.superActive();
             const bindings = self.config.key_bindings[0..self.config.key_binding_count];
-            if (classifyInput(bindings, sym, code, ctrl, shift, alt, super)) |classified| {
+            const fallbacks = self.binding_fallbacks[0..self.config.key_binding_count];
+            if (classifyInput(bindings, fallbacks, sym, code, ctrl, shift, alt, super)) |classified| {
                 // #333 — paste 는 우클릭 / command menu 와 공통 semantic helper(requestPaste)
                 // 로 정책을 정확히 한 번 적용한다. generic resolve/switch 보다 먼저 분기해
                 // 이중 commit 을 막는다.
@@ -8181,6 +8239,37 @@ const Client = struct {
     /// #282 C1 — deferred info dialog 를 reentrancy 밖(main loop)에서 연다.
     /// 다른 dialog 가 이미 떠 있으면(About/confirm 등) 이번 info 는 버린다
     /// (advisory 알림 — 탭 한도/shell 소실). fire-and-forget 이라 pump 불필요.
+    /// #496 1-a — **비라틴 layout 에서 글자 단축키를 살린다.**
+    ///
+    /// 키릴 · 그리스 · 아랍 layout 에서는 그 자판의 어느 키도 라틴 글자를 내지 않아
+    /// `ctrl+shift+w` 가 영원히 발동하지 않고, **다른 글자로 재바인딩해도 해결되지
+    /// 않는다** (라틴 알파벳 전체가 없다). 그럴 때만 US 자판에서 그 글자가 있던
+    /// **자리**로 대신 매칭하게 표를 채운다.
+    ///
+    /// **"그럴 때만" 이 요점이다.** 현재 keymap 이 그 글자를 낼 수 있으면 항목을
+    /// 만들지 않는다 — AZERTY 는 `w` 를 낼 수 있으므로 fallback 이 없고, 따라서 `Z` 라
+    /// 인쇄된 키 (US `w` 자리) 가 `close_tab` 을 발동시키지 않는다. 무조건 2 차 pass 를
+    /// 돌리면 그 layout 에서 한 동작에 키가 둘 생기고 사용자가 설명할 수 없다.
+    ///
+    /// 판정할 수 없으면 (libxkbcommon 이 keymap 조회 심볼을 안 내준다) **아무것도
+    /// 만들지 않는다.** "낼 수 없다" 로 읽으면 없어도 되는 fallback 이 생긴다.
+    fn resolveBindingFallbacks(self: *Client) void {
+        const bindings = self.config.key_bindings[0..self.config.key_binding_count];
+        var resolved: usize = 0;
+        for (bindings, 0..) |b, i| {
+            self.binding_fallbacks[i] = null;
+            const candidate = config_mod.fallbackCandidate(b.hotkey) orelse continue;
+            const reachable = self.keyboard.canProduceKeysym(candidate.keysym) orelse continue;
+            if (reachable) continue;
+            self.binding_fallbacks[i] = candidate.code;
+            resolved += 1;
+        }
+        if (resolved > 0) {
+            // 이 로그가 있어야 "왜 이 키가 저 동작을 했는가" 를 사후에 설명할 수 있다.
+            log.appendLine("keys", "latin fallback active for {d} binding(s) — layout cannot type their labels", .{resolved});
+        }
+    }
+
     /// #501 — 로드 실패 안내를 한 번 보여준다. **fatal 이 아니다** — 기본값으로 계속
     /// 돈다. 다른 다이얼로그가 떠 있으면 다음 iteration 으로 미룬다 (info 경로처럼
     /// 그냥 버리지 않는다 — 이 안내는 사용자가 놓치면 증상만 남는다).

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -49,6 +49,26 @@ const XkbStateModNameIsActive = *const fn (
     component: c_uint,
 ) callconv(.c) c_int;
 
+// #496 1-a — keymap 전수 조회용. **비라틴 layout 에서 "이 문자를 낼 수 있는 키가
+// 하나도 없다" 를 판정**하는 데 쓴다. state 가 아니라 keymap 을 보는 이유는 현재
+// modifier / layout 과 무관하게 물어야 하기 때문이다 — `xkb_state_key_get_one_sym`
+// 은 지금 눌린 modifier 와 활성 group 만 본다.
+//
+// **이 다섯은 optional 이다.** 없으면 fallback 기능만 끄고 키보드는 정상 동작한다.
+// 기존 심볼처럼 `error.XkbSymbolMissing` 으로 묶으면 오래된 libxkbcommon 에서
+// 키보드가 통째로 죽는데, 그것은 이 기능이 감당할 대가가 아니다.
+const XkbKeymapMinKeycode = *const fn (keymap: *xkb_keymap) callconv(.c) c_uint;
+const XkbKeymapMaxKeycode = *const fn (keymap: *xkb_keymap) callconv(.c) c_uint;
+const XkbKeymapNumLayoutsForKey = *const fn (keymap: *xkb_keymap, key: c_uint) callconv(.c) c_uint;
+const XkbKeymapNumLevelsForKey = *const fn (keymap: *xkb_keymap, key: c_uint, layout: c_uint) callconv(.c) c_uint;
+const XkbKeymapKeyGetSymsByLevel = *const fn (
+    keymap: *xkb_keymap,
+    key: c_uint,
+    layout: c_uint,
+    level: c_uint,
+    syms_out: *[*]const c_uint,
+) callconv(.c) c_int;
+
 // libxkbcommon `enum xkb_state_component`. MODS_EFFECTIVE = (1 << 3).
 // 처음에 (1 << 7) = LAYOUT_EFFECTIVE 로 잘못 적어 mod_name_is_active 가
 // modifier component 를 안 보고 항상 0 반환 → 단축키 분기 fail (1차 시연 발견).
@@ -66,6 +86,9 @@ const Api = struct {
     state_key_get_utf8: XkbStateKeyGetUtf8,
     state_key_get_one_sym: XkbStateKeyGetOneSym,
     state_mod_name_is_active: XkbStateModNameIsActive,
+    // #496 1-a — optional. 하나라도 없으면 `keymapScan` 이 null 이 되고 fallback 이
+    // 꺼진다 (위 주석 참고).
+    keymap_scan: ?KeymapScan = null,
 
     fn load() !Api {
         const handle = std.c.dlopen("libxkbcommon.so.0", .{ .LAZY = true }) orelse return error.XkbLibraryMissing;
@@ -83,11 +106,32 @@ const Api = struct {
             .state_key_get_utf8 = lookup(handle, XkbStateKeyGetUtf8, "xkb_state_key_get_utf8") orelse return error.XkbSymbolMissing,
             .state_key_get_one_sym = lookup(handle, XkbStateKeyGetOneSym, "xkb_state_key_get_one_sym") orelse return error.XkbSymbolMissing,
             .state_mod_name_is_active = lookup(handle, XkbStateModNameIsActive, "xkb_state_mod_name_is_active") orelse return error.XkbSymbolMissing,
+            .keymap_scan = KeymapScan.load(handle),
         };
     }
 
     fn deinit(self: *Api) void {
         _ = std.c.dlclose(self.handle);
+    }
+};
+
+/// #496 1-a — keymap 전수 조회에 필요한 심볼 묶음. **다 있어야 의미가 있으므로 묶어서
+/// all-or-nothing 으로 다룬다** — 넷만 있으면 부분 조회가 되어 오히려 잘못된 답을 낸다.
+const KeymapScan = struct {
+    min_keycode: XkbKeymapMinKeycode,
+    max_keycode: XkbKeymapMaxKeycode,
+    num_layouts_for_key: XkbKeymapNumLayoutsForKey,
+    num_levels_for_key: XkbKeymapNumLevelsForKey,
+    key_get_syms_by_level: XkbKeymapKeyGetSymsByLevel,
+
+    fn load(handle: *anyopaque) ?KeymapScan {
+        return .{
+            .min_keycode = lookup(handle, XkbKeymapMinKeycode, "xkb_keymap_min_keycode") orelse return null,
+            .max_keycode = lookup(handle, XkbKeymapMaxKeycode, "xkb_keymap_max_keycode") orelse return null,
+            .num_layouts_for_key = lookup(handle, XkbKeymapNumLayoutsForKey, "xkb_keymap_num_layouts_for_key") orelse return null,
+            .num_levels_for_key = lookup(handle, XkbKeymapNumLevelsForKey, "xkb_keymap_num_levels_for_key") orelse return null,
+            .key_get_syms_by_level = lookup(handle, XkbKeymapKeyGetSymsByLevel, "xkb_keymap_key_get_syms_by_level") orelse return null,
+        };
     }
 };
 
@@ -161,6 +205,43 @@ pub const Keyboard = struct {
         );
     }
 
+    /// #496 1-a — **현재 keymap 의 어느 키라도 이 keysym 을 낼 수 있는가.**
+    ///
+    /// layout (group) 과 level 을 전수로 훑는다. modifier 상태를 보지 않는 것이
+    /// 요점이다 — "Shift 를 눌러야 나오는 문자" 도 *낼 수 있는* 것으로 세야 하고,
+    /// 사용자가 여러 layout 을 들고 있으면 (`us,ru` 처럼 흔하다) 그중 하나에만 있어도
+    /// 된다.
+    ///
+    /// null = 판정할 수 없다 (libxkbcommon 이 필요한 심볼을 안 내주거나 keymap 이
+    /// 없다). **false 와 구분해야 한다** — 판정 불가일 때 "낼 수 없다" 로 읽으면
+    /// 없어도 되는 fallback 을 만들어 동작을 넓힌다.
+    pub fn canProduceKeysym(self: *Keyboard, keysym: u32) ?bool {
+        const api = if (self.api) |*a| a else return null;
+        const scan = api.keymap_scan orelse return null;
+        const keymap = self.keymap orelse return null;
+
+        const min = scan.min_keycode(keymap);
+        const max = scan.max_keycode(keymap);
+        var key: c_uint = min;
+        while (key <= max) : (key += 1) {
+            const layouts = scan.num_layouts_for_key(keymap, key);
+            var layout: c_uint = 0;
+            while (layout < layouts) : (layout += 1) {
+                const levels = scan.num_levels_for_key(keymap, key, layout);
+                var level: c_uint = 0;
+                while (level < levels) : (level += 1) {
+                    var syms: [*]const c_uint = undefined;
+                    const count = scan.key_get_syms_by_level(keymap, key, layout, level, &syms);
+                    if (count <= 0) continue;
+                    for (syms[0..@intCast(count)]) |sym| {
+                        if (sym == keysym) return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     pub fn oneSym(self: *Keyboard, key: u32) ?u32 {
         const api = if (self.api) |*api| api else return null;
         const state = self.state orelse return null;
@@ -223,3 +304,31 @@ pub const Keyboard = struct {
         }
     }
 };
+
+test "#496 1-a canProduceKeysym — 판정 불가는 false 가 아니라 null 이다" {
+    // keymap 이 없으면 (또는 libxkbcommon 이 조회 심볼을 안 내주면) **null 이다.**
+    // false 로 주면 호출자가 "이 라벨은 낼 수 없다" 로 읽어 없어도 되는 라틴 fallback
+    // 을 만들고, 그러면 라틴 자판에서 한 동작에 키가 둘 생긴다 (#496 1-a).
+    var kb: Keyboard = .{};
+    defer kb.deinit();
+    try std.testing.expectEqual(@as(?bool, null), kb.canProduceKeysym('w'));
+}
+
+// 실측 확인 (2026-08-24, 이 개발 머신 · libxkbcommon.so.0). `xkbcli compile-keymap`
+// 으로 뽑은 실제 keymap 을 넣어 확인한 값이다 — keymap 은 하나에 70 KB 대라 fixture
+// 로 커밋하지 않았다.
+//
+// | layout  | `w` 를 낼 수 있나 | US `w` 자리 (evdev 17) 가 내는 keysym |
+// |---------|------------------|--------------------------------------|
+// | `us`    | true             | `0x77` (`w`)                          |
+// | `ru`    | **false**        | `0x6c3` (`Cyrillic_tse`)              |
+// | `us,ru` | true             | `0x77`                                |
+//
+// 세 줄이 이 기능의 설계를 그대로 보여 준다:
+//
+//   - `ru` 단독 → 라벨이 닿지 않으므로 fallback 이 생기고 글자 단축키가 살아난다.
+//   - `us,ru` → `w` 가 닿으므로 fallback 이 **생기지 않는다.** GTK 가 "영어 layout 이
+//     설정돼 있어야 한다" 고 요구하는 것과 같은 결과인데, 우리는 사용자에게 요구하지
+//     않고 keymap 을 보고 스스로 판정한다.
+//   - 도착하는 keysym 이 Unicode 형 (`0x01000426`) 이 아니라 **이름 있는 Cyrillic
+//     keysym** (`0x6c3`) 이다. xkb 의 `ru` 는 Cyrillic 블록 keysym 을 쓴다.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -66,6 +66,7 @@ test "aggregate root imports every common and native-host test module" {
             _ = @import("host/linux/shell_extension.zig");
             _ = @import("host/linux/software_terminal.zig");
             _ = @import("host/linux/wayland_minimal.zig");
+            _ = @import("host/linux/xkb.zig");
             _ = @import("shortcut_sync/linux.zig");
             _ = @import("terminal/posix/pty.zig");
         },


### PR DESCRIPTION
`#496` 1-a. 키릴 · 그리스 · 아랍 layout 에서 **기본값이 그냥 동작하게** 한다.

`#498` 이 위치 표기(`ctrl+shift+[KeyW]`)를 넣어 사용자가 *고칠 수는* 있게 했지만, 갓 설치한 상태에서는 글자 단축키가 여전히 전부 죽어 있었다.

## 규칙

keymap 을 받을 때마다 각 라벨 binding 에 대해 **현재 keymap 이 그 문자를 낼 수 있는지** 묻고, 낼 수 없으면 그 문자가 US 자판에서 있던 **자리**로 매칭한다. GTK · i3 · sway · VS Code 가 하는 것과 같은 해법이다.

**Linux 전용이다.** Windows 는 비라틴 layout DLL 이 물리 위치에 라틴 VK 를 배정하고(`KBDRU` 의 scancode 0x11 → `VK_W`) macOS 는 `kVK_ANSI_*` 가 애초에 위치라, 두 platform 은 키릴에서도 이미 동작한다.

## 실측 — `xkbcli compile-keymap` 으로 뽑은 실제 keymap 으로 확인

| layout | `w` 를 낼 수 있나 | US `w` 자리(evdev 17)가 내는 keysym |
|---|---|---|
| `us` | true | `0x77` (`w`) |
| **`ru`** | **false** | `0x6c3` (`Cyrillic_tse`) |
| `us,ru` | true | `0x77` |

세 줄이 설계를 그대로 보여준다:

- **`ru` 단독** → 라벨이 닿지 않으므로 fallback 이 생기고 글자 단축키가 살아난다.
- **`us,ru`** (흔한 다중 layout 설정) → `w` 가 닿으므로 fallback 이 **생기지 않는다.** GTK 는 같은 문제를 *"영어 layout 이 첫 layout 으로 설정돼 있어야 한다"* 는 **요구**로 푸는데, 우리는 요구하지 않고 keymap 을 보고 스스로 판정한다.

그리고 도착하는 keysym 이 Unicode 형(`0x01000426`)이 아니라 **이름 있는 Cyrillic keysym**(`0x6c3`)이었다 — `#498` 테스트에 적어 뒀던 값을 실측으로 고쳤다.

## 경계를 세 곳에서 지킨다 — 여기가 검토 포인트다

**① 닿지 않을 때만 만든다.** 무조건 2 차 pass 를 돌리면 AZERTY 에서 `Z` 라 인쇄된 키(US `w` 자리)가 `close_tab` 을 발동시켜 **한 동작에 키가 둘 생긴다.** 사용자가 설명할 수 없는 동작이고, 테스트가 이 경계를 고정한다.

**② 판정 불가와 false 를 구분한다.** `canProduceKeysym` 이 `?bool` 이다. libxkbcommon 이 keymap 조회 심볼을 안 내주면 `null` 이고, 그때는 fallback 을 만들지 않는다 — `false` 로 읽으면 없어도 되는 fallback 이 생긴다. 이 계약을 테스트로 고정했다.

**③ 라벨이 먼저다.** 라벨로 잡히는 event 가 fallback 때문에 다른 액션이 되면 사용자가 설명할 수 없다.

## xkb 심볼 다섯은 **optional** 이다

`xkb_keymap_min_keycode` · `max_keycode` · `num_layouts_for_key` · `num_levels_for_key` · `key_get_syms_by_level`.

기존 심볼처럼 `error.XkbSymbolMissing` 으로 묶으면 오래된 libxkbcommon 에서 **키보드가 통째로 죽는다** — 이 기능이 감당할 대가가 아니다. 없으면 fallback 만 꺼진다. 다섯을 `KeymapScan` 으로 묶어 all-or-nothing 으로 다루는데, 넷만 있으면 부분 조회가 되어 오히려 잘못된 답을 낸다.

**state 가 아니라 keymap 을 본다.** `xkb_state_key_get_one_sym` 으로는 "Shift 를 눌러야 나오는 문자" 와 "다른 group 에 있는 문자" 를 놓치는데, 둘 다 *낼 수 있는* 것으로 세야 한다.

## layout 변경에 따라 다시 푼다

`wl_keyboard.keymap` 은 사용자가 layout 을 바꿔도 다시 오므로 그때마다 재계산한다. 로드 시점에 한 번 굳히면 layout 을 바꾼 뒤 틀린다 — VS Code 는 같은 자리에서 *"layout 을 바꿨으면 재시작을 권한다"* 고 안내하는데 우리는 그럴 필요가 없다.

fallback 이 하나라도 활성되면 로그에 남긴다. "왜 이 키가 저 동작을 했는가" 를 사후에 설명할 수 있어야 한다.

## 문서

기존 안내가 *"위치로 적으라"* 고 했는데 이제 기본값이 그냥 동작하므로 **그 안내가 틀렸다.** `KEYBINDINGS.md` · `CONFIG.md` 를 고치고 경계(`us,ru` 는 라벨 유지, Linux 전용)를 함께 적었다. `SPEC.md` 에 규칙과 세 안전장치를 기록했다.

## 그 밖에

`src/host/linux/xkb.zig` 가 **테스트 집계에 없었다.** 추가했다.

## 검증

깨끗한 캐시(`--cache-dir` 새로 지정)로 `zig build check`(6 타깃) · `test` · `-Dsimd=true` 전부 통과.

**`canProduceKeysym` 은 실제 `us` / `ru` / `us,ru` keymap 으로 확인했다** (위 표). keymap 이 하나에 70 KB 대라 fixture 로 커밋하지는 않고, 측정값과 방법을 `xkb.zig` 주석에 남겼다. 커밋된 테스트는 매처 로직과 "판정 불가는 null" 계약을 덮는다.

**실기 확인이 남은 것**: 실제 `ru` layout 데스크톱에서 `Ctrl+Shift+W` 가 동작하는지. 지금은 keymap 조회 결과와 매처 단위 테스트까지다.