### PR TITLE
fix(linux): 라틴 fallback 판정이 활성 layout group 을 보게 한다 (#496 1-a 결함)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -388,11 +388,14 @@ Latin-letter shortcut back to the key you actually pressed on a Cyrillic or Gree
 layout. On sway and Hyprland they do not, so a letter hotkey can stop working
 there while a non-Latin layout is active.
 
-**Punctuation is the riskier choice**, and not only on non-Latin layouts. A
-`grave` hotkey has no key to bind to on a German layout — that layout has no
-`grave` character at all — and GNOME's fallback does not cover it, because the
-fallback only triggers when the layout is missing the Latin *alphabet*. The
-binding is then accepted and simply never fires.
+**Punctuation is the riskier choice**, and not only on non-Latin layouts. German
+and Spanish cannot type `` ` `` at all — the key in that position is a dead accent
+— so a ``Ctrl+` `` hotkey is silently dead there. GNOME's fallback does not rescue
+it either, because that fallback only triggers when the layout is missing the
+Latin *alphabet*.
+
+KEYBINDINGS.md has a measured table of which layouts can type which keys, and the
+sway / Hyprland limitation it matters most for.
 
 ### New tab working directory
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -271,8 +271,9 @@ Positions and labels can be mixed freely, including within one action's list.
 When TildaZ loads a keymap it checks whether the current layout can produce each
 binding's label at all; if nothing can, it falls back to the physical spot that
 character has on a US keyboard. So the defaults work on a Cyrillic layout
-untouched. The fallback applies only to bindings whose label is unreachable, so a
-`us,ru` setup keeps matching by label. KEYBINDINGS.md has the details.
+untouched. The check follows the layout you are currently typing in, so a `us,ru`
+setup matches by label while you are on `us` and falls back the moment you switch
+to `ru`. KEYBINDINGS.md has the details.
 
 #### Accepted keys
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -372,6 +372,26 @@ invalid value shows an error dialog and exits):
   way. Widening it means verifying real key codes on Linux, macOS, and Windows,
   which has not been done yet. A rejected value shows an error dialog naming the
   accepted keys rather than failing silently.
+- **The position form is not accepted here.** `hotkey` is registered with your
+  desktop, and every path TildaZ uses for that takes a character rather than a
+  key position. A value like `"ctrl+[KeyW]"` is rejected with a message saying so,
+  rather than being registered as something that never fires.
+
+#### Prefer a function key
+
+`F1`–`F12` are the same on every keyboard layout, which is why the default is
+`F1`. Letters and punctuation are not, and the failure is quiet.
+
+Letters are usually fine: GNOME, Cinnamon, COSMIC and KDE all translate a
+Latin-letter shortcut back to the key you actually pressed on a Cyrillic or Greek
+layout. On sway and Hyprland they do not, so a letter hotkey can stop working
+there while a non-Latin layout is active.
+
+**Punctuation is the riskier choice**, and not only on non-Latin layouts. A
+`grave` hotkey has no key to bind to on a German layout — that layout has no
+`grave` character at all — and GNOME's fallback does not cover it, because the
+fallback only triggers when the layout is missing the Latin *alphabet*. The
+binding is then accepted and simply never fires.
 
 ### New tab working directory
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -163,6 +163,46 @@ which is why the default is `F1`. Punctuation is the worst choice — a `grave`
 hotkey has no key to bind to on a German layout, and GNOME's fallback does not
 cover that case because it only triggers when the *alphabet* is missing.
 
