### PR TITLE
feat(macos): 글자 단축키를 활성 layout 의 라벨로 매칭한다 (#496)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -261,19 +261,24 @@ Use a position when a label cannot reach the key you want:
 
 | Situation | Why the label fails | Position form |
 |---|---|---|
-| Cyrillic, Greek, Arabic, Hebrew… | no key produces a Latin letter — but see below, TildaZ already handles this on Linux | `ctrl+shift+[KeyW]` |
+| Cyrillic, Greek, Arabic, Hebrew… | no key produces a Latin letter — but see below, TildaZ already handles this on Linux and macOS | `ctrl+shift+[KeyW]` |
 | French AZERTY brackets | `[` is AltGr+5, so the label needs four fingers | `ctrl+shift+[BracketLeft]` |
 | Keys outside the label set | `-` `=` `\` `;` `'` `,` `.` `/`, numpad, arrows | `ctrl+[Minus]` |
 
 Positions and labels can be mixed freely, including within one action's list.
 
-**On Linux you usually do not need the position form for non-Latin layouts.**
-When TildaZ loads a keymap it checks whether the current layout can produce each
-binding's label at all; if nothing can, it falls back to the physical spot that
-character has on a US keyboard. So the defaults work on a Cyrillic layout
-untouched. The check follows the layout you are currently typing in, so a `us,ru`
-setup matches by label while you are on `us` and falls back the moment you switch
-to `ru`. KEYBINDINGS.md has the details.
+**On Linux and macOS you usually do not need the position form for non-Latin
+layouts.** TildaZ checks whether the layout you are currently typing in can
+produce each binding's label at all; if nothing can, it falls back to the
+physical spot that character has on a US keyboard. So the defaults work on a
+Cyrillic layout — or a Korean, Japanese, or Chinese input source — untouched.
+The check follows the live layout, so a `us,ru` setup matches by label while you
+are on `us` and falls back the moment you switch to `ru`. KEYBINDINGS.md has the
+details.
+
+**Windows does not need it either**, for a different reason: a non-Latin layout
+DLL assigns Latin virtual-keys to the physical spots, so the OS has already done
+the equivalent work.
 
 #### Accepted keys
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -72,11 +72,11 @@ $ xkbcli how-to-type --layout ru 'w'
 Rebinding to another letter does not help, because the problem is the whole
 Latin alphabet.
 
-**TildaZ handles this for you.** When it loads a keymap it checks, for every
-label binding, whether the current keymap can produce that character at all. If
-nothing can, it matches that binding by the physical spot the character occupies
-on a US keyboard instead. So the defaults work on a Cyrillic layout with no
-config changes: you press the same key a US user presses.
+**TildaZ handles this for you.** It checks, for every label binding, whether the
+layout you are currently typing in can produce that character at all. If nothing
+can, it matches that binding by the physical spot the character occupies on a US
+keyboard instead. So the defaults work on a Cyrillic layout with no config
+changes: you press the same key a US user presses.
 
 Two details worth knowing:
 
@@ -84,10 +84,12 @@ Two details worth knowing:
   currently typing in.** With `us,ru` — the common setup — nothing changes while
   you are on `us`, and the fallback takes over the moment you switch to `ru`. It
   is re-evaluated on every layout switch, so you never have to restart.
-- **It is Linux-only, because only Linux needs it.** Windows non-Latin layouts
-  assign Latin virtual keys to the physical spots (`KBDRU` puts `VK_W` on the
-  `w` position), and macOS matches physical key codes to begin with, so letter
-  shortcuts already work there.
+- **Linux and macOS both do this; Windows does not need it.** A Windows
+  non-Latin layout DLL assigns Latin virtual keys to the physical spots (`KBDRU`
+  puts `VK_W` on the `w` position), so the OS has already done the equivalent
+  work. On macOS the fallback also covers Korean, Japanese, and Chinese input
+  sources — those keyboard layouts produce no Latin letters either, so the same
+  rule keeps their shortcuts working.
 
 You can still name a key by **position** explicitly, which is useful if you want
 a shortcut pinned to a spot regardless of layout:
@@ -132,11 +134,17 @@ is `[IntlBackslash]` if you want to bind it.
 
 ### macOS
 
-macOS reports the physical key, so a shortcut lands on the same *spot* on every
-layout. That is Apple's convention and it cuts both ways: an AZERTY user's
-`Cmd+W` is the key printed `Z`, because that spot is where US QWERTY has `w`.
-Nothing to configure — but worth knowing if the letter in the menu does not
-match the key you press.
+**Letter shortcuts match the letter printed on the key**, the same way Safari and
+other Mac apps do. On AZERTY, `Cmd+W` is the key printed `W`. If your layout
+produces no Latin letters at all — Cyrillic, Greek, or a Korean / Japanese /
+Chinese input source — the Latin fallback above takes over and you press the spot
+a US user presses. Nothing to configure either way.
+
+This is a change: TildaZ used to match the physical *spot* on macOS, so an AZERTY
+user's `Cmd+W` was the key printed `Z` — a different key from the one Safari
+wanted on the same Mac ([#496](https://github.com/ensky0/tildaz/issues/496)).
+**Dvorak and Colemak users are affected by the same change**: shortcuts now
+follow the letters printed on your keys rather than the US spots.
 
 Mac laptops have no dedicated PgUp / PgDn keys; they are Fn+Up / Fn+Down. The
 `Shift+Cmd+[` / `]` and `Cmd+1`–`9` defaults are unchanged, so nothing is lost.
@@ -151,6 +159,14 @@ A few positions do not exist on macOS — `[PrintScreen]`, `[ScrollLock]` and
 `hotkey` is registered with the desktop rather than handled inside TildaZ, and
 every path TildaZ uses for that — sway, Hyprland, GNOME, Cinnamon, COSMIC, KDE —
 accepts only a character, so it does **not** take the position form.
+
+**On macOS the global hotkey matches by position, not by label.** It is caught by
+an event tap before any layout translation, so `hotkey` and `[keys]` use
+different criteria there. The default `F1` is layout-independent, so this stays
+invisible unless you change `hotkey` to a letter combination *and* use a non-US
+layout — then the global hotkey wants the US spot while a `[keys]` binding for
+the same letter wants the printed key. Unifying the two is tracked in
+[#496](https://github.com/ensky0/tildaz/issues/496) (item 1-c).
 
 Most desktops paper over this for you: GNOME (since 3.28), Cinnamon (since 5.4),
 COSMIC and KDE all translate a Latin-letter shortcut back to the key you actually

--- a/SPEC.md
+++ b/SPEC.md
@@ -313,9 +313,12 @@ modifier 차이를 흡수하지만 macOS 는 **Shift 의 유무까지 다르다*
 
 **keyboard layout 독립성** ([#482](https://github.com/ensky0/tildaz/issues/482) ·
 [#496](https://github.com/ensky0/tildaz/issues/496)). 세 platform 이 단축키를 매칭하는 대상이
-다르다 — Windows 는 virtual-key (`VK_1`, `VK_OEM_4`), macOS 는 `kVK_ANSI_*` 로 **물리 위치**를
-보고, Linux 는 **xkb keysym** 으로 *눌러서 나오는 문자*를 본다. 그래서 layout 종속 결함의 모양이
-platform 마다 다르다.
+다르다 — Windows 는 virtual-key (`VK_1`, `VK_OEM_4`) 로 **물리 위치**를 보고, macOS · Linux 는
+*눌러서 나오는 문자* (**라벨**) 를 본다. macOS 는 `NSEvent charactersByApplyingModifiers:`,
+Linux 는 **xkb keysym** 이다. **macOS 가 라벨로 바뀐 것은 #496 항목 2 이고, 그전에는
+`kVK_ANSI_*` (물리 위치) 였다** — 그래서 AZERTY 에서 `Cmd+W` 가 `Z` 라 인쇄된 키였고, 같은 Mac
+의 Safari (Cocoa 메뉴 `keyEquivalent` = 문자 비교) 와 다른 키를 요구했다. 그래서 layout 종속
+결함의 모양이 platform 마다 다르다.
 
 - **비라틴 layout (키릴 · 그리스 · 아랍 ...) 에서는 글자 단축키를 라벨로 적을 수 없다.**
   `xkbcli how-to-type --layout ru 'w'` 가 빈 결과다 — 그 자판의 어느 키도 `w` 를 내지 않으므로
@@ -324,9 +327,11 @@ platform 마다 다르다.
   이름은 [W3C `KeyboardEvent.code`](https://www.w3.org/TR/uievents-code/) 값이고 (2025 년
   Recommendation) 표기는 VS Code 와 같은 대괄호다. 세 platform 값의 단일 출처는
   `src/physical_key.zig` 다.
-- **그리고 기본값이 그대로 동작하도록 라틴 fallback 을 둔다** (1-a, Linux 전용).
-  각 라벨 binding 에 대해 **활성 layout group 이 그 문자를 낼 수 있는지** 묻고
-  (`xkb.canProduceKeysym`), 낼 수 없으면 그 문자가 US 자판에서 있던 자리로 매칭한다.
+- **그리고 기본값이 그대로 동작하도록 라틴 fallback 을 둔다** (1-a, **Linux · macOS**).
+  각 라벨 binding 에 대해 **지금 layout 이 그 문자를 낼 수 있는지** 묻고, 낼 수 없으면 그 문자가
+  US 자판에서 있던 자리로 매칭한다. 묻는 방법은 platform 마다 다르다 — Linux 는 활성 group 에
+  `xkb.canProduceKeysym` 으로 묻고, macOS 는 keycode `0..127` 을 훑어 라벨 표를 만든다
+  (`host/macos.zig` 의 `macRebuildLayoutLabels`).
   - **판정은 활성 group 만 본다.** 처음에 group 을 전수로 훑었는데 그것이 결함이었다 —
     매처는 활성 group 이 내는 keysym 만 보므로 판정도 같은 group 을 봐야 한다. 실측
     (`us,ru` keymap): group 0 은 `sym@KeyW=0x77`, group 1 은 `0x6c3`
@@ -340,6 +345,17 @@ platform 마다 다르다.
     한다. 키마다 layout 수가 달라 유효 layout 은 `group % num_layouts_for_key` 다.
   - **닿지 않을 때만 만든다.** 무조건 2 차 pass 를 돌리면 AZERTY 에서 `Z` 라 인쇄된
     키 (US `w` 자리) 가 `close_tab` 을 발동시켜 한 동작에 키가 둘 생긴다.
+  - **macOS 의 재해석 트리거는 `NSTextInputContext.selectedKeyboardInputSource` 다.** 헤더가
+    *"The ID corresponds to the kTISPropertyInputSourceID attribute"* 라고 적는 값이고,
+    **Carbon 을 링크하지 않고** 현재 layout 을 식별할 수 있다. 키 이벤트마다 그 문자열을
+    비교해 바뀌었을 때만 표를 다시 만든다 (대개 비교 한 번으로 끝난다).
+  - **macOS 는 라벨을 뽑을 때 Shift 만 반영한다.** AZERTY 는 숫자열이 Shift 를 눌러야 숫자가
+    나오므로 (무시프트는 `&é"'(-è_çà`) Shift 까지 빼고 뽑으면 `cmd+1` 이 그 layout 에서 영영
+    매칭되지 않는다 (#482 의 숫자 예외가 무력해진다). 라벨 표에도 base 와 shift 두 벌을 담는다.
+  - **`charactersByApplyingModifiers:` 는 modifier keycode 에서 죽는다.** `0x36`–`0x3F`
+    (`kVK_RightCommand` ~ `kVK_Function`) 를 넘기면 헤더 서술 (*"will return nil"*) 과 달리
+    `NSAssertionHandler` 를 거쳐 `abort()` 다 (실측, macOS 26.6.2 · SDK 26.5). 거르지 않으면
+    **Shift 를 누르는 것만으로 앱이 죽는다.**
   - **판정 불가 (`null`) 와 false 를 구분한다.** libxkbcommon 이 keymap 조회 심볼을
     안 내주면 fallback 을 만들지 않는다 — false 로 읽으면 없어도 되는 fallback 이
     생긴다. 그 심볼 다섯은 **optional** 이다: 기존 심볼처럼 묶으면 오래된

--- a/src/config.zig
+++ b/src/config.zig
@@ -755,6 +755,71 @@ test "#496 macOS 에 값이 없는 자리는 그 platform 에서만 거부한다
     try std.testing.expect(parseHotkeyString("[NumLock]", .app_binding) == .ok);
 }
 
+test "#496 항목 2 — macOS 라벨 binding 은 이벤트가 낸 글자로 매칭한다" {
+    // macOS 가 라벨 매칭으로 바뀐 뒤의 계약을 고정한다. 이 테스트가 없으면 "AZERTY
+    // 에서 어느 키가 잡히는가" 가 실기로만 확인되고, 되돌아가도 조용하다.
+    if (!is_macos) return;
+
+    const parse = struct {
+        fn f(text: []const u8) !Hotkey {
+            return switch (parseHotkeyString(text, .app_binding)) {
+                .ok => |v| Hotkey.fromParsed(v),
+                else => error.TestUnexpectedResult,
+            };
+        }
+    }.f;
+
+    // (1) 라벨 binding 은 `label` 을 갖고 위치 binding 은 갖지 않는다.
+    const label_w = try parse("cmd+w");
+    try std.testing.expectEqual(@as(u32, 'w'), label_w.label);
+    try std.testing.expectEqual(@as(?PhysicalCode, null), label_w.code);
+
+    const position_w = try parse("cmd+[KeyW]");
+    try std.testing.expectEqual(@as(u32, 0), position_w.label);
+    try std.testing.expect(position_w.code != null);
+
+    // (2) layout 무관 키는 라벨을 쓰지 않고, layout 에 따라 글자가 바뀌는 기호는 쓴다.
+    try std.testing.expectEqual(@as(u32, 0), (try parse("cmd+f1")).label);
+    try std.testing.expectEqual(@as(u32, 0), (try parse("cmd+space")).label);
+    try std.testing.expectEqual(@as(u32, 0x60), (try parse("cmd+grave")).label);
+    try std.testing.expectEqual(@as(u32, 0x5B), (try parse("cmd+[")).label);
+
+    var buf: [MAX_KEY_BINDINGS]KeyBinding = undefined;
+    buf[0] = .{ .hotkey = label_w, .action = .close_tab };
+    const bindings = buf[0..1];
+
+    const cmd = Hotkey.MOD_SUPER;
+    const kvk_w: u32 = 0x0D; // kVK_ANSI_W — AZERTY 에서 `z` 를 낸다
+    const kvk_z: u32 = 0x06; // kVK_ANSI_Z — AZERTY 에서 `w` 를 낸다
+
+    // (3) AZERTY — `W` 라 인쇄된 키 (US `Z` 자리) 가 잡혀야 한다. Safari 와 같은 키다.
+    try std.testing.expectEqual(@as(?KeyAction, .close_tab), lookupAction(
+        bindings,
+        .{ .keycode = kvk_z, .modifiers = cmd, .label = 'w' },
+        physical_key.fromMacKeyCode(kvk_z),
+    ));
+    // (4) 같은 자판에서 US `W` 자리는 라벨이 `z` 라 잡히면 **안 된다** (예전 동작).
+    try std.testing.expectEqual(@as(?KeyAction, null), lookupAction(
+        bindings,
+        .{ .keycode = kvk_w, .modifiers = cmd, .label = 'z' },
+        physical_key.fromMacKeyCode(kvk_w),
+    ));
+
+    // (5) 라틴을 한 자도 못 내는 layout (키릴 · 한글) 은 fallback 후보를 갖는다.
+    const candidate = fallbackCandidate(label_w) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(u32, 'w'), candidate.keysym);
+    try std.testing.expectEqual(physical_key.fromName("KeyW").?, candidate.code);
+
+    // (6) 그 fallback 이 켜지면 US `w` 자리가 잡힌다 — 한글에서 지금까지의 동작 그대로다.
+    var fallbacks = [_]?PhysicalCode{candidate.code};
+    try std.testing.expectEqual(@as(?KeyAction, .close_tab), lookupActionWithFallback(
+        bindings,
+        &fallbacks,
+        .{ .keycode = kvk_w, .modifiers = cmd, .label = 0 },
+        physical_key.fromMacKeyCode(kvk_w),
+    ));
+}
+
 test "#496 physical_key 의 macOS 열이 keycodeFromKey 와 같다" {
     // `physical_key.zig` 의 `mac` 열과 `MacHotkey.keycodeFromKey` 는 **같은 US 위치
     // 표** 다. 두 곳에 값을 두는 것은 어쩔 수 없다 (한쪽은 라벨 → 위치, 한쪽은 위치
@@ -1131,6 +1196,21 @@ const MacHotkey = struct {
     /// event 가 라벨 binding 과 위치 binding 에 동시에 걸려야 한다) 필드를 나눈다.
     code: ?PhysicalCode = null,
 
+    /// #496 항목 2 — **라벨** binding 이 기다리는 글자 (유니코드 코드포인트).
+    /// `0` 은 "라벨로 매칭하지 않는다" 는 뜻이고, 그때는 `keycode` 로 매칭한다.
+    ///
+    /// 이 필드가 없던 시절 macOS 는 라벨 binding (`w`) 도 `keycode` (= US 위치)
+    /// 로 저장했다. 그래서 AZERTY 에서 `Cmd+W` 가 `Z` 라 인쇄된 키였다 — 비교할
+    /// 라벨 값 자체가 없었던 것이 원인이다.
+    ///
+    /// **layout 에 따라 글자가 바뀌는 키만** 채운다:
+    ///   - 글자 · 숫자 (`w` · `1`)
+    ///   - `` ` `` · `[` · `]` — AZERTY 에서 `<` · `^` · `$` 로 바뀐다 (실측)
+    /// `F1` · `space` 처럼 어느 자판에나 같은 자리에 있는 키는 `0` 이다. 그런 키에
+    /// 라벨 매칭을 쓰면 `NSEvent` 의 private codepoint (`0xF700`~) 에 기대게 되어
+    /// 이득 없이 취약해진다.
+    label: u32 = 0,
+
     pub fn fromString(s: []const u8) ?MacHotkey {
         const parsed = switch (parseHotkeyString(s, .global_hotkey)) {
             .ok => |p| p,
@@ -1156,6 +1236,26 @@ const MacHotkey = struct {
             .keycode = keycodeFromKey(parsed.key),
             .modifiers = modifiers,
             .code = if (parsed.key == .code) parsed.key.code else null,
+            .label = labelFromKey(parsed.key),
+        };
+    }
+
+    /// 정규화된 key → **라벨** (유니코드 코드포인트). `0` = 라벨 매칭 안 함.
+    /// 무엇을 채우고 무엇을 비우는지는 `label` 필드 주석에 있다.
+    fn labelFromKey(key: HotkeyKeyToken) u32 {
+        return switch (key) {
+            // 위치 표기는 라벨과 무관하다 — `code` 필드가 매칭을 맡는다.
+            .code => 0,
+            // parseHotkeyString 의 char 는 소문자 letter / digit 만이라 그대로 쓴다.
+            .char => |c| c,
+            .named => |n| switch (n) {
+                .grave => 0x60,
+                .bracket_left => 0x5B,
+                .bracket_right => 0x5D,
+                // 나머지는 layout 무관 — keycode 로 매칭한다.
+                .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12 => 0,
+                .space, .tab, .escape, .@"return", .page_up, .page_down => 0,
+            },
         };
     }
 
@@ -1846,20 +1946,30 @@ pub fn inputForAction(action: KeyAction) ActionInput {
 /// 생기지 않고, 따라서 `Z` 라 인쇄된 키 (US `w` 자리) 가 `close_tab` 을 발동시키지
 /// **않는다.** 무조건 두 번째 pass 를 돌리면 그 layout 에서 한 동작에 키가 둘 생긴다.
 pub const FallbackCandidate = struct {
-    /// 이 binding 이 기다리는 라벨 keysym. 호출자가 keymap 에 물어볼 값이다.
+    /// 이 binding 이 기다리는 라벨. 호출자가 "지금 layout 이 이 글자를 낼 수 있나"
+    /// 를 물어볼 값이다. Linux 에서는 keysym, **macOS 에서는 `MacHotkey.label`**
+    /// 이고 라틴 글자 범위에서는 둘이 같은 값 (ASCII) 이라 이름을 나누지 않았다.
     keysym: u32,
     /// 그 글자가 US 자판에서 있던 자리.
     code: PhysicalCode,
 };
 
 pub fn fallbackCandidate(hotkey: Hotkey) ?FallbackCandidate {
-    // Linux 만이 라벨 (keysym) 로 매칭한다. Windows 는 비라틴 layout DLL 이 물리
-    // 위치에 라틴 VK 를 배정하고 (`KBDRU` 의 scancode 0x11 → `VK_W`) macOS 는
-    // `kVK_ANSI_*` 가 애초에 위치라, 두 platform 은 키릴에서도 이미 동작한다.
-    if (is_windows or is_macos) return null;
+    // Windows 는 fallback 이 필요 없다 — 비라틴 layout DLL 이 물리 위치에 라틴 VK 를
+    // 배정하므로 (`KBDRU` 의 scancode 0x11 → `VK_W`) OS 가 이미 해 준다.
+    //
+    // **macOS 는 #496 항목 2 부터 필요하다.** 그전에는 `kVK_ANSI_*` (위치) 로
+    // 매칭해서 키릴에서도 그냥 동작했지만, 라벨 매칭으로 바꾸면 키릴 · 한글처럼
+    // **라틴 글자를 한 자도 못 내는 layout** 에서 글자 단축키가 전부 죽는다
+    // (실측: `ru` · 2-Set Korean 모두 라틴 0 개). Linux 와 같은 fallback 이 그것을 막는다.
+    if (is_windows) return null;
     if (hotkey.code != null) return null;
-    const code = usPositionForKeysym(hotkey.keysym) orelse return null;
-    return .{ .keysym = hotkey.keysym, .code = code };
+    const label = if (is_macos) hotkey.label else hotkey.keysym;
+    // macOS 의 `label == 0` 은 "라벨로 매칭하지 않는 키" (`F1` 등) 다 — layout 과
+    // 무관하므로 fallback 도 필요 없다.
+    if (label == 0) return null;
+    const code = usPositionForKeysym(label) orelse return null;
+    return .{ .keysym = label, .code = code };
 }
 
 /// keysym → US 자판에서 그 글자가 있던 자리. `LinuxHotkey.keysymFromKey` 의 역방향
@@ -1925,6 +2035,27 @@ pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey, code: ?Physica
             if (got == want) return b.action;
             continue;
         }
+        if (is_macos) {
+            // #496 항목 2 — macOS 는 binding 마다 비교 대상이 갈린다.
+            //
+            //   `label != 0`  라벨 binding (`w` · `` ` ``). **이벤트가 실제로 낸
+            //                 글자**와 비교한다. 그래서 AZERTY 에서는 `W` 라 인쇄된
+            //                 키가, US 에서는 같은 자리가 걸린다.
+            //   `label == 0`  layout 무관 키 (`F1` · `space` …). keycode 로 본다.
+            //
+            // 이벤트가 라벨을 못 낸 경우 (modifier 키 · function 키) `hotkey.label`
+            // 이 0 이라 라벨 binding 에 걸리지 않는다 — 그게 맞다.
+            //
+            // 다른 두 platform 처럼 `modifiersAside` 하나로 비교할 수 없다. 그쪽은
+            // 라벨 값 하나 (keysym / vkey) 로 모든 키를 표현하지만 macOS 의 `keycode`
+            // 는 위치라서, 라벨과 위치를 같은 칸에 넣을 수 없다.
+            if (b.hotkey.label != 0) {
+                if (hotkey.label != 0 and hotkey.label == b.hotkey.label) return b.action;
+            } else if (hotkey.keycode == b.hotkey.keycode) {
+                return b.action;
+            }
+            continue;
+        }
         if (b.hotkey.code == null and hotkey.code == null and modifiersAside(b.hotkey) == modifiersAside(hotkey)) {
             return b.action;
         }
@@ -1936,6 +2067,9 @@ pub fn lookupAction(bindings: []const KeyBinding, hotkey: Hotkey, code: ?Physica
 /// 표현할 수 없어 (아래) 키 값만 따로 꺼낸다.
 fn modifiersAside(h: Hotkey) u32 {
     if (is_windows) return h.vkey;
+    // macOS 는 위의 `lookupAction` 이 먼저 갈라져서 여기 오지 않는다 (#496 항목 2).
+    // 값을 남겨 두는 것은 `Hotkey` 가 comptime 으로 갈리는 타입이라 세 분기가 다
+    // 컴파일되어야 하기 때문이다.
     if (is_macos) return h.keycode;
     return h.keysym;
 }

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -146,6 +146,15 @@ extern fn CGEventTapEnable(tap: CFMachPortRef, enable: bool) void;
 extern fn CGEventGetIntegerValueField(event: CGEventRef, field: CGEventField) i64;
 extern fn CGEventGetFlags(event: CGEventRef) u64;
 
+// #496 항목 2 — 라벨 표를 만들 때 keycode 마다 이벤트를 하나씩 지어 `NSEvent` 로
+// 바꾼다. `CGEventKeyboardGetUnicodeString` 은 쓰지 않는다 — 그쪽은 **프로세스가
+// 시작할 때의 layout 에 고정**되어 전환을 못 따라온다 (실측). 우리가 쓰는
+// `charactersByApplyingModifiers:` 는 이벤트가 어느 source 에서 났든 *지금* layout
+// 으로 번역하므로, 여기서 만든 source 가 낡아도 결과가 맞다.
+const kCGEventSourceStateHIDSystemState: u32 = 1;
+extern fn CGEventSourceCreate(state_id: u32) ?*anyopaque;
+extern fn CGEventCreateKeyboardEvent(source: ?*anyopaque, virtual_key: u16, key_down: bool) CGEventRef;
+
 extern fn CFMachPortCreateRunLoopSource(
     allocator: ?*anyopaque,
     port: CFMachPortRef,
@@ -415,6 +424,32 @@ var g_app: objc.id = null;
 var g_window: objc.id = null;
 var g_visible: bool = false;
 var g_config: config.Config = .{};
+
+// --- #496 항목 2 — 라벨 매칭이 쓰는 layout 상태 ---
+//
+// 라벨 binding (`cmd+w`) 은 *지금 layout 이 그 자리에 둔 글자*와 비교한다. 그런데
+// 키릴 · 한글처럼 **라틴 글자를 한 자도 못 내는** layout 에서는 비교 대상이 아예
+// 없어서 글자 단축키가 전부 죽는다 (실측: `ru` · 2-Set Korean 모두 라틴 0 개).
+// 그래서 Linux 와 같은 라틴 fallback 을 둔다 — 그 layout 에서만 US 자리로 매칭한다.
+//
+// 판정에 쓰는 표는 layout 이 바뀔 때만 다시 만든다. 바뀌었는지는
+// `NSTextInputContext.selectedKeyboardInputSource` 로 안다 — 헤더가 *"The ID
+// corresponds to the kTISPropertyInputSourceID attribute"* 라고 적는 값이고,
+// **Carbon 을 링크하지 않고** 현재 layout 을 식별할 수 있는 유일한 길이다.
+
+/// 마지막으로 본 입력 소스 ID (`com.apple.keylayout.French` 등).
+var g_layout_id: [192]u8 = undefined;
+var g_layout_id_len: usize = 0;
+/// 한 번이라도 표를 만들었는가. ID 조회가 실패해도 첫 회에는 표를 만들어야 한다.
+var g_layout_table_built: bool = false;
+
+/// 지금 layout 이 낼 수 있는 라벨 (인쇄 가능 ASCII, 소문자 정규화). **Shift 를 눌러야
+/// 나오는 글자도 담는다** — AZERTY 숫자열이 그렇다 (무시프트는 `&é"'(-è_çà`).
+var g_layout_labels: [128]bool = [_]bool{false} ** 128;
+
+/// binding 별 라틴 fallback 자리. `null` = fallback 없음 (= 그 라벨을 낼 수 있는 layout).
+var g_binding_fallbacks: [config.MAX_KEY_BINDINGS]?config.PhysicalCode =
+    [_]?config.PhysicalCode{null} ** config.MAX_KEY_BINDINGS;
 /// #451 — 진입점이 만든 `Io` · 환경변수. macOS host 는 Cocoa 콜백이 전역에서 도는
 /// 구조라 (`g_host` · `g_config` 와 같은 자리) 여기 보관한다. `run(rt, …)` 이 심는다.
 var g_rt: Runtime = undefined;
@@ -878,16 +913,21 @@ fn applyPasteInputPolicy() void {
 /// #493 3-c — NSEvent 의 keyCode + modifier flags 를 `[keys]` 와 맞춘다. 예전엔
 /// `macCmdShortcut` 이 `kc == 8` 같은 상수 열두 줄로 같은 일을 했다.
 ///
-/// macOS 는 `keyCode` 자체가 **물리 위치**다. 그래서 이 platform 은 위치로 적은
-/// binding (`[KeyW]`) 과 라벨 binding (`w`) 이 같은 값을 내고, 둘 다 자연히 잡힌다
-/// — 그 대가로 AZERTY 사용자는 `Z` 라고 새겨진 키를 눌러야 `close_tab` 이 되는
-/// 것이고 (#496 항목 2), 그것은 이 커밋의 범위가 아니다.
+/// macOS 는 `keyCode` 자체가 **물리 위치**다. 예전에는 그것 하나로 매칭해서 위치
+/// binding (`[KeyW]`) 과 라벨 binding (`w`) 이 같은 값을 냈고, 그 대가로 AZERTY
+/// 사용자는 `Z` 라고 새겨진 키를 눌러야 `close_tab` 이 됐다. **#496 항목 2 에서
+/// 갈랐다** — 라벨 binding 은 `macEventLabel` 이 뽑은 *지금 layout 의 글자*와,
+/// 위치 binding 은 `PhysicalCode` 와 비교한다.
 ///
 /// modifier 비트가 우연히 같다: `MacHotkey.MOD_*` 는 `kCGEventFlagMask*` 값이고
 /// `NSEventModifierFlag*` 도 같은 비트 자리를 쓴다 (shift 1<<17 · control 1<<18 ·
 /// option 1<<19 · command 1<<20). 그래도 마스크를 명시해 옮긴다 — 두 상수 집합이
 /// 같다는 사실에 조용히 기대지 않는다.
-fn macLookupAction(kc: c_ushort, flags: c_ulong) ?config.KeyAction {
+fn macLookupAction(view: objc.id, event: objc.id, kc: c_ushort, flags: c_ulong) ?config.KeyAction {
+    // layout 이 바뀌었으면 라벨 표와 fallback 을 다시 만든다 (대개는 문자열 비교
+    // 한 번으로 끝난다).
+    macSyncLayout(view);
+
     const ns_shift: c_ulong = 1 << 17;
     const ns_control: c_ulong = 1 << 18;
     const ns_option: c_ulong = 1 << 19;
@@ -899,11 +939,159 @@ fn macLookupAction(kc: c_ushort, flags: c_ulong) ?config.KeyAction {
     if ((flags & ns_option) != 0) modifiers |= config.Hotkey.MOD_ALT;
     if ((flags & ns_command) != 0) modifiers |= config.Hotkey.MOD_SUPER;
 
-    return config.lookupAction(
+    return config.lookupActionWithFallback(
         g_config.key_bindings[0..g_config.key_binding_count],
-        .{ .keycode = kc, .modifiers = modifiers },
+        g_binding_fallbacks[0..g_config.key_binding_count],
+        .{ .keycode = kc, .modifiers = modifiers, .label = macEventLabel(event, flags, kc) },
         physical_key.fromMacKeyCode(kc),
     );
+}
+
+/// #496 항목 2 — keycode 하나가 지금 layout 에서 내는 라벨. 라벨 표를 만들 때만 쓴다
+/// (실제 키 이벤트는 `macEventLabel` 이 그 이벤트를 직접 본다).
+fn macLabelForKeycode(source: ?*anyopaque, kc: u16, shift: c_ulong) u32 {
+    const cg = CGEventCreateKeyboardEvent(source, kc, true) orelse return 0;
+    defer CFRelease(cg);
+    const ns_event_class = objc.getClass("NSEvent");
+    const with_cg = objc.objcSend(fn (objc.Class, objc.SEL, CGEventRef) callconv(.c) objc.id);
+    const ns = with_cg(ns_event_class, objc.sel("eventWithCGEvent:"), cg);
+    if (ns == null) return 0;
+    return macEventLabel(ns, shift, @intCast(kc));
+}
+
+/// 지금 layout 이 낼 수 있는 라벨을 전부 모은다. `Shift` 를 눌러야 나오는 글자도
+/// 담는 것이 중요하다 — AZERTY 는 숫자열이 그렇고, 안 담으면 `cmd+1` 이 그 layout
+/// 에서 "낼 수 없는 라벨" 로 잘못 판정돼 쓸데없는 fallback 이 생긴다.
+fn macRebuildLayoutLabels() void {
+    g_layout_labels = [_]bool{false} ** 128;
+
+    const source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+    defer if (source) |src| CFRelease(src);
+
+    const NSEventModifierFlagShiftTable: c_ulong = 1 << 17;
+    var kc: u16 = 0;
+    while (kc < 128) : (kc += 1) {
+        // modifier 자리는 `macEventLabel` 이 어차피 거른다 (넘기면 abort 한다).
+        if (kc >= 0x36 and kc <= 0x3F) continue;
+        const base = macLabelForKeycode(source, kc, 0);
+        if (base != 0 and base < g_layout_labels.len) g_layout_labels[base] = true;
+        const shifted = macLabelForKeycode(source, kc, NSEventModifierFlagShiftTable);
+        if (shifted != 0 and shifted < g_layout_labels.len) g_layout_labels[shifted] = true;
+    }
+}
+
+/// binding 별로 라틴 fallback 을 둘지 정한다. Linux 의 `resolveBindingFallbacks` 와
+/// 같은 규칙이다.
+///
+/// **"낼 수 없을 때만" 이 요점이다.** 지금 layout 이 그 글자를 낼 수 있으면 항목을
+/// 만들지 않는다 — AZERTY 는 `w` 를 내므로 fallback 이 없고, 따라서 US `w` 자리
+/// (`Z` 라 인쇄된 키) 가 `close_tab` 을 발동시키지 **않는다.** 무조건 2 차 pass 를
+/// 돌리면 그 layout 에서 한 동작에 키가 둘 생기고 사용자가 설명할 수 없다.
+fn macResolveBindingFallbacks() void {
+    const bindings = g_config.key_bindings[0..g_config.key_binding_count];
+    var resolved: usize = 0;
+    for (bindings, 0..) |b, i| {
+        if (i >= g_binding_fallbacks.len) break;
+        g_binding_fallbacks[i] = null;
+        const candidate = config.fallbackCandidate(b.hotkey) orelse continue;
+        if (candidate.keysym < g_layout_labels.len and g_layout_labels[candidate.keysym]) continue;
+        g_binding_fallbacks[i] = candidate.code;
+        resolved += 1;
+    }
+    if (resolved > 0) {
+        // 이 로그가 있어야 "왜 이 키가 저 동작을 했는가" 를 사후에 설명할 수 있다.
+        log.appendLine("keys", "latin fallback active for {d} binding(s) — layout cannot type their labels", .{resolved});
+    }
+}
+
+/// 입력 소스가 바뀌었으면 라벨 표와 fallback 을 다시 만든다.
+///
+/// `NSTextInputContext.selectedKeyboardInputSource` 는 헤더가 *"The ID corresponds to
+/// the kTISPropertyInputSourceID attribute"* 라고 적는 값이다 — **Carbon 을 링크하지
+/// 않고** 현재 layout 을 식별할 수 있다. 값이 그대로면 문자열 비교 한 번으로 끝나므로
+/// 키 이벤트마다 불러도 싸다.
+fn macSyncLayout(view: objc.id) void {
+    var id_buf: [192]u8 = undefined;
+    var id_len: usize = 0;
+
+    const get_ic = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) objc.id);
+    const ic = get_ic(view, objc.sel("inputContext"));
+    if (ic != null) {
+        const get_source = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) objc.id);
+        const src = get_source(ic, objc.sel("selectedKeyboardInputSource"));
+        if (src != null) {
+            const get_utf8 = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) ?[*:0]const u8);
+            if (get_utf8(src, objc.sel("UTF8String"))) |cstr| {
+                const text = std.mem.span(cstr);
+                id_len = @min(text.len, id_buf.len);
+                @memcpy(id_buf[0..id_len], text[0..id_len]);
+            }
+        }
+    }
+
+    // ID 를 못 읽었으면 표를 유지한다. "바뀌었다" 로 읽으면 키를 누를 때마다 이벤트
+    // 128 개를 다시 지어 헛돈다. 단 **첫 회에는 만들어야 한다** — 표가 비어 있으면
+    // 모든 라벨이 "낼 수 없음" 이 되어 fallback 이 전부 켜진다.
+    if (g_layout_table_built and id_len == 0) return;
+    if (g_layout_table_built and id_len == g_layout_id_len and
+        std.mem.eql(u8, g_layout_id[0..g_layout_id_len], id_buf[0..id_len]))
+    {
+        return;
+    }
+
+    if (id_len > 0) @memcpy(g_layout_id[0..id_len], id_buf[0..id_len]);
+    g_layout_id_len = id_len;
+    macRebuildLayoutLabels();
+    macResolveBindingFallbacks();
+    g_layout_table_built = true;
+    log.appendLine("keys", "keyboard layout changed: {s}", .{g_layout_id[0..g_layout_id_len]});
+}
+
+/// #496 항목 2 — 이 이벤트가 **지금 활성 layout 에서 실제로 내는 글자**. 라벨
+/// binding (`w` · `` ` ``) 은 이 값과 비교한다. `0` 은 "쓸 라벨이 없다" 는 뜻이고,
+/// 그때 `lookupAction` 은 keycode 로 매칭한다 (`F1` 같은 layout 무관 키가 그렇다).
+///
+/// `charactersByApplyingModifiers:` 를 쓴다. `UnicodeUtilities.h` 가 `UCKeyTranslate`
+/// 대신 권하는 API 이고, 실측에서 **`TIS` + `UCKeyTranslate` 와 128 개 중 118 개가
+/// 일치**했다 (차이는 아래 modifier 범위뿐). Carbon 을 링크하지 않아도 되고, dead key
+/// 자리도 제대로 낸다.
+///
+/// **Shift 는 반영하고 나머지 modifier 는 뺀다.** Linux 가 비교하는 keysym 과 같은
+/// 상태를 만들기 위해서다. AZERTY 는 숫자열이 Shift 를 눌러야 숫자가 나오므로
+/// (무시프트는 `&é"'(-è_çà`) Shift 까지 빼고 뽑으면 `cmd+1` 이 그 layout 에서 영영
+/// 매칭되지 않는다 — #482 가 둔 숫자 예외가 무력해진다.
+fn macEventLabel(event: objc.id, flags: c_ulong, kc: c_ushort) u32 {
+    // ⚠️ `charactersByApplyingModifiers:` 는 **modifier keycode 를 넘기면 죽는다.**
+    // `NSEvent.h` 는 *"If there is invalid data in this event, ... will return nil"*
+    // 이라고 적지만, 실기에서는 nil 이 아니라 `NSAssertionHandler` 를 거쳐 `abort()`
+    // 다 (#496 실측, macOS 26.6.2 · SDK 26.5). `kVK_RightCommand`(0x36) ~
+    // `kVK_Function`(0x3F) 이 그 범위다. 여기서 거르지 않으면 **Shift 를 누르는 것만
+    // 으로 앱이 죽는다.**
+    if (kc >= 0x36 and kc <= 0x3F) return 0;
+
+    const NSEventModifierFlagShiftLabel: c_ulong = 1 << 17;
+    const shift_only = flags & NSEventModifierFlagShiftLabel;
+
+    const apply = objc.objcSend(fn (objc.id, objc.SEL, c_ulong) callconv(.c) objc.id);
+    const text = apply(event, objc.sel("charactersByApplyingModifiers:"), shift_only);
+    if (text == null) return 0;
+
+    // 라벨은 글자 하나다. 두 글자 이상이 나오는 자리 (일부 layout 의 합자) 는 우리
+    // 라벨 집합에 없으므로 keycode 매칭으로 넘긴다.
+    const get_len = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) usize);
+    if (get_len(text, objc.sel("length")) != 1) return 0;
+
+    const char_at = objc.objcSend(fn (objc.id, objc.SEL, usize) callconv(.c) u16);
+    const unit = char_at(text, objc.sel("characterAtIndex:"), 0);
+
+    // 라벨로 쓸 수 있는 것은 인쇄 가능한 ASCII 뿐이다. function key 는 `NSEvent` 가
+    // private 영역 (`0xF700`~) 을 내는데, 그런 키는 layout 무관이라 keycode 로
+    // 매칭하는 편이 맞다 (`config.MacHotkey.label` 주석).
+    if (unit < 0x20 or unit > 0x7E) return 0;
+
+    // 대소문자는 소문자로 모은다 — binding 쪽 라벨이 소문자이고, `shift+w` 는 이
+    // 함수가 `W` 를 내기 때문이다. Linux 도 대소문자 두 keysym 을 모두 본다.
+    return std.ascii.toLower(@intCast(unit));
 }
 
 /// #493 3-c — 액션 실행. 예전엔 `tildazKeyDown` 의 switch 가 `keyCode` 를 다시 읽어
@@ -1002,7 +1190,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
         //
         // 인식 못한 Cmd+key 는 mainMenu (Cmd+Q 등) 로 가야 하므로 소비하지 않고
         // `return` 한다 — 기존 동작이다.
-        if (macLookupAction(kc, flags)) |action| {
+        if (macLookupAction(self_view, event, kc, flags)) |action| {
             if (runKeyAction(action)) return;
         }
         return;
@@ -1024,7 +1212,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
     // Windows 도 config 가 먼저이고, 무엇이 이겼는지 설명할 수 있어야 한다.
     // 기본 macOS config 는 전부 `cmd` 조합이라 기본 사용자에게는 변화가 없다.
     if (flags & (NSEventModifierFlagShift | NSEventModifierFlagOption | (1 << 18)) != 0) {
-        if (macLookupAction(get_keycode(event, objc.sel("keyCode")), flags)) |action| {
+        if (macLookupAction(self_view, event, get_keycode(event, objc.sel("keyCode")), flags)) |action| {
             if (runKeyAction(action)) return;
         }
     }


### PR DESCRIPTION
[#496](https://github.com/ensky0/tildaz/issues/496) **항목 2 의 macOS 쪽**이다. 경로 판정과 구현 계획은 이슈에 있다 — [경로 실측](https://github.com/ensky0/tildaz/issues/496#issuecomment-5402848174) · [구현 계획](https://github.com/ensky0/tildaz/issues/496#issuecomment-5402925489).

## 무엇을 바꾸나

macOS 의 글자 단축키를 **물리 위치**가 아니라 **지금 layout 이 그 키에 둔 글자**로 매칭한다.

| layout | 지금까지 | 이 PR 이후 |
|---|---|---|
| US QWERTY | `Cmd`+`W` | 변화 없음 |
| **AZERTY · QWERTZ** | US `W` 자리 (= `Z` 라 인쇄된 키) | **`W` 라 인쇄된 키** — Safari 와 같아진다 |
| **Dvorak · Colemak** | US `W` 자리 | **`W` 라 인쇄된 키** ← *이것도 동작 변경이다* |
| 키릴 · 그리스 · 아랍 | US `W` 자리 | **그대로** (라틴 fallback) |
| 한글 · 일본어 · 중국어 IME | US `W` 자리 | **그대로** (같은 이유) |
| `[KeyW]` 위치 표기 | 위치 | **그대로** |

고치려던 것은 AZERTY 지만 **Dvorak · Colemak 사용자도 누르는 키가 바뀐다.** Cocoa 표준에 맞추는 방향이라 그대로 가되, 릴리즈 노트에 적어야 한다.

## 왜 이 경로인가

네 경로를 실기로 재고 골랐다 (자세한 표는 이슈 코멘트).

| 경로 | 판정 |
|---|---|
| (A) Carbon 링크 + `TIS*` + `UCKeyTranslate` | 성립. 다만 의존성이 는다 |
| (B) HIToolbox `dlopen` | 성립. 심볼을 문자열로 들고 실패 경로를 다뤄야 한다 |
| (C) `CGEventKeyboardGetUnicodeString` | ❌ **탈락** — 프로세스 시작 시점 layout 에 고정되고 dead key 를 못 낸다 |
| **(D) `NSEvent charactersByApplyingModifiers:`** | ✅ **채택** — Carbon 불필요, A 와 128 개 중 118 개 일치 (차이는 modifier keycode 뿐) |

`UnicodeUtilities.h:521` 이 `UCKeyTranslate` 대신 이 API 를 권한다. layout 변경 감지도 Carbon 없이 된다 — `NSTextInputContext.selectedKeyboardInputSource` 가 헤더 기준 `kTISPropertyInputSourceID` 와 같은 값이다.

## 라틴 fallback 이 함께 들어간다

키릴 · 한글처럼 **라틴 글자를 한 자도 못 내는** layout 에서는 비교할 라벨이 아예 없어 글자 단축키가 전부 죽는다 (실측: `ru` · 2-Set Korean 모두 라틴 0 개). Linux 가 이미 하는 규칙 그대로, **그 layout 에서만** US 자리로 매칭한다.

**낼 수 있으면 만들지 않는 것이 요점이다.** 무조건 두 번째 pass 를 돌리면 AZERTY 에서 한 동작에 키가 둘 생긴다.

## 코드에 못 박은 함정 두 개

- **`charactersByApplyingModifiers:` 는 modifier keycode 에서 죽는다.** `0x36`–`0x3F` 를 넘기면 헤더 서술 (*"will return nil"*) 과 달리 `NSAssertionHandler` 를 거쳐 `abort()` 다 (실측, macOS 26.6.2 · SDK 26.5). 거르지 않으면 **Shift 를 누르는 것만으로 앱이 죽는다.**
- **라벨은 Shift 만 반영해 뽑는다.** AZERTY 는 숫자열이 Shift 를 눌러야 숫자라 (무시프트는 `&é"'(-è_çà`), Shift 까지 빼면 `cmd+1` 이 그 layout 에서 영영 매칭되지 않는다 — [#482](https://github.com/ensky0/tildaz/issues/482) 가 둔 숫자 예외가 무력해진다.

## 검증

**단위 테스트** — `zig build check` (6 타겟) · `zig build test` 통과. `#496 항목 2 — macOS 라벨 binding 은 이벤트가 낸 글자로 매칭한다` 를 추가해 계약을 고정했다 (라벨/위치 구분, AZERTY 양쪽 키, fallback 후보, fallback 경로).

**실기** — MacBook Pro (M5 Pro) · macOS 26.6.2 (25G83) · `--instance 1`:

| layout | 누른 키 | 결과 | 로그 |
|---|---|---|---|
| 한글 | `Cmd` + 각인 `W` | ✅ 탭 3 → 2 (fallback) | `fallback 9개` = 글자 binding 수와 일치 |
| French | `Cmd` + 각인 `Z` (라벨 `w`) | ✅ 탭 3 → 2 | `fallback 2개` = `[` · `]` (AltGr 라 못 냄) |
| French | `Cmd` + 각인 `W` (라벨 `z`) | ✅ **무반응** | 한 동작에 키가 둘 생기지 않았다 |
| ABC | `Cmd` + 각인 `W` | ✅ 탭 3 → 2 | **fallback 0개** |

modifier 를 계속 눌렀는데 죽지 않았다 (위 함정 1).

## 범위 밖

- **전역 `hotkey` 는 그대로 위치로 매칭한다.** 그 경로는 CGEventTap 이라 이번 변경이 닿지 않는다. 그래서 **전역 핫키는 위치, 앱 내 단축키는 라벨**로 기준이 갈린다. 기본값 `F1` 이 layout 무관이라 드러나지 않지만 `KEYBINDINGS.md` 에 명시했다. 통합은 **1-c** 에서 세 platform 을 가로질러 정한다.
- **Windows 쪽 (`VkKeyScanExW`) 은 별건이다.** Windows 는 라틴 layout 에서 이미 라벨이라 성격이 다르다.

## 문서

`SPEC.md` (매칭 기준 · fallback 세부) · `CONFIG.md` (라틴 fallback 이 macOS 에도 있다) · `KEYBINDINGS.md` (macOS 절 재작성 + 전역 핫키 기준 차이) 를 같은 PR 에 담았다.
