### PR TITLE
feat(sway): 전역 핫키를 물리 위치로 등록한다 — bindcode (#496 1-b)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -385,8 +385,9 @@ invalid value shows an error dialog and exits):
 
 Letters are usually fine: GNOME, Cinnamon, COSMIC and KDE all translate a
 Latin-letter shortcut back to the key you actually pressed on a Cyrillic or Greek
-layout. On sway and Hyprland they do not, so a letter hotkey can stop working
-there while a non-Latin layout is active.
+layout, and on sway TildaZ registers the hotkey by physical key position so the
+same thing happens. **Hyprland is the exception** — a letter hotkey can stop
+working there while a non-Latin layout is active.
 
 **Punctuation is the riskier choice**, and not only on non-Latin layouts. German
 and Spanish cannot type `` ` `` at all — the key in that position is a dead accent

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -163,20 +163,25 @@ which is why the default is `F1`. Punctuation is the worst choice — a `grave`
 hotkey has no key to bind to on a German layout, and GNOME's fallback does not
 cover that case because it only triggers when the *alphabet* is missing.
 
-### Known limitation: the global hotkey on sway and Hyprland
+### Known limitation: the global hotkey on Hyprland
 
-Every other desktop translates a hotkey back to the key you actually pressed when
-your layout cannot type its character. **sway and Hyprland do not.** There, the
-hotkey is matched against the character the active layout produces, so it stops
-working while a layout that cannot type that character is active — and starts
-working again when you switch back.
+Every desktop except Hyprland gets this right, by one route or another:
 
-The binding is registered successfully either way. Nothing warns you; it just
-does not fire.
+| Desktop | How the hotkey survives a layout it cannot type |
+|---|---|
+| GNOME (3.28+), Cinnamon (5.4+) | the compositor falls back to a US layout it compiles itself |
+| COSMIC, KDE | the compositor falls back to another layout you have configured |
+| **sway** | **TildaZ registers it by physical key position** (`bindcode`) |
+| **Hyprland** | — nothing |
 
-**So on sway or Hyprland, do not use a letter or punctuation for `hotkey` if you
-type in any of the layouts below. Use a function key.** `F1`–`F12` are the same
-on every layout, which is why the default is `F1`.
+On Hyprland the hotkey is matched against the character the active layout
+produces, so it stops working while a layout that cannot type that character is
+active, and starts working again when you switch back. The binding is registered
+successfully either way. Nothing warns you; it just does not fire.
+
+**So on Hyprland, do not use a letter or punctuation for `hotkey` if you type in
+any of the layouts below. Use a function key.** `F1`–`F12` are the same on every
+layout, which is why the default is `F1`.
 
 Measured with `xkbcli how-to-type` — ✅ means that layout can type the character,
 so a hotkey using it keeps working:
@@ -199,9 +204,14 @@ Three of those are easy to get wrong:
 - **Thai cannot type digits**, so even `Alt+1` is dead — the only layout here
   where a digit hotkey fails.
 
-This affects the **global hotkey only**. Shortcuts inside TildaZ (`[keys]`) are
-matched by TildaZ itself and fall back to the physical key position, so they keep
-working on every layout above.
+This affects the **global hotkey on Hyprland only**. Shortcuts inside TildaZ
+(`[keys]`) are matched by TildaZ itself and fall back to the physical key
+position, so they keep working on every layout above — on every desktop.
+
+TildaZ could do the same for Hyprland, but its hotkeys are written from the
+launcher, before any keyboard exists, so there is no keymap to ask which physical
+key types your hotkey. sway is different only because TildaZ registers there from
+inside the running terminal, after the keymap has arrived.
 
 ### What stays fixed
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -382,7 +382,23 @@ platform 마다 다르다.
   제약을 다룬다.
   - **DE 넷은 이미 스스로 라틴 fallback 을 한다** — GNOME (Mutter 3.28+) · Cinnamon (Muffin
     5.4+) · COSMIC (2026-02+) · KDE (Plasma 5.22+). 그래서 1-b 가 손댈 곳은 그것을 하지 않는
-    sway · Hyprland 다.
+    sway · Hyprland 였다.
+  - **sway 는 `bindcode` 로 등록한다** (1-b). 자리를 고르는 규칙이 1-a 와 같다 — 활성
+    layout 이 그 문자를 내면 그 키, 못 내면 US 자판에서 그 문자가 있던 자리. 판정할 수
+    없으면 `bindsym` 으로 되돌아간다 (핫키를 아예 잃는 것보다 낫다).
+    - **숫자는 evdev 가 아니라 xkb keycode (= evdev + 8)** 다. sway 는 2018 년 커밋
+      *"Use XKB keycode numbering for bindcode"* 로 evdev 를 일부러 뺐고, **잘못된 숫자를
+      거부하지 않는다** (`xkb_keycode_is_legal_ext` 가 `XKB_KEYCODE_MAX` 까지 통과) — off-by-8
+      이면 조용히 옆 키에 붙는다. `sway_ipc.zig` 의 test 가 그 +8 을 고정한다.
+    - **등록을 keymap 도착 뒤로 미룬다.** 위치로 등록하려면 "이 문자를 내는 키가 어디인가" 를
+      알아야 하는데 `client.run()` 앞에는 keymap 이 없다. 미루는 창은 밀리초 단위다 (keymap 은
+      seat 의 keyboard capability 가 생길 때 오고 focus 와 무관하다).
+    - **재등록이 없다.** 한 번 자리에 고정하면 group 전환에 영향받지 않는다 — 그것이 위치
+      등록을 고른 이유다. `bindsym` 은 활성 layout 이 바뀔 때마다 죽었다 살았다 한다.
+  - **Hyprland 는 남는다** (known limitation). 그쪽 등록은 launcher 단계 (`shortcut_sync`)
+    라 keyboard 자체가 없어 물어볼 keymap 이 없다. sway 가 되는 이유는 등록이 *떠 있는
+    터미널 안*에서 일어나기 때문이다. 덮으려면 `hyprctl getoption input:kb_layout` 조회 +
+    `xkb_keymap_new_from_names` 심볼 추가 + host 재동기화 배관이 필요하다.
   - 다만 **비라틴 단독 layout** 에서는 갈린다. Mutter · Muffin 은 `us` keymap 을 즉석에
     컴파일해 (`create_us_layout()`) 라틴 layout 이 없어도 동작하고, COSMIC · KDE 는 *사용자의
     다른 xkb group* 을 훑으므로 `ru` 단독이면 실패한다. 그 둘은 API 가 keysym 만 받아

--- a/src/host/linux/sway_ipc.zig
+++ b/src/host/linux/sway_ipc.zig
@@ -40,7 +40,29 @@ const ipc_header_len = ipc_magic.len + 8; // magic(6) + len(4) + type(4)
 /// sway 가 아니거나 (`SWAYSOCK` 없음 + `XDG_CURRENT_DESKTOP` 에 sway 토큰 없음)
 /// 등록 실패는 모두 graceful — log 만 남기고 반환한다. single_instance toggle
 /// listener 는 그대로 살아 있어 사용자가 수동 등록도 가능.
-pub fn registerToggleIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *const config_mod.Config) void {
+/// #496 1-b — 전역 핫키를 **물리 위치**로 등록한다.
+///
+/// sway 는 `bindsym` 을 **활성 layout 의 keysym** 에 맞춘다. 그래서 사용자가 `hotkey`
+/// 를 글자 조합으로 바꾸면 비라틴 layout 으로 전환했을 때 조용히 안 먹는다 — 등록은
+/// 성공하고 경고도 없다. 나머지 DE 는 자기가 라틴 fallback 을 하는데 (GNOME 3.28+ ·
+/// Cinnamon 5.4+ · COSMIC · KDE) sway 와 Hyprland 는 하지 않는다.
+///
+/// `keycode` 가 있으면 `bindcode` 로 등록해 **자리에 고정**한다. 한 번 고정하면 group
+/// 전환에 영향받지 않으므로 재등록이 필요 없다 — 그것이 위치 등록의 요점이다.
+///
+/// **숫자는 evdev 가 아니라 xkb keycode (= evdev + 8) 다.** sway 는 2018 년 커밋
+/// *"Use XKB keycode numbering for bindcode"* 로 evdev 를 일부러 뺐고, 잘못된 숫자를
+/// **거부하지 않는다** (`xkb_keycode_is_legal_ext` 가 `XKB_KEYCODE_MAX` 까지 통과).
+/// off-by-8 이면 조용히 옆 키에 붙는다.
+///
+/// `keycode` 가 null 이면 예전처럼 `bindsym` 으로 등록한다 — libxkbcommon 이 keymap
+/// 조회 심볼을 안 내주는 환경에서 핫키를 아예 잃는 것보다 낫다.
+pub fn registerToggleIfSway(
+    rt: Runtime,
+    allocator: std.mem.Allocator,
+    cfg: *const config_mod.Config,
+    keycode: ?u16,
+) void {
     // sway 판별 — `SWAYSOCK` 존재가 가장 확실 (IPC 가능 == socket 있음).
     // `XDG_CURRENT_DESKTOP` 토큰은 보조 (SWAYSOCK 미설정 환경 hedge).
     //
@@ -62,26 +84,30 @@ pub fn registerToggleIfSway(rt: Runtime, allocator: std.mem.Allocator, cfg: *con
     };
     const exe_path = exe_buf[0..exe_len];
 
-    // accel 문자열 (`Shift+Ctrl+Alt+Super+<key>`).
+    // accel 문자열 (`Shift+Ctrl+Alt+Super+<key>`). 위치 등록이면 key 자리가 숫자다.
     var accel_buf: [96]u8 = undefined;
-    const accel = buildAccel(&accel_buf, cfg.hotkey.keysym, cfg.hotkey.modifiers);
+    const accel = if (keycode) |code|
+        buildCodeAccel(&accel_buf, code, cfg.hotkey.modifiers)
+    else
+        buildAccel(&accel_buf, cfg.hotkey.keysym, cfg.hotkey.modifiers);
+    const verb = if (keycode == null) "bindsym" else "bindcode";
 
     // sway command — `exec` 인자는 sway 가 sh -c 로 실행하므로 path 를 따옴표로.
     var cmd_buf: [std.Io.Dir.max_path_bytes + 128]u8 = undefined;
-    const command = std.fmt.bufPrint(&cmd_buf, "bindsym --no-warn {s} exec \"{s}\" --toggle {d}", .{ accel, exe_path, instance_context.requireWorkerIndex() }) catch {
-        log.appendLine("sway", "bindsym command too long — skip", .{});
+    const command = std.fmt.bufPrint(&cmd_buf, "{s} --no-warn {s} exec \"{s}\" --toggle {d}", .{ verb, accel, exe_path, instance_context.requireWorkerIndex() }) catch {
+        log.appendLine("sway", "bind command too long — skip", .{});
         return;
     };
 
     log.appendLineVerbose("sway", "RUN_COMMAND payload=[{s}] (sock={s})", .{ command, sock_path });
     const ok = runCommand(allocator, sock_path, command) catch |err| {
-        log.appendLine("sway", "bindsym IPC failed: {s} — single_instance toggle retained (user can register manually)", .{@errorName(err)});
+        log.appendLine("sway", "{s} IPC failed: {s} — single_instance toggle retained (user can register manually)", .{ verb, @errorName(err) });
         return;
     };
     if (ok) {
-        log.appendLine("sway", "bindsym auto-registered OK — {s} → tildaz --toggle (runtime, refreshed each launch)", .{accel});
+        log.appendLine("sway", "{s} auto-registered OK — {s} → tildaz --toggle (runtime, refreshed each launch)", .{ verb, accel });
     } else {
-        log.appendLine("sway", "bindsym auto-register rejected (sway success=false) — accel={s}", .{accel});
+        log.appendLine("sway", "{s} auto-register rejected (sway success=false) — accel={s}", .{ verb, accel });
     }
 }
 
@@ -326,6 +352,22 @@ fn isSwayDesktop(rt: Runtime) bool {
 /// `config.hotkey` → sway accel 문자열. modifier prefix 는 sway 가 수용하는
 /// 친화 이름 (`Shift` / `Ctrl` / `Alt` / `Super`), key 이름은 공통 `hotkey_format.gtkName`
 /// 재사용 (XKB keysym name — sway bindsym 과 1:1, nested 시연 확인).
+/// #496 1-b — `bindcode` 용 accel. modifier 표기는 `bindsym` 과 같고 key 자리만
+/// 숫자다 (sway 는 둘을 같은 파서로 처리한다 — `cmd_bindsym_or_bindcode`).
+///
+/// **evdev + 8 을 쓴다.** 그 이유와 위험은 `registerToggleIfSway` 주석 참고.
+fn buildCodeAccel(buf: []u8, evdev_keycode: u16, modifiers: u32) []const u8 {
+    const H = config_mod.Hotkey;
+    var fbs: std.Io.Writer = .fixed(buf);
+    const w = &fbs;
+    if ((modifiers & H.MOD_SHIFT) != 0) w.writeAll("Shift+") catch {};
+    if ((modifiers & H.MOD_CTRL) != 0) w.writeAll("Ctrl+") catch {};
+    if ((modifiers & H.MOD_ALT) != 0) w.writeAll("Alt+") catch {};
+    if ((modifiers & H.MOD_SUPER) != 0) w.writeAll("Super+") catch {};
+    w.print("{d}", .{@as(u32, evdev_keycode) + 8}) catch {};
+    return fbs.buffered();
+}
+
 fn buildAccel(buf: []u8, keysym: u32, modifiers: u32) []const u8 {
     const H = config_mod.Hotkey;
     var fbs: std.Io.Writer = .fixed(buf);
@@ -399,4 +441,36 @@ fn readAll(fd: posix.fd_t, buf: []u8) !void {
         if (n == 0) return error.SwayIpcEof;
         off += n;
     }
+}
+
+test "#496 1-b bindcode accel 은 evdev + 8 을 쓴다" {
+    const H = config_mod.Hotkey;
+    var buf: [96]u8 = undefined;
+
+    // `KeyT` = evdev 20 → xkb 28. sway 는 xkb keycode 를 받는다 (2018 커밋
+    // "Use XKB keycode numbering for bindcode"). **이 +8 이 틀리면 sway 가 거부하지
+    // 않고 조용히 옆 키에 붙는다** — `xkb_keycode_is_legal_ext` 가 거의 다 통과시킨다.
+    try std.testing.expectEqualStrings("28", buildCodeAccel(&buf, 20, 0));
+    try std.testing.expectEqualStrings(
+        "Shift+Ctrl+28",
+        buildCodeAccel(&buf, 20, H.MOD_SHIFT | H.MOD_CTRL),
+    );
+    // modifier 표기와 순서는 `bindsym` 쪽과 같아야 한다 — sway 가 둘을 같은 파서로
+    // 처리하므로 (`cmd_bindsym_or_bindcode`) 갈라 둘 이유가 없다.
+    try std.testing.expectEqualStrings(
+        "Shift+Ctrl+Alt+Super+28",
+        buildCodeAccel(&buf, 20, H.MOD_SHIFT | H.MOD_CTRL | H.MOD_ALT | H.MOD_SUPER),
+    );
+    // `KeyW` = evdev 17 → 25, `Digit1` = evdev 2 → 10.
+    try std.testing.expectEqualStrings("Super+25", buildCodeAccel(&buf, 17, H.MOD_SUPER));
+    try std.testing.expectEqualStrings("Alt+10", buildCodeAccel(&buf, 2, H.MOD_ALT));
+}
+
+test "#496 1-b physical_key 의 evdev 값이 위 기대치와 맞는다" {
+    // 위 test 의 20 · 17 · 2 는 손으로 적은 값이다. 표와 어긋나면 test 가 스스로
+    // 거짓이 되므로 여기서 묶는다.
+    const pk = @import("../../physical_key.zig");
+    try std.testing.expectEqual(@as(u16, 20), pk.evdev(.key_t));
+    try std.testing.expectEqual(@as(u16, 17), pk.evdev(.key_w));
+    try std.testing.expectEqual(@as(u16, 2), pk.evdev(.digit1));
 }

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1210,6 +1210,13 @@ const Client = struct {
     /// 로드 시점에 한 번 굳히면 사용자가 layout 을 바꾼 뒤 틀린다.
     binding_fallbacks: [config_mod.MAX_KEY_BINDINGS]?config_mod.PhysicalCode =
         [_]?config_mod.PhysicalCode{null} ** config_mod.MAX_KEY_BINDINGS,
+    /// #496 1-b — sway 전역 핫키 등록을 **keymap 이 온 뒤로** 미룬다. 등록을 위치
+    /// (`bindcode`) 로 하려면 "이 문자를 내는 키가 어디인가" 를 알아야 하는데,
+    /// `client.run()` 앞에서는 `wl_keyboard.keymap` 이 아직 오지 않았다.
+    ///
+    /// 미루는 창은 밀리초 단위다 — keymap 은 seat 의 keyboard capability 가 생길 때
+    /// 오고 focus 와 무관하다. 그 사이 핫키가 없지만, 그 시점엔 창도 막 뜨는 중이다.
+    pending_sway_toggle_register: bool = false,
     /// #282 C1 — info/error dialog 도 About 과 같은 deferred. `showInfo` 는
     /// 탭 한도(Ctrl+Shift+T)·shell 소실 알림에서 `handleNewTab`(= processKeyEvent
     /// reentrant) 를 통해 동기 호출되는데, `openInfoDialog` → `createDialogSurface`
@@ -1894,6 +1901,7 @@ const Client = struct {
             self.drainAboutRequest();
             self.drainInfoRequest();
             self.drainConfigNotice();
+            self.drainSwayToggleRegister();
             self.drainNewInstanceRequest();
             // L12-β — exit 한 탭들을 main thread 에서 close. read thread 의
             // `linuxTabExit` 가 pending_close_buf 에 ptr 쌓아둠. drain 이
@@ -8246,6 +8254,38 @@ const Client = struct {
     /// #282 C1 — deferred info dialog 를 reentrancy 밖(main loop)에서 연다.
     /// 다른 dialog 가 이미 떠 있으면(About/confirm 등) 이번 info 는 버린다
     /// (advisory 알림 — 탭 한도/shell 소실). fire-and-forget 이라 pump 불필요.
+    /// #496 1-b — sway 전역 핫키를 **물리 위치**로 등록한다. keymap 이 온 뒤에 한 번만
+    /// 돈다 (`pending_sway_toggle_register` 주석 참고).
+    ///
+    /// 자리를 고르는 규칙이 1-a 와 같다 — 활성 layout 이 그 문자를 내면 **그 키**,
+    /// 못 내면 US 자판에서 그 문자가 있던 자리. 판정할 수 없으면 (libxkbcommon 이
+    /// keymap 조회 심볼을 안 내준다) 위치를 포기하고 예전처럼 keysym 으로 등록한다 —
+    /// 핫키를 아예 잃는 것보다 낫다.
+    ///
+    /// **한 번 자리에 고정하면 group 전환에 영향받지 않는다.** 그래서 재등록이 없다 —
+    /// 그것이 위치 등록을 고른 이유다. `bindsym` 으로 두면 활성 layout 이 바뀔 때마다
+    /// 죽었다 살았다 한다.
+    fn drainSwayToggleRegister(self: *Client) void {
+        if (!self.pending_sway_toggle_register) return;
+        if (self.keyboard.keymap == null) return;
+        self.pending_sway_toggle_register = false;
+
+        const keysym = self.config.hotkey.keysym;
+        const keycode: ?u16 = switch (self.keyboard.canProduceKeysym(keysym) orelse return sway_ipc.registerToggleIfSway(
+            self.rt,
+            self.allocator,
+            self.config,
+            null,
+        )) {
+            true => self.keyboard.evdevKeycodeForKeysym(keysym),
+            false => blk: {
+                const code = config_mod.fallbackCandidate(self.config.hotkey) orelse break :blk null;
+                break :blk physical_key.evdev(code.code);
+            },
+        };
+        sway_ipc.registerToggleIfSway(self.rt, self.allocator, self.config, keycode);
+    }
+
     /// #496 1-a — **비라틴 layout 에서 글자 단축키를 살린다.**
     ///
     /// 키릴 · 그리스 · 아랍 layout 에서는 그 자판의 어느 키도 라틴 글자를 내지 않아
@@ -8642,7 +8682,9 @@ pub fn runBaselineWindow(
     // 않는 compositor 에 bindsym 을 등록하는 것은 무의미하고, 무엇보다 stale `SWAYSOCK`
     // 이 **응답 없는 소켓**을 가리키면 `runCommand` 의 read 가 부팅을 영원히 막는다
     // (KDE 실기 — mute 소켓 시뮬레이션에서 boot 로그 후 hang 확정).
-    if (!opts.isStressRun() and client.is_sway) sway_ipc.registerToggleIfSway(rt, allocator, cfg);
+    // #496 1-b — 등록을 loop 로 미룬다. 위치 (`bindcode`) 로 등록하려면 keymap 이
+    // 필요한데 여기서는 아직 오지 않았다 (`pending_sway_toggle_register` 주석).
+    if (!opts.isStressRun() and client.is_sway) client.pending_sway_toggle_register = true;
     // #454 — sway 면 창 규칙(`for_window`)을 **창을 만들기 전에** 등록한다. layer-shell 을
     // 쓰지 않는 대신 배치를 이 규칙이 맡는다. `client.run()` 안에서 창이 뜨므로 순서가
     // 여기서 보장된다. 측정 인스턴스는 제외 — 사용자의 드롭다운이 아니다 (#382).

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -229,7 +229,27 @@ pub const Keyboard = struct {
     /// null = 판정할 수 없다 (libxkbcommon 이 필요한 심볼을 안 내주거나 keymap 이
     /// 없다). **false 와 구분해야 한다** — 판정 불가일 때 "낼 수 없다" 로 읽으면
     /// 없어도 되는 fallback 을 만들어 동작을 넓힌다.
-    pub fn canProduceKeysym(self: *Keyboard, keysym: u32) ?bool {
+    /// #496 1-b — **활성 group 에서 이 keysym 을 내는 물리 키의 evdev keycode.**
+    ///
+    /// 전역 핫키를 위치로 등록할 때 쓴다 (sway `bindcode`). 반환값은 **evdev** 이고,
+    /// compositor 에 넘길 때 `+ 8` 을 해야 한다 — sway 와 Hyprland 둘 다 xkb keycode
+    /// (= evdev + 8) 를 받는다 (sway 2018 커밋 *"Use XKB keycode numbering for
+    /// bindcode"*, Hyprland `// "code:NN" binds store the xkb keycode`). 그 둘은
+    /// 잘못된 숫자를 거부하지 않으므로 off-by-8 이면 조용히 옆 키에 붙는다.
+    ///
+    /// null = 못 찾았거나 판정할 수 없다. 호출자가 US 위치표로 떨어지거나 keysym 등록을
+    /// 유지한다.
+    pub fn evdevKeycodeForKeysym(self: *Keyboard, keysym: u32) ?u16 {
+        const xkb_code = self.findKeycode(keysym) orelse return null;
+        // xkb keycode 는 evdev + 8 이다. 8 미만은 나올 수 없지만 방어한다.
+        if (xkb_code < 8) return null;
+        return @intCast(xkb_code - 8);
+    }
+
+    /// 활성 group 에서 `keysym` 을 내는 첫 xkb keycode. `canProduceKeysym` 과
+    /// `evdevKeycodeForKeysym` 이 같은 순회를 쓰게 한다 — 둘이 갈라지면 "닿는다고
+    /// 했는데 keycode 는 못 찾는" 모순이 생긴다.
+    fn findKeycode(self: *Keyboard, keysym: u32) ?c_uint {
         const api = if (self.api) |*a| a else return null;
         const scan = api.keymap_scan orelse return null;
         const keymap = self.keymap orelse return null;
@@ -250,11 +270,19 @@ pub const Keyboard = struct {
                 const count = scan.key_get_syms_by_level(keymap, key, layout, level, &syms);
                 if (count <= 0) continue;
                 for (syms[0..@intCast(count)]) |sym| {
-                    if (sym == keysym) return true;
+                    if (sym == keysym) return key;
                 }
             }
         }
-        return false;
+        return null;
+    }
+
+    pub fn canProduceKeysym(self: *Keyboard, keysym: u32) ?bool {
+        // 판정 불가 (심볼 / keymap 없음) 와 "못 찾았다" 를 갈라야 한다.
+        if (self.api == null) return null;
+        if (self.api.?.keymap_scan == null) return null;
+        if (self.keymap == null) return null;
+        return self.findKeycode(keysym) != null;
     }
 
     pub fn oneSym(self: *Keyboard, key: u32) ?u32 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -64,6 +64,7 @@ test "aggregate root imports every common and native-host test module" {
             _ = @import("host/linux/kglobalaccel.zig");
             _ = @import("host/linux/instance_identity.zig");
             _ = @import("host/linux/shell_extension.zig");
+            _ = @import("host/linux/sway_ipc.zig");
             _ = @import("host/linux/software_terminal.zig");
             _ = @import("host/linux/wayland_minimal.zig");
             _ = @import("host/linux/xkb.zig");


### PR DESCRIPTION
`#496` 1-b. sway 전역 핫키를 **물리 위치**로 등록해 layout 과 무관하게 만든다.

sway 는 `bindsym` 을 **활성 layout 의 keysym** 에 맞춘다. 그래서 사용자가 `hotkey` 를 글자 조합으로 바꾸면 비라틴 layout 으로 전환했을 때 조용히 안 먹었다 — **등록은 성공하고 경고도 없다.**

나머지 DE 는 자기가 라틴 fallback 을 하는데(GNOME 3.28+ · Cinnamon 5.4+ · COSMIC 2026-02+ · KDE 5.22+) sway · Hyprland 는 하지 않는다.

## 규칙이 1-a 와 같다

활성 layout 이 그 문자를 내면 **그 키**, 못 내면 **US 자판에서 그 문자가 있던 자리**. 앱 내부 단축키와 전역 핫키가 같은 판정을 쓰므로 어긋나지 않는다.

`canProduceKeysym` 과 `evdevKeycodeForKeysym` 이 **같은 순회**(`findKeycode`)를 쓰게 묶었다 — 갈라지면 *"닿는다고 했는데 keycode 는 못 찾는"* 모순이 생긴다.

## 검토 포인트 ① — 숫자는 evdev 가 아니라 xkb keycode (evdev + 8)

sway 는 2018 년 커밋 **"Use XKB keycode numbering for bindcode"** 로 evdev 를 일부러 뺐다. 그리고 **잘못된 숫자를 거부하지 않는다** — `xkb_keycode_is_legal_ext` 가 `XKB_KEYCODE_MAX` 까지 통과시켜서 off-by-8 이면 **조용히 옆 키에 붙는다.** 가드가 없다.

그래서 test 로 고정했다: `KeyT`(evdev 20) → `"28"`, `Shift+Ctrl` 조합 → `"Shift+Ctrl+28"`.

test 의 `20` · `17` · `2` 는 손으로 적은 값이라 **`physical_key` 표와 묶는 test 를 하나 더** 뒀다 — 표가 바뀌면 앞의 test 가 스스로 거짓이 되기 때문이다.

## 검토 포인트 ② — 등록을 keymap 도착 뒤로 미룬다

위치로 등록하려면 *"이 문자를 내는 키가 어디인가"* 를 알아야 하는데 `client.run()` 앞에는 `wl_keyboard.keymap` 이 아직 오지 않았다. 그래서 loop 의 `drainSwayToggleRegister` 로 옮겼다.

미루는 창은 밀리초 단위다 — keymap 은 seat 의 keyboard capability 가 생길 때 오고 focus 와 무관하다. 그 사이 핫키가 없지만 그 시점엔 창도 막 뜨는 중이다.

## 검토 포인트 ③ — 재등록이 없다

**한 번 자리에 고정하면 group 전환에 영향받지 않는다.** 그것이 위치 등록을 고른 이유다. `bindsym` 으로 두면 활성 layout 이 바뀔 때마다 죽었다 살았다 하고, 그걸 따라가려면 group 전환마다 `unbindsym` + `bindsym` 을 쳐야 한다.

판정할 수 없으면(libxkbcommon 이 keymap 조회 심볼을 안 내준다) **`bindsym` 으로 되돌아간다** — 핫키를 아예 잃는 것보다 낫다. 로그도 어느 쪽으로 등록했는지 남긴다.

## `sway_ipc.zig` 가 테스트 집계에 없었다

추가하고 **실제로 도는지 확인했다** — 일부러 기대값을 `"999"` 로 깨서 실패하는 것을 본 뒤 되돌렸다. `xkb.zig` 때와 같은 구멍이다.

아직 빠져 있는 것: `dbus.zig` · `egl.zig` · `single_instance.zig` · `unix_socket.zig`. 넷 다 현재 test 가 0 개라 이번엔 두지 않았다.

## Hyprland 는 known limitation 으로 남는다

그쪽 등록은 **launcher 단계**(`shortcut_sync`)라 keyboard 자체가 없어 물어볼 keymap 이 없다. sway 가 되는 이유는 등록이 *떠 있는 터미널 안*에서 일어나기 때문이다.

덮으려면 `hyprctl getoption input:kb_layout` 조회 + `xkb_keymap_new_from_names` 심볼 추가 + host 재동기화 배관이 필요하다. 작지 않아서 이번 범위에서 뺐다.

문서에서 sway 를 limitation 표에서 빼고 데스크톱별로 *"무엇이 그 핫키를 살리는가"* 를 한 줄씩 적었다.

## 검증

`--cache-dir` 를 새로 준 **깨끗한 캐시**로 `zig build check`(6 타깃) · `test` · `-Dsimd=true` 통과.

**실기 확인이 남아 있다** — 실제 sway 세션에서 `bindcode` 가 먹는지, 그리고 `ru` layout 으로 전환한 뒤에도 핫키가 사는지. 지금은 IPC 문자열과 +8 이 맞다는 것까지다.