+### Known limitation: the global hotkey on sway and Hyprland
+
+Every other desktop translates a hotkey back to the key you actually pressed when
+your layout cannot type its character. **sway and Hyprland do not.** There, the
+hotkey is matched against the character the active layout produces, so it stops
+working while a layout that cannot type that character is active — and starts
+working again when you switch back.
+
+The binding is registered successfully either way. Nothing warns you; it just
+does not fire.
+
+**So on sway or Hyprland, do not use a letter or punctuation for `hotkey` if you
+type in any of the layouts below. Use a function key.** `F1`–`F12` are the same
+on every layout, which is why the default is `F1`.
+
+Measured with `xkbcli how-to-type` — ✅ means that layout can type the character,
+so a hotkey using it keeps working:
+
+| Layout | `A`–`Z` | `0`–`9` | `` ` `` | `[` `]` |
+|---|:--:|:--:|:--:|:--:|
+| US, UK, French, Italian, Japanese | ✅ | ✅ | ✅ | ✅ |
+| **German, Spanish** | ✅ | ✅ | **❌** | ✅ |
+| Greek, Arabic | ❌ | ✅ | ✅ | ✅ |
+| Ukrainian, Bulgarian, Hebrew | ❌ | ✅ | ❌ | ✅ |
+| **Russian** | ❌ | ✅ | ❌ | **❌** |
+| **Thai** | ❌ | **❌** | ❌ | ❌ |
+
+Three of those are easy to get wrong:
+
+- **German and Spanish cannot type `` ` ``** even though they are Latin layouts.
+  A ``Ctrl+` `` hotkey is dead there. Their key in that position is a dead
+  accent, not a backtick.
+- **Greek and Arabic can**, so ``Ctrl+` `` survives on those while letters do not.
+- **Thai cannot type digits**, so even `Alt+1` is dead — the only layout here
+  where a digit hotkey fails.
+
+This affects the **global hotkey only**. Shortcuts inside TildaZ (`[keys]`) are
+matched by TildaZ itself and fall back to the physical key position, so they keep
+working on every layout above.
+
 ### What stays fixed
 
 `Shift+PgUp` / `Shift+PgDn` scroll the scrollback and cannot be rebound —

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -149,9 +149,19 @@ A few positions do not exist on macOS — `[PrintScreen]`, `[ScrollLock]` and
 ### The global hotkey is different
 
 `hotkey` is registered with the desktop rather than handled inside TildaZ, and
-every path TildaZ uses for that (sway, Hyprland, COSMIC, KDE) accepts only a
-character — so it does **not** take the position form. A function key is the
-safest choice: `F1`–`F12` are identical on every layout.
+every path TildaZ uses for that — sway, Hyprland, GNOME, Cinnamon, COSMIC, KDE —
+accepts only a character, so it does **not** take the position form.
+
+Most desktops paper over this for you: GNOME (since 3.28), Cinnamon (since 5.4),
+COSMIC and KDE all translate a Latin-letter shortcut back to the key you actually
+pressed on a Cyrillic or Greek layout. GNOME and Cinnamon do it even if a Latin
+layout is not among the ones you have configured; COSMIC and KDE need one.
+**sway and Hyprland do not do it at all.**
+
+**A function key is the safest choice**: `F1`–`F12` are identical on every layout,
+which is why the default is `F1`. Punctuation is the worst choice — a `grave`
+hotkey has no key to bind to on a German layout, and GNOME's fallback does not
+cover that case because it only triggers when the *alphabet* is missing.
 
 ### What stays fixed
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -80,10 +80,10 @@ config changes: you press the same key a US user presses.
 
 Two details worth knowing:
 
-- **It only kicks in when the label is unreachable.** If you have a Latin layout
-  configured alongside — `us,ru` is the common setup — `w` is reachable, so
-  nothing changes and the label keeps working as usual. That also means the
-  shortcut follows the *label* on that setup, which is what you want.
+- **It only kicks in when the label is unreachable in the layout you are
+  currently typing in.** With `us,ru` — the common setup — nothing changes while
+  you are on `us`, and the fallback takes over the moment you switch to `ru`. It
+  is re-evaluated on every layout switch, so you never have to restart.
 - **It is Linux-only, because only Linux needs it.** Windows non-Latin layouts
   assign Latin virtual keys to the physical spots (`KBDRU` puts `VK_W` on the
   `w` position), and macOS matches physical key codes to begin with, so letter

--- a/SPEC.md
+++ b/SPEC.md
@@ -365,10 +365,22 @@ platform 마다 다르다.
   정당하게 바인딩하는데 터미널이 삼키면 통과시킬 방법이 없다. PgUp / PgDn 은 GNOME Terminal ·
   Konsole · Windows Terminal 이 탭 전환에 쓰는, 터미널이 관습적으로 소유하는 조합이다.
 - **기존 PgUp / PgDn 경로는 그대로다** — Shift 동반은 scrollback (§2.5), 맨 키는 PTY.
-- **전역 `hotkey` 는 위치 표기를 받지 않는다.** OS / compositor 에 *등록* 해야 하고 그 4 경로가
-  모두 문자 기반이다 (sway `bindsym` · Hyprland keysym · COSMIC RON `key:` · KGlobalAccel
-  `qtKey`). 조용히 keysym 0 을 등록하는 대신 원인이 분명한 실패를 낸다 —
-  [#496](https://github.com/ensky0/tildaz/issues/496) 1-b 가 그 제약을 다룬다.
+- **전역 `hotkey` 는 위치 표기를 받지 않는다.** OS / compositor 에 *등록* 해야 하고 우리가 쓰는
+  **다섯** 경로가 모두 문자 기반이다 — sway `bindsym` · Hyprland keysym · GNOME / Cinnamon
+  GTK accelerator (`buildGtkAccel`) · COSMIC RON `key:` · KGlobalAccel `qtKey`. (처음에
+  "4 경로" 로 적었는데 GNOME · Cinnamon 이 빠져 있었다.) 조용히 keysym 0 을 등록하는 대신
+  원인이 분명한 실패를 낸다 — [#496](https://github.com/ensky0/tildaz/issues/496) 1-b 가 그
+  제약을 다룬다.
+  - **DE 넷은 이미 스스로 라틴 fallback 을 한다** — GNOME (Mutter 3.28+) · Cinnamon (Muffin
+    5.4+) · COSMIC (2026-02+) · KDE (Plasma 5.22+). 그래서 1-b 가 손댈 곳은 그것을 하지 않는
+    sway · Hyprland 다.
+  - 다만 **비라틴 단독 layout** 에서는 갈린다. Mutter · Muffin 은 `us` keymap 을 즉석에
+    컴파일해 (`create_us_layout()`) 라틴 layout 이 없어도 동작하고, COSMIC · KDE 는 *사용자의
+    다른 xkb group* 을 훑으므로 `ru` 단독이면 실패한다. 그 둘은 API 가 keysym 만 받아
+    **우리가 고칠 수 없다.**
+  - **COSMIC 의 RON `keycode:` 필드는 쓰면 안 된다.** 파싱은 되는데 cosmic-comp 가 값을 읽지
+    않고, `key:` 가 없으면 matcher 가 *modifier 전용 바인딩* 으로 취급해 modifier 를 뗄 때
+    발동한다. cosmic-settings 자신이 저장 전에 그 필드를 지운다.
 - **macOS 에 없는 위치가 있다.** `PrintScreen` · `ScrollLock` · `Pause` 는 **없는 것이 아니라
   `F13` · `F14` · `F15` 로 보고된다** (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). `F21`~`F24`
   와 JIS 입력 전환 키 3 개는 정말 없다. 두 경우의 안내가 다르다 — 앞쪽은 "그 이름을 쓰라",
@@ -842,6 +854,16 @@ hotkey = "ctrl+f7"              # ✅ KDE — kwin ExposeClass 충돌 → takeov
 hotkey = "shift+cmd+t"          # mac 친숙 표기 (`cmd` = `super` = `meta` 모두 동일 키)
 hotkey = "ctrl+grave"           # backtick — `grave` 또는 `` ` `` 둘 다 가능
 ```
+
+> **전역 핫키에 punctuation 을 권하지 않는다** ([#496](https://github.com/ensky0/tildaz/issues/496)
+> 1-b 조사). Mutter 의 `needs_secondary_layout()` 은 `a`–`z` 만 보고 라틴 fallback 여부를
+> 정하는데, **라틴이지만 US 가 아닌 layout** 에는 그 문자가 아예 없을 수 있다 — `de` 에는
+> `grave` keysym 이 없다. 그러면 fallback 을 받지 못한 채 바인딩이 keycode 0 개로 해석돼
+> **조용히 죽는다** (`meta_display_grab_accelerator` 가 `ACTION_NONE` 을 낸다). GNOME 자신은
+> 같은 문제를 `grave` 대신 위치 토큰 `Above_Tab` 을 써서 피한다.
+>
+> 위 예제에서 `ctrl+grave` 는 **US 자판 기준의 예시**로만 읽어야 한다. 어느 자판에서나
+> 안전한 것은 **함수 키** (`F1`~`F12`) 다 — 기본값이 `F1` 인 이유이기도 하다.
 
 **Modifier 토큰** (대소문자 무관, `+` 분리, 임의 개수 결합):
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -325,11 +325,19 @@ platform 마다 다르다.
   Recommendation) 표기는 VS Code 와 같은 대괄호다. 세 platform 값의 단일 출처는
   `src/physical_key.zig` 다.
 - **그리고 기본값이 그대로 동작하도록 라틴 fallback 을 둔다** (1-a, Linux 전용).
-  keymap 을 받을 때마다 (`wl_keyboard.keymap` — layout 을 바꿔도 다시 온다) 각 라벨
-  binding 에 대해 **현재 keymap 이 그 문자를 낼 수 있는지** 묻고
-  (`xkb.canProduceKeysym` — layout group × level 전수 조회, modifier 상태를 보지
-  않는다), 낼 수 없으면 그 문자가 US 자판에서 있던 자리로 매칭한다. 실측: `ru` 단독은
-  `w` 를 못 내고 (`us w` 자리가 `0x6c3` `Cyrillic_tse` 를 낸다), `us,ru` 는 낼 수 있다.
+  각 라벨 binding 에 대해 **활성 layout group 이 그 문자를 낼 수 있는지** 묻고
+  (`xkb.canProduceKeysym`), 낼 수 없으면 그 문자가 US 자판에서 있던 자리로 매칭한다.
+  - **판정은 활성 group 만 본다.** 처음에 group 을 전수로 훑었는데 그것이 결함이었다 —
+    매처는 활성 group 이 내는 keysym 만 보므로 판정도 같은 group 을 봐야 한다. 실측
+    (`us,ru` keymap): group 0 은 `sym@KeyW=0x77`, group 1 은 `0x6c3`
+    (`Cyrillic_tse`) 인데 전수 조회는 양쪽에서 `canProduceKeysym('w') = true` 를 낸다.
+    그래서 ru group 으로 전환한 사용자는 fallback 을 받지 못해 단축키가 죽었고, 그것이
+    비라틴 사용자의 **가장 흔한 설정**이라 정작 다수 사례를 놓쳤다.
+  - **재해석 트리거가 둘이다.** keymap 교체는 `wl_keyboard.keymap`, **group 전환은
+    `wl_keyboard.modifiers` 의 `group` 필드**로 온다. 후자를 빠뜨리면 위 결함이 된다.
+    Mutter 도 `keymap-changed` 와 `keymap-layout-group-changed` 둘 다 훅한다.
+  - level 은 전수로 훑는다 — "Shift 를 눌러야 나오는 문자" 도 낼 수 있는 것으로 세야
+    한다. 키마다 layout 수가 달라 유효 layout 은 `group % num_layouts_for_key` 다.
   - **닿지 않을 때만 만든다.** 무조건 2 차 pass 를 돌리면 AZERTY 에서 `Z` 라 인쇄된
     키 (US `w` 자리) 가 `close_tab` 을 발동시켜 한 동작에 키가 둘 생긴다.
   - **판정 불가 (`null`) 와 false 를 구분한다.** libxkbcommon 이 keymap 조회 심볼을
@@ -339,8 +347,9 @@ platform 마다 다르다.
   - **라벨이 먼저다.** 라벨로 잡히는 event 가 fallback 때문에 다른 액션이 되면
     사용자가 설명할 수 없다.
   - GTK 는 같은 문제를 "영어 layout 이 첫 layout 으로 설정돼 있어야 한다" 는 *요구*로
-    푼다. 우리는 요구하지 않고 keymap 을 보고 스스로 판정한다 — `us,ru` 사용자에게는
-    결과가 같고, `ru` 단독 사용자에게는 다르다.
+    푼다. 우리는 요구하지 않고 활성 group 을 보고 스스로 판정하므로 `us,ru` · `ru` 단독
+    양쪽에서 동작한다. Mutter 는 `us` keymap 을 즉석 컴파일해 같은 결과를 얻는다
+    (`create_us_layout()`) — 우리는 내장 W3C 위치표가 그 자리를 대신한다.
 - **수용 집합은 라벨 쪽이 좁고 위치 쪽이 넓다.** 의도한 비대칭이다. 라벨을 넓히려면 `-` 에
   값을 줘야 하는데 쓸 수 있는 고정값 (`VK_OEM_MINUS` · `kVK_ANSI_Minus`) 은 라벨이 아니라 "US
   자판에서 `-` 가 있는 자리" 다. 그것을 라벨이라 부르면 같은 config 가 platform 마다 다른 키를

--- a/src/config.zig
+++ b/src/config.zig
@@ -144,9 +144,14 @@ pub const HotkeyFailure = enum {
     /// key 는 유효하지만 modifier 없이 전역 등록할 수 없는 키다 (F1~F12 만 허용).
     modifier_required,
     /// #496 — 위치 표기 (`[KeyW]`) 를 전역 `hotkey` 에 썼다. 아직 `[keys]` 에서만
-    /// 받는다: 전역 핫키는 OS / compositor 에 *등록* 해야 하고 그 4 경로가 모두
-    /// 문자 기반이라 (sway `bindsym` · Hyprland keysym · COSMIC RON · KGlobalAccel
-    /// `qtKey`) 위치를 넘길 자리가 없다. 조용히 keysym 0 을 등록하는 대신 거부한다.
+    /// 받는다: 전역 핫키는 OS / compositor 에 *등록* 해야 하고 우리가 쓰는 **다섯**
+    /// 경로가 모두 문자 기반이라 위치를 넘길 자리가 없다 — sway `bindsym` · Hyprland
+    /// keysym · GNOME / Cinnamon GTK accelerator · COSMIC RON `key:` · KGlobalAccel
+    /// `qtKey`. (처음에 "4 경로" 로 적었는데 GNOME · Cinnamon 이 빠져 있었다.)
+    ///
+    /// 조용히 keysym 0 을 등록하는 대신 거부한다. 다섯 중 위치를 *받아 주는* 것이
+    /// 넷이라 (sway `bindcode` · Hyprland `code:` · GNOME / Cinnamon `0xNN`) 1-b 에서
+    /// 그쪽부터 푼다. COSMIC · KDE 는 API 자체가 keysym 만 받는다.
     position_in_global_hotkey,
     /// #496 — macOS 가 이 자리를 **다른 이름으로 보고**한다. `PrintScreen` ·
     /// `ScrollLock` · `Pause` 를 PC 자판에서 누르면 `F13` · `F14` · `F15` 로 온다

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -5935,12 +5935,19 @@ const Client = struct {
 
     fn handleKeyboardModifiers(self: *Client, payload: []const u8) void {
         if (payload.len < 20) return;
+        const group = readU32(payload[16..20]);
+        // #496 1-a — **layout group 전환이 여기로 온다** (`keymap` event 가 아니다).
+        // 라틴 fallback 판정이 활성 group 종속이므로 바뀔 때마다 다시 푼다. 이것이
+        // 없으면 `us,ru` 사용자가 ru group 으로 전환했을 때 fallback 이 생기지 않아
+        // 글자 단축키가 죽는다 — 비라틴 사용자의 가장 흔한 설정이다.
+        const group_changed = group != self.keyboard.active_group;
         self.keyboard.updateMask(
             readU32(payload[4..8]),
             readU32(payload[8..12]),
             readU32(payload[12..16]),
-            readU32(payload[16..20]),
+            group,
         );
+        if (group_changed) self.resolveBindingFallbacks();
     }
 
     fn handleKeyboardRepeatInfo(self: *Client, payload: []const u8) void {

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -141,6 +141,13 @@ fn lookup(handle: *anyopaque, comptime T: type, name: [*:0]const u8) ?T {
 }
 
 pub const Keyboard = struct {
+    /// #496 1-a — 마지막으로 받은 layout group (`wl_keyboard.modifiers` 의 `group`).
+    /// **라틴 fallback 판정이 이 값을 봐야 한다** — 매처는 활성 group 이 내는 keysym 만
+    /// 보기 때문이다. 처음엔 모든 group 을 훑었는데, 그러면 `us,ru` 사용자가 ru group
+    /// 으로 전환했을 때 "us group 이 `w` 를 낼 수 있다" 는 이유로 fallback 을 만들지
+    /// 않아 단축키가 죽었다 (실측: group1 에서 `sym@KeyW=0x6c3` 인데
+    /// `canProduceKeysym('w')` 가 true 였다).
+    active_group: u32 = 0,
     api: ?Api = null,
     context: ?*xkb_context = null,
     keymap: ?*xkb_keymap = null,
@@ -192,6 +199,9 @@ pub const Keyboard = struct {
         locked_mods: u32,
         group: u32,
     ) void {
+        // #496 1-a — 판정이 활성 group 을 봐야 하므로 기억한다. keymap 이 없어 아래에서
+        // 돌아가더라도 값은 남긴다 — 다음 keymap 이 오면 그 group 으로 판정한다.
+        self.active_group = group;
         const api = if (self.api) |*api| api else return;
         const state = self.state orelse return;
         _ = api.state_update_mask(
@@ -205,12 +215,16 @@ pub const Keyboard = struct {
         );
     }
 
-    /// #496 1-a — **현재 keymap 의 어느 키라도 이 keysym 을 낼 수 있는가.**
+    /// #496 1-a — **활성 layout group 의 어느 키라도 이 keysym 을 낼 수 있는가.**
     ///
-    /// layout (group) 과 level 을 전수로 훑는다. modifier 상태를 보지 않는 것이
-    /// 요점이다 — "Shift 를 눌러야 나오는 문자" 도 *낼 수 있는* 것으로 세야 하고,
-    /// 사용자가 여러 layout 을 들고 있으면 (`us,ru` 처럼 흔하다) 그중 하나에만 있어도
-    /// 된다.
+    /// **group 을 전수로 훑지 않는다.** 매처는 활성 group 이 내는 keysym 만 보므로
+    /// 판정도 같은 group 을 봐야 한다. 처음엔 모든 group 을 훑었고, 그래서 `us,ru`
+    /// 사용자가 ru group 으로 전환하면 — 도착하는 것은 `Cyrillic_tse` 인데 "us group
+    /// 이 `w` 를 낼 수 있다" 는 이유로 fallback 을 만들지 않아 — 단축키가 죽었다.
+    /// 비라틴 사용자의 **가장 흔한 설정**이 그것이라 정작 다수 사례를 놓쳤다.
+    ///
+    /// level 은 전수로 훑는다. modifier 상태를 보지 않는 것이 요점이다 — "Shift 를
+    /// 눌러야 나오는 문자" 도 *낼 수 있는* 것으로 세야 한다.
     ///
     /// null = 판정할 수 없다 (libxkbcommon 이 필요한 심볼을 안 내주거나 keymap 이
     /// 없다). **false 와 구분해야 한다** — 판정 불가일 때 "낼 수 없다" 로 읽으면
@@ -225,17 +239,18 @@ pub const Keyboard = struct {
         var key: c_uint = min;
         while (key <= max) : (key += 1) {
             const layouts = scan.num_layouts_for_key(keymap, key);
-            var layout: c_uint = 0;
-            while (layout < layouts) : (layout += 1) {
-                const levels = scan.num_levels_for_key(keymap, key, layout);
-                var level: c_uint = 0;
-                while (level < levels) : (level += 1) {
-                    var syms: [*]const c_uint = undefined;
-                    const count = scan.key_get_syms_by_level(keymap, key, layout, level, &syms);
-                    if (count <= 0) continue;
-                    for (syms[0..@intCast(count)]) |sym| {
-                        if (sym == keysym) return true;
-                    }
+            if (layouts == 0) continue;
+            // xkb 규칙 — 그 키의 layout 수보다 group 이 크면 wrap 한다. 키마다 layout
+            // 수가 다를 수 있어 (`num_layouts_for_key` 가 키별이다) 나눗셈이 필요하다.
+            const layout: c_uint = @intCast(self.active_group % layouts);
+            const levels = scan.num_levels_for_key(keymap, key, layout);
+            var level: c_uint = 0;
+            while (level < levels) : (level += 1) {
+                var syms: [*]const c_uint = undefined;
+                const count = scan.key_get_syms_by_level(keymap, key, layout, level, &syms);
+                if (count <= 0) continue;
+                for (syms[0..@intCast(count)]) |sym| {
+                    if (sym == keysym) return true;
                 }
             }
         }
@@ -305,6 +320,20 @@ pub const Keyboard = struct {
     }
 };
 
+test "#496 1-a canProduceKeysym 은 활성 group 만 본다 — 기본 group 은 0" {
+    // 이 결함을 두 번 내지 않기 위한 못이다. keymap 이 없으면 판정 자체가 불가라
+    // (`null`) 값 검사는 못 하지만, **`updateMask` 가 group 을 기억한다**는 계약은
+    // 여기서 고정할 수 있다 — 그것이 group 인지 판정의 입력이다.
+    var kb: Keyboard = .{};
+    defer kb.deinit();
+    try std.testing.expectEqual(@as(u32, 0), kb.active_group);
+    // keymap / api 가 없어도 group 은 남는다 — 다음 keymap 이 그 group 으로 판정한다.
+    kb.updateMask(0, 0, 0, 1);
+    try std.testing.expectEqual(@as(u32, 1), kb.active_group);
+    kb.updateMask(0, 0, 0, 0);
+    try std.testing.expectEqual(@as(u32, 0), kb.active_group);
+}
+
 test "#496 1-a canProduceKeysym — 판정 불가는 false 가 아니라 null 이다" {
     // keymap 이 없으면 (또는 libxkbcommon 이 조회 심볼을 안 내주면) **null 이다.**
     // false 로 주면 호출자가 "이 라벨은 낼 수 없다" 로 읽어 없어도 되는 라틴 fallback
@@ -318,17 +347,22 @@ test "#496 1-a canProduceKeysym — 판정 불가는 false 가 아니라 null �
 // 으로 뽑은 실제 keymap 을 넣어 확인한 값이다 — keymap 은 하나에 70 KB 대라 fixture
 // 로 커밋하지 않았다.
 //
-// | layout  | `w` 를 낼 수 있나 | US `w` 자리 (evdev 17) 가 내는 keysym |
-// |---------|------------------|--------------------------------------|
-// | `us`    | true             | `0x77` (`w`)                          |
-// | `ru`    | **false**        | `0x6c3` (`Cyrillic_tse`)              |
-// | `us,ru` | true             | `0x77`                                |
+// | layout · 활성 group | `w` 를 낼 수 있나 | US `w` 자리 (evdev 17) 가 내는 keysym |
+// |---------------------|------------------|--------------------------------------|
+// | `us`                | true             | `0x77` (`w`)                          |
+// | `ru`                | **false**        | `0x6c3` (`Cyrillic_tse`)              |
+// | `us,ru` · group 0   | true             | `0x77`                                |
+// | `us,ru` · group 1   | **false**        | `0x6c3`                               |
 //
-// 세 줄이 이 기능의 설계를 그대로 보여 준다:
+// **마지막 줄이 이 함수를 다시 쓴 이유다.** 처음 구현은 group 을 전수로 훑어서
+// `us,ru` · group 1 에서도 `true` 를 냈다 — 도착하는 것은 `Cyrillic_tse` 인데
+// fallback 을 만들지 않아 단축키가 죽었다. 비라틴 사용자의 가장 흔한 설정이 그것이라
+// 정작 다수 사례를 놓쳤다.
+//
+// 나머지 줄이 보여 주는 것:
 //
 //   - `ru` 단독 → 라벨이 닿지 않으므로 fallback 이 생기고 글자 단축키가 살아난다.
-//   - `us,ru` → `w` 가 닿으므로 fallback 이 **생기지 않는다.** GTK 가 "영어 layout 이
-//     설정돼 있어야 한다" 고 요구하는 것과 같은 결과인데, 우리는 사용자에게 요구하지
-//     않고 keymap 을 보고 스스로 판정한다.
+//   - `us,ru` · group 0 → `w` 가 닿으므로 fallback 이 생기지 않고, 라벨 매칭이 그대로
+//     맞는다. group 을 전환하면 `wl_keyboard.modifiers` 가 오고 다시 푼다.
 //   - 도착하는 keysym 이 Unicode 형 (`0x01000426`) 이 아니라 **이름 있는 Cyrillic
 //     keysym** (`0x6c3`) 이다. xkb 의 `ru` 는 Cyrillic 블록 keysym 을 쓴다.


### PR DESCRIPTION
`#505` 로 머지한 1-a 가 **비라틴 사용자의 가장 흔한 설정을 못 고쳤다.** 그 결함과, 1-b 조사에서 나온 문서 정정 두 가지다.

## 결함 — 판정이 활성 group 을 보지 않았다

`canProduceKeysym` 이 layout group 을 **전수로** 훑는데, 매처는 **활성 group** 이 내는 keysym 만 본다. 기준이 어긋나 있었다.

실측 (`us,ru` keymap):

| 활성 group | US `w` 자리가 내는 keysym | `canProduceKeysym('w')` | 결과 |
|---|---|---|---|
| 0 (`us`) | `0x77` (`w`) | true | 라벨 매칭 ✅ |
| 1 (`ru`) | `0x6c3` (`Cyrillic_tse`) | **true** ← 결함 | fallback 없음 → **죽음** ❌ |

group 1 에서 도착하는 것은 `Cyrillic_tse` 라 라벨 binding 과 맞지 않는데, *"us group 이 `w` 를 낼 수 있다"* 는 이유로 fallback 을 만들지 않았다. 그래서 `us,ru` 사용자가 ru 로 전환하면 글자 단축키가 그대로 죽는다 — **`ru` 단독만 고쳐졌고 정작 다수 사례가 남아 있었다.**

`#505` PR 본문과 문서에 *"`us,ru` 는 `w` 가 닿으므로 fallback 이 생기지 않는다 — 그것이 원하는 결과다"* 라고 적었는데 **틀렸다.** 문서 세 곳을 고쳤다.

### 고친 것

- **`canProduceKeysym` 이 활성 group 만 본다.** 키마다 layout 수가 다를 수 있어 (`num_layouts_for_key` 가 키별) 유효 layout 은 `group % layouts` 다. level 은 그대로 전수로 훑는다 — "Shift 를 눌러야 나오는 문자" 도 낼 수 있는 것으로 세야 한다.
- **`Keyboard.active_group`** 을 `updateMask` 가 기억한다.
- **재해석 트리거가 둘이 됐다.** keymap 교체는 `wl_keyboard.keymap`, **group 전환은 `wl_keyboard.modifiers` 의 `group` 필드**로 온다. 후자를 빠뜨린 것이 이 결함이었다. Mutter 도 `keymap-changed` 와 `keymap-layout-group-changed` 둘 다 훅하는데, 절반만 따라간 셈이다.

### 테스트

`updateMask` 가 group 을 기억한다는 계약을 고정했다 — 그것이 판정의 입력이라, 이 못이 없으면 같은 실수가 되돌아온다. keymap 을 fixture 로 embed 하지 않는 이유는 그대로다 (하나에 70 KB 대). 실측값과 방법은 `xkb.zig` 주석의 표에 있고 **group 1 행을 추가**했다.

---

## 문서 정정 — 전역 핫키 등록 경로는 4 개가 아니라 5 개다

`#496` 본문에 "4 경로" 라고 적었는데 **GNOME · Cinnamon 이 빠져 있었다.** 그쪽은 `buildGtkAccel(keysym, modifiers)` 로 GTK accelerator 문자열을 GSettings 에 쓴다. 이슈 본문과 관련 코멘트 셋도 정정했다.

조사 결과 다섯 중 우리가 손댈 곳은 둘뿐이다:

| 백엔드 | 위치 표현 | DE 가 라틴 fallback | 비라틴 단독 layout |
|---|---|---|---|
| sway · Hyprland | ✅ | — | 우리가 keycode 를 줘야 |
| GNOME (3.28+) · Cinnamon (5.4+) | ✅ | ✅ | ✅ **동작** |
| COSMIC (2026-02+) · KDE (5.22+) | ❌ | ✅ | ❌ 라틴 layout 필요 |

**Mutter 방식이 우리보다 낫다** — `us` keymap 을 즉석 컴파일해 (`create_us_layout()`) 해석하므로 사용자가 라틴 layout 을 갖고 있지 않아도 된다. COSMIC · KDE 는 사용자의 다른 group 을 훑어 `ru` 단독이면 실패하고, 그 둘은 API 가 keysym 만 받아 **우리가 고칠 수 없다.**

**COSMIC 의 RON `keycode:` 필드는 쓰면 안 된다** — 파싱은 되는데 cosmic-comp 가 값을 읽지 않고, `key:` 가 없으면 matcher 가 *modifier 전용 바인딩*으로 취급해 modifier 를 뗄 때 발동한다.

## 문서에 실제 위험이 있었다

Mutter 의 `needs_secondary_layout()` 은 **`a`–`z` 만** 보고 fallback 여부를 정한다. 그래서 **라틴이지만 US 가 아닌 layout** 은 fallback 을 못 받는데 `de` 에는 `grave` keysym 이 아예 없다 → 바인딩이 keycode 0 개로 해석돼 **조용히 죽는다.**

`SPEC.md` §7.1 hotkey 예제에 `ctrl+grave` 가 있었다. 독일어 자판 GNOME 사용자가 따라 하면 무동작이다. GNOME 자신은 `grave` 대신 위치 토큰 `Above_Tab` 으로 피한다. 세 문서에 "함수 키가 안전하다 → 글자는 DE 넷이 번역해 주지만 sway · Hyprland 는 안 해 준다 → punctuation 이 가장 위험하다" 를 적었다.

## 검증

`--cache-dir` 를 새로 준 **깨끗한 캐시**로 `zig build check` (6 타깃) · `test` 통과. (warm cache 가 오류를 가린 적이 있어 중요한 검증은 캐시를 새로 준다.)

실기 확인은 여전히 남아 있다 — 실제 `us,ru` 데스크톱에서 group 전환 후 `Ctrl+Shift+W` 가 동작하는지.