### PR TITLE
feat(hotkey): 전역 hotkey 에서 위치 표기를 받는다 (#496 1-c)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,8 +515,11 @@ zig build-exe dist/windows/layout-probe.zig -O ReleaseSafe --cache-dir C:/ziglan
 | Hyprland 0.56.2 | `keycode=49` | 같은 기기 (nested) |
 | GNOME 50.4 | gsettings `<Control>0x31` + **확장 경로** `action != 0` · fr 단독에서 자리 유지 | 노트북 i5-1240P |
 | COSMIC 1.0.0 | us `grave` · fr `twosuperior` · ru `Cyrillic_io` · de 거둠 · 복구 | 같은 노트북 |
+| Cinnamon 6.6.9 (Muffin) | 확장 `<Control>0x31` grab · fallback gsettings `['<Control>0x31']` · fr · ru 단독에서 자리 유지 | 같은 노트북 |
 
-**Cinnamon · Windows · macOS 는 미검증이에요.** Cinnamon 은 확장 코드가 GNOME 과 한 test 로 묶여 있지만 세션에서 돌려 보지 않았어요.
+**Windows · macOS 는 미검증이에요.**
+
+**확장 경로는 `TILDAZ_VERBOSE=1` 로 계측 없이 관측해요.** GNOME · Cinnamon 의 확장은 창을 minimize/unminimize 로 토글하므로 앱이 남기는 lifecycle 로그가 없어요. verbose 를 켜면 `[wayland] drainSurfaceOutputs entered=[] …` (숨김) 과 `entered=[11 ] …` (복귀) 가 그대로 보여서, 확장에 로그를 심지 않고도 왕복을 확인할 수 있어요.
 
 **GNOME 은 gsettings 가 주 경로가 아니에요.** tildaz 가 부팅 때 Shell extension 을 스스로 켜고 (`ensureShellExtensionReady`), 켜져 있으면 gsettings 등록을 건너뛰어요 (`extension active — gsettings hotkey skipped`). 그래서 **스크립트의 GSettings 조회가 `''` 인 것이 정상**이고, 그때의 근거는 셸 로그예요 (`journalctl --user -b -o cat | grep tildaz`). gsettings 값을 직접 보려면 확장을 끄고 `~/.local/share/gnome-shell/extensions/tildaz@ensky0.github.io` 를 옮겨 둬야 해요 (설치돼 있으면 tildaz 가 다시 켜요).
 
@@ -561,6 +564,21 @@ WAYLAND_DISPLAY=wayland-0 XDG_CURRENT_DESKTOP=COSMIC cosmic-comp
     rules: "", model: "pc105", layout: "fr", variant: "",
     options: Some("grp:alt_shift_toggle"), repeat_delay: 600, repeat_rate: 25,
 )
+```
+
+**Cinnamon 에서 layout 전환하기.** 스키마가 **`org.cinnamon.desktop.input-sources`** 예요 — `org.gnome.desktop.input-sources` 도 `org.gnome.libgnomekbd.keyboard layouts` 도 **값만 바뀌고 아무 일도 안 일어나요** (`csd-keyboard` 가 전자를 읽기는 하지만 Wayland 에서 keymap 을 세우는 것은 `keyboardManager.js` 의 `Meta.get_backend().set_keymap` 이고, 그쪽은 cinnamon 스키마를 봐요). 이걸로 30 분 헤맸어요.
+
+```sh
+gsettings set org.cinnamon.desktop.input-sources sources "[('xkb','fr')]"
+```
+
+**적용됐는지는 앱 로그로 확인해요** — `ru` 로 바꾸면 `[keys] latin fallback active for N binding(s)` 이 떠요. `setxkbmap -query` 는 **쓸 수 없어요**: Cinnamon · COSMIC 둘 다 Xwayland 에 layout 을 안 내려서 늘 `us` 로 보여요.
+
+**Cinnamon 은 `org.Cinnamon.Eval` 이 열려 있어요** (GNOME 과 달라요). 셸 상태를 물어볼 때 씁니다 — 다만 `imports.ui` 는 막혀 있어요.
+
+```sh
+gdbus call --session --dest org.Cinnamon --object-path /org/Cinnamon \
+  --method org.Cinnamon.Eval '1+1'
 ```
 
 **GNOME 에서 layout 전환하기.** `gsettings set org.gnome.desktop.input-sources sources "[('xkb','fr')]"` 예요. **대조군은 layout 을 하나만 켜고 재요** — 둘 이상 켜면 Mutter 가 keysym 을 모든 group 에서 찾아 걸어 주므로 라벨 표기도 되는 것처럼 보여, 위치 표기와 갈리지 않아요 (실측).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,23 +496,39 @@ zig build-exe dist/windows/layout-probe.zig -O ReleaseSafe --cache-dir C:/ziglan
 ./dist/hotkey/position-hotkey-check.sh --keep           # 남겨 두고 직접 눌러 볼 때
 ```
 
-`--instance 9` 로만 돌고 (사용자의 일상 인스턴스를 안 건드려요) 끝나면 config · 로그 · KDE 등록을 스스로 지워요.
+`--instance 9` 로만 돌고 (사용자의 일상 인스턴스를 안 건드려요) 끝나면 만든 것을 스스로 지워요 — config · 로그 · KDE (D-Bus) · GNOME/Cinnamon (dconf 항목 **과 목록**) · COSMIC (RON 줄).
 
 | 데스크톱 | 받는 것 | 기대값 (`[Backquote]`) |
 |---|---|---|
-| sway · Hyprland · GNOME · Cinnamon | **자리** | `49` = evdev 41 + 8 (`0x31`) |
+| sway · Hyprland | **자리** | `49` = evdev 41 + 8 (`bindcode 49` · `keycode=49`) |
+| GNOME · Cinnamon | **자리** | `0x31`. 확장이 켜져 있으면 **확장이** `grab_accelerator("<Control>0x31")`, 없으면 gsettings `binding=<Control>0x31` |
 | KDE · COSMIC | **그 자리가 지금 내는 글자** | us `` ` `` · fr `²` · ru `Ё` · **de 는 등록 안 함** (dead key) |
 | Windows | 지금 layout 의 **VK** | `WM_INPUTLANGCHANGE` 로 재등록 |
 | macOS | 자리 (`kVK_*`) | 변화 없음 |
 
-**실측 완료** (2026-08-25 · 미니PC Firebat ZY-A8 · CachyOS · KWin 6.7.4): KDE (us · fr · ru · de + 해제/복구 왕복) · sway (`bindcode Ctrl+49`) · Hyprland (`keycode=49`). GNOME · Cinnamon · COSMIC · Windows 는 미검증이에요.
+**실측 완료** (2026-08-25):
 
-**함정 넷 — 스크립트가 이미 피하지만 손으로 할 때 걸려요.**
+| 환경 | 결과 | 기기 |
+|---|---|---|
+| KDE (KWin 6.7.4) | us · fr · ru · de + 해제/복구 왕복 | 미니PC Firebat ZY-A8 · CachyOS |
+| sway 1.12 | `bindcode Ctrl+49` | 같은 기기 (nested) |
+| Hyprland 0.56.2 | `keycode=49` | 같은 기기 (nested) |
+| GNOME 50.4 | gsettings `<Control>0x31` + **확장 경로** `action != 0` · fr 단독에서 자리 유지 | 노트북 i5-1240P |
+| COSMIC 1.0.0 | us `grave` · fr `twosuperior` · ru `Cyrillic_io` · de 거둠 · 복구 | 같은 노트북 |
+
+**Cinnamon · Windows · macOS 는 미검증이에요.** Cinnamon 은 확장 코드가 GNOME 과 한 test 로 묶여 있지만 세션에서 돌려 보지 않았어요.
+
+**GNOME 은 gsettings 가 주 경로가 아니에요.** tildaz 가 부팅 때 Shell extension 을 스스로 켜고 (`ensureShellExtensionReady`), 켜져 있으면 gsettings 등록을 건너뛰어요 (`extension active — gsettings hotkey skipped`). 그래서 **스크립트의 GSettings 조회가 `''` 인 것이 정상**이고, 그때의 근거는 셸 로그예요 (`journalctl --user -b -o cat | grep tildaz`). gsettings 값을 직접 보려면 확장을 끄고 `~/.local/share/gnome-shell/extensions/tildaz@ensky0.github.io` 를 옮겨 둬야 해요 (설치돼 있으면 tildaz 가 다시 켜요).
+
+**함정 일곱 — 앞의 넷은 스크립트가 이미 피하고, 뒤의 셋은 손으로 잴 때 걸려요.**
 
 - **`XDG_CURRENT_DESKTOP` 이 비면 등록 경로를 통째로 건너뛰어요.** tty · ssh 셸에는 대개 없고, 그러면 로그가 `de=(unset)` 이 되며 아무 데도 등록하지 않아요 — "등록이 안 된다" 로 오해하기 쉬워요.
 - **config 를 만들려고 그냥 띄우면 기본값 `F1` 이 사용자의 instance 0 과 충돌해요.** 그 충돌 다이얼로그는 **모달이라 부팅을 막고** 로그가 빈 채로 남아요. `env -u XDG_CURRENT_DESKTOP` 으로 한 번 띄워 config 만 만든 뒤 hotkey 를 바꿔요.
 - **`pkill -f 'instance 9'` 는 자기 명령줄을 매치해 셸을 죽여요** (그 문자열이 명령에도 들어 있어서요). `pgrep -x tildaz` 로 좁히고 `/proc/PID/cmdline` 에서 인자를 확인해요.
 - **layout 전환은 창을 띄우지 않고 해요.** Wayland 의 group 전환은 *포커스한 client* 에게만 가므로, 창을 띄우면 그 경로로 통과해 버려 D-Bus 통지 경로 (#496 1-c 의 ③) 가 검증되지 않아요.
+- **uinput 으로 가상 키보드를 새로 꽂으면 keymap 이 잠깐 바뀌어요.** cosmic-comp 실측에서 장치를 만든 직후 client 가 받은 keymap 이 `grave` → `twosuperior` 로 두 번 왔고, 그 사이에 키를 보내면 **발동하지 않아 거짓 실패**가 나요. 장치를 만든 뒤 **5 초쯤 두고** 눌러요 (`SETTLE`).
+- **GNOME 확장은 파일을 고쳐도 `disable`/`enable` 로 다시 안 읽어요.** ESM import 캐시라 셸이 새로 떠야 해요. 계측 로그를 심어 재려면 **nested 로 새로 띄워요** — 로그인 세션을 건드리지 않아요.
+- **GNOME 50 은 `--nested` 가 없어요.** `gnome-shell --nested` 가 `Unknown option` 이고, 그냥 `--wayland` 만 주면 native backend 를 골라 `Failed to take control of the session: EBUSY` 로 끝나요. 지금 이름은 **`--devkit`** 이에요.
 
 **KDE 에서 layout 전환하기.** 배열은 **시스템 설정 → 입력 장치 → 키보드 → 배열** 에서 먼저 추가해요 — `kxkbrc` 를 직접 고치면 KWin 이 재시작 전까지 안 읽어요 (`reconfigure` · `kcminit` 둘 다 무반응). 추가한 뒤에는 D-Bus 로 전환해요.
 
@@ -528,7 +544,26 @@ gdbus call --session --dest org.kde.keyboard --object-path /Layouts \
 ```sh
 WAYLAND_DISPLAY=wayland-0 XDG_CURRENT_DESKTOP=sway sway -c <config>
 env -u XDG_CURRENT_DESKTOP WAYLAND_DISPLAY=wayland-0 Hyprland -c <config>
+
+# GNOME 은 `--devkit` 이 nested 예요 (`--nested` 는 50 에서 없어졌어요). 자기 세션
+# 버스가 필요해서 `dbus-run-session` 으로 감싸요.
+XDG_CURRENT_DESKTOP=GNOME dbus-run-session -- \
+  gnome-shell --devkit --wayland --wayland-display=wayland-9
+
+# COSMIC 은 `WAYLAND_DISPLAY` 가 있으면 스스로 중첩해요.
+WAYLAND_DISPLAY=wayland-0 XDG_CURRENT_DESKTOP=COSMIC cosmic-comp
 ```
+
+**COSMIC 에서 layout 전환하기.** `~/.config/cosmic/com.system76.CosmicComp/v1/xkb_config` 의 `layout` 을 고치면 cosmic-comp 가 바로 읽어요 (KDE 처럼 재시작이 필요하지 않아요).
+
+```ron
+(
+    rules: "", model: "pc105", layout: "fr", variant: "",
+    options: Some("grp:alt_shift_toggle"), repeat_delay: 600, repeat_rate: 25,
+)
+```
+
+**GNOME 에서 layout 전환하기.** `gsettings set org.gnome.desktop.input-sources sources "[('xkb','fr')]"` 예요. **대조군은 layout 을 하나만 켜고 재요** — 둘 이상 켜면 Mutter 가 keysym 을 모든 group 에서 찾아 걸어 주므로 라벨 표기도 되는 것처럼 보여, 위치 표기와 갈리지 않아요 (실측).
 
 # 터미널 시각 회귀 테스트 (한 줄)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,6 +486,50 @@ zig build-exe dist/windows/layout-probe.zig -O ReleaseSafe --cache-dir C:/ziglan
 
 **tildaz 본체를 함께 검증할 때는 `--instance 9` 로 띄워요.** 사용자의 `config_0` 을 건드리지 않고 별 config 로 테스트할 수 있어요. 그 config 에 **`auto_start = false`** 를 넣고, 끝나면 `config_9.toml` · `tildaz_9.log` · `instance9*` 를 지워요 — 안 지우면 사용자 로그온 때 그 인스턴스가 같이 떠요.
 
+# 전역 hotkey 의 위치 표기 검증 — 데스크톱마다 받는 것이 다르다
+
+`hotkey = "ctrl+[Backquote]"` 같은 **위치 표기** ([#496](https://github.com/ensky0/tildaz/issues/496) 1-c) 는 데스크톱마다 등록 방식이 갈려요. 자리를 그대로 받는 곳, 그 자리가 *지금 내는 글자* 로 바꿔야 하는 곳, VK 로 바꿔야 하는 곳이 있어서 **한 환경에서 통과해도 다른 환경을 보장하지 못해요.** 그래서 어느 머신에서든 같은 절차로 돌리는 도구를 뒀어요.
+
+```sh
+./dist/hotkey/position-hotkey-check.sh                  # 기본 ctrl+[Backquote]
+./dist/hotkey/position-hotkey-check.sh --hotkey 'ctrl+[KeyT]'
+./dist/hotkey/position-hotkey-check.sh --keep           # 남겨 두고 직접 눌러 볼 때
+```
+
+`--instance 9` 로만 돌고 (사용자의 일상 인스턴스를 안 건드려요) 끝나면 config · 로그 · KDE 등록을 스스로 지워요.
+
+| 데스크톱 | 받는 것 | 기대값 (`[Backquote]`) |
+|---|---|---|
+| sway · Hyprland · GNOME · Cinnamon | **자리** | `49` = evdev 41 + 8 (`0x31`) |
+| KDE · COSMIC | **그 자리가 지금 내는 글자** | us `` ` `` · fr `²` · ru `Ё` · **de 는 등록 안 함** (dead key) |
+| Windows | 지금 layout 의 **VK** | `WM_INPUTLANGCHANGE` 로 재등록 |
+| macOS | 자리 (`kVK_*`) | 변화 없음 |
+
+**실측 완료** (2026-08-25 · 미니PC Firebat ZY-A8 · CachyOS · KWin 6.7.4): KDE (us · fr · ru · de + 해제/복구 왕복) · sway (`bindcode Ctrl+49`) · Hyprland (`keycode=49`). GNOME · Cinnamon · COSMIC · Windows 는 미검증이에요.
+
+**함정 넷 — 스크립트가 이미 피하지만 손으로 할 때 걸려요.**
+
+- **`XDG_CURRENT_DESKTOP` 이 비면 등록 경로를 통째로 건너뛰어요.** tty · ssh 셸에는 대개 없고, 그러면 로그가 `de=(unset)` 이 되며 아무 데도 등록하지 않아요 — "등록이 안 된다" 로 오해하기 쉬워요.
+- **config 를 만들려고 그냥 띄우면 기본값 `F1` 이 사용자의 instance 0 과 충돌해요.** 그 충돌 다이얼로그는 **모달이라 부팅을 막고** 로그가 빈 채로 남아요. `env -u XDG_CURRENT_DESKTOP` 으로 한 번 띄워 config 만 만든 뒤 hotkey 를 바꿔요.
+- **`pkill -f 'instance 9'` 는 자기 명령줄을 매치해 셸을 죽여요** (그 문자열이 명령에도 들어 있어서요). `pgrep -x tildaz` 로 좁히고 `/proc/PID/cmdline` 에서 인자를 확인해요.
+- **layout 전환은 창을 띄우지 않고 해요.** Wayland 의 group 전환은 *포커스한 client* 에게만 가므로, 창을 띄우면 그 경로로 통과해 버려 D-Bus 통지 경로 (#496 1-c 의 ③) 가 검증되지 않아요.
+
+**KDE 에서 layout 전환하기.** 배열은 **시스템 설정 → 입력 장치 → 키보드 → 배열** 에서 먼저 추가해요 — `kxkbrc` 를 직접 고치면 KWin 이 재시작 전까지 안 읽어요 (`reconfigure` · `kcminit` 둘 다 무반응). 추가한 뒤에는 D-Bus 로 전환해요.
+
+```sh
+gdbus call --session --dest org.kde.keyboard --object-path /Layouts \
+  --method org.kde.KeyboardLayouts.getLayoutsList
+gdbus call --session --dest org.kde.keyboard --object-path /Layouts \
+  --method org.kde.KeyboardLayouts.setLayout 1        # 목록 순서의 index
+```
+
+**nested 로도 돼요** — sway · Hyprland 는 KDE 안에서 중첩 실행해 잴 수 있어요. 단 **자식 세션이 부모의 `XDG_CURRENT_DESKTOP` 을 물려받으므로** 그 값을 명시해야 해요 (안 하면 `de=KDE` 인 채로 돌아 Hyprland 경로가 안 탑니다).
+
+```sh
+WAYLAND_DISPLAY=wayland-0 XDG_CURRENT_DESKTOP=sway sway -c <config>
+env -u XDG_CURRENT_DESKTOP WAYLAND_DISPLAY=wayland-0 Hyprland -c <config>
+```
+
 # 터미널 시각 회귀 테스트 (한 줄)
 
 색 emoji / 스킨톤 / ZWJ family / 라틴 / 한글 / block element 까지 한 번에 화면에 띄우는 표준 시연 입력. emoji path / ClearType path / wide char / block element 회귀 다 동시 확인 가능. WT 와 나란히 띄워 비교 시 표준 입력으로 사용.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,8 +503,19 @@ zig build-exe dist/windows/layout-probe.zig -O ReleaseSafe --cache-dir C:/ziglan
 | sway · Hyprland | **자리** | `49` = evdev 41 + 8 (`bindcode 49` · `keycode=49`) |
 | GNOME · Cinnamon | **자리** | `0x31`. 확장이 켜져 있으면 **확장이** `grab_accelerator("<Control>0x31")`, 없으면 gsettings `binding=<Control>0x31` |
 | KDE · COSMIC | **그 자리가 지금 내는 글자** | us `` ` `` · fr `²` · ru `Ё` · **de 는 등록 안 함** (dead key) |
-| Windows | 지금 layout 의 **VK** | `WM_INPUTLANGCHANGE` 로 재등록 |
+| Windows | **자리** (raw scan code) | `0x29`. `RegisterHotKey` 가 아니라 `WH_KEYBOARD_LL` 훅으로 잡아요 — 아래 |
 | macOS | 자리 (`kVK_*`) | 변화 없음 |
+
+**Windows 는 `RegisterHotKey` 로 위치 표기를 담을 수 없어요 — 실측으로 확정.** 그 API 는 VK 만 받는데 VK 는 layout DLL 이 배정하는 값이라 자판마다 자리가 움직여요 (`VK_OEM_3` 이 US `0x29` · 프랑스어 legacy `0x28` · 독일어 `0x27`). 그래서 자리를 VK 로 한 번 풀어 등록하면 그 값은 *그 layout 에서만* 맞아요. 처음 구현은 그 파생값을 캐시하고 `WM_INPUTLANGCHANGE` 에서 다시 풀었는데, **숨은 채 layout 이 바뀌면 핫키가 다른 물리 키로 옮겨갔어요** (실측: `[Backquote]` 로 적었는데 `1` 왼쪽 키는 죽고 `'` 키가 창을 띄웠어요 — [#512 코멘트](https://github.com/ensky0/tildaz/pull/512#issuecomment-5412301433)). 그 메시지가 **스레드별이고 포커스를 얻을 때** 와서, 핫키가 먹어야 포커스를 얻고 포커스를 얻어야 갱신되는 순환이라 그 구조로는 창을 좁힐 수만 있고 닫을 수 없어요.
+
+그래서 **위치 표기만 `WH_KEYBOARD_LL` 훅**으로 잡아요. `KBDLLHOOKSTRUCT.scanCode` 가 layout 이 개입하지 않은 raw 값이고 위치 표기가 뜻하는 것이 정확히 그 값이라, 변환도 캐시도 갱신도 없어져요. **라벨 표기는 계속 `RegisterHotKey`** 예요 — 라벨은 OS 가 keypress 시점에 layout DLL 로 풀어 주는 게 옳은 동작이고, 그래서 훅의 대가는 위치 표기를 쓴 사용자에게만 발생해요.
+
+훅을 만질 때 지킬 것:
+
+- **콜백에서 블로킹하지 않아요.** `LowLevelHooksTimeout` (기본 300 ms) 을 넘기면 **훅이 조용히 제거돼요** — 오류도 로그도 없이 핫키가 죽어요. 비교만 하고 실제 작업은 `PostMessageW(WM_HOTKEY)` 로 창의 메시지 큐에 넘겨요 (라벨 경로와 처리부가 하나로 남는 이점도 있어요).
+- **modifier 는 `GetAsyncKeyState` 로 읽고 "요구한 것만" 을 확인해요.** 훅은 modifier 상태를 주지 않아요. `RegisterHotKey` 는 여분 modifier 가 있으면 발동하지 않으므로 (`Ctrl+Alt+X` 가 `ctrl+x` 를 안 잡아요) 그 규칙을 훅 쪽에서도 그대로 만들어야 두 표기가 같은 config 로 같게 동작해요.
+- **injected 입력을 걸러내지 않아요** (`LLKHF_INJECTED`). `RegisterHotKey` 가 합성 입력에도 반응하므로 (실측) 맞춰요. 덕분에 `SendInput` 으로 핫키 검증을 자동화할 수 있어요.
+- **`extended` 를 함께 비교해요.** `0xE0` prefix 가 없으면 control pad 와 numpad 가 같은 하위 바이트를 써서 섞여요 (`physical_key.zig` 헤더).
 
 **실측 완료** (2026-08-25):
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -350,10 +350,8 @@ file shadow it would mean one typo costs you the ability to interrupt a command.
 
 The global `hotkey` is separate for a different reason: it is registered with the
 operating system rather than handled inside TildaZ, so it lives at the top level
-and takes a single value. It does **not** accept the position form — every path
-TildaZ registers it through (sway, Hyprland, COSMIC, KDE) accepts only a
-character. A function key is the safest choice there, being identical on every
-layout.
+and takes a single value. It accepts both forms, but a function key is still the
+safest choice there, being identical on every layout.
 
 ## Hotkey syntax
 
@@ -378,10 +376,20 @@ invalid value shows an error dialog and exits):
   way. Widening it means verifying real key codes on Linux, macOS, and Windows,
   which has not been done yet. A rejected value shows an error dialog naming the
   accepted keys rather than failing silently.
-- **The position form is not accepted here.** `hotkey` is registered with your
-  desktop, and every path TildaZ uses for that takes a character rather than a
-  key position. A value like `"ctrl+[KeyW]"` is rejected with a message saying so,
-  rather than being registered as something that never fires.
+- **The position form works here too**, with one caveat below. TildaZ registers
+  the hotkey with your desktop, and the desktops differ in what they accept.
+  sway, Hyprland, GNOME and Cinnamon take a key position directly. COSMIC and KDE
+  take only a character, so TildaZ registers **whatever that position types on
+  your current layout** — on a French layout `"ctrl+[Backquote]"` becomes `Ctrl+²`.
+  It re-registers when you switch layouts while TildaZ is running.
+- **The caveat is dead keys.** If the position you picked is a dead key on your
+  layout — the `[Backquote]` spot is `dead_circumflex` on a German layout — COSMIC
+  and KDE cannot express it, and TildaZ logs that instead of registering something
+  that would fire the wrong key. The other desktops are unaffected, because they
+  take the position itself.
+- **On COSMIC the entry appears once TildaZ has run.** Resolving a position to a
+  character needs the keyboard layout, which only the running terminal knows, so
+  the shortcut is written on first launch rather than by the installer.
 
 #### Prefer a function key
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -157,8 +157,24 @@ A few positions do not exist on macOS — `[PrintScreen]`, `[ScrollLock]` and
 ### The global hotkey is different
 
 `hotkey` is registered with the desktop rather than handled inside TildaZ, and
-every path TildaZ uses for that — sway, Hyprland, GNOME, Cinnamon, COSMIC, KDE —
-accepts only a character, so it does **not** take the position form.
+the desktops do not agree on what they accept. It takes the position form, but
+how that reaches the desktop differs:
+
+| Desktop | How a position is registered |
+|---|---|
+| sway, Hyprland | by key position (`bindcode`, `code:`) |
+| GNOME, Cinnamon | by key position (`0x31`) |
+| **COSMIC, KDE** | **by the character that position types on your current layout** |
+| Windows | by the virtual key that position holds on your current layout |
+| macOS | by key position |
+
+The rows that follow your layout re-register themselves when you switch layouts
+while TildaZ is running. A layout switch while TildaZ is closed is picked up the
+next time it starts.
+
+**Dead keys are the exception.** On a German layout the `[Backquote]` position is
+a dead accent, and COSMIC and KDE have no way to express that, so TildaZ logs it
+instead of registering a shortcut that would fire the wrong key.
 
 **On macOS the global hotkey matches by position, not by label.** It is caught by
 an event tap before any layout translation, so `hotkey` and `[keys]` use

--- a/SPEC.md
+++ b/SPEC.md
@@ -407,12 +407,18 @@ AZERTY 에서 `Cmd+W` 가 `Z` 라 인쇄된 키였고, 같은 Mac 의 Safari (Co
   정당하게 바인딩하는데 터미널이 삼키면 통과시킬 방법이 없다. PgUp / PgDn 은 GNOME Terminal ·
   Konsole · Windows Terminal 이 탭 전환에 쓰는, 터미널이 관습적으로 소유하는 조합이다.
 - **기존 PgUp / PgDn 경로는 그대로다** — Shift 동반은 scrollback (§2.5), 맨 키는 PTY.
-- **전역 `hotkey` 는 위치 표기를 받지 않는다.** OS / compositor 에 *등록* 해야 하고 우리가 쓰는
-  **다섯** 경로가 모두 문자 기반이다 — sway `bindsym` · Hyprland keysym · GNOME / Cinnamon
-  GTK accelerator (`buildGtkAccel`) · COSMIC RON `key:` · KGlobalAccel `qtKey`. (처음에
-  "4 경로" 로 적었는데 GNOME · Cinnamon 이 빠져 있었다.) 조용히 keysym 0 을 등록하는 대신
-  원인이 분명한 실패를 낸다 — [#496](https://github.com/ensky0/tildaz/issues/496) 1-b 가 그
-  제약을 다룬다.
+- **전역 `hotkey` 도 위치 표기를 받는다** ([#496](https://github.com/ensky0/tildaz/issues/496)
+  1-c). 다만 `[keys]` 와 달리 **OS / compositor 에 *등록* 해야** 해서 경로마다 담을 수 있는 것이
+  다르고, 그것이 이 절 아래의 갈림들이다. 등록 경로는 **다섯**이다 — sway `bindcode` · Hyprland
+  keysym · GNOME / Cinnamon GTK accelerator (`buildGtkAccel`) · COSMIC RON `key:` ·
+  KGlobalAccel `qtKey`. (처음에 "4 경로" 로 적었는데 GNOME · Cinnamon 이 빠져 있었다.)
+  - **Windows 는 `RegisterHotKey` 가 아니라 저수준 훅으로 잡는다.** 그 API 는 VK 만 받는데 VK 는
+    layout DLL 이 배정하는 슬롯이라 자판마다 자리가 움직인다 (`VK_OEM_3` 이 US `0x29` · 프랑스어
+    legacy `0x28` · 독일어 `0x27`). 자리를 VK 로 풀어 캐시하면 layout 이 바뀔 때 **핫키가 다른
+    물리 키로 옮겨간다** (실측). `WM_INPUTLANGCHANGE` 로 갱신하는 길은 그 메시지가 스레드별 ·
+    포커스 의존이라 숨은 드롭다운에서 닫히지 않는다 — 핫키가 먹어야 포커스를 얻는 순환이다.
+    `WH_KEYBOARD_LL` 의 `scanCode` 는 layout 이 개입하지 않은 raw 값이라 변환도 캐시도 없다.
+    **라벨 표기는 계속 `RegisterHotKey`** 다 (라벨을 layout 으로 푸는 것은 OS 의 몫이다).
   - **DE 넷은 이미 스스로 라틴 fallback 을 한다** — GNOME (Mutter 3.28+) · Cinnamon (Muffin
     5.4+) · COSMIC (2026-02+) · KDE (Plasma 5.22+). 그래서 1-b 가 손댈 곳은 그것을 하지 않는
     sway · Hyprland 였다.
@@ -930,8 +936,9 @@ hotkey = "ctrl+f9"              # punctuation 대신 함수 키 — 어느 자�
 >   ([실기 확정](https://github.com/ensky0/tildaz/issues/496#issuecomment-5404000121)).
 >
 > 어느 자판에서나 안전한 것은 **함수 키** (`F1`~`F12`) 다 — 기본값이 `F1` 인 이유이기도 하다.
-> 자리로 고정하고 싶으면 `[keys]` 처럼 위치 표기를 쓰는 길이 있는데, 전역 `hotkey` 는 아직
-> 받지 않는다 (#496 1-c).
+> 자리로 고정하고 싶으면 위치 표기를 쓴다 — 전역 `hotkey` 도 받는다 (#496 1-c). 다만
+> COSMIC · KDE 는 자리를 못 받아 *그 자리가 지금 layout 에서 내는 글자* 로 등록되므로,
+> 그 자리가 dead key 인 layout (독일어의 `[Backquote]`) 에서는 등록되지 않는다.
 
 **Modifier 토큰** (대소문자 무관, `+` 분리, 임의 개수 결합):
 

--- a/build.zig
+++ b/build.zig
@@ -317,6 +317,16 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     }).module("toml"));
+
+    // #496 1-c — GNOME · Cinnamon Shell extension 의 위치 표를 `physical_key.zig` 와
+    // 견주는 test 가 원본을 읽어야 한다. `@embedFile` 은 package path 를 벗어나지
+    // 못하므로 (`src/` 밖) 익명 import 로 넘긴다.
+    test_mod.addAnonymousImport("gnome_extension_js", .{
+        .root_source_file = b.path("dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js"),
+    });
+    test_mod.addAnonymousImport("cinnamon_extension_js", .{
+        .root_source_file = b.path("dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js"),
+    });
     if (is_linux_target) test_mod.link_libc = true;
     if (is_macos_target) {
         test_mod.linkSystemLibrary("objc", .{});

--- a/dist/hotkey/position-hotkey-check.sh
+++ b/dist/hotkey/position-hotkey-check.sh
@@ -31,8 +31,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 TILDAZ=${TILDAZ:-$ROOT/zig-out/bin/tildaz}
 [ -x "$TILDAZ" ] || { echo "빌드가 없다: $TILDAZ  (zig build -Doptimize=ReleaseSafe)" >&2; exit 1; }
 
-CONFIG_DIR=${XDG_CONFIG_HOME:-$HOME/.config}/tildaz
+XDG_CONFIG=${XDG_CONFIG_HOME:-$HOME/.config}
+CONFIG_DIR=$XDG_CONFIG/tildaz
 STATE_DIR=${XDG_STATE_HOME:-$HOME/.local/state}/tildaz
+# 등록 자리는 **인스턴스별**이다 — `tildaz-9`. 예전엔 조회만 `tildaz/` 로 고정돼 있어
+# 늘 빈 값이 나왔다 (#496 1-c 검증에서 걸렸다).
+GNOME_PATH=/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/tildaz-$INSTANCE/
+CINNAMON_PATH=/org/cinnamon/desktop/keybindings/custom-keybindings/tildaz-$INSTANCE/
+COSMIC_RON=$XDG_CONFIG/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom
 CONFIG=$CONFIG_DIR/config_$INSTANCE.toml
 LOG=$STATE_DIR/tildaz_$INSTANCE.log
 
@@ -60,6 +66,33 @@ kill_instance() {
     done
 }
 
+# 등록은 데스크톱마다 **다른 곳에 남는다** — KDE 는 D-Bus 데몬, GNOME · Cinnamon 은
+# dconf, COSMIC 은 RON 파일이다. 하나라도 빠뜨리면 사용자 단축키 목록에 우리 항목이
+# 죽은 채로 남는다 (#496 1-c 검증에서 dconf 를 손으로 치웠다).
+gsettings_list_drop() {
+    # $1 schema · $2 key (strv) · $3 지울 값
+    command -v gsettings >/dev/null 2>&1 || return 0
+    command -v python3 >/dev/null 2>&1 || return 0
+    TZ_DROP="$3" python3 - "$1" "$2" 2>/dev/null <<'PY' || true
+import ast, os, subprocess, sys
+
+schema, key = sys.argv[1], sys.argv[2]
+got = subprocess.run(["gsettings", "get", schema, key], capture_output=True, text=True)
+if got.returncode != 0:
+    raise SystemExit(0)
+raw = got.stdout.strip()
+if raw.startswith("@as "):          # 빈 strv 는 `@as []` 로 온다
+    raw = raw[4:]
+try:
+    items = ast.literal_eval(raw)
+except (ValueError, SyntaxError):
+    raise SystemExit(0)
+kept = [item for item in items if item != os.environ["TZ_DROP"]]
+if len(kept) != len(items):
+    subprocess.run(["gsettings", "set", schema, key, repr(kept)])
+PY
+}
+
 cleanup() {
     [ "$KEEP" = "1" ] && { echo; echo "--keep — 남겨 둔다: $CONFIG"; return; }
     kill_instance
@@ -70,7 +103,20 @@ cleanup() {
         --dest org.kde.kglobalaccel --object-path /kglobalaccel \
         --method org.kde.KGlobalAccel.unregister \
         "tildaz.instance$INSTANCE" "toggle-$INSTANCE" >/dev/null 2>&1 || true
-    echo; echo "정리 완료 — config · 로그 · KDE 등록"
+    # GNOME · Cinnamon — dconf 에 **항목과 목록** 두 군데가 남는다.
+    if command -v dconf >/dev/null 2>&1; then
+        dconf reset -f "$GNOME_PATH" 2>/dev/null || true
+        dconf reset -f "$CINNAMON_PATH" 2>/dev/null || true
+    fi
+    gsettings_list_drop org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$GNOME_PATH"
+    gsettings_list_drop org.cinnamon.desktop.keybindings custom-list "tildaz-$INSTANCE"
+    # COSMIC — RON 파일의 우리 줄. `mv` 는 mktemp 의 0600 을 옮기므로 내용만 덮어쓴다.
+    if [ -f "$COSMIC_RON" ] && grep -q "TildaZ_$INSTANCE" "$COSMIC_RON"; then
+        tmp=$(mktemp)
+        grep -v "\"TildaZ_$INSTANCE\"" "$COSMIC_RON" > "$tmp" && cat "$tmp" > "$COSMIC_RON"
+        rm -f "$tmp"
+    fi
+    echo; echo "정리 완료 — config · 로그 · KDE · GNOME/Cinnamon · COSMIC 등록"
 }
 trap cleanup EXIT INT TERM
 
@@ -100,7 +146,7 @@ sleep 6
 
 echo
 echo "③ 등록 결과"
-grep -iE '\[(kglobalaccel|sway|hyprland|cosmic|gsettings)\]' "$LOG" 2>/dev/null | sed 's/^/   /' || true
+grep -iE '\[(kglobalaccel|sway|hyprland|cosmic|gsettings-hotkey|gnome|cinnamon)\]' "$LOG" 2>/dev/null | sed 's/^/   /' || true
 
 case "$DE" in
     *KDE*|*kde*|*plasma*|*Plasma*)
@@ -110,11 +156,11 @@ case "$DE" in
         ;;
     *GNOME*|*gnome*|*ubuntu*)
         echo "   --- GSettings (GNOME) ---"
-        gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/tildaz/ binding 2>&1 | sed 's/^/   /'
+        gsettings get "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$GNOME_PATH" binding 2>&1 | sed 's/^/   /'
         ;;
     *Cinnamon*|*cinnamon*|*X-Cinnamon*)
         echo "   --- GSettings (Cinnamon) ---"
-        gsettings get org.cinnamon.desktop.keybindings.custom-keybinding:/org/cinnamon/desktop/keybindings/custom-keybindings/tildaz/ binding 2>&1 | sed 's/^/   /'
+        gsettings get "org.cinnamon.desktop.keybindings.custom-keybinding:$CINNAMON_PATH" binding 2>&1 | sed 's/^/   /'
         ;;
     *Hyprland*|*hyprland*)
         echo "   --- hyprctl binds ---"
@@ -132,7 +178,7 @@ for b in d:
         ;;
     *COSMIC*|*cosmic*)
         echo "   --- COSMIC RON ---"
-        grep -n 'TildaZ_' "${XDG_CONFIG_HOME:-$HOME/.config}/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom" 2>/dev/null | sed 's/^/   /' \
+        grep -n "TildaZ_$INSTANCE" "$COSMIC_RON" 2>/dev/null | sed 's/^/   /' \
             || echo "   (항목 없음 — 워커가 keymap 을 받은 뒤에 쓴다)"
         ;;
 esac
@@ -147,7 +193,11 @@ cat <<'MSG'
    Hyprland        keycode=49, key 는 빈 값
    GNOME/Cinnamon  <Control>0x31       (0x31 = 49)
    KDE             us: Ctrl+`   fr: Ctrl+²   ru: Ctrl+Ё   de: 등록 안 됨 (dead key)
-   COSMIC          key: "grave" / "twosuperior" / "Cyrillic_io" / de 는 안 씀
+   COSMIC          key: "grave" / "twosuperior" / "Cyrillic_io" / de 는 등록 안 됨
+
+   ⚠️ GNOME · Cinnamon 은 **확장이 켜져 있으면 위 GSettings 값이 안 나온다.** 확장이
+   hotkey 를 전담하고 gsettings 등록은 건너뛰기 때문이다 (로그의 `extension active`).
+   그때의 근거는 셸 로그다 — `journalctl --user -b -o cat | grep tildaz`.
 
    layout 을 바꿔 가며 보려면 KDE 에서는 아래로 전환할 수 있다 (배열을 먼저 추가해 둔다).
    전환은 **창을 띄우지 않고** 해야 D-Bus 통지 경로가 검증된다.

--- a/dist/hotkey/position-hotkey-check.sh
+++ b/dist/hotkey/position-hotkey-check.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# #496 1-c — 전역 hotkey 의 **위치 표기** 가 이 데스크톱에서 실제로 등록되는지 재는 도구.
+#
+# 데스크톱마다 받는 것이 달라서 (자리 · 글자 · VK) 한 환경에서 통과해도 다른 환경을
+# 보장하지 못한다. 그래서 어느 머신에서든 같은 절차로 돌릴 수 있게 만들어 둔다.
+#
+#   ./dist/hotkey/position-hotkey-check.sh                     # 기본 ctrl+[Backquote]
+#   ./dist/hotkey/position-hotkey-check.sh --hotkey 'ctrl+[KeyT]'
+#   ./dist/hotkey/position-hotkey-check.sh --keep              # 끝나고 안 지움 (직접 눌러 볼 때)
+#
+# 끝나면 만든 것을 전부 지운다 — 테스트 config · 로그 · KDE 등록.
+set -eu
+
+INSTANCE=9
+HOTKEY='ctrl+[Backquote]'
+KEEP=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --instance) INSTANCE="$2"; shift 2 ;;
+        --hotkey)   HOTKEY="$2";   shift 2 ;;
+        --keep)     KEEP=1;        shift ;;
+        -h|--help)  sed -n '2,14p' "$0"; exit 0 ;;
+        *) echo "모르는 인자: $1" >&2; exit 2 ;;
+    esac
+done
+
+# instance 0 은 사용자가 매일 쓰는 것이다. 그것으로 테스트하면 config 와 등록을 덮는다.
+[ "$INSTANCE" = "0" ] && { echo "instance 0 으로는 테스트하지 않는다 (사용자의 일상 인스턴스)" >&2; exit 2; }
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TILDAZ=${TILDAZ:-$ROOT/zig-out/bin/tildaz}
+[ -x "$TILDAZ" ] || { echo "빌드가 없다: $TILDAZ  (zig build -Doptimize=ReleaseSafe)" >&2; exit 1; }
+
+CONFIG_DIR=${XDG_CONFIG_HOME:-$HOME/.config}/tildaz
+STATE_DIR=${XDG_STATE_HOME:-$HOME/.local/state}/tildaz
+CONFIG=$CONFIG_DIR/config_$INSTANCE.toml
+LOG=$STATE_DIR/tildaz_$INSTANCE.log
+
+# ── 함정 ① — `XDG_CURRENT_DESKTOP` 이 없으면 데스크톱 경로를 통째로 건너뛴다 ──────────
+# tty · ssh 셸에는 대개 비어 있고, 그러면 로그가 `de=(unset)` 이 되며 아무 데도 등록하지
+# 않는다. "등록이 안 됐다" 로 오해하기 딱 좋아서 먼저 막는다.
+if [ -z "${XDG_CURRENT_DESKTOP:-}" ]; then
+    cat >&2 <<'MSG'
+XDG_CURRENT_DESKTOP 이 비어 있다. 이대로 돌리면 어느 데스크톱 경로도 타지 않는다.
+데스크톱 세션의 터미널에서 돌리거나, 그 값을 명시해서 돌린다:
+
+    XDG_CURRENT_DESKTOP=KDE ./dist/hotkey/position-hotkey-check.sh
+MSG
+    exit 2
+fi
+DE=$XDG_CURRENT_DESKTOP
+
+# ── 함정 ③ — `pkill -f 'instance 9'` 는 **자기 명령줄**을 매치해 셸을 죽인다 ───────────
+# 그 문자열이 스크립트 명령줄에도 들어 있기 때문이다. 프로세스 이름으로 좁힌 뒤
+# /proc 에서 인자를 직접 확인한다.
+kill_instance() {
+    for p in $(pgrep -x tildaz 2>/dev/null || true); do
+        args=$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null || true)
+        case "$args" in *"--instance $INSTANCE"*) kill "$p" 2>/dev/null || true ;; esac
+    done
+}
+
+cleanup() {
+    [ "$KEEP" = "1" ] && { echo; echo "--keep — 남겨 둔다: $CONFIG"; return; }
+    kill_instance
+    sleep 1
+    rm -f "$CONFIG" "$LOG"
+    # KDE 는 등록이 사용자 설정 파일에 남으므로 명시적으로 거둔다.
+    command -v gdbus >/dev/null 2>&1 && gdbus call --session \
+        --dest org.kde.kglobalaccel --object-path /kglobalaccel \
+        --method org.kde.KGlobalAccel.unregister \
+        "tildaz.instance$INSTANCE" "toggle-$INSTANCE" >/dev/null 2>&1 || true
+    echo; echo "정리 완료 — config · 로그 · KDE 등록"
+}
+trap cleanup EXIT INT TERM
+
+echo "데스크톱 : $DE"
+echo "hotkey   : $HOTKEY"
+echo "인스턴스 : $INSTANCE"
+echo
+
+# ── 함정 ② — config 를 만들려고 그냥 띄우면 **기본값 F1 이 instance 0 과 충돌**한다 ────
+# 그 충돌 다이얼로그는 모달이라 부팅을 막고, 로그가 빈 채로 남아 원인이 안 보인다.
+# 데스크톱 환경을 지운 채 한 번 띄우면 등록 경로를 안 타므로 충돌 없이 config 만 생긴다.
+kill_instance; sleep 1; rm -f "$CONFIG"
+echo "① 테스트 config 생성 (등록 경로를 타지 않는 환경에서)"
+env -u XDG_CURRENT_DESKTOP setsid "$TILDAZ" --instance "$INSTANCE" >/dev/null 2>&1 </dev/null &
+sleep 5
+kill_instance; sleep 2
+[ -f "$CONFIG" ] || { echo "config 가 생성되지 않았다: $CONFIG" >&2; exit 1; }
+
+sed -i "s|^hotkey  *= .*|hotkey           = \"$HOTKEY\"|; s|^auto_start  *= .*|auto_start       = false|" "$CONFIG"
+grep -E '^hotkey|^auto_start' "$CONFIG" | sed 's/^/   /'
+
+echo
+echo "② 이 데스크톱에서 기동"
+: > "$LOG" 2>/dev/null || true
+setsid "$TILDAZ" --instance "$INSTANCE" >/dev/null 2>&1 </dev/null &
+sleep 6
+
+echo
+echo "③ 등록 결과"
+grep -iE '\[(kglobalaccel|sway|hyprland|cosmic|gsettings)\]' "$LOG" 2>/dev/null | sed 's/^/   /' || true
+
+case "$DE" in
+    *KDE*|*kde*|*plasma*|*Plasma*)
+        echo "   --- kglobalshortcutsrc ---"
+        grep -A 2 "tildaz.instance$INSTANCE" "${XDG_CONFIG_HOME:-$HOME/.config}/kglobalshortcutsrc" 2>/dev/null | sed 's/^/   /' \
+            || echo "   (항목 없음)"
+        ;;
+    *GNOME*|*gnome*|*ubuntu*)
+        echo "   --- GSettings (GNOME) ---"
+        gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/tildaz/ binding 2>&1 | sed 's/^/   /'
+        ;;
+    *Cinnamon*|*cinnamon*|*X-Cinnamon*)
+        echo "   --- GSettings (Cinnamon) ---"
+        gsettings get org.cinnamon.desktop.keybindings.custom-keybinding:/org/cinnamon/desktop/keybindings/custom-keybindings/tildaz/ binding 2>&1 | sed 's/^/   /'
+        ;;
+    *Hyprland*|*hyprland*)
+        echo "   --- hyprctl binds ---"
+        hyprctl -j binds 2>/dev/null | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: print("   (파싱 실패)"); raise SystemExit
+for b in d:
+    if "tildaz" in (b.get("arg") or ""):
+        print("   key=%r keycode=%s modmask=%s -> %s" % (b.get("key"), b.get("keycode"), b.get("modmask"), b.get("arg")))
+' || echo "   (hyprctl 실패)"
+        ;;
+    *sway*)
+        echo "   --- sway 는 IPC 로 걸고 조회 API 가 없다. 위 로그의 bindcode 줄이 근거다 ---"
+        ;;
+    *COSMIC*|*cosmic*)
+        echo "   --- COSMIC RON ---"
+        grep -n 'TildaZ_' "${XDG_CONFIG_HOME:-$HOME/.config}/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom" 2>/dev/null | sed 's/^/   /' \
+            || echo "   (항목 없음 — 워커가 keymap 을 받은 뒤에 쓴다)"
+        ;;
+esac
+
+cat <<'MSG'
+
+④ 기대값
+   `[Backquote]` 자리는 layout 마다 다른 글자를 낸다. 자리를 그대로 받는 데스크톱은
+   숫자 49 (= evdev 41 + 8) 로, 글자만 받는 데스크톱은 그 자리가 지금 내는 글자로 등록된다.
+
+   sway            bindcode ... Ctrl+49
+   Hyprland        keycode=49, key 는 빈 값
+   GNOME/Cinnamon  <Control>0x31       (0x31 = 49)
+   KDE             us: Ctrl+`   fr: Ctrl+²   ru: Ctrl+Ё   de: 등록 안 됨 (dead key)
+   COSMIC          key: "grave" / "twosuperior" / "Cyrillic_io" / de 는 안 씀
+
+   layout 을 바꿔 가며 보려면 KDE 에서는 아래로 전환할 수 있다 (배열을 먼저 추가해 둔다).
+   전환은 **창을 띄우지 않고** 해야 D-Bus 통지 경로가 검증된다.
+
+     gdbus call --session --dest org.kde.keyboard --object-path /Layouts \
+       --method org.kde.KeyboardLayouts.setLayout 1
+
+   실제로 눌러 보려면 --keep 으로 남겨 두고 그 조합을 눌러 본다.
+MSG

--- a/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
@@ -46,7 +46,7 @@
  *     화면 중앙에 그리므로(드롭다운 밖), extension 이 잡아 managed 터미널 위 중앙으로
  *     옮긴다(SPEC §6 "main 위 modal" 실현).
  *
- * config = single source of truth: $XDG_CONFIG_HOME/tildaz/config_N.json
+ * config = single source of truth: $XDG_CONFIG_HOME/tildaz/config_N.toml
  * (fallback: ~/.config/tildaz) 의 hotkey 와
  * window.{dock_position,width_percent,height_percent,offset_percent} + hidden_start.
  *
@@ -279,17 +279,17 @@ function disable() {
   st = null;
 }
 
-/** XDG config의 config_N.json 읽기 (실패 시 해당 항목 제외). */
+/** XDG config의 config_N.toml 읽기 (실패 시 해당 항목 제외). */
 function readConfig(index) {
   const out = { accel: "", dock: "top", wp: 50, hp: 100, op: 100, hidden: false };
   try {
     const path = GLib.build_filenamev([
       configDirPath(),
-      `config_${index}.json`,
+      `config_${index}.toml`,
     ]);
     const [ok, bytes] = GLib.file_get_contents(path);
     if (ok) {
-      const j = JSON.parse(new TextDecoder().decode(bytes));
+      const j = parseTomlSubset(new TextDecoder().decode(bytes));
       if (typeof j.hotkey === "string") {
         const a = toAccel(j.hotkey);
         if (a) out.accel = a;
@@ -314,7 +314,7 @@ function readConfigs() {
     const dir = GLib.Dir.open(path, 0);
     let name;
     while ((name = dir.read_name()) !== null) {
-      const match = /^config_(0|[1-9][0-9]*)\.json$/.exec(name);
+      const match = /^config_(0|[1-9][0-9]*)\.toml$/.exec(name);
       if (match) configs.set(Number(match[1]), readConfig(Number(match[1])));
     }
     dir.close();
@@ -350,6 +350,72 @@ function syncHotkeys(nextConfigs) {
   }
   st.configs = nextConfigs;
   for (const [index, cfg] of nextConfigs) registerHotkey(index, cfg);
+}
+
+/**
+ * TOML 의 **아주 좁은 부분집합** 파서 — 최상위 스칼라와 `[window]` 같은 한 단계
+ * 테이블, 문자열 · 숫자 · 참거짓만 본다.
+ *
+ * GJS 에 TOML 파서가 없어서 직접 둔다. 읽을 파일은 `src/config.zig` 가 만든 템플릿
+ * 하나뿐이라 (사용자 편집 포함) 문법 범위가 좁다. 배열 (`glyph_fallback` ·
+ * `[keys]` 의 값들) · 여러 줄 문자열 · 점 표기 키는 값을 건너뛴다 — 우리가 읽는
+ * 키에는 그런 값이 없다.
+ *
+ * 주석은 **문자열 밖에서만** 자른다. 안 그러면 `hotkey = "ctrl+#"` 같은 값이 잘린다.
+ */
+function parseTomlSubset(text) {
+  const root = {};
+  let table = root;
+  for (const rawLine of String(text).split("\n")) {
+    const line = tomlStripComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([A-Za-z0-9_]+)\]$/.exec(line);
+    if (section) {
+      if (typeof root[section[1]] !== "object" || root[section[1]] === null) root[section[1]] = {};
+      table = root[section[1]];
+      continue;
+    }
+    const pair = /^([A-Za-z0-9_-]+)\s*=\s*(.*)$/.exec(line);
+    if (!pair) continue;
+    const value = tomlValue(pair[2].trim());
+    if (value !== undefined) table[pair[1]] = value;
+  }
+  return root;
+}
+
+function tomlStripComment(line) {
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (quoted) {
+      if (c === "\\") i++;
+      else if (c === '"') quoted = false;
+    } else if (c === '"') quoted = true;
+    else if (c === "#") return line.slice(0, i);
+  }
+  return line;
+}
+
+function tomlValue(text) {
+  if (text.startsWith('"')) {
+    let out = "";
+    for (let i = 1; i < text.length; i++) {
+      const c = text[i];
+      if (c === "\\") {
+        const next = text[++i];
+        out += next === "n" ? "\n" : next === "t" ? "\t" : next;
+      } else if (c === '"') {
+        return out;
+      } else {
+        out += c;
+      }
+    }
+    return undefined; // 닫히지 않은 문자열
+  }
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (/^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/.test(text)) return Number(text);
+  return undefined; // 배열 등 — 우리가 안 읽는 값
 }
 
 /**

--- a/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
@@ -330,7 +330,13 @@ function registerHotkey(index, cfg) {
   if (st.hotkeys.has(name)) {
     try { Main.keybindingManager.removeHotKey(name); } catch (_e) {}
   }
-  Main.keybindingManager.addHotKey(name, cfg.accel, () => toggle(index));
+  // **실패가 조용하면 진단이 안 된다.** #496 1-c 검증에서 GNOME 쪽 같은 자리가
+  // 위치 표기를 못 받아 grab 이 실패했는데 로그가 없어 원인이 안 보였다. 실패한
+  // 것은 `st.hotkeys` 에 넣지 않는다 — 넣으면 config 가 다시 와도 재시도하지 않는다.
+  if (Main.keybindingManager.addHotKey(name, cfg.accel, () => toggle(index)) === false) {
+    global.logError(`[tildaz] hotkey registration failed — index ${index} accel ${JSON.stringify(cfg.accel)}`);
+    return;
+  }
   st.hotkeys.set(name, cfg.accel);
 }
 
@@ -346,7 +352,38 @@ function syncHotkeys(nextConfigs) {
   for (const [index, cfg] of nextConfigs) registerHotkey(index, cfg);
 }
 
+/**
+ * #496 1-c — 위치 표기(`[Backquote]`)가 가리키는 **xkb keycode** (= evdev + 8).
+ *
+ * `src/physical_key.zig` 의 표와 같은 값이어야 한다. 어긋나면 조용히 **옆 키**에
+ * 붙으므로 (Muffin 은 틀린 숫자를 거부하지 않는다) zig 쪽 test 가 두 표를 묶는다 —
+ * `#496 1-c the Shell extension position tables match physical_key`.
+ */
+const POSITION_KEYCODES = {
+  f1: 0x43, f2: 0x44, f3: 0x45, f4: 0x46, f5: 0x47, f6: 0x48,
+  f7: 0x49, f8: 0x4a, f9: 0x4b, f10: 0x4c, f11: 0x5f, f12: 0x60,
+  f13: 0xbf, f14: 0xc0, f15: 0xc1, f16: 0xc2, f17: 0xc3, f18: 0xc4,
+  f19: 0xc5, f20: 0xc6, f21: 0xc7, f22: 0xc8, f23: 0xc9, f24: 0xca,
+  keya: 0x26, keyb: 0x38, keyc: 0x36, keyd: 0x28, keye: 0x1a, keyf: 0x29,
+  keyg: 0x2a, keyh: 0x2b, keyi: 0x1f, keyj: 0x2c, keyk: 0x2d, keyl: 0x2e,
+  keym: 0x3a, keyn: 0x39, keyo: 0x20, keyp: 0x21, keyq: 0x18, keyr: 0x1b,
+  keys: 0x27, keyt: 0x1c, keyu: 0x1e, keyv: 0x37, keyw: 0x19, keyx: 0x35,
+  keyy: 0x1d, keyz: 0x34, digit1: 0x0a, digit2: 0x0b, digit3: 0x0c, digit4: 0x0d,
+  digit5: 0x0e, digit6: 0x0f, digit7: 0x10, digit8: 0x11, digit9: 0x12, digit0: 0x13,
+  backquote: 0x31, minus: 0x14, equal: 0x15, bracketleft: 0x22, bracketright: 0x23, backslash: 0x33,
+  semicolon: 0x2f, quote: 0x30, comma: 0x3b, period: 0x3c, slash: 0x3d, intlbackslash: 0x5e,
+  intlyen: 0x84, intlro: 0x61, space: 0x41, tab: 0x17, escape: 0x09, enter: 0x24,
+  backspace: 0x16, capslock: 0x42, printscreen: 0x6b, scrolllock: 0x4e, pause: 0x7f, contextmenu: 0x87,
+  lang1: 0x82, lang2: 0x83, convert: 0x64, nonconvert: 0x66, kanamode: 0x65, insert: 0x76,
+  delete: 0x77, home: 0x6e, end: 0x73, pageup: 0x70, pagedown: 0x75, arrowup: 0x6f,
+  arrowdown: 0x74, arrowleft: 0x71, arrowright: 0x72, numlock: 0x4d, numpad0: 0x5a, numpad1: 0x57,
+  numpad2: 0x58, numpad3: 0x59, numpad4: 0x53, numpad5: 0x54, numpad6: 0x55, numpad7: 0x4f,
+  numpad8: 0x50, numpad9: 0x51, numpaddivide: 0x6a, numpadmultiply: 0x3f, numpadsubtract: 0x52, numpadadd: 0x56,
+  numpadenter: 0x68, numpaddecimal: 0x5b, numpadequal: 0x7d,
+};
+
 /** tildaz hotkey 문자열("ctrl+shift+t" / "f1" / "super+grave") → GTK accelerator. */
+
 function toAccel(s) {
   let mods = "";
   let key = "";
@@ -360,6 +397,22 @@ function toAccel(s) {
     else if (t.length > 0) key = t;
   }
   if (!key) return null;
+  // #496 1-c — 위치 표기 `[Backquote]` 는 **자리**다. GTK 의 `is_keycode()` 가 `0x` +
+  // **정확히 두 자리** hex 만 keycode 로 인정하고, Muffin 은 그 값을 변환 없이
+  // `combo->keycode` 에 넣어 xkb keycode (= evdev + 8) 와 견준다. zig 쪽
+  // `buildGtkAccel` (gsettings fallback 경로) 이 내는 형식과 같다.
+  //
+  // 실측 (GNOME 50.4, nested): `<Control>[backquote]` 는 `grab_accelerator` 가 0
+  // (`KeyBindingAction.NONE`) 을 내고 `<Control>0x31` 은 받는다 (#496 1-c).
+  const position = /^\[(.+)\]$/.exec(key);
+  if (position) {
+    const code = POSITION_KEYCODES[position[1]];
+    if (code === undefined) {
+      console.log(`[tildaz] unknown position "${key}" in hotkey "${s}"`);
+      return null;
+    }
+    return mods + "0x" + code.toString(16).padStart(2, "0");
+  }
   if (/^f([1-9]|1[0-2])$/.test(key)) key = key.toUpperCase();
   else if (key === "`" || key === "grave") key = "grave";
   else if (key === "space") key = "space";

--- a/dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js
@@ -9,7 +9,7 @@
  * 이 번호별 창을 잡아 배치/토글한다. tildaz.desktop은 launcher 전용이라 앱 아이콘
  * 재클릭도 기존 창 activate가 아니라 launcher Exec을 호출한다.
  *
- * config = single source of truth: $XDG_CONFIG_HOME/tildaz/config_N.json
+ * config = single source of truth: $XDG_CONFIG_HOME/tildaz/config_N.toml
  * (fallback: ~/.config/tildaz) 의 hotkey 와
  * window.{dock_position,width_percent,height_percent,offset_percent} 를 읽는다.
  *
@@ -49,6 +49,72 @@ function workerIndex(win) {
   const ci = win.get_wm_class_instance?.();
   const matches = value => typeof value === "string" && value.toLowerCase() === expected;
   return matches(c) || matches(ci) ? index : null;
+}
+
+/**
+ * TOML 의 **아주 좁은 부분집합** 파서 — 최상위 스칼라와 `[window]` 같은 한 단계
+ * 테이블, 문자열 · 숫자 · 참거짓만 본다.
+ *
+ * GJS 에 TOML 파서가 없어서 직접 둔다. 읽을 파일은 `src/config.zig` 가 만든 템플릿
+ * 하나뿐이라 (사용자 편집 포함) 문법 범위가 좁다. 배열 (`glyph_fallback` ·
+ * `[keys]` 의 값들) · 여러 줄 문자열 · 점 표기 키는 값을 건너뛴다 — 우리가 읽는
+ * 키에는 그런 값이 없다.
+ *
+ * 주석은 **문자열 밖에서만** 자른다. 안 그러면 `hotkey = "ctrl+#"` 같은 값이 잘린다.
+ */
+function parseTomlSubset(text) {
+  const root = {};
+  let table = root;
+  for (const rawLine of String(text).split("\n")) {
+    const line = tomlStripComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([A-Za-z0-9_]+)\]$/.exec(line);
+    if (section) {
+      if (typeof root[section[1]] !== "object" || root[section[1]] === null) root[section[1]] = {};
+      table = root[section[1]];
+      continue;
+    }
+    const pair = /^([A-Za-z0-9_-]+)\s*=\s*(.*)$/.exec(line);
+    if (!pair) continue;
+    const value = tomlValue(pair[2].trim());
+    if (value !== undefined) table[pair[1]] = value;
+  }
+  return root;
+}
+
+function tomlStripComment(line) {
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (quoted) {
+      if (c === "\\") i++;
+      else if (c === '"') quoted = false;
+    } else if (c === '"') quoted = true;
+    else if (c === "#") return line.slice(0, i);
+  }
+  return line;
+}
+
+function tomlValue(text) {
+  if (text.startsWith('"')) {
+    let out = "";
+    for (let i = 1; i < text.length; i++) {
+      const c = text[i];
+      if (c === "\\") {
+        const next = text[++i];
+        out += next === "n" ? "\n" : next === "t" ? "\t" : next;
+      } else if (c === '"') {
+        return out;
+      } else {
+        out += c;
+      }
+    }
+    return undefined; // 닫히지 않은 문자열
+  }
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (/^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/.test(text)) return Number(text);
+  return undefined; // 배열 등 — 우리가 안 읽는 값
 }
 
 /**
@@ -245,7 +311,7 @@ export default class TildazExtension extends Extension {
     this._dialogIdleIds = null;
   }
 
-  /** XDG config의 config_N.json 읽기 (실패 시 해당 항목 제외). */
+  /** XDG config의 config_N.toml 읽기 (실패 시 해당 항목 제외). */
   _readConfig(index) {
     const out = {
       accel: "<Super>grave",
@@ -259,11 +325,11 @@ export default class TildazExtension extends Extension {
     try {
       const path = GLib.build_filenamev([
         configDirPath(),
-        `config_${index}.json`,
+        `config_${index}.toml`,
       ]);
       const [ok, bytes] = GLib.file_get_contents(path);
       if (ok) {
-        const j = JSON.parse(new TextDecoder().decode(bytes));
+        const j = parseTomlSubset(new TextDecoder().decode(bytes));
         if (typeof j.hotkey === "string") {
           // **못 읽으면 기본값으로 떨어지지 않는다.** config 가 source of truth 인데
           // `<Super>grave` 로 조용히 바뀌면 사용자가 적지 않은 조합이 걸린다 — 위치
@@ -292,7 +358,7 @@ export default class TildazExtension extends Extension {
       const dir = GLib.Dir.open(dirPath, 0);
       let name;
       while ((name = dir.read_name()) !== null) {
-        const match = /^config_(0|[1-9][0-9]*)\.json$/.exec(name);
+        const match = /^config_(0|[1-9][0-9]*)\.toml$/.exec(name);
         if (match) configs.set(Number(match[1]), this._readConfig(Number(match[1])));
       }
       dir.close();
@@ -496,7 +562,7 @@ export default class TildazExtension extends Extension {
       if (index === null) return;
 
       // tildaz 가 뜰 때마다 config 를 다시 읽는다 (config = single source of truth).
-      // 사용자가 config_N.json 의 hidden_start / 위치(dock/width/...) 를 바꾸고 tildaz 만
+      // 사용자가 config_N.toml 의 hidden_start / 위치(dock/width/...) 를 바꾸고 tildaz 만
       // 재실행해도 extension reload 없이 반영된다. (hotkey 는 enable 의 gschema 바인딩
       // 이라 예외 — 바꾸면 extension reload/relogin 이 필요하다.)
       const cfg = this._readConfig(index);

--- a/dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js
@@ -51,6 +51,36 @@ function workerIndex(win) {
   return matches(c) || matches(ci) ? index : null;
 }
 
+/**
+ * #496 1-c — 위치 표기(`[Backquote]`)가 가리키는 **xkb keycode** (= evdev + 8).
+ *
+ * `src/physical_key.zig` 의 표와 같은 값이어야 한다. 어긋나면 조용히 **옆 키**에
+ * 붙으므로 (Mutter 는 틀린 숫자를 거부하지 않는다) zig 쪽 test 가 두 표를 묶는다 —
+ * `#496 1-c the Shell extension position tables match physical_key`.
+ */
+const POSITION_KEYCODES = {
+  f1: 0x43, f2: 0x44, f3: 0x45, f4: 0x46, f5: 0x47, f6: 0x48,
+  f7: 0x49, f8: 0x4a, f9: 0x4b, f10: 0x4c, f11: 0x5f, f12: 0x60,
+  f13: 0xbf, f14: 0xc0, f15: 0xc1, f16: 0xc2, f17: 0xc3, f18: 0xc4,
+  f19: 0xc5, f20: 0xc6, f21: 0xc7, f22: 0xc8, f23: 0xc9, f24: 0xca,
+  keya: 0x26, keyb: 0x38, keyc: 0x36, keyd: 0x28, keye: 0x1a, keyf: 0x29,
+  keyg: 0x2a, keyh: 0x2b, keyi: 0x1f, keyj: 0x2c, keyk: 0x2d, keyl: 0x2e,
+  keym: 0x3a, keyn: 0x39, keyo: 0x20, keyp: 0x21, keyq: 0x18, keyr: 0x1b,
+  keys: 0x27, keyt: 0x1c, keyu: 0x1e, keyv: 0x37, keyw: 0x19, keyx: 0x35,
+  keyy: 0x1d, keyz: 0x34, digit1: 0x0a, digit2: 0x0b, digit3: 0x0c, digit4: 0x0d,
+  digit5: 0x0e, digit6: 0x0f, digit7: 0x10, digit8: 0x11, digit9: 0x12, digit0: 0x13,
+  backquote: 0x31, minus: 0x14, equal: 0x15, bracketleft: 0x22, bracketright: 0x23, backslash: 0x33,
+  semicolon: 0x2f, quote: 0x30, comma: 0x3b, period: 0x3c, slash: 0x3d, intlbackslash: 0x5e,
+  intlyen: 0x84, intlro: 0x61, space: 0x41, tab: 0x17, escape: 0x09, enter: 0x24,
+  backspace: 0x16, capslock: 0x42, printscreen: 0x6b, scrolllock: 0x4e, pause: 0x7f, contextmenu: 0x87,
+  lang1: 0x82, lang2: 0x83, convert: 0x64, nonconvert: 0x66, kanamode: 0x65, insert: 0x76,
+  delete: 0x77, home: 0x6e, end: 0x73, pageup: 0x70, pagedown: 0x75, arrowup: 0x6f,
+  arrowdown: 0x74, arrowleft: 0x71, arrowright: 0x72, numlock: 0x4d, numpad0: 0x5a, numpad1: 0x57,
+  numpad2: 0x58, numpad3: 0x59, numpad4: 0x53, numpad5: 0x54, numpad6: 0x55, numpad7: 0x4f,
+  numpad8: 0x50, numpad9: 0x51, numpaddivide: 0x6a, numpadmultiply: 0x3f, numpadsubtract: 0x52, numpadadd: 0x56,
+  numpadenter: 0x68, numpaddecimal: 0x5b, numpadequal: 0x7d,
+};
+
 export default class TildazExtension extends Extension {
   enable() {
     this._appSystem = Shell.AppSystem.get_default();
@@ -139,6 +169,11 @@ export default class TildazExtension extends Extension {
           Meta.external_binding_name_for_action(action),
           Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW | Shell.ActionMode.POPUP
         );
+      } else {
+        // **실패가 조용하면 진단이 안 된다.** #496 1-c 검증에서 위치 표기가
+        // `<Control>[backquote]` 로 흘러 grab 이 0 을 냈는데, 로그가 없어 nested
+        // GNOME 에 계측을 심고서야 원인을 봤다. 그 한 줄을 여기 남긴다.
+        console.log(`[tildaz] accelerator grab failed — index ${index} accel ${JSON.stringify(cfg.accel)}`);
       }
     }
   }
@@ -230,8 +265,11 @@ export default class TildazExtension extends Extension {
       if (ok) {
         const j = JSON.parse(new TextDecoder().decode(bytes));
         if (typeof j.hotkey === "string") {
-          const a = this._toAccel(j.hotkey);
-          if (a) out.accel = a;
+          // **못 읽으면 기본값으로 떨어지지 않는다.** config 가 source of truth 인데
+          // `<Super>grave` 로 조용히 바뀌면 사용자가 적지 않은 조합이 걸린다 — 위치
+          // 표기를 받으면서 이 경로가 처음 닿게 됐다 (#496 1-c). Cinnamon 쪽은
+          // 기본값이 빈 문자열이라 이미 이렇게 동작한다.
+          out.accel = this._toAccel(j.hotkey);
         }
         const w = j.window || {};
         if (typeof w.dock_position === "string") out.dock = w.dock_position;
@@ -265,6 +303,7 @@ export default class TildazExtension extends Extension {
   }
 
   /** tildaz hotkey 문자열("ctrl+shift+t" / "f1" / "super+grave") → GTK accelerator. */
+
   _toAccel(s) {
     let mods = "";
     let key = "";
@@ -278,6 +317,22 @@ export default class TildazExtension extends Extension {
       else if (t.length > 0) key = t;
     }
     if (!key) return null;
+    // #496 1-c — 위치 표기 `[Backquote]` 는 **자리**다. GTK 의 `is_keycode()` 가 `0x` +
+    // **정확히 두 자리** hex 만 keycode 로 인정하고, Mutter 는 그 값을 변환 없이
+    // `combo->keycode` 에 넣어 xkb keycode (= evdev + 8) 와 견준다. zig 쪽
+    // `buildGtkAccel` (gsettings fallback 경로) 이 내는 형식과 같다.
+    //
+    // 실측 (GNOME 50.4, nested): `<Control>[backquote]` 는 `grab_accelerator` 가 0
+    // (`KeyBindingAction.NONE`) 을 내고 `<Control>0x31` 은 받는다 (#496 1-c).
+    const position = /^\[(.+)\]$/.exec(key);
+    if (position) {
+      const code = POSITION_KEYCODES[position[1]];
+      if (code === undefined) {
+        console.log(`[tildaz] unknown position "${key}" in hotkey "${s}"`);
+        return null;
+      }
+      return mods + "0x" + code.toString(16).padStart(2, "0");
+    }
     if (/^f([1-9]|1[0-2])$/.test(key)) key = key.toUpperCase();
     else if (key === "`" || key === "grave") key = "grave";
     else if (key === "space") key = "space";

--- a/dist/linux/gnome-extension/tildaz@ensky0.github.io/metadata.json
+++ b/dist/linux/gnome-extension/tildaz@ensky0.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "tildaz@ensky0.github.io",
   "name": "TildaZ Drop-down",
-  "description": "Drop-down placement and numbered global hotkeys for TildaZ on GNOME. Reads $XDG_CONFIG_HOME/tildaz/config_N.json files (with the standard ~/.config fallback) as the source of truth.",
+  "description": "Drop-down placement and numbered global hotkeys for TildaZ on GNOME. Reads $XDG_CONFIG_HOME/tildaz/config_N.toml files (with the standard ~/.config fallback) as the source of truth.",
   "shell-version": ["45", "46", "47", "48", "49", "50"],
   "settings-schema": "org.gnome.shell.extensions.tildaz",
   "url": "https://github.com/ensky0/tildaz"

--- a/dist/linux/gnome-extension/tildaz@ensky0.github.io/schemas/org.gnome.shell.extensions.tildaz.gschema.xml
+++ b/dist/linux/gnome-extension/tildaz@ensky0.github.io/schemas/org.gnome.shell.extensions.tildaz.gschema.xml
@@ -4,7 +4,7 @@
     <key name="toggle-hotkey" type="as">
       <default><![CDATA[['<Super>grave']]]></default>
       <summary>Toggle the TildaZ drop-down</summary>
-      <description>GTK accelerator fallback. Numbered accelerators are read from $XDG_CONFIG_HOME/tildaz/config_N.json files, with the standard ~/.config fallback.</description>
+      <description>GTK accelerator fallback. Numbered accelerators are read from $XDG_CONFIG_HOME/tildaz/config_N.toml files, with the standard ~/.config fallback.</description>
     </key>
   </schema>
 </schemalist>

--- a/src/config.zig
+++ b/src/config.zig
@@ -1544,8 +1544,39 @@ pub fn defaultConfigTomlWithHotkey(
         \\# Field meanings and accepted ranges: CONFIG.md
         \\
         \\# Global hotkey -- the OS delivers this even when TildaZ is not focused.
-        \\# Takes a label ("ctrl+space") or a position ("ctrl+[Backquote]"). A
-        \\# function key is the safest: it is the same on every keyboard layout.
+        \\#
+        \\# Two ways to name the key:
+        \\#   label      "ctrl+space"        the character the key types
+        \\#   position   "ctrl+[Backquote]"  the physical spot, whatever it prints
+        \\#
+        \\# A function key is the safest choice: F1-F12 sit in the same place on
+        \\# every layout. Function-key positions are also the only ones accepted
+        \\# without a modifier -- "[F13]" is valid, "[KeyW]" is not.
+        \\#
+        \\# Reach for a position when the key you want prints something different
+        \\# from one layout to the next. The key left of 1 is the clearest case;
+        \\# these are measured, not guessed:
+        \\#
+        \\#   layout                      that key prints
+        \\#   US QWERTY                   `      (same on all three platforms)
+        \\#   French   (Linux)            ²
+        \\#   French   (Windows legacy)   ²
+        \\#   French   (Windows standard) @
+        \\#   French   (macOS)            <
+        \\#   Russian  (Linux, Windows)   ё
+        \\#   Russian  (macOS)            ]
+        \\#   German   (Linux)            a dead key -- refused, with a message
+        \\#
+        \\# "ctrl+[Backquote]" means that one physical key on every row above. A
+        \\# label such as "ctrl+grave" only fires where the layout types a backtick.
+        \\#
+        \\# More positions worth knowing:
+        \\#   "ctrl+[BracketLeft]"   [ on US. On French it needs AltGr, so the
+        \\#                          label form would be a four-finger chord.
+        \\#   "[F13]"                On a PC keyboard attached to a Mac this is
+        \\#                          the PrintScreen spot -- macOS reports F13.
+        \\#
+        \\# Position names are W3C KeyboardEvent.code values. Full list: CONFIG.md
         \\hotkey           = "{s}"
         \\
         \\shell            = "{s}"

--- a/src/config.zig
+++ b/src/config.zig
@@ -731,6 +731,30 @@ test "#496 macOS 에 값이 없는 자리는 그 platform 에서만 거부한다
         // 안내가 가리키는 대체 자리는 실제로 받아야 한다 — 그러지 않으면 막다른
         // 길이 된다 (#484).
         try std.testing.expect(parseHotkeyString("ctrl+[F13]", .app_binding) == .ok);
+
+        // #496 1-c — **전역 `hotkey` scope 에서도 같은 거부가 난다.** 위치 표기를 받기
+        // 시작하면서 생긴 경로이고, config 로드부는 이것을 `unreachable` 로 두고 있었다.
+        // ReleaseFast 는 안전 검사가 없어 크래시 대신 `modifier_required` 안내로
+        // 떨어졌고, `ctrl` 을 이미 준 사용자에게 "modifier 를 달라" 고 말했다 (macOS
+        // 실기 확인). 여기서 고정해 두면 그 전제가 다시 깨질 때 테스트가 잡는다.
+        try std.testing.expectEqual(
+            HotkeyParse.position_aliased_on_macos,
+            parseHotkeyString("ctrl+[PrintScreen]", .global_hotkey),
+        );
+        try std.testing.expectEqual(
+            HotkeyParse.position_absent_on_macos,
+            parseHotkeyString("ctrl+[F21]", .global_hotkey),
+        );
+        // config 로드부는 `parseHotkeyString` 이 아니라 `hotkeyFailure` 로 분기하므로
+        // 그쪽도 같은 값을 내야 한다.
+        try std.testing.expectEqual(
+            HotkeyFailure.position_aliased_on_macos,
+            hotkeyFailure("ctrl+[PrintScreen]").?,
+        );
+        try std.testing.expectEqual(
+            HotkeyFailure.position_absent_on_macos,
+            hotkeyFailure("ctrl+[F21]").?,
+        );
     } else {
         try std.testing.expect(parseHotkeyString("ctrl+[PrintScreen]", .app_binding) == .ok);
         try std.testing.expect(parseHotkeyString("ctrl+[F21]", .app_binding) == .ok);
@@ -2406,9 +2430,16 @@ pub const Config = struct {
                         messages.config_hotkey_unknown_key_fallback_msg,
                     .modifier_required => std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
                         messages.config_hotkey_invalid_fallback_msg,
-                    // 전역 `hotkey` 는 위치 표기를 아예 안 받으므로 그 전에 걸린다 —
-                    // 이 둘은 `[keys]` 쪽 경로에서만 나온다.
-                    .position_aliased_on_macos, .position_absent_on_macos => unreachable,
+                    // #496 1-c — **여기는 `unreachable` 이었다.** 전역 `hotkey` 가 위치
+                    // 표기를 아예 안 받던 시절의 전제였는데 1-c 가 그것을 받게 하면서
+                    // 깨졌다. ReleaseFast 는 안전 검사가 없어 크래시 대신 위의
+                    // `modifier_required` 안내로 떨어졌고, `ctrl` 을 이미 준 사용자에게
+                    // "modifier 를 달라" 고 말했다 (macOS 실기 확인) — 바로 위 주석이
+                    // 막으려던 실패다.
+                    .position_aliased_on_macos => std.fmt.bufPrint(&buf, messages.config_hotkey_position_aliased_format, .{v.string}) catch
+                        messages.config_hotkey_position_aliased_fallback_msg,
+                    .position_absent_on_macos => std.fmt.bufPrint(&buf, messages.config_hotkey_position_absent_format, .{v.string}) catch
+                        messages.config_hotkey_position_absent_fallback_msg,
                 };
                 showConfigFatalMsg(rt, config_path, msg);
             }

--- a/src/config.zig
+++ b/src/config.zig
@@ -143,19 +143,6 @@ pub const HotkeyFailure = enum {
     unknown_key,
     /// key 는 유효하지만 modifier 없이 전역 등록할 수 없는 키다 (F1~F12 만 허용).
     modifier_required,
-    /// #496 — 위치 표기 (`[KeyW]`) 를 전역 `hotkey` 에 썼다. 아직 `[keys]` 에서만
-    /// 받는다: 전역 핫키는 OS / compositor 에 *등록* 해야 하는데, 등록 5 경로 중
-    /// **COSMIC RON `key:` 와 KGlobalAccel `qtKey` 는 문자만 받아** 위치를 넘길 자리가
-    /// 없다. (처음에 "4 경로" 로 적었는데 GNOME · Cinnamon 이 빠져 있었다.)
-    ///
-    /// 조용히 keysym 0 을 등록하는 대신 거부한다. 나머지 셋은 위치를 받는다 — sway
-    /// `bindcode` · Hyprland `code:` · GNOME / Cinnamon `0xNN`.
-    ///
-    /// **이 거부를 푸는 것은 1-b 가 아니라 1-c 다.** 1-b 는 사용자가 *라벨로* 적은
-    /// hotkey 를 sway 에 *위치로* 등록하는 일이었고 (그래서 지금 sway 는 `bindcode`
-    /// 를 쓴다), 사용자가 *위치 표기로 적을 수 있게* 하는 일은 그것과 별개다. COSMIC ·
-    /// KDE 에 무엇을 줄지가 1-c 의 결정거리다.
-    position_in_global_hotkey,
     /// #496 — macOS 가 이 자리를 **다른 이름으로 보고**한다. `PrintScreen` ·
     /// `ScrollLock` · `Pause` 를 PC 자판에서 누르면 `F13` · `F14` · `F15` 로 온다
     /// (Apple 확장 자판이 그 자리에 F13~F15 를 둔다). 키가 없는 것이 아니므로
@@ -174,7 +161,6 @@ pub fn hotkeyFailure(s: []const u8) ?HotkeyFailure {
         .ok => null,
         .unknown_key => .unknown_key,
         .modifier_required => .modifier_required,
-        .position_in_global_hotkey => .position_in_global_hotkey,
         .position_aliased_on_macos => .position_aliased_on_macos,
         .position_absent_on_macos => .position_absent_on_macos,
     };
@@ -184,7 +170,6 @@ const HotkeyParse = union(enum) {
     ok: ParsedHotkey,
     unknown_key,
     modifier_required,
-    position_in_global_hotkey,
     position_aliased_on_macos,
     position_absent_on_macos,
 };
@@ -226,8 +211,6 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
     // key 토큰이 아예 없는 경우 (예: `"ctrl"` 하나만) 도 "모르는 key" 로 묶는다 —
     // 사용자가 받아야 하는 안내가 같다 (받는 key 목록).
     const resolved = key orelse return .unknown_key;
-    // #496 — 위치 표기는 아직 `[keys]` 전용이다 (`HotkeyFailure` 주석 참고).
-    if (scope == .global_hotkey and resolved == .code) return .position_in_global_hotkey;
     // #496 — 이 platform 에서 값이 없는 자리는 거부한다. 조용히 미동작으로 두면
     // 사용자가 config 를 몇 번이고 다시 읽게 된다 (#208 이 막으려던 것).
     if (is_macos and resolved == .code and !physical_key.availableOnThisPlatform(resolved.code)) {
@@ -245,9 +228,21 @@ fn parseHotkeyString(s: []const u8, scope: HotkeyScope) HotkeyParse {
             else => false,
         },
         .char => false,
-        // `global_hotkey` 는 위 분기에서 이미 돌아갔으므로 여기 오는 위치는
-        // `app_binding` 뿐이고, 그 판정은 아래 `types_text` 가 한다.
-        .code => false,
+        // #496 1-c — 위치 표기가 전역 hotkey 에 들어오면서 이 자리가 살아났다.
+        // 기준은 라벨과 같다: **글자를 내지 않는 함수 키만** modifier 없이 받는다.
+        //
+        // `F13`~`F24` 까지 넣는 것은 라벨 집합보다 넓지만 의도한 것이다. 그 자리는
+        // 라벨로 적을 방법이 아예 없고 (이름이 없다), 물리 자판에 달린 경우가 드물어
+        // **QMK · ZMK 로 다른 키를 그 코드에 매핑해 쓰는** 것이 실제 쓰임이다
+        // (`physical_key.zig` 헤더). 그런 사용자에게 modifier 를 요구하면 그 키를
+        // 전역 핫키로 쓸 방법이 없어진다. 글자를 내지 않으므로 일상 입력을 훔치지도
+        // 않는다 — 이 규칙이 막으려는 것이 그것이다.
+        .code => |c| switch (c) {
+            .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12 => true,
+            .f13, .f14, .f15, .f16, .f17, .f18, .f19, .f20 => true,
+            .f21, .f22, .f23, .f24 => true,
+            else => false,
+        },
     };
     if (scope == .global_hotkey) {
         if (!(ctrl or alt or super) and !is_function_key) return .modifier_required;
@@ -921,14 +916,22 @@ test "#496 위치 표기 파싱" {
     try std.testing.expect(parseHotkeyString("[PageUp]", .app_binding) == .ok);
     try std.testing.expect(parseHotkeyString("shift+[PageUp]", .app_binding) == .ok);
 
-    // 전역 `hotkey` 는 아직 위치를 받지 않는다 (1-b 미구현). 조용히 keysym 0 을
-    // 등록하는 대신 원인이 분명한 실패를 낸다.
+    // #496 1-c — 전역 `hotkey` 도 위치를 받는다.
+    try std.testing.expect(parseHotkeyString("ctrl+[KeyW]", .global_hotkey) == .ok);
+    try std.testing.expectEqual(@as(?HotkeyFailure, null), hotkeyFailure("ctrl+[KeyW]"));
+    try std.testing.expect(Hotkey.fromString("ctrl+[KeyW]") != null);
+
+    // modifier 없이 받는 것은 함수 키 자리뿐이다 — 라벨 규칙과 짝이다.
+    try std.testing.expect(parseHotkeyString("[F1]", .global_hotkey) == .ok);
+    try std.testing.expect(parseHotkeyString("[F13]", .global_hotkey) == .ok);
     try std.testing.expectEqual(
-        HotkeyParse.position_in_global_hotkey,
-        parseHotkeyString("ctrl+[KeyW]", .global_hotkey),
+        HotkeyParse.modifier_required,
+        parseHotkeyString("[KeyW]", .global_hotkey),
     );
-    try std.testing.expectEqual(HotkeyFailure.position_in_global_hotkey, hotkeyFailure("ctrl+[KeyW]").?);
-    try std.testing.expectEqual(@as(?Hotkey, null), Hotkey.fromString("ctrl+[KeyW]"));
+    try std.testing.expectEqual(
+        HotkeyParse.modifier_required,
+        parseHotkeyString("shift+[Backquote]", .global_hotkey),
+    );
 }
 
 test "#493 default [keys] has no conflicting bindings" {
@@ -1517,6 +1520,8 @@ pub fn defaultConfigTomlWithHotkey(
         \\# Field meanings and accepted ranges: CONFIG.md
         \\
         \\# Global hotkey -- the OS delivers this even when TildaZ is not focused.
+        \\# Takes a label ("ctrl+space") or a position ("ctrl+[Backquote]"). A
+        \\# function key is the safest: it is the same on every keyboard layout.
         \\hotkey           = "{s}"
         \\
         \\shell            = "{s}"
@@ -2399,10 +2404,6 @@ pub const Config = struct {
                 const msg = switch (hotkeyFailure(v.string).?) {
                     .unknown_key => std.fmt.bufPrint(&buf, messages.config_hotkey_unknown_key_format, .{v.string}) catch
                         messages.config_hotkey_unknown_key_fallback_msg,
-                    // #496 — 원인이 셋이 됐다. 위치 표기를 "modifier 를 달라" 로
-                    // 안내하면 #484 와 같은 막다른 길이 된다.
-                    .position_in_global_hotkey => std.fmt.bufPrint(&buf, messages.config_hotkey_position_format, .{v.string}) catch
-                        messages.config_hotkey_position_fallback_msg,
                     .modifier_required => std.fmt.bufPrint(&buf, messages.config_hotkey_invalid_format, .{v.string}) catch
                         messages.config_hotkey_invalid_fallback_msg,
                     // 전역 `hotkey` 는 위치 표기를 아예 안 받으므로 그 전에 걸린다 —
@@ -2571,10 +2572,6 @@ pub const Config = struct {
                     messages.config_key_needs_modifier_fallback_msg;
                 showConfigFatalMsg(rt, config_path, msg);
             },
-            // `app_binding` scope 는 이 값을 내지 않는다 (`parseHotkeyString` 이
-            // `global_hotkey` 에서만 낸다). exhaustive switch 를 유지하려고 둔다 —
-            // scope 별 규칙이 바뀌어 여기 도달하면 조용히 넘기지 말고 멈춰야 한다.
-            .position_in_global_hotkey => unreachable,
             // #496 — macOS 에서만 나온다. 겹침 / 부재를 갈라 다른 안내를 준다.
             .position_aliased_on_macos => {
                 var buf: [640]u8 = undefined;

--- a/src/host/linux/gsettings_hotkey.zig
+++ b/src/host/linux/gsettings_hotkey.zig
@@ -31,6 +31,7 @@ const Runtime = @import("../../runtime.zig").Runtime;
 const log = @import("../../log.zig");
 const config_mod = @import("../../config.zig");
 const hotkey_format = @import("hotkey_format.zig");
+const physical_key = @import("../../physical_key.zig");
 const instance_context = @import("../../instance_context.zig");
 const instance_identity = @import("instance_identity.zig");
 const shell_extension = @import("shell_extension.zig");
@@ -368,7 +369,7 @@ fn registerWithVariant(rt: Runtime, allocator: std.mem.Allocator, api: *const Ap
     var cmd_buf: [std.Io.Dir.max_path_bytes + 16]u8 = undefined;
     const command = std.fmt.bufPrintSentinel(&cmd_buf, "{s} --toggle {d}", .{ exe_path, instance_context.requireWorkerIndex() }, 0) catch return;
     var accel_buf: [96]u8 = undefined;
-    const accel = buildGtkAccel(&accel_buf, cfg.hotkey.keysym, cfg.hotkey.modifiers) catch return;
+    const accel = buildGtkAccel(&accel_buf, cfg.hotkey) catch return;
 
     // ⚠️ 순서 중요 — name/command/binding 을 **먼저** set 하고, 리스트 추가를
     // **마지막**에 한다. Cinnamon 은 `changed::custom-list` 를 런타임에 감시해 새
@@ -505,18 +506,57 @@ fn desktopValueHasToken(value: []const u8, wanted: []const []const u8) bool {
 /// `config.hotkey` → GTK accelerator (GNOME `binding` 형식, Cinnamon strv 의 원소).
 /// modifier 는 `<Control><Shift><Alt><Super>` (gtk_accelerator_parse 표준), key
 /// 이름은 공통 `hotkey_format.gtkName` 재사용 (`F1` / `a` / `space` / `grave` 등).
-fn buildGtkAccel(buf: []u8, keysym: u32, modifiers: u32) ![:0]const u8 {
+/// GTK accelerator 문자열. GNOME (Mutter) · Cinnamon (Muffin) 이 GSettings 에서 읽는다.
+///
+/// #496 1-c — 위치 표기는 **`0xNN` (하드웨어 keycode)** 으로 넘긴다. GTK 의
+/// `is_keycode()` 가 `0x` + **정확히 두 자리 hex** 만 그 형태로 인정하고 (`memcpy` 로
+/// 4 바이트를 떼어 본다), Mutter 는 그 값을 `combo->keycode` 에 **변환 없이** 넣는다.
+/// 그래서 우리가 주는 숫자는 Mutter 가 입력에서 만드는 것과 같은 **xkb keycode
+/// (= evdev + 8)** 여야 한다 (`meta_xkb_evdev_to_keycode`) — sway `bindcode` ·
+/// Hyprland `code:` 와 같은 번호다.
+///
+/// **두 자리에 들어가는지는 표가 보장한다** — `physical_key.zig` 의 최대 evdev 가
+/// 194 (`F24`) 라 +8 해도 `0xCA` 다. 세 자리가 되면 GTK 는 앞 두 자리만 읽고 Mutter 는
+/// 전체를 읽어 **둘이 다른 키를 가리키므로**, 표가 넓어지면 이 가정을 다시 봐야 한다.
+fn buildGtkAccel(buf: []u8, hotkey: config_mod.Hotkey) ![:0]const u8 {
     const H = config_mod.Hotkey;
     var fbs: std.Io.Writer = .fixed(buf);
     const w = &fbs;
-    if ((modifiers & H.MOD_CTRL) != 0) try w.writeAll("<Control>");
-    if ((modifiers & H.MOD_SHIFT) != 0) try w.writeAll("<Shift>");
-    if ((modifiers & H.MOD_ALT) != 0) try w.writeAll("<Alt>");
-    if ((modifiers & H.MOD_SUPER) != 0) try w.writeAll("<Super>");
-    try w.writeAll(hotkey_format.gtkName(keysym));
+    if ((hotkey.modifiers & H.MOD_CTRL) != 0) try w.writeAll("<Control>");
+    if ((hotkey.modifiers & H.MOD_SHIFT) != 0) try w.writeAll("<Shift>");
+    if ((hotkey.modifiers & H.MOD_ALT) != 0) try w.writeAll("<Alt>");
+    if ((hotkey.modifiers & H.MOD_SUPER) != 0) try w.writeAll("<Super>");
+    if (hotkey.code) |code| {
+        const xkb_code = @as(u32, physical_key.evdev(code)) + 8;
+        if (xkb_code > 0xff) return error.PositionKeycodeTooWide;
+        try w.print("0x{x:0>2}", .{xkb_code});
+    } else {
+        try w.writeAll(hotkey_format.gtkName(hotkey.keysym));
+    }
     try w.writeByte(0);
     const written = fbs.buffered();
     return written[0 .. written.len - 1 :0];
+}
+
+test "#496 1-c GNOME takes a position as 0xNN in xkb numbering" {
+    var buf: [96]u8 = undefined;
+
+    // GTK 의 `is_keycode()` 는 `0x` + **정확히 두 자리** hex 만 keycode 로 인정하고
+    // (`memcpy` 로 4 바이트를 뗀다), Mutter 는 그 값을 변환 없이 `combo->keycode` 에
+    // 넣어 xkb keycode (= evdev + 8) 와 견준다. 그래서 자리수와 번호 둘 다 고정한다.
+    try std.testing.expectEqualStrings(
+        "<Control><Shift>0x31",
+        try buildGtkAccel(&buf, config_mod.Hotkey.fromString("ctrl+shift+[Backquote]").?),
+    );
+    try std.testing.expectEqualStrings(
+        "<Control>0x1c",
+        try buildGtkAccel(&buf, config_mod.Hotkey.fromString("ctrl+[KeyT]").?),
+    );
+    // 라벨 binding 은 예전 그대로다.
+    try std.testing.expectEqualStrings(
+        "<Control><Shift>t",
+        try buildGtkAccel(&buf, config_mod.Hotkey.fromString("ctrl+shift+t").?),
+    );
 }
 
 test "Shell extension target follows exact GNOME and Cinnamon desktop tokens" {

--- a/src/host/linux/kglobalaccel.zig
+++ b/src/host/linux/kglobalaccel.zig
@@ -22,6 +22,16 @@ const destination: [*:0]const u8 = "org.kde.kglobalaccel";
 const root_path: [*:0]const u8 = "/kglobalaccel";
 const root_interface: [*:0]const u8 = "org.kde.KGlobalAccel";
 const component_interface: [*:0]const u8 = "org.kde.kglobalaccel.Component";
+/// #496 1-c — KWin 의 키보드 배열 전환 통지. **포커스와 무관하게** 온다는 것이 요점이다.
+///
+/// Wayland 의 group 전환 (`wl_keyboard.modifiers`) 은 **포커스한 client 에게만** 가는데,
+/// 드롭다운 터미널은 대개 숨어 있다. 그 상태에서 layout 을 바꾸면 위치 표기 hotkey 가 옛
+/// 글자로 등록된 채 남고, 그 hotkey 가 창을 부르는 유일한 수단이라 **스스로 빠져나올 수
+/// 없다.** 실기에서 확인한 함정이다 (French 로 바꿔도 `Ctrl+\`` 그대로였고 창을 띄우자
+/// `Ctrl+²` 로 바뀌었다).
+const layout_interface: [*:0]const u8 = "org.kde.KeyboardLayouts";
+const layout_changed: [*:0]const u8 = "layoutChanged";
+const layout_match: [:0]const u8 = "type='signal',interface='org.kde.KeyboardLayouts',member='layoutChanged'";
 const component_pressed: [*:0]const u8 = "globalShortcutPressed";
 const dbus_interface: [*:0]const u8 = "org.freedesktop.DBus";
 const dbus_name_owner_changed: [*:0]const u8 = "NameOwnerChanged";
@@ -66,28 +76,28 @@ fn appendStringArray(api: *const dbus.Api, iter: *dbus.DBusMessageIter, values: 
     if (api.iter_close_container(iter, &array) == 0) return error.KGlobalAccelAppendFailed;
 }
 
-fn unregisterShortcut(bus: *dbus.SessionBus, component_name: [*:0]const u8, action_name: [*:0]const u8) !void {
-    const call = bus.api.message_new_method_call(destination, root_path, root_interface, "unregister") orelse return error.KGlobalAccelMessageAllocFailed;
-    defer bus.api.message_unref(call);
+fn unregisterShortcut(api: *const dbus.Api, conn: *dbus.DBusConnection, component_name: [*:0]const u8, action_name: [*:0]const u8) !void {
+    const call = api.message_new_method_call(destination, root_path, root_interface, "unregister") orelse return error.KGlobalAccelMessageAllocFailed;
+    defer api.message_unref(call);
 
     var iter: dbus.DBusMessageIter = .{};
-    bus.api.iter_init_append(call, &iter);
+    api.iter_init_append(call, &iter);
     var component_var: [*:0]const u8 = component_name;
-    if (bus.api.iter_append_basic(&iter, dbus.dbus_type_string, @ptrCast(&component_var)) == 0) return error.KGlobalAccelAppendFailed;
+    if (api.iter_append_basic(&iter, dbus.dbus_type_string, @ptrCast(&component_var)) == 0) return error.KGlobalAccelAppendFailed;
     var action_var: [*:0]const u8 = action_name;
-    if (bus.api.iter_append_basic(&iter, dbus.dbus_type_string, @ptrCast(&action_var)) == 0) return error.KGlobalAccelAppendFailed;
+    if (api.iter_append_basic(&iter, dbus.dbus_type_string, @ptrCast(&action_var)) == 0) return error.KGlobalAccelAppendFailed;
 
     var err: dbus.DBusError = .{};
-    bus.api.error_init(&err);
-    defer bus.api.error_free(&err);
-    const reply = bus.api.send_with_reply_and_block(bus.conn, call, method_call_timeout_ms, &err) orelse {
-        if (bus.api.error_is_set(&err) != 0) {
+    api.error_init(&err);
+    defer api.error_free(&err);
+    const reply = api.send_with_reply_and_block(conn, call, method_call_timeout_ms, &err) orelse {
+        if (api.error_is_set(&err) != 0) {
             const msg = if (err.message) |value| std.mem.span(value) else "(no message)";
             log.appendLine("kglobalaccel", "kglobalaccel unregister failed: {s}", .{msg});
         }
         return error.KGlobalAccelMethodCallFailed;
     };
-    defer bus.api.message_unref(reply);
+    defer api.message_unref(reply);
     log.appendLineVerbose("kglobalaccel", "kglobalaccel unregister succeeded — component={s} action={s}", .{ std.mem.span(component_name), std.mem.span(action_name) });
 }
 
@@ -127,7 +137,7 @@ pub fn syncNumberedIdentities(rt: Runtime, allocator: std.mem.Allocator, indices
         defer allocator.free(component_z);
         var stale_action_buf: [32]u8 = undefined;
         const stale_action = std.fmt.bufPrintSentinel(&stale_action_buf, "toggle-{d}", .{index}, 0) catch continue;
-        unregisterShortcut(&bus, component_z.ptr, stale_action.ptr) catch |err| {
+        unregisterShortcut(&bus.api, bus.conn, component_z.ptr, stale_action.ptr) catch |err| {
             log.appendLineVerbose("kglobalaccel", "stale KDE action cleanup skipped for instance {}: {s}", .{ index, @errorName(err) });
             continue;
         };
@@ -214,13 +224,13 @@ pub fn cleanupLegacyIdentity(rt: Runtime, bus: *dbus.SessionBus) void {
 
     const legacy_component: [*:0]const u8 = "tildaz";
     if (instance_context.requireWorkerIndex() == 0) {
-        unregisterShortcut(bus, legacy_component, "toggle") catch |err| {
+        unregisterShortcut(&bus.api, bus.conn, legacy_component, "toggle") catch |err| {
             log.appendLineVerbose("kglobalaccel", "legacy KDE action cleanup skipped: {s}", .{@errorName(err)});
         };
     }
     var legacy_action_buf: [32]u8 = undefined;
     const legacy_action = std.fmt.bufPrintSentinel(&legacy_action_buf, "toggle-{d}", .{instance_context.requireWorkerIndex()}, 0) catch return;
-    unregisterShortcut(bus, legacy_component, legacy_action.ptr) catch |err| {
+    unregisterShortcut(&bus.api, bus.conn, legacy_component, legacy_action.ptr) catch |err| {
         log.appendLineVerbose("kglobalaccel", "legacy numbered KDE action cleanup skipped: {s}", .{@errorName(err)});
     };
 }
@@ -236,7 +246,7 @@ pub fn cleanupLegacyIdentity(rt: Runtime, bus: *dbus.SessionBus) void {
 /// **dead keysym 은 거부한다.** 실측에서 `Qt::Key_Dead_Circumflex` 를 주니 KDE 가
 /// 엉뚱한 문자 (`ោ`) 로 적었다. 독일어 자판의 `[Backquote]` 자리가 `dead_circumflex`
 /// 라 실제로 닿는 경로다 (#496 1-c 계획 코멘트의 실측 표).
-pub fn qtKey(keysym: u32, modifiers: u32) ?i32 {
+pub fn qtKey(keysym: u32, modifiers: u32, codepoint: ?u21) ?i32 {
     var key: i32 = 0;
     if ((modifiers & 0x4) != 0) key |= 0x02000000;
     if ((modifiers & 0x2) != 0) key |= 0x04000000;
@@ -246,7 +256,20 @@ pub fn qtKey(keysym: u32, modifiers: u32) ?i32 {
     // dead key — 위 주석 참고. 범위는 `xkbcommon-keysyms.h` 의 `XKB_KEY_dead_*` 다.
     if (keysym >= 0xfe50 and keysym <= 0xfe93) return null;
 
-    const key_code: i32 = switch (keysym) {
+    // ① 전용 Qt 값이 있는 키 — 글자를 내지 않아 코드포인트로 표현할 수 없다.
+    if (specialQtKey(keysym)) |code| return key | code;
+
+    // ② 나머지는 **문자**다. 코드포인트를 알면 그것으로, 모르면 keysym 값에서 유도한다.
+    const cp = codepoint orelse codepointFromKeysym(keysym) orelse return null;
+    if (cp < 0x20) return null;
+    // Qt 는 글자 키를 대문자로 센다. ASCII 밖의 대소문자 규칙은 만들지 않는다 — 실측에서
+    // KDE 가 소문자 `Cyrillic_io` 를 받아 스스로 `Ё` 로 정규화했다.
+    const upper: u32 = if (cp >= 'a' and cp <= 'z') @as(u32, cp) - 0x20 else @as(u32, cp);
+    return key | @as(i32, @intCast(upper));
+}
+
+fn specialQtKey(keysym: u32) ?i32 {
+    return switch (keysym) {
         0xffbe => 0x01000030,
         0xffbf => 0x01000031,
         0xffc0 => 0x01000032,
@@ -262,21 +285,25 @@ pub fn qtKey(keysym: u32, modifiers: u32) ?i32 {
         0xff09 => 0x01000001,
         0xff0d => 0x01000004,
         0xff1b => 0x01000000,
-        0x0020 => 0x20,
-        0x0060 => 0x60,
-        '0'...'9' => @intCast(keysym),
-        'a'...'z' => @intCast(keysym - 0x20),
-        // #496 1-c — Latin-1 keysym 은 값이 곧 유니코드 코드포인트이고, Qt 의 key 값도
-        // 그 구간에서는 코드포인트와 같다 (`Qt::Key_twosuperior` = 0xB2). 실측에서 KDE 가
-        // `178` 을 `²` 로, `Ctrl+178` 을 `Ctrl+²` 로 받았다.
-        0x00a0...0x00ff => @intCast(keysym),
-        // X11 이 Latin-1 밖의 문자를 담는 방식 — `0x01000000 | codepoint`. 실측에서
-        // `Cyrillic_io` (U+0451) 를 KDE 가 `Ё` 로 받았다 (대문자 정규화는 KDE 가 한다).
-        0x01000100...0x0110ffff => @intCast(keysym & 0x00ffffff),
-        // 표에 없는 keysym 은 **0 을 내지 않고 실패**로 만든다. 위 주석 참고.
-        else => return null,
+        else => null,
     };
-    return key | key_code;
+}
+
+/// keysym 값만으로 알 수 있는 코드포인트. **여기서 알 수 있는 것은 두 구간뿐이다.**
+///
+/// - Latin-1 (`0x20`~`0xff`) — X11 이 그 구간을 코드포인트와 같은 값으로 둔다.
+/// - modern 유니코드 keysym (`0x01000000 | cp`).
+///
+/// **legacy 국가별 keysym 은 여기 없다.** `Cyrillic_io` 는 `0x06b3`, 그리스 · 히브리 ·
+/// 아랍도 각자 블록이 따로다. 그 값들은 libxkbcommon 에 물어야 알 수 있어서 호출부가
+/// `codepoint` 로 넘긴다 — 이 함수는 그것을 못 받았을 때의 fallback 이다.
+///
+/// 처음에 이 두 구간을 손으로 나열하고 끝냈다가 **실기에서 러시아어가 통째로 실패**했다
+/// (#496 1-c 검증). 이 이슈가 정면으로 다루는 layout 부류였다.
+fn codepointFromKeysym(keysym: u32) ?u21 {
+    if (keysym >= 0x20 and keysym <= 0xff) return @intCast(keysym);
+    if (keysym >= 0x01000020 and keysym <= 0x0110ffff) return @intCast(keysym & 0x00ffffff);
+    return null;
 }
 
 const OwnerActionId = struct {
@@ -510,6 +537,12 @@ pub const Client = struct {
     component_path: ?[]u8 = null,
     is_registered: bool = false,
     owner_restart_pending: bool = false,
+    /// #496 1-c — `layoutChanged` 가 준 layout index. **KDE 의 index 가 곧 xkb group 이다**
+    /// — 하나의 keymap 에 group 이 여러 개 실리고 그 순서가 `LayoutList` 순서다. 포커스가
+    /// 없으면 `wl_keyboard.modifiers` 가 안 와서 우리 `active_group` 이 낡으므로, 이 값을
+    /// 그 자리에 대신 쓴다.
+    pending_layout_index: ?u32 = null,
+    layout_match_installed: bool = false,
     filter_installed: bool = false,
     owner_match_installed: bool = false,
     component_match_installed: bool = false,
@@ -520,6 +553,9 @@ pub const Client = struct {
         bus: *dbus.SessionBus,
         keysym: u32,
         modifiers: u32,
+        /// #496 1-c — 위치 표기 hotkey 는 keysym 만으로 문자를 알 수 없어 (legacy 국가별
+        /// 블록) 호출부가 libxkbcommon 에 물어 넘긴다. 라벨 binding 은 null 이다.
+        codepoint: ?u21,
         callback: PressedCallback,
         user_data: ?*anyopaque,
     ) !*Client {
@@ -544,13 +580,18 @@ pub const Client = struct {
         if (bus.api.add_filter(bus.conn, signalFilter, self, null) == 0) {
             return error.KGlobalAccelAddFilterFailed;
         }
+
+        // #496 1-c — 실패해도 계속한다. 이 match 가 없으면 포커스를 얻을 때 따라가는
+        // 예전 경로로 떨어질 뿐이고, hotkey 등록 자체는 성립한다.
+        self.addMatch(layout_match, "layout") catch {};
+        self.layout_match_installed = true;
         self.filter_installed = true;
         errdefer self.removeFilterAndMatches();
 
         try self.addMatch(owner_rule, "NameOwnerChanged");
         self.owner_match_installed = true;
 
-        self.register(keysym, modifiers) catch |err| {
+        self.register(keysym, modifiers, codepoint) catch |err| {
             self.setInactiveNoAutostart();
             return err;
         };
@@ -572,17 +613,38 @@ pub const Client = struct {
         return self.is_registered;
     }
 
+    /// #496 1-c — `layoutChanged` 로 온 layout index 를 꺼내 간다 (한 번만).
+    pub fn takeLayoutChange(self: *Client) ?u32 {
+        const index = self.pending_layout_index orelse return null;
+        self.pending_layout_index = null;
+        return index;
+    }
+
     /// NameOwnerChanged filter는 D-Bus dispatch 안에서 이 flag만 세운다. 실제
     /// synchronous method call과 match 교체는 main loop가 callback 밖에서 수행한다.
-    pub fn drainOwnerRestart(self: *Client, keysym: u32, modifiers: u32) void {
+    pub fn drainOwnerRestart(self: *Client, keysym: u32, modifiers: u32, codepoint: ?u21) void {
         if (!self.owner_restart_pending) return;
         self.owner_restart_pending = false;
-        self.register(keysym, modifiers) catch |err| {
+        self.register(keysym, modifiers, codepoint) catch |err| {
             self.is_registered = false;
             log.appendLine("kglobalaccel", "daemon restart re-registration failed: {s}", .{@errorName(err)});
             return;
         };
         log.appendLine("kglobalaccel", "daemon restart re-registration completed", .{});
+    }
+
+    /// #496 1-c — 등록을 **거둔다.** 그 자리가 지금 layout 에서 글자를 못 낼 때 쓴다
+    /// (dead key 등).
+    ///
+    /// 남겨 두면 직전 layout 의 글자가 KDE 단축키 목록에 그대로 남는다. 발동하지는 않지만
+    /// (그 자판에 그 글자를 내는 키가 없다) 사용자에게는 **죽은 항목**으로 보이므로 거둔다.
+    /// 되살아날 때는 `rebind` 가 `doRegister` 부터 다시 하므로 복구에 문제가 없다.
+    pub fn unbind(self: *Client) void {
+        self.is_registered = false;
+        unregisterShortcut(self.api, self.conn, component(), action()) catch |err| {
+            log.appendLine("kglobalaccel", "unbind failed: {s}", .{@errorName(err)});
+            return;
+        };
     }
 
     /// #496 1-c — layout 이 바뀌어 **그 자리가 내는 글자**가 달라졌을 때 다시 등록한다.
@@ -593,8 +655,8 @@ pub const Client = struct {
     /// **재등록은 사용자 설정을 어지럽히지 않는다** — 서로 다른 키로 5 회 재등록한 뒤
     /// `kglobalshortcutsrc` 전체 diff 가 우리 블록 한 줄 덮어쓰기뿐이었다 (실측,
     /// KWin 6.7.4). 그 확인이 이 경로를 고른 근거다.
-    pub fn rebind(self: *Client, keysym: u32, modifiers: u32) void {
-        self.register(keysym, modifiers) catch |err| {
+    pub fn rebind(self: *Client, keysym: u32, modifiers: u32, codepoint: ?u21) void {
+        self.register(keysym, modifiers, codepoint) catch |err| {
             self.is_registered = false;
             log.appendLine("kglobalaccel", "layout change re-registration failed: {s}", .{@errorName(err)});
             return;
@@ -602,9 +664,9 @@ pub const Client = struct {
         log.appendLine("kglobalaccel", "layout changed -- global hotkey re-registered keysym=0x{x}", .{keysym});
     }
 
-    fn register(self: *Client, keysym: u32, modifiers: u32) !void {
+    fn register(self: *Client, keysym: u32, modifiers: u32, codepoint: ?u21) !void {
         self.is_registered = false;
-        const qt_key = qtKey(keysym, modifiers) orelse return error.KGlobalAccelUnsupportedKey;
+        const qt_key = qtKey(keysym, modifiers, codepoint) orelse return error.KGlobalAccelUnsupportedKey;
 
         try callActionIdVoid(self.api, self.conn, "doRegister", true);
         const new_path = try getComponentPath(self.allocator, self.api, self.conn);
@@ -679,6 +741,7 @@ pub const Client = struct {
     fn removeFilterAndMatches(self: *Client) void {
         self.removeComponentMatch();
         if (self.owner_match_installed) {
+            if (self.layout_match_installed) removeMatch(self.api, self.conn, layout_match);
             removeMatch(self.api, self.conn, self.owner_match_rule);
             self.owner_match_installed = false;
         }
@@ -875,6 +938,19 @@ fn signalFilter(conn: *dbus.DBusConnection, message: *dbus.DBusMessage, user_dat
         return dbus.dbus_handler_result_handled;
     }
 
+    if (self.api.message_is_signal(message, layout_interface, layout_changed) != 0) {
+        var iter: dbus.DBusMessageIter = .{};
+        if (self.api.iter_init(message, &iter) == 0) return dbus.dbus_handler_result_not_yet_handled;
+        if (self.api.iter_get_arg_type(&iter) != dbus.dbus_type_uint32) return dbus.dbus_handler_result_not_yet_handled;
+        var index: u32 = 0;
+        self.api.iter_get_basic(&iter, @ptrCast(&index));
+        // filter 안에서는 flag 만 세운다. 실제 재등록은 main loop 가 callback 밖에서
+        // 한다 — `owner_restart_pending` 과 같은 규칙이다 (동기 method call 을 filter
+        // 안에서 하면 안 된다).
+        self.pending_layout_index = index;
+        return dbus.dbus_handler_result_handled;
+    }
+
     if (self.api.message_is_signal(message, dbus_interface, dbus_name_owner_changed) != 0) {
         var iter: dbus.DBusMessageIter = .{};
         if (self.api.iter_init(message, &iter) == 0) return dbus.dbus_handler_result_not_yet_handled;
@@ -926,13 +1002,13 @@ test "KDE desktop token is exact and case insensitive" {
 }
 
 test "XKB to Qt key conversion keeps function offsets and modifiers" {
-    try std.testing.expectEqual(@as(?i32, 0x01000030), qtKey(0xffbe, 0));
-    try std.testing.expectEqual(@as(?i32, 0x01000035), qtKey(0xffc3, 0));
-    try std.testing.expectEqual(@as(?i32, 0x01000036), qtKey(0xffc4, 0));
-    try std.testing.expectEqual(@as(?i32, 0x0100003b), qtKey(0xffc9, 0));
-    try std.testing.expectEqual(@as(?i32, 0x16000054), qtKey('t', 0x2 | 0x4 | 0x8));
-    try std.testing.expectEqual(@as(?i32, 0x20), qtKey(' ', 0));
-    try std.testing.expectEqual(@as(?i32, 0x60), qtKey('`', 0));
+    try std.testing.expectEqual(@as(?i32, 0x01000030), qtKey(0xffbe, 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x01000035), qtKey(0xffc3, 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x01000036), qtKey(0xffc4, 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x0100003b), qtKey(0xffc9, 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x16000054), qtKey('t', 0x2 | 0x4 | 0x8, null));
+    try std.testing.expectEqual(@as(?i32, 0x20), qtKey(' ', 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x60), qtKey('`', 0, null));
 
     // #496 1-c — 위치 표기가 들어오면서 임의의 keysym 이 온다. 아래 세 값은 이 머신
     // (CachyOS · KWin 6.7.4) 에서 `gdbus` 로 실제 등록해 확인한 것이다.
@@ -940,17 +1016,27 @@ test "XKB to Qt key conversion keeps function offsets and modifiers" {
     //   `twosuperior` (fr 자판의 `[Backquote]`) → `²`
     //   `Ctrl+twosuperior`                      → `Ctrl+²`
     //   `Cyrillic_io`  (ru 자판의 같은 자리)     → `Ё`
-    try std.testing.expectEqual(@as(?i32, 0xb2), qtKey(0xb2, 0));
-    try std.testing.expectEqual(@as(?i32, 0x040000b2), qtKey(0xb2, 0x2));
-    try std.testing.expectEqual(@as(?i32, 0x451), qtKey(0x01000451, 0));
+    try std.testing.expectEqual(@as(?i32, 0xb2), qtKey(0xb2, 0, null));
+    try std.testing.expectEqual(@as(?i32, 0x040000b2), qtKey(0xb2, 0x2, null));
+    try std.testing.expectEqual(@as(?i32, 0x451), qtKey(0x01000451, 0, null));
+
+    // **legacy 국가별 keysym 은 값만으로 못 푼다.** `Cyrillic_io` = `0x06b3` 은 Latin-1 도
+    // modern 유니코드 keysym 도 아니라 fallback 이 null 을 낸다 — 그래서 호출부가
+    // libxkbcommon 에서 받은 코드포인트를 넘긴다. 실기에서 이것을 놓쳐 러시아어 등록이
+    // 통째로 실패했다 (#496 1-c 검증).
+    try std.testing.expectEqual(@as(?i32, null), qtKey(0x06b3, 0x2, null));
+    try std.testing.expectEqual(@as(?i32, 0x04000451), qtKey(0x06b3, 0x2, 0x451));
+
+    // ASCII 구두점도 코드포인트가 곧 Qt key 다 (`Qt::Key_Minus` = 0x2D).
+    try std.testing.expectEqual(@as(?i32, 0x0400002d), qtKey('-', 0x2, null));
 
     // dead keysym 은 거부한다 — KDE 가 엉뚱한 문자로 적는 것을 실측했다. 독일어
     // 자판의 `[Backquote]` 자리가 `dead_circumflex` 라 실제로 닿는 경로다.
-    try std.testing.expectEqual(@as(?i32, null), qtKey(0xfe52, 0x2));
+    try std.testing.expectEqual(@as(?i32, null), qtKey(0xfe52, 0x2, null));
 
     // 표에 없는 keysym 은 0 이 아니라 실패다. 0 을 내면 KDE 에 modifier 만의
     // 단축키가 등록돼 `Ctrl` 을 뗄 때 발동한다.
-    try std.testing.expectEqual(@as(?i32, null), qtKey(0xffe1, 0x2));
+    try std.testing.expectEqual(@as(?i32, null), qtKey(0xffe1, 0x2, null));
 }
 
 test "conflict takeover removes only an exact one-chord key sequence" {

--- a/src/host/linux/kglobalaccel.zig
+++ b/src/host/linux/kglobalaccel.zig
@@ -225,12 +225,26 @@ pub fn cleanupLegacyIdentity(rt: Runtime, bus: *dbus.SessionBus) void {
     };
 }
 
-pub fn qtKey(keysym: u32, modifiers: u32) i32 {
+/// keysym → Qt key. **못 만들면 `null`** 이다.
+///
+/// #496 1-c 이전에는 `i32` 를 돌려주며 모르는 keysym 에 **0** 을 냈다. 그 값은 KDE 에
+/// 그대로 등록되는데, key 자리가 0 이면 **modifier 만의 단축키**가 되어 `Ctrl` 을 뗄
+/// 때 발동한다 — 이슈가 COSMIC 의 `keycode:` 함정으로 적어 둔 것과 같은 종류의 조용한
+/// 오동작이다. 라벨 집합이 좁을 때는 모든 값이 표에 있어 드러나지 않았지만, 위치 표기가
+/// 전역 hotkey 에 들어오면서 **임의의 keysym** 이 오게 됐다. 그래서 실패를 값으로 만든다.
+///
+/// **dead keysym 은 거부한다.** 실측에서 `Qt::Key_Dead_Circumflex` 를 주니 KDE 가
+/// 엉뚱한 문자 (`ោ`) 로 적었다. 독일어 자판의 `[Backquote]` 자리가 `dead_circumflex`
+/// 라 실제로 닿는 경로다 (#496 1-c 계획 코멘트의 실측 표).
+pub fn qtKey(keysym: u32, modifiers: u32) ?i32 {
     var key: i32 = 0;
     if ((modifiers & 0x4) != 0) key |= 0x02000000;
     if ((modifiers & 0x2) != 0) key |= 0x04000000;
     if ((modifiers & 0x1) != 0) key |= 0x08000000;
     if ((modifiers & 0x8) != 0) key |= 0x10000000;
+
+    // dead key — 위 주석 참고. 범위는 `xkbcommon-keysyms.h` 의 `XKB_KEY_dead_*` 다.
+    if (keysym >= 0xfe50 and keysym <= 0xfe93) return null;
 
     const key_code: i32 = switch (keysym) {
         0xffbe => 0x01000030,
@@ -252,7 +266,15 @@ pub fn qtKey(keysym: u32, modifiers: u32) i32 {
         0x0060 => 0x60,
         '0'...'9' => @intCast(keysym),
         'a'...'z' => @intCast(keysym - 0x20),
-        else => 0,
+        // #496 1-c — Latin-1 keysym 은 값이 곧 유니코드 코드포인트이고, Qt 의 key 값도
+        // 그 구간에서는 코드포인트와 같다 (`Qt::Key_twosuperior` = 0xB2). 실측에서 KDE 가
+        // `178` 을 `²` 로, `Ctrl+178` 을 `Ctrl+²` 로 받았다.
+        0x00a0...0x00ff => @intCast(keysym),
+        // X11 이 Latin-1 밖의 문자를 담는 방식 — `0x01000000 | codepoint`. 실측에서
+        // `Cyrillic_io` (U+0451) 를 KDE 가 `Ё` 로 받았다 (대문자 정규화는 KDE 가 한다).
+        0x01000100...0x0110ffff => @intCast(keysym & 0x00ffffff),
+        // 표에 없는 keysym 은 **0 을 내지 않고 실패**로 만든다. 위 주석 참고.
+        else => return null,
     };
     return key | key_code;
 }
@@ -563,10 +585,26 @@ pub const Client = struct {
         log.appendLine("kglobalaccel", "daemon restart re-registration completed", .{});
     }
 
+    /// #496 1-c — layout 이 바뀌어 **그 자리가 내는 글자**가 달라졌을 때 다시 등록한다.
+    ///
+    /// 위치 표기 hotkey 에서만 쓴다. KDE 는 keysym 만 받으므로 자리를 고정할 수 없고,
+    /// 그래서 sway `bindcode` 와 달리 layout 을 따라다녀야 한다.
+    ///
+    /// **재등록은 사용자 설정을 어지럽히지 않는다** — 서로 다른 키로 5 회 재등록한 뒤
+    /// `kglobalshortcutsrc` 전체 diff 가 우리 블록 한 줄 덮어쓰기뿐이었다 (실측,
+    /// KWin 6.7.4). 그 확인이 이 경로를 고른 근거다.
+    pub fn rebind(self: *Client, keysym: u32, modifiers: u32) void {
+        self.register(keysym, modifiers) catch |err| {
+            self.is_registered = false;
+            log.appendLine("kglobalaccel", "layout change re-registration failed: {s}", .{@errorName(err)});
+            return;
+        };
+        log.appendLine("kglobalaccel", "layout changed -- global hotkey re-registered keysym=0x{x}", .{keysym});
+    }
+
     fn register(self: *Client, keysym: u32, modifiers: u32) !void {
         self.is_registered = false;
-        const qt_key = qtKey(keysym, modifiers);
-        if (qt_key == 0) return error.KGlobalAccelUnsupportedKey;
+        const qt_key = qtKey(keysym, modifiers) orelse return error.KGlobalAccelUnsupportedKey;
 
         try callActionIdVoid(self.api, self.conn, "doRegister", true);
         const new_path = try getComponentPath(self.allocator, self.api, self.conn);
@@ -888,13 +926,31 @@ test "KDE desktop token is exact and case insensitive" {
 }
 
 test "XKB to Qt key conversion keeps function offsets and modifiers" {
-    try std.testing.expectEqual(@as(i32, 0x01000030), qtKey(0xffbe, 0));
-    try std.testing.expectEqual(@as(i32, 0x01000035), qtKey(0xffc3, 0));
-    try std.testing.expectEqual(@as(i32, 0x01000036), qtKey(0xffc4, 0));
-    try std.testing.expectEqual(@as(i32, 0x0100003b), qtKey(0xffc9, 0));
-    try std.testing.expectEqual(@as(i32, 0x16000054), qtKey('t', 0x2 | 0x4 | 0x8));
-    try std.testing.expectEqual(@as(i32, 0x20), qtKey(' ', 0));
-    try std.testing.expectEqual(@as(i32, 0x60), qtKey('`', 0));
+    try std.testing.expectEqual(@as(?i32, 0x01000030), qtKey(0xffbe, 0));
+    try std.testing.expectEqual(@as(?i32, 0x01000035), qtKey(0xffc3, 0));
+    try std.testing.expectEqual(@as(?i32, 0x01000036), qtKey(0xffc4, 0));
+    try std.testing.expectEqual(@as(?i32, 0x0100003b), qtKey(0xffc9, 0));
+    try std.testing.expectEqual(@as(?i32, 0x16000054), qtKey('t', 0x2 | 0x4 | 0x8));
+    try std.testing.expectEqual(@as(?i32, 0x20), qtKey(' ', 0));
+    try std.testing.expectEqual(@as(?i32, 0x60), qtKey('`', 0));
+
+    // #496 1-c — 위치 표기가 들어오면서 임의의 keysym 이 온다. 아래 세 값은 이 머신
+    // (CachyOS · KWin 6.7.4) 에서 `gdbus` 로 실제 등록해 확인한 것이다.
+    //
+    //   `twosuperior` (fr 자판의 `[Backquote]`) → `²`
+    //   `Ctrl+twosuperior`                      → `Ctrl+²`
+    //   `Cyrillic_io`  (ru 자판의 같은 자리)     → `Ё`
+    try std.testing.expectEqual(@as(?i32, 0xb2), qtKey(0xb2, 0));
+    try std.testing.expectEqual(@as(?i32, 0x040000b2), qtKey(0xb2, 0x2));
+    try std.testing.expectEqual(@as(?i32, 0x451), qtKey(0x01000451, 0));
+
+    // dead keysym 은 거부한다 — KDE 가 엉뚱한 문자로 적는 것을 실측했다. 독일어
+    // 자판의 `[Backquote]` 자리가 `dead_circumflex` 라 실제로 닿는 경로다.
+    try std.testing.expectEqual(@as(?i32, null), qtKey(0xfe52, 0x2));
+
+    // 표에 없는 keysym 은 0 이 아니라 실패다. 0 을 내면 KDE 에 modifier 만의
+    // 단축키가 등록돼 `Ctrl` 을 뗄 때 발동한다.
+    try std.testing.expectEqual(@as(?i32, null), qtKey(0xffe1, 0x2));
 }
 
 test "conflict takeover removes only an exact one-chord key sequence" {

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -49,6 +49,7 @@ const checkErr = unix_socket.checkErr;
 const sway_ipc = @import("sway_ipc.zig");
 const signal_exit = @import("../../signal_exit.zig");
 const gsettings_hotkey = @import("gsettings_hotkey.zig");
+const shortcut_sync_linux = @import("../../shortcut_sync/linux.zig");
 const about = @import("../../about.zig");
 const paths = @import("../../paths.zig");
 const shell_validate = @import("../../shell_validate.zig");
@@ -1371,6 +1372,11 @@ const Client = struct {
     // KGlobalAccel filter 안에서는 Wayland roundtrip을 시작하지 않는다. Pressed
     // callback은 이 flag만 세우고 main loop가 D-Bus dispatch 반환 뒤 toggle한다.
     kglobalaccel_toggle_pending: bool = false,
+    /// #496 1-c — KDE 에 지금 등록돼 있는 keysym (위치 표기 hotkey 일 때만 쓴다).
+    /// layout 이 바뀌었는지 비교하는 기준이라 0 은 "아직 등록 안 함" 이다.
+    kde_position_keysym: u32 = 0,
+    /// #496 1-c — COSMIC RON 에 지금 쓰여 있는 keysym. KDE 쪽과 같은 역할이다.
+    cosmic_position_keysym: u32 = 0,
     // surface visibility toggle state. macOS `g_visible` 동등. false
     // = 평소 (layer-shell mapped), true = hidden (wl_surface.attach(NULL) +
     // commit 송신 끝난 상태). 다음 toggle → flip + re-attach.
@@ -1728,7 +1734,13 @@ const Client = struct {
         // 정체를 바꾸는 것으로는 부족하다 (창 타이틀 · app_id 와 다른 점이다). 이름을
         // 달리해도 KDE 단축키 레지스트리에 측정용 항목이 남으므로 **등록 자체를 건너뛴다** —
         // 같은 파일의 sway `bindsym` · GSettings 등록과 같은 형태다.
-        if (!self.run_opts.isStressRun()) self.tryConnectKGlobalAccel();
+        // #496 1-c — **라벨 binding 만 여기서 등록한다.** 위치 표기는 그 자리가 내는
+        // keysym 을 알아야 하는데 (KDE 는 자리를 못 받는다) keymap 이 아직 없다. 아래
+        // `keyboard ready` roundtrip 뒤로 미루는데, 그 자리는 `hidden_at_start` 판단보다
+        // **앞이라** 동작이 달라지지 않는다 — 미룬 등록이 늦어 `has_kde_hotkey` 가 false
+        // 로 읽히면 숨은 채 시작해야 할 창이 뜬다.
+        if (!self.run_opts.isStressRun() and self.config.hotkey.code == null)
+            self.tryConnectKGlobalAccel(self.config.hotkey.keysym);
         self.logBootElapsed("KGlobalAccel");
         // L13-γ — ARGB8888 광고 필수 (opacity_percent 적용을 위한 alpha
         // channel). 거의 모든 compositor 가 광고하므로 fallback 없이 fatal.
@@ -1736,6 +1748,11 @@ const Client = struct {
         try self.createKeyboardIfAvailable();
         if (self.keyboard_id != 0) try self.roundtrip();
         self.logBootElapsed("keyboard ready");
+        // #496 1-c — 위치 표기 hotkey 의 KDE 등록. keymap 이 방금 도착했다.
+        if (!self.run_opts.isStressRun()) {
+            self.registerKdePositionHotkey();
+            self.writeCosmicPositionHotkey();
+        }
 
         // #282 C2 — startup shell 검증. Windows / macOS host 는 Config.load 직후
         // `shell_validate.validateOrFatal` 로 잘못된 `config.shell` 을 안내 후 종료하지만
@@ -5635,6 +5652,8 @@ const Client = struct {
         log.appendLineVerbose("wayland", "keyboard keymap loaded size={}", .{size});
         // #496 1-a — layout 이 바뀌면 이 event 가 다시 온다. 그래서 매번 다시 푼다.
         self.resolveBindingFallbacks();
+        self.refreshKdePositionHotkey();
+        self.writeCosmicPositionHotkey();
     }
 
     fn handleKeyboardKey(self: *Client, payload: []const u8) !void {
@@ -5968,7 +5987,11 @@ const Client = struct {
             readU32(payload[12..16]),
             group,
         );
-        if (group_changed) self.resolveBindingFallbacks();
+        if (group_changed) {
+            self.resolveBindingFallbacks();
+            self.refreshKdePositionHotkey();
+            self.writeCosmicPositionHotkey();
+        }
     }
 
     fn handleKeyboardRepeatInfo(self: *Client, payload: []const u8) void {
@@ -7056,7 +7079,7 @@ const Client = struct {
     /// 등록한다. 다른 desktop은 launcher/extension/compositor가 `--toggle N`
     /// IPC를 호출하므로 worker에서 D-Bus hotkey client를 만들지 않는다.
     /// 연결·등록 실패는 fatal이 아니며 hidden_start는 즉시 표시로 fallback한다.
-    fn tryConnectKGlobalAccel(self: *Client) void {
+    fn tryConnectKGlobalAccel(self: *Client, keysym: u32) void {
         if (!kglobalaccel.isCurrentDesktop(self.rt)) return;
         const session = dbus.SessionBus.connect() catch |err| {
             log.appendLine("dbus", "session bus connect skipped: {s} — hotkey disabled", .{@errorName(err)});
@@ -7069,7 +7092,7 @@ const Client = struct {
             self.rt,
             self.allocator,
             &self.dbus_session.?,
-            self.config.hotkey.keysym,
+            keysym,
             self.config.hotkey.modifiers,
             onKGlobalAccelPressed,
             self,
@@ -7095,7 +7118,13 @@ const Client = struct {
             }
         }
         if (self.kglobalaccel_client) |client| {
-            client.drainOwnerRestart(self.config.hotkey.keysym, self.config.hotkey.modifiers);
+            // #496 1-c — 위치 표기는 `hotkey.keysym` 이 sentinel 0 이라 그대로 넘기면
+            // 재등록이 실패한다. 우리가 풀어 둔 값을 준다.
+            const keysym = if (self.config.hotkey.code == null)
+                self.config.hotkey.keysym
+            else
+                self.kde_position_keysym;
+            client.drainOwnerRestart(keysym, self.config.hotkey.modifiers);
         }
         if (self.kglobalaccel_toggle_pending) {
             self.kglobalaccel_toggle_pending = false;
@@ -7103,6 +7132,92 @@ const Client = struct {
                 log.appendLine("kglobalaccel", "toggle failed: {s}", .{@errorName(err)});
             };
         }
+    }
+
+    /// #496 1-c — 위치 표기 hotkey 가 **지금 layout 에서** 내는 keysym.
+    ///
+    /// KDE 와 COSMIC 은 자리를 받지 못하고 글자만 받으므로, 그 자리를 눌렀을 때 실제로
+    /// 나오는 글자로 등록한다. AZERTY 에서 `[Backquote]` 는 `twosuperior` 가 된다 —
+    /// #484 가 요청한 그 키다.
+    fn positionHotkeyKeysym(self: *Client) ?u32 {
+        const code = self.config.hotkey.code orelse return null;
+        return self.keyboard.keysymAtEvdev(physical_key.evdev(code));
+    }
+
+    /// #496 1-c — **dead keysym 은 글자로 넘길 수 없다.**
+    ///
+    /// KDE 실측에서 `Qt::Key_Dead_Circumflex` 를 주니 엉뚱한 문자 (`ោ`) 로 적혔다.
+    /// 독일어 자판의 `[Backquote]` 자리가 `dead_circumflex` 라 실제로 닿는 경로다
+    /// (`xkbcli compile-keymap --layout de` 의 `<TLDE>`). 자리를 그대로 받는 경로
+    /// (sway · Hyprland · GNOME) 는 해당이 없다 — 거기엔 글자가 끼지 않는다.
+    ///
+    /// 범위는 `xkbcommon-keysyms.h` 의 `XKB_KEY_dead_*` 다.
+    fn isDeadKeysym(keysym: u32) bool {
+        return keysym >= 0xfe50 and keysym <= 0xfe93;
+    }
+
+    /// #496 1-c — 위치 표기 hotkey 를 COSMIC 의 RON 에 쓴다 (`keyboard ready` 직후).
+    ///
+    /// launcher 가 이 인스턴스의 항목을 건너뛰고 기존 줄을 남겨 두므로
+    /// (`shortcut_sync/linux.zig` 의 `cosmicDeferredToWorker`), 여기서 쓰지 않으면
+    /// 항목이 없거나 낡은 채로 남는다.
+    fn writeCosmicPositionHotkey(self: *Client) void {
+        if (self.config.hotkey.code == null) return;
+        if (!cosmicCompositor(self.rt)) return;
+        const keysym = self.positionHotkeyKeysym() orelse {
+            log.appendLine("cosmic", "position hotkey unresolved -- keymap has no keysym at that spot", .{});
+            return;
+        };
+        if (isDeadKeysym(keysym)) {
+            log.appendLine("cosmic", "position hotkey is a dead key on this layout -- not registered (use a function key)", .{});
+            return;
+        }
+        if (keysym == self.cosmic_position_keysym) return;
+        var name_buf: [64]u8 = undefined;
+        const name = self.keyboard.keysymName(keysym, &name_buf) orelse {
+            log.appendLine("cosmic", "position hotkey keysym 0x{x} has no xkb name -- not registered", .{keysym});
+            return;
+        };
+        shortcut_sync_linux.writeCosmicPositionEntry(
+            self.rt,
+            self.allocator,
+            instance_context.requireWorkerIndex(),
+            name,
+            self.config.hotkey.modifiers,
+        ) catch |err| {
+            log.appendLine("cosmic", "position hotkey entry write failed: {s}", .{@errorName(err)});
+            return;
+        };
+        self.cosmic_position_keysym = keysym;
+    }
+
+    /// #496 1-c — 위치 표기 hotkey 를 KDE 에 등록한다 (`keyboard ready` 직후).
+    fn registerKdePositionHotkey(self: *Client) void {
+        if (self.config.hotkey.code == null) return;
+        if (!kglobalaccel.isCurrentDesktop(self.rt)) return;
+        const keysym = self.positionHotkeyKeysym() orelse {
+            log.appendLine("kglobalaccel", "position hotkey unresolved -- keymap has no keysym at that spot, hotkey disabled", .{});
+            return;
+        };
+        if (isDeadKeysym(keysym)) {
+            log.appendLine("kglobalaccel", "position hotkey is a dead key on this layout -- not registered (use a function key)", .{});
+            return;
+        }
+        self.kde_position_keysym = keysym;
+        self.tryConnectKGlobalAccel(keysym);
+    }
+
+    /// #496 1-c — layout 이 바뀌면 그 자리가 내는 글자도 바뀌므로 다시 등록한다.
+    ///
+    /// 자리를 그대로 받는 경로 (sway `bindcode`) 는 이것이 필요 없다 — 한 번 고정하면
+    /// 끝이다. KDE 는 글자만 받아서 따라다녀야 한다.
+    fn refreshKdePositionHotkey(self: *Client) void {
+        const client = self.kglobalaccel_client orelse return;
+        if (self.config.hotkey.code == null) return;
+        const keysym = self.positionHotkeyKeysym() orelse return;
+        if (keysym == self.kde_position_keysym) return;
+        self.kde_position_keysym = keysym;
+        client.rebind(keysym, self.config.hotkey.modifiers);
     }
 
     fn onKGlobalAccelPressed(user_data: ?*anyopaque, timestamp: i64) void {
@@ -8446,6 +8561,13 @@ const Client = struct {
         if (!self.pending_sway_toggle_register) return;
         if (self.keyboard.keymap == null) return;
         self.pending_sway_toggle_register = false;
+
+        // #496 1-c — 위치 표기는 **판정이 필요 없다.** 자리가 곧 답이라 layout 을 물어볼
+        // 것이 없다. 라벨은 "지금 자판이 그 글자를 내는가" 를 물어야 하지만 자리는 아니다.
+        if (self.config.hotkey.code) |code| {
+            sway_ipc.registerToggleIfSway(self.rt, self.allocator, self.config, physical_key.evdev(code));
+            return;
+        }
 
         const keysym = self.config.hotkey.keysym;
         const keycode: ?u16 = switch (self.keyboard.canProduceKeysym(keysym) orelse return sway_ipc.registerToggleIfSway(

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1740,7 +1740,7 @@ const Client = struct {
         // **앞이라** 동작이 달라지지 않는다 — 미룬 등록이 늦어 `has_kde_hotkey` 가 false
         // 로 읽히면 숨은 채 시작해야 할 창이 뜬다.
         if (!self.run_opts.isStressRun() and self.config.hotkey.code == null)
-            self.tryConnectKGlobalAccel(self.config.hotkey.keysym);
+            self.tryConnectKGlobalAccel(self.config.hotkey.keysym, null);
         self.logBootElapsed("KGlobalAccel");
         // L13-γ — ARGB8888 광고 필수 (opacity_percent 적용을 위한 alpha
         // channel). 거의 모든 compositor 가 광고하므로 fallback 없이 fatal.
@@ -1932,6 +1932,7 @@ const Client = struct {
             self.drainInfoRequest();
             self.drainConfigNotice();
             self.drainSwayToggleRegister();
+            self.drainKdeLayoutChange();
             self.drainNewInstanceRequest();
             // L12-β — exit 한 탭들을 main thread 에서 close. read thread 의
             // `linuxTabExit` 가 pending_close_buf 에 ptr 쌓아둠. drain 이
@@ -7079,7 +7080,7 @@ const Client = struct {
     /// 등록한다. 다른 desktop은 launcher/extension/compositor가 `--toggle N`
     /// IPC를 호출하므로 worker에서 D-Bus hotkey client를 만들지 않는다.
     /// 연결·등록 실패는 fatal이 아니며 hidden_start는 즉시 표시로 fallback한다.
-    fn tryConnectKGlobalAccel(self: *Client, keysym: u32) void {
+    fn tryConnectKGlobalAccel(self: *Client, keysym: u32, codepoint: ?u21) void {
         if (!kglobalaccel.isCurrentDesktop(self.rt)) return;
         const session = dbus.SessionBus.connect() catch |err| {
             log.appendLine("dbus", "session bus connect skipped: {s} — hotkey disabled", .{@errorName(err)});
@@ -7094,6 +7095,7 @@ const Client = struct {
             &self.dbus_session.?,
             keysym,
             self.config.hotkey.modifiers,
+            codepoint,
             onKGlobalAccelPressed,
             self,
         ) catch |err| {
@@ -7124,7 +7126,11 @@ const Client = struct {
                 self.config.hotkey.keysym
             else
                 self.kde_position_keysym;
-            client.drainOwnerRestart(keysym, self.config.hotkey.modifiers);
+            const codepoint: ?u21 = if (self.config.hotkey.code == null)
+                null
+            else
+                self.keyboard.keysymToUtf32(keysym);
+            client.drainOwnerRestart(keysym, self.config.hotkey.modifiers, codepoint);
         }
         if (self.kglobalaccel_toggle_pending) {
             self.kglobalaccel_toggle_pending = false;
@@ -7204,7 +7210,24 @@ const Client = struct {
             return;
         }
         self.kde_position_keysym = keysym;
-        self.tryConnectKGlobalAccel(keysym);
+        self.tryConnectKGlobalAccel(keysym, self.keyboard.keysymToUtf32(keysym));
+    }
+
+    /// #496 1-c — KDE 가 D-Bus 로 알려 준 layout 전환을 처리한다.
+    ///
+    /// **포커스가 없어도 온다는 것이 이 경로의 전부다.** Wayland 의 group 전환은 포커스한
+    /// client 에게만 가는데 드롭다운은 대개 숨어 있고, 그때 layout 을 바꾸면 hotkey 가 옛
+    /// 글자로 남아 **창을 부를 수단이 사라진다** (실기 확인).
+    ///
+    /// `active_group` 을 여기서 직접 세우는 이유도 같다 — `wl_keyboard.modifiers` 가 오지
+    /// 않았으므로 그 값이 낡아 있고, 그대로 조회하면 옛 글자를 다시 등록한다. KDE 의
+    /// layout index 가 곧 xkb group 이라 그 자리에 쓸 수 있다.
+    fn drainKdeLayoutChange(self: *Client) void {
+        const client = self.kglobalaccel_client orelse return;
+        const index = client.takeLayoutChange() orelse return;
+        if (self.config.hotkey.code == null) return;
+        self.keyboard.active_group = index;
+        self.refreshKdePositionHotkey();
     }
 
     /// #496 1-c — layout 이 바뀌면 그 자리가 내는 글자도 바뀌므로 다시 등록한다.
@@ -7217,7 +7240,18 @@ const Client = struct {
         const keysym = self.positionHotkeyKeysym() orelse return;
         if (keysym == self.kde_position_keysym) return;
         self.kde_position_keysym = keysym;
-        client.rebind(keysym, self.config.hotkey.modifiers);
+        // **가드가 여기에도 있어야 한다.** 처음엔 등록 경로에만 뒀는데, 실기에서 독일어로
+        // 전환하니 dead key 가 그대로 `rebind` 로 흘러 일반 실패
+        // (`KGlobalAccelUnsupportedKey`) 로 끝났다 — 결과는 "등록 안 됨" 으로 같지만
+        // 원인이 로그에 남지 않아 진단이 어렵다 (#496 1-c 검증).
+        if (isDeadKeysym(keysym)) {
+            // 직전 등록을 거둔다. 남겨 두면 옛 layout 의 글자가 KDE 단축키 목록에 죽은
+            // 항목으로 남는다 (실기에서 독일어로 바꾼 뒤 `Ctrl+Ё` 가 그대로 남았다).
+            client.unbind();
+            log.appendLine("kglobalaccel", "layout changed -- position is a dead key now, hotkey unregistered", .{});
+            return;
+        }
+        client.rebind(keysym, self.config.hotkey.modifiers, self.keyboard.keysymToUtf32(keysym));
     }
 
     fn onKGlobalAccelPressed(user_data: ?*anyopaque, timestamp: i64) void {

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -7175,6 +7175,22 @@ const Client = struct {
             return;
         };
         if (isDeadKeysym(keysym)) {
+            // **직전 등록을 거둔다.** KDE 의 같은 자리 (`drainKdeLayoutChange`) 와 짝이다 —
+            // 남겨 두면 옛 layout 의 글자가 COSMIC 단축키 목록에 죽은 항목으로 남는다
+            // (실기: fr → de 로 바꾸니 `key: "twosuperior"` 가 그대로 남았다).
+            //
+            // `cosmic_position_keysym` 을 보지 않고 항상 부르는 이유는 **부팅 경로** 때문이다.
+            // 그 값은 매 실행 0 에서 시작하는데 RON 은 파일이라 지난 실행의 줄이 남아 있다.
+            // dead key layout 에서 tildaz 를 켜면 여기가 유일한 정리 시점이다. 실제 쓰기는
+            // `writeFileIfChanged` 가 거르므로 keymap 이벤트마다 파일이 바뀌지는 않는다.
+            self.cosmic_position_keysym = 0;
+            shortcut_sync_linux.removeCosmicPositionEntry(
+                self.rt,
+                self.allocator,
+                instance_context.requireWorkerIndex(),
+            ) catch |err| {
+                log.appendLine("cosmic", "position hotkey entry removal failed: {s}", .{@errorName(err)});
+            };
             log.appendLine("cosmic", "position hotkey is a dead key on this layout -- not registered (use a function key)", .{});
             return;
         }

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -69,6 +69,14 @@ const XkbKeymapKeyGetSymsByLevel = *const fn (
     syms_out: *[*]const c_uint,
 ) callconv(.c) c_int;
 
+/// #496 1-c — `xkb_keysym_get_name(keysym, buffer, size)`. 이름 길이를 돌려주고
+/// 버퍼가 모자라면 필요한 길이를 준다 (음수는 실패).
+const XkbKeysymGetName = *const fn (
+    keysym: c_uint,
+    buffer: [*]u8,
+    size: usize,
+) callconv(.c) c_int;
+
 // libxkbcommon `enum xkb_state_component`. MODS_EFFECTIVE = (1 << 3).
 // 처음에 (1 << 7) = LAYOUT_EFFECTIVE 로 잘못 적어 mod_name_is_active 가
 // modifier component 를 안 보고 항상 0 반환 → 단축키 분기 fail (1차 시연 발견).
@@ -118,6 +126,14 @@ const Api = struct {
 /// #496 1-a — keymap 전수 조회에 필요한 심볼 묶음. **다 있어야 의미가 있으므로 묶어서
 /// all-or-nothing 으로 다룬다** — 넷만 있으면 부분 조회가 되어 오히려 잘못된 답을 낸다.
 const KeymapScan = struct {
+    /// #496 1-c — keysym → 이름 (`twosuperior` · `Cyrillic_io`). COSMIC 의 RON `key:` 가
+    /// 이름 문자열을 받으므로 필요하다. 우리 고정표 (`config.linuxKeysymName`) 는 라벨
+    /// 집합만 알아서 위치 표기가 닿는 임의의 keysym 을 이름으로 만들지 못한다.
+    ///
+    /// **이 묶음에 넣는 이유** — 위치 표기 hotkey 를 처리하려면 조회 심볼과 이 심볼이
+    /// *함께* 있어야 한다. 하나만 있으면 자리는 풀되 이름을 못 만들어 결국 등록을 못
+    /// 하므로, 갈라 두면 실패 경로만 늘어난다.
+    keysym_get_name: XkbKeysymGetName,
     min_keycode: XkbKeymapMinKeycode,
     max_keycode: XkbKeymapMaxKeycode,
     num_layouts_for_key: XkbKeymapNumLayoutsForKey,
@@ -126,6 +142,7 @@ const KeymapScan = struct {
 
     fn load(handle: *anyopaque) ?KeymapScan {
         return .{
+            .keysym_get_name = lookup(handle, XkbKeysymGetName, "xkb_keysym_get_name") orelse return null,
             .min_keycode = lookup(handle, XkbKeymapMinKeycode, "xkb_keymap_min_keycode") orelse return null,
             .max_keycode = lookup(handle, XkbKeymapMaxKeycode, "xkb_keymap_max_keycode") orelse return null,
             .num_layouts_for_key = lookup(handle, XkbKeymapNumLayoutsForKey, "xkb_keymap_num_layouts_for_key") orelse return null,
@@ -283,6 +300,51 @@ pub const Keyboard = struct {
         if (self.api.?.keymap_scan == null) return null;
         if (self.keymap == null) return null;
         return self.findKeycode(keysym) != null;
+    }
+
+    /// #496 1-c — 그 **자리**가 지금 layout 에서 내는 keysym (level 0).
+    /// `findKeycode` 의 반대 방향이고 group 규칙도 같다 (`active_group % layouts`).
+    ///
+    /// **level 0 만 본다.** 전역 hotkey 의 modifier 는 따로 실려 가므로 (`Ctrl+Shift+T`
+    /// 가 keysym `t` + Shift 비트로 등록된다) 우리가 알아야 하는 것은 그 자리의 *기본*
+    /// 문자다. Shift 레벨을 뽑으면 `Ctrl+Shift+[Digit1]` 이 `!` 로 등록돼 어긋난다.
+    ///
+    /// **`oneSym` 을 쓰지 않는 이유** — 그쪽은 `xkb_state` 를 보므로 *지금 눌려 있는*
+    /// modifier 가 결과를 바꾼다. 등록은 부팅 · layout 전환 시점에 일어나 대개 아무 키도
+    /// 안 눌려 있지만, 그 우연에 기대면 사용자가 키를 누른 채 layout 을 바꿀 때 조용히
+    /// 다른 값이 등록된다.
+    ///
+    /// 판정 불가 (심볼 / keymap 없음) 와 "그 자리에 keysym 이 없다" 를 **가르지 않는다**
+    /// — 호출부의 처리가 같기 때문이다 (등록하지 않고 알린다). 1-a 에서 둘을 가른 것은
+    /// 거기서는 결과가 달랐기 때문이다 (fallback 을 만드느냐 마느냐).
+    pub fn keysymAtEvdev(self: *Keyboard, evdev: u16) ?u32 {
+        const api = if (self.api) |*a| a else return null;
+        const scan = api.keymap_scan orelse return null;
+        const keymap = self.keymap orelse return null;
+
+        const key: c_uint = @as(c_uint, evdev) + 8; // xkb keycode = evdev + 8
+        if (key < scan.min_keycode(keymap) or key > scan.max_keycode(keymap)) return null;
+        const layouts = scan.num_layouts_for_key(keymap, key);
+        if (layouts == 0) return null;
+        const layout: c_uint = @intCast(self.active_group % layouts);
+        var syms: [*]const c_uint = undefined;
+        const count = scan.key_get_syms_by_level(keymap, key, layout, 0, &syms);
+        if (count <= 0) return null;
+        return @intCast(syms[0]);
+    }
+
+    /// #496 1-c — keysym → xkb 이름 (`twosuperior` · `Cyrillic_io` · `grave`).
+    /// COSMIC RON 의 `key:` 가 이 이름을 받는다. 버퍼에 담아 slice 로 돌려준다.
+    pub fn keysymName(self: *Keyboard, keysym: u32, buf: []u8) ?[]const u8 {
+        const api = if (self.api) |*a| a else return null;
+        const scan = api.keymap_scan orelse return null;
+        const n = scan.keysym_get_name(@intCast(keysym), buf.ptr, buf.len);
+        if (n <= 0) return null;
+        const len: usize = @intCast(n);
+        // 버퍼가 모자라면 필요한 길이를 돌려준다 — 잘린 이름을 쓰면 COSMIC 이 못 읽는
+        // 값을 파일에 남기게 되므로 실패로 다룬다.
+        if (len >= buf.len) return null;
+        return buf[0..len];
     }
 
     pub fn oneSym(self: *Keyboard, key: u32) ?u32 {

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -71,6 +71,12 @@ const XkbKeymapKeyGetSymsByLevel = *const fn (
 
 /// #496 1-c — `xkb_keysym_get_name(keysym, buffer, size)`. 이름 길이를 돌려주고
 /// 버퍼가 모자라면 필요한 길이를 준다 (음수는 실패).
+/// #496 1-c — `xkb_keysym_to_utf32(keysym)`. 문자를 내지 않는 keysym 은 0 이다.
+/// **legacy 국가별 keysym 을 값만으로는 알 수 없어서** 필요하다 — `Cyrillic_io` 는
+/// `0x06b3` 이라 Latin-1 구간도, modern 유니코드 keysym (`0x01000000 | cp`) 도 아니다.
+/// 그 블록을 손으로 나열하려다 실기에서 키릴이 통째로 빠진 것을 발견했다.
+const XkbKeysymToUtf32 = *const fn (keysym: c_uint) callconv(.c) u32;
+
 const XkbKeysymGetName = *const fn (
     keysym: c_uint,
     buffer: [*]u8,
@@ -134,6 +140,7 @@ const KeymapScan = struct {
     /// *함께* 있어야 한다. 하나만 있으면 자리는 풀되 이름을 못 만들어 결국 등록을 못
     /// 하므로, 갈라 두면 실패 경로만 늘어난다.
     keysym_get_name: XkbKeysymGetName,
+    keysym_to_utf32: XkbKeysymToUtf32,
     min_keycode: XkbKeymapMinKeycode,
     max_keycode: XkbKeymapMaxKeycode,
     num_layouts_for_key: XkbKeymapNumLayoutsForKey,
@@ -143,6 +150,7 @@ const KeymapScan = struct {
     fn load(handle: *anyopaque) ?KeymapScan {
         return .{
             .keysym_get_name = lookup(handle, XkbKeysymGetName, "xkb_keysym_get_name") orelse return null,
+            .keysym_to_utf32 = lookup(handle, XkbKeysymToUtf32, "xkb_keysym_to_utf32") orelse return null,
             .min_keycode = lookup(handle, XkbKeymapMinKeycode, "xkb_keymap_min_keycode") orelse return null,
             .max_keycode = lookup(handle, XkbKeymapMaxKeycode, "xkb_keymap_max_keycode") orelse return null,
             .num_layouts_for_key = lookup(handle, XkbKeymapNumLayoutsForKey, "xkb_keymap_num_layouts_for_key") orelse return null,
@@ -345,6 +353,15 @@ pub const Keyboard = struct {
         // 값을 파일에 남기게 되므로 실패로 다룬다.
         if (len >= buf.len) return null;
         return buf[0..len];
+    }
+
+    /// #496 1-c — keysym 이 내는 유니코드 코드포인트. 문자를 안 내면 null.
+    pub fn keysymToUtf32(self: *Keyboard, keysym: u32) ?u21 {
+        const api = if (self.api) |*a| a else return null;
+        const scan = api.keymap_scan orelse return null;
+        const cp = scan.keysym_to_utf32(@intCast(keysym));
+        if (cp == 0 or cp > 0x10ffff) return null;
+        return @intCast(cp);
     }
 
     pub fn oneSym(self: *Keyboard, key: u32) ?u32 {

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -201,7 +201,7 @@ pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {
     // 폰트 · DC · 렌더 타이머 초기화까지 삼켰다 (`window.registerGlobalHotkey` 주석).
     // macOS 의 `if (!g_run_opts.isStressRun()) try installEventTap();` 와 같은 형태다.
     if (!opts.isStressRun()) {
-        app.window.registerGlobalHotkey(config.hotkey.vkey, config.hotkey.modifiers);
+        app.window.registerGlobalHotkey(config.hotkey.vkey, config.hotkey.modifiers, config.hotkey.code);
     } else {
         // 건너뛴 사실을 로그에 남긴다 — 측정 실행이 사용자의 핫키를 건드리지 않았는지
         // 확인하는 근거다 (세 host 의 `(stress run)` 로그와 같은 어휘).

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -387,12 +387,11 @@ pub const config_hotkey_unknown_key_fallback_msg = "Configuration: hotkey uses a
 /// 가로챈다). 이쪽은 기존 안내가 정확했다.
 pub const config_hotkey_invalid_format = "Configuration: failed to parse \"hotkey\" value \"{s}\".\n\nOnly F1-F12 may be used without modifiers. Other keys require Ctrl, Alt, Super, or Cmd.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
 pub const config_hotkey_invalid_fallback_msg = "Configuration: hotkey invalid";
-/// #496 — 위치 표기 (`[KeyW]`) 를 전역 `hotkey` 에 쓴 경우. `config_hotkey_invalid`
-/// 로 묶으면 "Only F1-F12 may be used without modifiers" 를 받는데, 사용자는 modifier
-/// 를 이미 줬으므로 #484 와 똑같이 막다른 길이 된다. 무엇이 안 되는지와 **대신 할 수
-/// 있는 것**을 같이 준다.
-pub const config_hotkey_position_format = "Configuration: \"hotkey\" value \"{s}\" uses the position form (in square brackets).\n\nThe position form works in [keys] but not for the global hotkey: TildaZ has to register that one with the desktop, and every path it uses (sway, Hyprland, COSMIC, KDE) accepts only a character.\n\nUse a key name instead -- a function key is the safest choice because it is the same on every keyboard layout.\n\nExamples: \"f1\", \"ctrl+space\", \"shift+cmd+t\"";
-pub const config_hotkey_position_fallback_msg = "Configuration: hotkey cannot use the position form";
+// #496 1-c — 위치 표기를 전역 `hotkey` 에서 거부하던 안내 두 개가 여기 있었다. 이제
+// 받으므로 지웠다. 등록이 실패할 수 있는 자리는 남아 있지만 (그 layout 에서 그 자리가
+// dead key 이거나 글자를 안 내는 경우) 그것은 **파싱이 아니라 등록 시점**에만 알 수
+// 있어 다이얼로그가 아니라 로그로 알린다 — config 를 읽는 시점에는 사용자의 자판이
+// 무엇을 내는지 모른다.
 /// #431 — 다른 TildaZ 인스턴스가 이미 쓰는 전역 핫키. 뒤에 있는 (index 가 큰) 쪽이 양보하므로
 /// 이 메시지는 그 인스턴스에만 나온다. **겹친 상대를 번호로 짚어 주는 것이 핵심이다** — 예전엔
 /// Windows 의 `RegisterHotKey` 실패 안내가 "Another app already registered the same combination"
@@ -498,6 +497,26 @@ pub const hotkey_registration_failed_format =
     \\{s}
 ;
 pub const hotkey_registration_failed_fallback_msg = "Failed to register the global hotkey. Edit this instance's config file and restart.";
+
+/// #496 1-c — a position hotkey is matched by physical key, so it needs a low-level
+/// keyboard hook rather than the OS hotkey table. The failure causes are different
+/// enough from `RegisterHotKey` that reusing that text would misdirect the user.
+pub const hotkey_hook_failed_format =
+    \\Failed to install the keyboard hook for the global hotkey (position [{s}], modifiers=0x{x}).
+    \\
+    \\A position hotkey such as "ctrl+[Backquote]" matches the physical key, which requires a
+    \\low-level keyboard hook. The OS hotkey table cannot express it: it stores a virtual-key,
+    \\and each keyboard layout assigns virtual-keys to different physical keys.
+    \\
+    \\Common causes:
+    \\• Security software blocks low-level keyboard hooks
+    \\• The session denies the hook
+    \\
+    \\Writing the key by label instead (for example "ctrl+space" or "F1") uses the OS hotkey
+    \\table and does not need the hook. Edit the config and restart:
+    \\{s}
+;
+pub const hotkey_hook_failed_fallback_msg = "Failed to install the keyboard hook for the global hotkey. Edit this instance's config file and restart.";
 
 pub const new_instance_title = "Create TildaZ Instance";
 pub const new_instance_hotkey_prompt_format =

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -392,6 +392,18 @@ pub const config_hotkey_invalid_fallback_msg = "Configuration: hotkey invalid";
 // dead key 이거나 글자를 안 내는 경우) 그것은 **파싱이 아니라 등록 시점**에만 알 수
 // 있어 다이얼로그가 아니라 로그로 알린다 — config 를 읽는 시점에는 사용자의 자판이
 // 무엇을 내는지 모른다.
+
+/// #496 1-c — **macOS 의 자리 거부는 전역 `hotkey` 에도 온다.** 위치 표기를 받기
+/// 시작하면서 생긴 경로다 — 그전에는 위치 표기가 파싱 앞단에서 막혀 이 둘이 `[keys]`
+/// 에서만 났고, 그래서 hotkey 쪽 config 로드부가 `unreachable` 로 두고 있었다.
+///
+/// 그 `unreachable` 은 ReleaseFast 에서 안전 검사가 없어 **`modifier_required` 안내로
+/// 떨어졌다** (macOS 실기 확인). `ctrl` 을 이미 준 사용자에게 "modifier 를 달라" 고
+/// 말하는 것이라, #484 가 "거부 이유별로 다른 안내를 보낸다" 로 막으려던 실패 그대로다.
+pub const config_hotkey_position_aliased_format = "Configuration: \"hotkey\" value \"{s}\" uses a key position that macOS reports under a different name.\n\nOn a PC keyboard attached to a Mac, PrintScreen, ScrollLock and Pause arrive as F13, F14 and F15 -- Apple's extended keyboard puts those function keys in the same spots.\n\nUse [F13], [F14] or [F15] instead.";
+pub const config_hotkey_position_aliased_fallback_msg = "Configuration: on macOS use [F13] / [F14] / [F15] for PrintScreen / ScrollLock / Pause";
+pub const config_hotkey_position_absent_format = "Configuration: \"hotkey\" value \"{s}\" uses a key position that macOS does not provide.\n\nApple's key codes stop at F20, and the Japanese input-switching keys (Convert, NonConvert, KanaMode) are handled by the input method rather than delivered as keys.\n\nPick a different key for the hotkey.";
+pub const config_hotkey_position_absent_fallback_msg = "Configuration: that key position does not exist on macOS";
 /// #431 — 다른 TildaZ 인스턴스가 이미 쓰는 전역 핫키. 뒤에 있는 (index 가 큰) 쪽이 양보하므로
 /// 이 메시지는 그 인스턴스에만 나온다. **겹친 상대를 번호로 짚어 주는 것이 핵심이다** — 예전엔
 /// Windows 의 `RegisterHotKey` 실패 안내가 "Another app already registered the same combination"

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -359,3 +359,27 @@ test "XDG home accepts only absolute non-empty values" {
     defer allocator.free(state);
     try std.testing.expectEqualStrings("/home/test/.local/state", state);
 }
+
+test "#496 1-c the Shell extensions read the same config filename we write" {
+    // GNOME · Cinnamon 확장은 zig 를 안 거치고 config 를 직접 읽는다. #493 이 파일을
+    // TOML 로 옮길 때 그 두 벌이 남겨져 **확장이 아무 config 도 못 봤다** — 등록 대상
+    // 0 개라 GNOME 에서 hotkey 가 하나도 안 걸렸다 (실기 확인, GNOME 50.4). 눈에 띄지
+    // 않은 이유는 이관 전의 `config_0.json` 이 디스크에 남아 있었기 때문이다.
+    const sources = [_]struct { label: []const u8, js: []const u8 }{
+        .{ .label = "gnome", .js = @embedFile("gnome_extension_js") },
+        .{ .label = "cinnamon", .js = @embedFile("cinnamon_extension_js") },
+    };
+    for (sources) |source| {
+        // 한 파일을 열 때 (`config_9.toml`) 와 디렉터리를 훑을 때 (`^config_N\.toml$`)
+        // 두 자리가 있고, 둘 다 이 확장자여야 한다.
+        if (std.mem.indexOf(u8, source.js, "config_${index}.toml") == null) {
+            std.debug.print("{s} extension 이 config_{{index}}.toml 을 안 읽는다\n", .{source.label});
+            return error.ExtensionConfigNameOutOfSync;
+        }
+        if (std.mem.indexOf(u8, source.js, "config_(0|[1-9][0-9]*)\\.toml$") == null) {
+            std.debug.print("{s} extension 의 디렉터리 훑기가 .toml 이 아니다\n", .{source.label});
+            return error.ExtensionConfigNameOutOfSync;
+        }
+        try std.testing.expect(std.mem.indexOf(u8, source.js, "config_${index}.json") == null);
+    }
+}

--- a/src/physical_key.zig
+++ b/src/physical_key.zig
@@ -634,3 +634,39 @@ test "evdev 와 scan code 가 main block 에서 같고 extended 에서 갈린다
     try std.testing.expect(evdev(.page_up) != scanCode(.page_up).value);
     try std.testing.expect(evdev(.arrow_up) != scanCode(.arrow_up).value);
 }
+
+test "#496 1-c the Shell extension position tables match physical_key" {
+    // GNOME · Cinnamon 은 zig 를 안 거친다 — 확장이 config 를 직접 읽어 GTK
+    // accelerator 로 바꾼다. 그래서 이 표가 JS 에 **한 벌 더** 있고, 두 벌이 갈리면
+    // 조용히 옆 키에 붙는다 (Mutter · Muffin 은 틀린 keycode 를 거부하지 않는다).
+    // sway `bindcode` 때와 같은 형태로 둘을 묶어 둔다.
+    const sources = [_]struct { label: []const u8, js: []const u8 }{
+        .{ .label = "gnome", .js = @embedFile("gnome_extension_js") },
+        .{ .label = "cinnamon", .js = @embedFile("cinnamon_extension_js") },
+    };
+    for (sources) |source| {
+        const open = std.mem.indexOf(u8, source.js, "const POSITION_KEYCODES = {").?;
+        const close = std.mem.indexOfPos(u8, source.js, open, "\n};").?;
+        const block = source.js[open..close];
+
+        for (table) |e| {
+            var lower_buf: [32]u8 = undefined;
+            const lower = std.ascii.lowerString(lower_buf[0..e.name.len], e.name);
+            var needle_buf: [64]u8 = undefined;
+            // JS 는 xkb keycode (= evdev + 8) 를 두 자리 hex 로 적는다 — GTK 의
+            // `is_keycode()` 가 그 형태만 인정하기 때문이다.
+            const needle = try std.fmt.bufPrint(&needle_buf, "{s}: 0x{x:0>2},", .{ lower, @as(u32, e.evdev) + 8 });
+            if (std.mem.indexOf(u8, block, needle) == null) {
+                std.debug.print("{s} extension 의 위치 표에 없다: {s}\n", .{ source.label, needle });
+                return error.PositionTableOutOfSync;
+            }
+        }
+
+        // 반대 방향 — JS 에만 있는 행이 남아 있으면 이 표에서 지운 자리가 확장에
+        // 살아 있다는 뜻이다. 개수로 잡는다.
+        var js_rows: usize = 0;
+        var offset: usize = 0;
+        while (std.mem.indexOfPos(u8, block, offset, ": 0x")) |at| : (offset = at + 4) js_rows += 1;
+        try std.testing.expectEqual(table.len, js_rows);
+    }
+}

--- a/src/physical_key.zig
+++ b/src/physical_key.zig
@@ -24,9 +24,13 @@
 //! 줄지 정해야 하는데, `VK_OEM_MINUS` / `kVK_ANSI_Minus` 는 라벨이 아니라 "US 자판
 //! 에서 `-` 가 있는 자리" 다. 그것을 라벨로 받으면 Linux 는 라벨로, Windows ·
 //! macOS 는 US 위치로 잡아 #496 의 세 갈래 불일치가 더 깊어진다. 라벨을 정직하게
-//! 넓히려면 live layout 조회가 필요하다 (macOS `UCKeyTranslate`, Windows
-//! `VkKeyScanExW`) — #496 항목 2 이고, 그것이 끝나면 라벨 집합은 "위치로 해석할
-//! 이름" 이 되어 이 표에 흡수된다.
+//! 넓히려면 live layout 조회가 필요하다 — #496 항목 2 다.
+//!
+//! **항목 2 는 그렇게 끝나지 않았다.** macOS 는 `NSEvent charactersByApplyingModifiers:`
+//! 로 라벨을 live layout 에서 해석하게 됐고 (Carbon 도 `UCKeyTranslate` 도 쓰지 않는다),
+//! Windows 는 layout DLL 이 이미 라벨을 따라가 손댈 것이 없었다. 그래서 **라벨 집합은
+//! 이 표에 흡수되지 않았고** 좁은 채로 남아 있다 — 넓히는 대신 이 부류의 답을 위치 표기로
+//! 정했기 때문이다. 남은 전제는 Windows 뿐이다 (거기만 라벨을 VK 로 바꿔야 한다).
 //!
 //! 위치 쪽은 그 문제가 없다. `[Minus]` 는 처음부터 "그 자리" 이고 세 platform 에
 //! 고정값이 있다. 그래서 기호 · numpad · 방향 · 편집 패드 · `F13`~`F24` · ISO / JIS

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -561,6 +561,33 @@ pub fn writeCosmicPositionEntry(
     key_name: []const u8,
     modifiers: u32,
 ) !void {
+    return rewriteCosmicPositionEntry(rt, allocator, index, key_name, modifiers);
+}
+
+/// #496 1-c — 이 인스턴스의 위치 표기 항목을 RON 에서 **거둔다.**
+///
+/// 그 자리가 지금 layout 에서 글자를 못 낼 때 쓴다 (dead key). KDE 쪽
+/// `KGlobalAccelClient.unbind` 와 같은 역할이고 이유도 같다 — 남겨 두면 직전 layout 의
+/// 글자가 COSMIC 단축키 목록에 **죽은 항목**으로 남는다. 실기에서 fr → de 로 바꾸니
+/// `key: "twosuperior"` 가 그대로 남았다 (#496 1-c 검증, cosmic-comp 1.0.0).
+///
+/// 발동하지는 않는다 — 독일어 자판에서 `²` 가 나는 자리 (`Ctrl+AltGr+2`) 를 눌러도
+/// cosmic-comp 가 걸어 주지 않는 것까지 같은 실측에서 확인했다. 그래도 사용자 눈에는
+/// 남으므로 거둔다.
+pub fn removeCosmicPositionEntry(rt: Runtime, allocator: std.mem.Allocator, index: u32) !void {
+    return rewriteCosmicPositionEntry(rt, allocator, index, null, 0);
+}
+
+/// `key_name` 이 `null` 이면 우리 줄을 지우기만 한다 (거두기), 값이 있으면 그 값으로 다시
+/// 쓴다. 두 경로가 **같은 한 줄 규칙**을 쓰게 묶어 둔다 — 지우는 쪽과 쓰는 쪽이 갈리면
+/// 같은 map 키가 둘 생기고, 중복 키가 있는 RON 은 COSMIC 이 파일 전체를 버린다 (#484).
+fn rewriteCosmicPositionEntry(
+    rt: Runtime,
+    allocator: std.mem.Allocator,
+    index: u32,
+    key_name: ?[]const u8,
+    modifiers: u32,
+) !void {
     const home = rt.environ.getPosix("HOME") orelse return error.HomeNotSet;
     const dir_path = try std.Io.Dir.path.join(allocator, &.{ home, ".config", "cosmic", "com.system76.CosmicSettings.Shortcuts", "v1" });
     defer allocator.free(dir_path);
@@ -583,31 +610,98 @@ pub fn writeCosmicPositionEntry(
     const exe_len = try std.process.executablePath(rt.io, &exe_buf);
     const exe = exe_buf[0..exe_len];
 
-    const close_offset = findClosingMapLine(content) orelse return error.UnsupportedCosmicShortcutFormat;
     var output: std.ArrayList(u8) = .empty;
     defer output.deinit(allocator);
+    try renderCosmicPositionRon(&output, allocator, content, exe, index, key_name, modifiers);
+
+    if (try paths.writeFileIfChanged(rt, allocator, path, output.items)) {
+        if (key_name) |name| {
+            log.appendLine("cosmic", "position hotkey entry written key={s}", .{name});
+        } else {
+            log.appendLine("cosmic", "position hotkey entry withdrawn", .{});
+        }
+    }
+}
+
+test "#496 1-c dead key layout withdraws the previous position entry" {
+    // 실기 (cosmic-comp 1.0.0): fr 에서 `twosuperior` 로 쓰인 뒤 de 로 바꾸면 그 줄이
+    // 그대로 남아 사용자 단축키 목록에 죽은 항목이 됐다. 거두는 쪽이 사용자 항목과 남의
+    // 인스턴스는 건드리지 않는 것까지 함께 고정한다.
+    const before =
+        \\{
+        \\    (modifiers: [], key: "F1"): Spawn("/usr/bin/tildaz --toggle 0"),
+        \\    (modifiers: [Ctrl], key: "twosuperior", description: Some("TildaZ_9")): Spawn("/usr/bin/tildaz --toggle 9"),
+        \\    (modifiers: [Super], key: "b", description: Some("TildaZ_3")): Spawn("/usr/bin/tildaz --toggle 3"),
+        \\}
+        \\
+    ;
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    try renderCosmicPositionRon(&output, std.testing.allocator, before, "/usr/bin/tildaz", 9, null, 0);
+    try std.testing.expectEqualStrings(
+        \\{
+        \\    (modifiers: [], key: "F1"): Spawn("/usr/bin/tildaz --toggle 0"),
+        \\    (modifiers: [Super], key: "b", description: Some("TildaZ_3")): Spawn("/usr/bin/tildaz --toggle 3"),
+        \\}
+        \\
+    , output.items);
+}
+
+test "#496 1-c rewriting a position entry replaces our line instead of adding one" {
+    // 같은 map 키가 둘 생기면 COSMIC 이 파일 전체를 버린다 (#484). 재등록이 layout 마다
+    // 도는 경로라 이 성질이 특히 중요하다 — 실기에서 us · fr · ru · de 를 오갔다.
+    const before =
+        \\{
+        \\    (modifiers: [Ctrl], key: "grave", description: Some("TildaZ_9")): Spawn("/usr/bin/tildaz --toggle 9"),
+        \\}
+        \\
+    ;
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    try renderCosmicPositionRon(&output, std.testing.allocator, before, "/usr/bin/tildaz", 9, "twosuperior", config.Hotkey.MOD_CTRL);
+    try std.testing.expectEqualStrings(
+        \\{
+        \\    (modifiers: [Ctrl], key: "twosuperior", description: Some("TildaZ_9")): Spawn("/usr/bin/tildaz --toggle 9"),
+        \\}
+        \\
+    , output.items);
+}
+
+/// 파일 내용 → 파일 내용. I/O 를 걷어 낸 순수부라 test 가 두 경로를 다 밟을 수 있다.
+fn renderCosmicPositionRon(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    content: []const u8,
+    exe: []const u8,
+    index: u32,
+    key_name: ?[]const u8,
+    modifiers: u32,
+) !void {
+    const close_offset = findClosingMapLine(content) orelse return error.UnsupportedCosmicShortcutFormat;
     var offset: usize = 0;
     while (offset < content.len) {
         const end = std.mem.findScalarPos(u8, content, offset, '\n') orelse content.len;
         const line = content[offset..end];
         if (offset == close_offset) {
-            try output.appendSlice(allocator, "    (modifiers: [");
-            var first = true;
-            const mods = [_]struct { bit: u32, name: []const u8 }{
-                .{ .bit = config.Hotkey.MOD_SUPER, .name = "Super" },
-                .{ .bit = config.Hotkey.MOD_CTRL, .name = "Ctrl" },
-                .{ .bit = config.Hotkey.MOD_ALT, .name = "Alt" },
-                .{ .bit = config.Hotkey.MOD_SHIFT, .name = "Shift" },
-            };
-            for (mods) |mod| {
-                if ((modifiers & mod.bit) == 0) continue;
-                if (!first) try output.appendSlice(allocator, ", ");
-                try output.appendSlice(allocator, mod.name);
-                first = false;
+            if (key_name) |name| {
+                try output.appendSlice(allocator, "    (modifiers: [");
+                var first = true;
+                const mods = [_]struct { bit: u32, name: []const u8 }{
+                    .{ .bit = config.Hotkey.MOD_SUPER, .name = "Super" },
+                    .{ .bit = config.Hotkey.MOD_CTRL, .name = "Ctrl" },
+                    .{ .bit = config.Hotkey.MOD_ALT, .name = "Alt" },
+                    .{ .bit = config.Hotkey.MOD_SHIFT, .name = "Shift" },
+                };
+                for (mods) |mod| {
+                    if ((modifiers & mod.bit) == 0) continue;
+                    if (!first) try output.appendSlice(allocator, ", ");
+                    try output.appendSlice(allocator, mod.name);
+                    first = false;
+                }
+                try output.appendSlice(allocator, "], key: \"");
+                try output.appendSlice(allocator, name);
+                try appendCosmicEntryTail(output, allocator, exe, index);
             }
-            try output.appendSlice(allocator, "], key: \"");
-            try output.appendSlice(allocator, key_name);
-            try appendCosmicEntryTail(&output, allocator, exe, index);
         }
         // **내 인스턴스의 줄만** 지운다. 남의 인스턴스는 launcher 소관이다.
         const mine = if (tildazCosmicEntryIndex(line)) |idx| idx == index else false;
@@ -616,10 +710,6 @@ pub fn writeCosmicPositionEntry(
             try output.append(allocator, '\n');
         }
         offset = if (end < content.len) end + 1 else content.len;
-    }
-
-    if (try paths.writeFileIfChanged(rt, allocator, path, output.items)) {
-        log.appendLine("cosmic", "position hotkey entry written key={s}", .{key_name});
     }
 }
 

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -6,6 +6,7 @@ const log = @import("../log.zig");
 const paths = @import("../paths.zig");
 const instance_identity = @import("../host/linux/instance_identity.zig");
 const gsettings_hotkey = @import("../host/linux/gsettings_hotkey.zig");
+const physical_key = @import("../physical_key.zig");
 const kglobalaccel = @import("../host/linux/kglobalaccel.zig");
 
 pub fn sync(rt: Runtime, allocator: std.mem.Allocator, indices: []const u32) !void {
@@ -214,8 +215,46 @@ pub fn hyprlandAccel(buf: []u8, hotkey: config.Hotkey) ![]const u8 {
     if ((hotkey.modifiers & config.Hotkey.MOD_ALT) != 0) try writer.writeAll("ALT ");
     if ((hotkey.modifiers & config.Hotkey.MOD_SUPER) != 0) try writer.writeAll("SUPER ");
     try writer.writeByte(',');
+    // #496 1-c — 위치 표기는 `code:NN` 으로 그대로 넘긴다. **keymap 을 물어볼 필요가
+    // 없어서** 이 launcher 단계에서도 된다 (COSMIC 은 keysym 만 받아 그렇지 못하다).
+    //
+    // **숫자는 xkb keycode (= evdev + 8) 다.** Hyprland 위키가 `code:28` 을 `t` 키의
+    // 예로 드는데 `t` 는 evdev 20 이다. sway `bindcode` 와 같은 번호 체계다.
+    if (hotkey.code) |code| {
+        try writer.print("code:{d}", .{physical_key.evdev(code) + 8});
+        return fbs.buffered();
+    }
     try writer.writeAll(config.linuxKeysymName(hotkey.keysym) orelse return error.InvalidConfig);
     return fbs.buffered();
+}
+
+test "#496 1-c Hyprland takes a position as code:NN in xkb numbering" {
+    var buf: [64]u8 = undefined;
+
+    // **evdev + 8 이다.** Hyprland 위키가 `code:28` 을 `t` 키의 예로 드는데 `t` 는
+    // evdev 20 이다. sway `bindcode` 와 같은 번호 체계이고, 틀려도 Hyprland 가 거부하지
+    // 않아 **조용히 옆 키에 붙으므로** 값을 test 로 고정한다.
+    try std.testing.expectEqualStrings(
+        "CTRL ,code:28",
+        try hyprlandAccel(&buf, config.Hotkey.fromString("ctrl+[KeyT]").?),
+    );
+    // `[Backquote]` = evdev 41 → 49. `xkbcli how-to-type --layout fr '²'` 가 같은
+    // 자리를 keycode 49 로 보고한다.
+    try std.testing.expectEqualStrings(
+        "CTRL ,code:49",
+        try hyprlandAccel(&buf, config.Hotkey.fromString("ctrl+[Backquote]").?),
+    );
+    // 라벨 binding 은 예전 그대로다.
+    try std.testing.expectEqualStrings(
+        "CTRL ,F3",
+        try hyprlandAccel(&buf, config.Hotkey.fromString("ctrl+f3").?),
+    );
+}
+
+test "#496 1-c the position table stays in step with the numbers above" {
+    // 위 test 의 28 · 49 는 손으로 적은 값이라 표가 바뀌면 스스로 거짓이 된다.
+    try std.testing.expectEqual(@as(u16, 20), physical_key.evdev(.key_t));
+    try std.testing.expectEqual(@as(u16, 41), physical_key.evdev(.backquote));
 }
 
 test "managed Hyprland bindings are identified and reconstructed" {
@@ -371,7 +410,14 @@ fn syncCosmic(rt: Runtime, allocator: std.mem.Allocator, indices: []const u32) !
         const end = std.mem.findScalarPos(u8, content, offset, '\n') orelse content.len;
         const line = content[offset..end];
         if (offset == close_offset) try appendCosmicEntries(rt, &output, allocator, indices);
-        if (!isTildazCosmicEntry(line)) {
+        // #496 1-c — 우리 줄은 지우고 다시 쓰는 구조다. 그런데 **위치 표기 인스턴스의
+        // 줄은 워커가 쓴 것**이라 여기서 지우면 launcher 가 돌 때마다 사라진다. 그래서
+        // 그 인스턴스의 줄만 남긴다.
+        const keep = if (tildazCosmicEntryIndex(line)) |idx|
+            cosmicDeferredToWorker(rt, allocator, idx)
+        else
+            true;
+        if (keep) {
             try output.appendSlice(allocator, line);
             try output.append(allocator, '\n');
         }
@@ -418,12 +464,30 @@ pub fn findClosingMapLine(content: []const u8) ?usize {
 /// 자리가 정말 정수인지 확인해 `TildaZ_backup` 같은 남의 이름을 집지 않는다 (Hyprland
 /// 쪽 `managedToggleCommand` 와 같은 엄격함).
 fn isTildazCosmicEntry(line: []const u8) bool {
-    const start = std.mem.find(u8, line, cosmic_entry_marker) orelse return false;
+    return tildazCosmicEntryIndex(line) != null;
+}
+
+/// 우리 항목이면 그 instance index. #496 1-c 가 필요로 한다 — **어느 인스턴스의 줄인지**
+/// 알아야 위치 표기 인스턴스의 줄을 지우지 않고 남길 수 있다.
+fn tildazCosmicEntryIndex(line: []const u8) ?u32 {
+    const start = std.mem.find(u8, line, cosmic_entry_marker) orelse return null;
     const rest = line[start + cosmic_entry_marker.len ..];
     // 표식 뒤는 `<index>")` 형태다. 닫는 큰따옴표까지가 index 자리.
-    const end = std.mem.findScalar(u8, rest, '"') orelse return false;
-    _ = std.fmt.parseInt(u32, rest[0..end], 10) catch return false;
-    return true;
+    const end = std.mem.findScalar(u8, rest, '"') orelse return null;
+    return std.fmt.parseInt(u32, rest[0..end], 10) catch null;
+}
+
+/// #496 1-c — 이 인스턴스의 hotkey 가 **위치 표기**인가.
+///
+/// 그렇다면 launcher 는 COSMIC 항목을 쓰지 못한다. COSMIC 의 RON `key:` 는 글자만 받는데
+/// 자리를 글자로 바꾸려면 keymap 이 있어야 하고, launcher 에는 keyboard 자체가 없다
+/// (Hyprland 가 1-b 에서 막혔던 그 자리다. 그쪽은 `code:` 로 자리를 그대로 받아 통과한다).
+/// 그래서 그 인스턴스의 항목은 **워커가 keymap 을 받은 뒤에** 쓴다.
+fn cosmicDeferredToWorker(rt: Runtime, allocator: std.mem.Allocator, index: u32) bool {
+    const text = instances.configHotkeyText(rt, allocator, index) catch return false;
+    defer allocator.free(text);
+    const hotkey = config.Hotkey.fromString(text) orelse return false;
+    return hotkey.code != null;
 }
 
 /// `appendCosmicEntries` 의 writer 와 `isTildazCosmicEntry` 의 matcher 가 **같은**
@@ -441,6 +505,8 @@ fn appendCosmicEntries(rt: Runtime, output: *std.ArrayList(u8), allocator: std.m
         const text = try instances.configHotkeyText(rt, allocator, index);
         defer allocator.free(text);
         const hotkey = config.Hotkey.fromString(text) orelse return error.InvalidConfig;
+        // #496 1-c — 위치 표기는 워커가 쓴다 (`cosmicDeferredToWorker` 주석).
+        if (hotkey.code != null) continue;
         try output.appendSlice(allocator, "    (modifiers: [");
         var first = true;
         const mods = [_]struct { bit: u32, name: []const u8 }{
@@ -457,15 +523,103 @@ fn appendCosmicEntries(rt: Runtime, output: *std.ArrayList(u8), allocator: std.m
         }
         try output.appendSlice(allocator, "], key: \"");
         try output.appendSlice(allocator, config.linuxKeysymName(hotkey.keysym) orelse return error.InvalidConfig);
-        // 표식은 `cosmic_entry_marker` 를 그대로 쓴다 — matcher 와 문자열이 갈라지면
-        // 자기 항목을 못 알아본다 (#484 의 원인이 정확히 그것이었다).
-        const description = try std.fmt.allocPrint(allocator, "\", " ++ cosmic_entry_marker ++ "{d}\")): Spawn(\"", .{index});
-        defer allocator.free(description);
-        try output.appendSlice(allocator, description);
-        try appendRonString(output, allocator, exe);
-        const suffix = try std.fmt.allocPrint(allocator, " --toggle {d}\"),\n", .{index});
-        defer allocator.free(suffix);
-        try output.appendSlice(allocator, suffix);
+        try appendCosmicEntryTail(output, allocator, exe, index);
+    }
+}
+
+/// 엔트리의 `key:` 뒤쪽. **writer 를 한 곳으로 묶어 둔다** — 표식이 matcher 와 갈라지면
+/// 자기 항목을 못 알아보고 중복 키를 써서 COSMIC 이 파일을 통째로 버린다 (#484 의 기전).
+/// #496 1-c 가 워커 쪽 writer 를 하나 더 만들면서 그 위험이 두 배가 되므로 뽑아 둔다.
+fn appendCosmicEntryTail(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    exe: []const u8,
+    index: u32,
+) !void {
+    const description = try std.fmt.allocPrint(allocator, "\", " ++ cosmic_entry_marker ++ "{d}\")): Spawn(\"", .{index});
+    defer allocator.free(description);
+    try output.appendSlice(allocator, description);
+    try appendRonString(output, allocator, exe);
+    const suffix = try std.fmt.allocPrint(allocator, " --toggle {d}\"),\n", .{index});
+    defer allocator.free(suffix);
+    try output.appendSlice(allocator, suffix);
+}
+
+/// #496 1-c — **워커가** 자기 인스턴스의 COSMIC 항목을 쓴다. 위치 표기 hotkey 전용이다.
+///
+/// launcher 가 못 하는 이유는 `cosmicDeferredToWorker` 주석에 있다 — 자리를 글자로
+/// 바꾸려면 keymap 이 필요한데 그 시점엔 keyboard 가 없다. 여기서는 `key_name` 을
+/// 이미 푼 상태로 받는다 (`xkb_keysym_get_name` 의 결과).
+///
+/// **대가 하나** — 그 인스턴스를 한 번은 직접 띄워야 항목이 생긴다. RON 은 파일이라 한
+/// 번 쓰이면 남으므로 그 뒤로는 정상이고, sway 가 매 실행 `bindcode` 를 다시 거는 것과
+/// 같은 성질이다.
+pub fn writeCosmicPositionEntry(
+    rt: Runtime,
+    allocator: std.mem.Allocator,
+    index: u32,
+    key_name: []const u8,
+    modifiers: u32,
+) !void {
+    const home = rt.environ.getPosix("HOME") orelse return error.HomeNotSet;
+    const dir_path = try std.Io.Dir.path.join(allocator, &.{ home, ".config", "cosmic", "com.system76.CosmicSettings.Shortcuts", "v1" });
+    defer allocator.free(dir_path);
+    try paths.ensureDir(rt, dir_path);
+    const path = try std.Io.Dir.path.join(allocator, &.{ dir_path, "custom" });
+    defer allocator.free(path);
+
+    const content = blk: {
+        const file = std.Io.Dir.openFileAbsolute(rt.io, path, .{}) catch |err| switch (err) {
+            error.FileNotFound => break :blk try allocator.dupe(u8, "{\n}\n"),
+            else => return err,
+        };
+        defer file.close(rt.io);
+        var file_reader = file.reader(rt.io, &.{});
+        break :blk try file_reader.interface.allocRemaining(allocator, .limited(1024 * 1024));
+    };
+    defer allocator.free(content);
+
+    var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const exe_len = try std.process.executablePath(rt.io, &exe_buf);
+    const exe = exe_buf[0..exe_len];
+
+    const close_offset = findClosingMapLine(content) orelse return error.UnsupportedCosmicShortcutFormat;
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+    var offset: usize = 0;
+    while (offset < content.len) {
+        const end = std.mem.findScalarPos(u8, content, offset, '\n') orelse content.len;
+        const line = content[offset..end];
+        if (offset == close_offset) {
+            try output.appendSlice(allocator, "    (modifiers: [");
+            var first = true;
+            const mods = [_]struct { bit: u32, name: []const u8 }{
+                .{ .bit = config.Hotkey.MOD_SUPER, .name = "Super" },
+                .{ .bit = config.Hotkey.MOD_CTRL, .name = "Ctrl" },
+                .{ .bit = config.Hotkey.MOD_ALT, .name = "Alt" },
+                .{ .bit = config.Hotkey.MOD_SHIFT, .name = "Shift" },
+            };
+            for (mods) |mod| {
+                if ((modifiers & mod.bit) == 0) continue;
+                if (!first) try output.appendSlice(allocator, ", ");
+                try output.appendSlice(allocator, mod.name);
+                first = false;
+            }
+            try output.appendSlice(allocator, "], key: \"");
+            try output.appendSlice(allocator, key_name);
+            try appendCosmicEntryTail(&output, allocator, exe, index);
+        }
+        // **내 인스턴스의 줄만** 지운다. 남의 인스턴스는 launcher 소관이다.
+        const mine = if (tildazCosmicEntryIndex(line)) |idx| idx == index else false;
+        if (!mine) {
+            try output.appendSlice(allocator, line);
+            try output.append(allocator, '\n');
+        }
+        offset = if (end < content.len) end + 1 else content.len;
+    }
+
+    if (try paths.writeFileIfChanged(rt, allocator, path, output.items)) {
+        log.appendLine("cosmic", "position hotkey entry written key={s}", .{key_name});
     }
 }
 

--- a/src/window.zig
+++ b/src/window.zig
@@ -248,6 +248,22 @@ extern "user32" fn BringWindowToTop(HWND) callconv(.c) BOOL;
 extern "user32" fn SetFocus(HWND) callconv(.c) HWND;
 extern "user32" fn RegisterHotKey(HWND, c_int, UINT, UINT) callconv(.c) BOOL;
 extern "user32" fn UnregisterHotKey(HWND, c_int) callconv(.c) BOOL;
+// #496 1-c — 위치 표기 hotkey 를 잡는 저수준 훅. 왜 `RegisterHotKey` 가 아닌지는
+// `Window.installPositionHotkey` 주석에 있다.
+const LowLevelKeyboardProc = fn (c_int, WPARAM, LPARAM) callconv(.c) LRESULT;
+extern "user32" fn SetWindowsHookExW(c_int, *const LowLevelKeyboardProc, ?*anyopaque, DWORD) callconv(.c) ?*anyopaque;
+extern "user32" fn UnhookWindowsHookEx(?*anyopaque) callconv(.c) BOOL;
+extern "user32" fn CallNextHookEx(?*anyopaque, c_int, WPARAM, LPARAM) callconv(.c) LRESULT;
+// modifier 상태는 아래 `GetAsyncKeyState` 로 읽는다 (이미 선언돼 있다).
+/// `WH_KEYBOARD_LL` 콜백이 받는 구조체. **`scanCode` 가 이 훅을 쓰는 이유다** — layout
+/// 이 개입하지 않은 raw 값이고, 위치 표기가 뜻하는 것이 정확히 그 값이다.
+const KBDLLHOOKSTRUCT = extern struct {
+    vkCode: DWORD,
+    scanCode: DWORD,
+    flags: DWORD,
+    time: DWORD,
+    dwExtraInfo: usize,
+};
 extern "user32" fn GetCursorPos(*POINT) callconv(.c) BOOL;
 extern "user32" fn MonitorFromPoint(POINT, DWORD) callconv(.c) ?*anyopaque;
 extern "user32" fn MonitorFromWindow(HWND, DWORD) callconv(.c) ?*anyopaque;
@@ -578,9 +594,29 @@ pub const Window = struct {
     hotkey_vkey: UINT = 0,
     hotkey_modifiers: UINT = 0,
     hotkey_registered: bool = false,
+    /// #496 1-c — 위치 표기로 적은 hotkey 의 자리. null 이면 라벨 binding 이다.
+    /// 이 값이 non-null 이면 등록 경로가 통째로 갈린다 — `hotkeyAcquire` 참고.
+    hotkey_code: ?physical_key.PhysicalCode = null,
+
+    /// #496 1-c — 위치 표기 hotkey 의 훅 상태.
+    ///
+    /// **왜 인스턴스 필드가 아니라 여기인가.** `WH_KEYBOARD_LL` 콜백은 `hwnd` 를 받지
+    /// 않아 `getSelf` 로 창을 찾을 수 없다. 전역 hotkey 를 가진 창은 프로세스에 하나뿐
+    /// (`HOTKEY_ID` 가 상수 하나인 것과 같은 전제) 이므로 콜백이 볼 값을 container 범위에
+    /// 둔다. 콜백은 이 값들을 **읽기만** 한다.
+    var g_hook: ?*anyopaque = null;
+    var g_hook_hwnd: ?HWND = null;
+    var g_hook_scan: u16 = 0;
+    var g_hook_extended: bool = false;
+    var g_hook_modifiers: UINT = 0;
 
     const CLASS_NAME = std.unicode.utf8ToUtf16LeStringLiteral(@import("instances.zig").window_class_name);
     const HOTKEY_ID: c_int = 1;
+    const WH_KEYBOARD_LL: c_int = 13;
+    const HC_ACTION: c_int = 0;
+    /// `KBDLLHOOKSTRUCT.flags` bit 0 — `0xE0` prefix 자리다 (control pad / numpad 구분).
+    const LLKHF_EXTENDED: DWORD = 0x01;
+    // 필요한 `VK_*` (`CONTROL` · `SHIFT` · `MENU` · `LWIN` · `RWIN`) 는 파일 범위에 이미 있다.
     const VK_F1: UINT = 0x70;
     const VK_RETURN: WPARAM = 0x0D;
     const RENDER_TIMER_ID: usize = 1;
@@ -740,19 +776,37 @@ pub const Window = struct {
     /// `if (!opts.isStressRun()) window.registerGlobalHotkey(...)` 로 정책을 드러내며,
     /// macOS 의 `installEventTap` · Linux 의 `sway_ipc.registerToggleIfSway` 와 같은
     /// 형태다. 이제 이 정책 분기가 창 초기화를 삼킬 구조 자체가 없다.
-    pub fn registerGlobalHotkey(self: *Window, hotkey_vkey: u32, hotkey_modifiers: u32) void {
-        self.hotkey_vkey = hotkey_vkey;
+    ///
+    /// #496 1-c — 위치 표기 (`ctrl+[Backquote]`) 도 받는다. 그쪽은 `RegisterHotKey` 를
+    /// 쓰지 않는다 — 이유는 `installPositionHotkey` 주석에 있다.
+    pub fn registerGlobalHotkey(
+        self: *Window,
+        hotkey_vkey: u32,
+        hotkey_modifiers: u32,
+        hotkey_code: ?physical_key.PhysicalCode,
+    ) void {
+        self.hotkey_code = hotkey_code;
         self.hotkey_modifiers = hotkey_modifiers;
-        if (!RegisterHotKey(self.requireHwnd(), HOTKEY_ID, hotkey_modifiers, hotkey_vkey).toBool()) {
+        self.hotkey_vkey = hotkey_vkey;
+        if (!self.hotkeyAcquire(self.requireHwnd())) {
             var alloc_buf: [4096]u8 = undefined;
             var fba = std.heap.FixedBufferAllocator.init(&alloc_buf);
             const cfg_path = paths.configPath(self.rt, fba.allocator()) catch messages.unknown_path_msg;
             var msg_buf: [1024]u8 = undefined;
-            const msg = std.fmt.bufPrint(
-                &msg_buf,
-                messages.hotkey_registration_failed_format,
-                .{ hotkey_vkey, hotkey_modifiers, cfg_path },
-            ) catch messages.hotkey_registration_failed_fallback_msg;
+            // 두 경로의 실패 원인이 겹치지 않으므로 안내도 갈라야 한다 — 위치 표기는
+            // 훅 설치가 막힌 것이고, 라벨은 OS hotkey 표가 이미 차 있는 것이다.
+            const msg = if (self.hotkey_code) |code|
+                std.fmt.bufPrint(
+                    &msg_buf,
+                    messages.hotkey_hook_failed_format,
+                    .{ physical_key.name(code), self.hotkey_modifiers, cfg_path },
+                ) catch messages.hotkey_hook_failed_fallback_msg
+            else
+                std.fmt.bufPrint(
+                    &msg_buf,
+                    messages.hotkey_registration_failed_format,
+                    .{ self.hotkey_vkey, self.hotkey_modifiers, cfg_path },
+                ) catch messages.hotkey_registration_failed_fallback_msg;
             dialog.showFatal(self.rt, messages.hotkey_registration_failed_title, msg);
         }
         // 등록에 성공한 경로에만 세운다 — `deinit` 의 `UnregisterHotKey` 와
@@ -768,6 +822,124 @@ pub const Window = struct {
         // `FindWindowW` 로 worker 타이틀을 찾으므로 측정 창을 집지 않는다
         // (`instances.windowTitleForCurrentRole`).
         self.hotkey_registered = true;
+    }
+
+    /// #496 1-c — 전역 hotkey 를 잡는다. **두 표기가 서로 다른 OS 기능을 쓴다.**
+    ///
+    /// 등록 · 해제가 세 곳에서 일어나므로 (`registerGlobalHotkey` ·
+    /// `WM_HOTKEY_CAPTURE_BEGIN`/`_END` · `deinit`) 분기를 이 한 쌍에 모은다. 예전에는
+    /// 세 곳이 각자 `RegisterHotKey` / `UnregisterHotKey` 를 불렀는데, 표기에 따라 기능이
+    /// 갈리면 그 형태로는 한 곳만 고쳐도 어긋난다.
+    fn hotkeyAcquire(self: *Window, hwnd: HWND) bool {
+        if (self.hotkey_code) |code| return self.installPositionHotkey(hwnd, code);
+        return RegisterHotKey(hwnd, HOTKEY_ID, self.hotkey_modifiers, self.hotkey_vkey).toBool();
+    }
+
+    fn hotkeyRelease(self: *Window, hwnd: HWND) bool {
+        if (self.hotkey_code != null) return removePositionHotkey();
+        return UnregisterHotKey(hwnd, HOTKEY_ID).toBool();
+    }
+
+    /// #496 1-c — 위치 표기 hotkey 를 `WH_KEYBOARD_LL` 훅으로 잡는다.
+    ///
+    /// **왜 `RegisterHotKey` 가 아닌가.** 그 API 는 virtual-key 만 받는데 **VK 는 layout
+    /// DLL 이 배정하는 값이라 자판마다 자리가 움직인다** (실측: `VK_OEM_3` 이 US `0x29` ·
+    /// 프랑스어 legacy `0x28` · 독일어 `0x27`). 그래서 자리를 VK 로 한 번 풀어 등록하면
+    /// 그 값은 *그 layout 에서만* 맞는 파생값이 된다. 처음 구현이 그 파생값을 캐시하고
+    /// `WM_INPUTLANGCHANGE` 에서 다시 풀었는데, 그 메시지는 **스레드별이고 포커스를 얻을
+    /// 때 온다**. 드롭다운은 숨어 있는 것이 기본 상태라, 숨은 동안 layout 이 바뀌면
+    /// 캐시가 낡은 채 남고 — 실측 — **핫키가 다른 물리 키로 옮겨갔다.** 위치 표기가
+    /// 없애려던 바로 그 증상이다. 게다가 핫키가 먹어야 포커스를 얻고 포커스를 얻어야
+    /// 캐시가 갱신되는 순환이라, 그 구조로는 창을 좁힐 수만 있고 닫을 수 없다.
+    ///
+    /// `KBDLLHOOKSTRUCT.scanCode` 는 layout 이 개입하지 않은 raw 값이고 위치 표기가 뜻하는
+    /// 것이 정확히 그 값이다. 변환도 캐시도 없어 갱신할 대상 자체가 생기지 않는다.
+    ///
+    /// **라벨 표기는 계속 `RegisterHotKey` 다.** 라벨은 OS 가 keypress 시점에 layout DLL 로
+    /// 풀어 주는 것이 옳은 동작이라 우리가 개입할 이유가 없다. 그래서 훅의 대가는 위치
+    /// 표기를 쓴 사용자에게만 발생한다.
+    ///
+    /// 훅은 `hMod = null` · `threadId = 0` 으로 건다 — `WH_KEYBOARD_LL` 은 별 DLL 없이
+    /// 이 프로세스의 콜백을 시스템이 부르는 형태다 (다른 훅 종류와 다르다).
+    fn installPositionHotkey(self: *Window, hwnd: HWND, code: physical_key.PhysicalCode) bool {
+        if (g_hook != null) _ = removePositionHotkey();
+        const sc = physical_key.scanCode(code);
+        g_hook_scan = sc.value;
+        g_hook_extended = sc.extended;
+        g_hook_modifiers = self.hotkey_modifiers;
+        g_hook_hwnd = hwnd;
+        g_hook = SetWindowsHookExW(WH_KEYBOARD_LL, &lowLevelKeyboardProc, null, 0);
+        if (g_hook == null) {
+            g_hook_hwnd = null;
+            log.appendLine("hotkey", "position hotkey hook install failed for [{s}]", .{physical_key.name(code)});
+            return false;
+        }
+        log.appendLine(
+            "hotkey",
+            "position hotkey armed: [{s}] scan=0x{x:0>2} extended={} modifiers=0x{x}",
+            .{ physical_key.name(code), sc.value, sc.extended, g_hook_modifiers },
+        );
+        return true;
+    }
+
+    fn removePositionHotkey() bool {
+        const hook = g_hook orelse return true;
+        const ok = UnhookWindowsHookEx(hook).toBool();
+        g_hook = null;
+        g_hook_hwnd = null;
+        return ok;
+    }
+
+    /// #496 1-c — 위치 표기 hotkey 의 훅 콜백.
+    ///
+    /// **여기서는 비교와 `PostMessageW` 만 한다.** 이 콜백은 시스템이 입력 스레드에서
+    /// 부르고, `LowLevelHooksTimeout` (기본 300 ms) 을 넘기면 **훅이 조용히 제거된다** —
+    /// 그러면 오류도 로그도 없이 핫키가 죽는다. 그래서 토글 같은 실제 작업은 창의
+    /// 메시지 큐로 넘기고, 여기서는 절대 블로킹하지 않는다. `WM_HOTKEY` 를 그대로 쓰므로
+    /// 라벨 경로와 처리부가 하나로 남는다.
+    ///
+    /// 맞으면 `1` 을 돌려 **삼킨다** — 아래 앱에 그 키가 새면 사용자가 핫키를 누를 때마다
+    /// 편집기에 문자가 들어간다. `RegisterHotKey` 도 같은 자리에서 키를 소비한다.
+    ///
+    /// **injected 입력을 걸러내지 않는다** (`LLKHF_INJECTED`). `RegisterHotKey` 가 합성
+    /// 입력에도 반응하므로 (실측) 그쪽과 동작을 맞춘다 — 자동화 · 접근성 도구가 핫키를
+    /// 누를 수 있어야 하고, 두 표기가 여기서 갈릴 이유가 없다.
+    fn lowLevelKeyboardProc(code: c_int, wParam: WPARAM, lParam: LPARAM) callconv(.c) LRESULT {
+        match: {
+            if (code != HC_ACTION) break :match;
+            if (wParam != WM_KEYDOWN and wParam != WM_SYSKEYDOWN) break :match;
+            const hwnd = g_hook_hwnd orelse break :match;
+            const kb: *const KBDLLHOOKSTRUCT = @ptrFromInt(@as(usize, @bitCast(lParam)));
+            if (@as(u16, @truncate(kb.scanCode)) != g_hook_scan) break :match;
+            if (((kb.flags & LLKHF_EXTENDED) != 0) != g_hook_extended) break :match;
+            if (!modifiersExactlyHeld(g_hook_modifiers)) break :match;
+            _ = PostMessageW(hwnd, WM_HOTKEY, @intCast(HOTKEY_ID), 0);
+            return 1;
+        }
+        return CallNextHookEx(null, code, wParam, lParam);
+    }
+
+    /// 요구한 modifier 가 눌려 있고 **나머지는 눌려 있지 않은지**. `RegisterHotKey` 가
+    /// 그렇게 동작한다 — `Ctrl+Alt+X` 는 `ctrl+x` 를 발동시키지 않는다. 그 규칙을 여기서
+    /// 다시 만들지 않으면 두 표기가 같은 config 로 다르게 동작한다.
+    ///
+    /// 훅은 modifier 상태를 주지 않으므로 `GetAsyncKeyState` 로 읽는다. 이 콜백은 키가
+    /// 눌린 그 순간에 불리므로 시점이 어긋나지 않는다.
+    fn modifiersExactlyHeld(mods: UINT) bool {
+        const held = struct {
+            fn f(vk: c_int) bool {
+                return (@as(u16, @bitCast(GetAsyncKeyState(vk))) & 0x8000) != 0;
+            }
+        }.f;
+        const want_alt = (mods & config_mod.Hotkey.MOD_ALT) != 0;
+        const want_ctrl = (mods & config_mod.Hotkey.MOD_CTRL) != 0;
+        const want_shift = (mods & config_mod.Hotkey.MOD_SHIFT) != 0;
+        const want_super = (mods & config_mod.Hotkey.MOD_SUPER) != 0;
+        if (held(VK_MENU) != want_alt) return false;
+        if (held(VK_CONTROL) != want_ctrl) return false;
+        if (held(VK_SHIFT) != want_shift) return false;
+        if ((held(VK_LWIN) or held(VK_RWIN)) != want_super) return false;
+        return true;
     }
 
     /// (Re)create the GDI font at `new_dpi` and re-measure cell metrics.
@@ -871,7 +1043,7 @@ pub const Window = struct {
             // clock 스레드를 **창을 부수기 전에** join 한다 — 아니면 죽은 hwnd 로
             // `PostMessageW` 가 갈 수 있다.
             self.stopFrameClock();
-            if (self.hotkey_registered) _ = UnregisterHotKey(hwnd, HOTKEY_ID);
+            if (self.hotkey_registered) _ = self.hotkeyRelease(hwnd);
             if (self.dc) |dc| _ = ReleaseDC(hwnd, dc);
             _ = DestroyWindow(hwnd);
         }
@@ -1650,16 +1822,18 @@ pub const Window = struct {
                 // SendMessageW caller가 동기 처리 성공을 판별하는 protocol result.
                 return 1;
             },
+            // #496 1-c — `WM_INPUTLANGCHANGE` 를 듣지 않는다. 위치 표기가 훅으로 바뀌어
+            // layout 에 따라 다시 풀 값이 없어졌다 (`installPositionHotkey` 주석).
             WM_HOTKEY_CAPTURE_BEGIN => {
                 if (self.hotkey_registered) {
-                    if (!UnregisterHotKey(hwnd, HOTKEY_ID).toBool()) return 0;
+                    if (!self.hotkeyRelease(hwnd)) return 0;
                     self.hotkey_registered = false;
                 }
                 return 1;
             },
             WM_HOTKEY_CAPTURE_END => {
                 if (!self.hotkey_registered) {
-                    if (!RegisterHotKey(hwnd, HOTKEY_ID, self.hotkey_modifiers, self.hotkey_vkey).toBool()) return 0;
+                    if (!self.hotkeyAcquire(hwnd)) return 0;
                     self.hotkey_registered = true;
                 }
                 return 1;


### PR DESCRIPTION
`hotkey = "ctrl+[Backquote]"` 를 받는다. #496 의 마지막 항목이다.

파싱은 세 platform 이 이미 `code` 를 채우고 있었고 전역 경로에서만 거부했다. 어려운 쪽은
**등록 6 경로가 서로 다른 것을 받는다**는 점이었다.

| 경로 | 무엇을 주나 |
|---|---|
| macOS (CGEventTap) | keycode 가 곧 위치 — **손댈 것 없음** |
| sway `bindcode` · Hyprland `code:` · GNOME / Cinnamon `0xNN` | **자리** (xkb keycode = evdev + 8) |
| COSMIC RON `key:` · KDE `qtKey` | **그 자리가 지금 layout 에서 내는 글자** |
| Windows `RegisterHotKey` | 지금 layout 이 그 자리에 배정한 VK |

## 이 PR 이 실제로 푸는 것

AZERTY 에서 `[Backquote]` 는 `twosuperior` 다. COSMIC · KDE 에 그 이름으로 등록되므로
**#484 의 `²` 요청이 여기서 풀린다.**

## 먼저 막은 조용한 오동작 둘

- **`qtKey` 가 모르는 keysym 에 `0` 을 냈다.** key 자리가 0 이면 KDE 에 *modifier 만의
  단축키*가 등록돼 `Ctrl` 을 뗄 때 발동한다. 라벨 집합이 좁을 때는 모든 값이 표에 있어
  드러나지 않았지만 위치 표기는 임의의 keysym 을 데려온다. `?i32` 로 바꿔 실패를 값으로
  만들었다.
- **COSMIC 은 우리 줄을 전부 지우고 다시 쓴다.** 워커가 쓴 항목이 launcher 가 돌 때마다
  사라질 뻔했다. 줄에서 instance index 를 꺼내 그 인스턴스만 보존한다.

## 실측이 정한 것

- **KDE 재등록은 안전하다** (CachyOS · KWin 6.7.4). Qt key 178 → `²` 로 받고, 서로 다른
  키로 5 회 재등록해도 `kglobalshortcutsrc` 전체 diff 가 우리 블록 한 줄 덮어쓰기뿐이었다.
- **dead key 는 거부한다.** 독일어 `[Backquote]` 자리가 `dead_circumflex` 인데 KDE 가
  엉뚱한 문자 (`ោ`) 로 적었다. 글자로 넘기는 두 경로에서만 거부하고 로그로 알린다.
- **번호는 evdev + 8** — Hyprland 위키의 `code:28` = `t` (evdev 20), GTK `is_keycode()` +
  Mutter `combo->keycode` 소스. off-by-8 이면 조용히 옆 키에 붙어서 test 로 고정했다.

## 등록 시점

위치를 글자로 풀려면 keymap 이 필요하다. **KDE** 는 `keyboard ready` roundtrip 직후로
옮겼다 — `hidden_at_start` 판단보다 앞이라 동작이 그대로다. **COSMIC** 은 등록이 launcher
라 keyboard 자체가 없어 위치 binding 인 인스턴스만 워커로 미룬다 (그 인스턴스를 한 번
띄워야 항목이 생긴다). Hyprland 는 `code:` 라 keymap 이 필요 없어 1-b 의 known limitation
이 **위치 표기에서는 풀린다** (라벨은 그대로).

# 실기 검증 — 여섯 환경, 결함 일곱을 잡았다

착수 뒤 **KDE · sway · Hyprland · GNOME · Cinnamon · COSMIC** 여섯 곳에서 실제로 쟀다.
그 과정에서 라틴 layout 에서는 안 보이는 결함 일곱이 나왔고, 전부 이 PR 안에서 고쳤다.

측정 기기 둘이다.

- **미니PC Firebat ZY-A8** · AMD Ryzen 7 8845HS · CachyOS (커널 7.2.0-rc7) ·
  KWin 6.7.4 · sway 1.12 · Hyprland 0.56.2 · libxkbcommon 1.13.2
- **노트북 i5-1240P** · Iris Xe · CachyOS · GNOME Shell 50.4 · Cinnamon 6.6.9 (Muffin) ·
  cosmic-comp 1.0.0 (`314fc67`) — 셋 다 Wayland 실 세션

## 최종 결과

| 환경 | 등록된 값 | 실제 키 입력 | layout 대조군 |
|---|---|---|---|
| **KDE** | us `` Ctrl+` `` · fr `Ctrl+²` · ru `Ctrl+Ё` · de **등록 안 함** | 창 토글 확인 | fr → us 왕복 복구 |
| **sway** | `bindcode auto-registered OK — Ctrl+49` | — | 자리 고정 (해당 없음) |
| **Hyprland** | `key='' keycode=49 modmask=4` | — | 자리 고정 |
| **GNOME** | 확장 `<Control>0x31` grab · fallback gsettings `'<Control>0x31'` | `entered=[]` ↔ `entered=[11]` 왕복 · fallback 은 `--toggle 9` 실행 | **fr 단독에서 위치만 발동, 라벨 `ctrl+grave` 는 안 됨** |
| **Cinnamon** | 확장 `<Control>0x31` · fallback `['<Control>0x31']` | `toggle 9` 발동 · fallback 은 `--toggle 9` | **fr · ru 단독에서 위치만 발동, 라벨 `ctrl+grave` 는 안 됨** |
| **COSMIC** | us `grave` · fr `twosuperior` · ru `Cyrillic_io` · de **거둠** | 토글 확인 (us · fr 같은 자리) | 창을 안 띄운 채 재등록 · 복구 |

여섯 중 **다섯에서 layout 축까지** 쟀다 (sway · Hyprland 는 자리를 고정해 해당 없음).

`49` = evdev 41 + 8. **1-b 의 Hyprland known limitation 이 위치 표기에서는 실제로 풀리는
것**과, **fr 의 `Ctrl+²` ([#484](https://github.com/ensky0/tildaz/issues/484) 가 요청한 키)**
가 이것으로 확인됐다.

`grab_accelerator` 는 숫자로 답해서 대조군이 깔끔하다 (GNOME 50.4).

| accel | action |
|---|---|
| `<Control>[backquote]` (고치기 전) | **0** = `KeyBindingAction.NONE` |
| `<Control>0x31` | 129 |
| `<Control>0x1c` (`[KeyT]`) | 130 |
| `<Control><Shift>0x31` | 131 |

Muffin 도 같은 hex 파서다. 로그에 `Overwriting existing binding … (keycode 31)` 이라고
나와 십진으로 읽은 줄 알았는데, `[KeyQ]`(`0x18`) 로 바꿔 재니 **Q 자리에서 발동하고 십진
18 자리(숫자 9)에서는 안 한다** — 그 메시지가 hex 로 찍을 뿐이다.

## 실기가 잡아낸 결함 일곱

**KDE 에서 셋** (`07e4c49`)

1. **키릴이 통째로 실패했다.** `qtKey` 가 Latin-1 과 modern 유니코드 두 구간만 알았는데
   **legacy 국가별 keysym 이 그 사이에 따로 있다** — `Cyrillic_io` 는 `0x06b3` 이고 그리스 ·
   히브리 · 아랍도 각자 블록이다. **범위를 손으로 나열한 표가 이 이슈의 주 대상 layout 을
   빠뜨린** 셈이다. `xkb_keysym_to_utf32` 로 libxkbcommon 에 묻게 고쳤다. 덤으로 `-` · `;`
   같은 ASCII 구두점도 함께 풀렸다.
2. **dead key 가드가 재등록 경로에 없었다.** 독일어로 바꾸면 일반 실패로 끝나 원인이 로그에
   안 남았다. 그리고 **직전 등록을 거두게 했다** — 남겨 두면 옛 layout 의 글자가 KDE 단축키
   목록에 죽은 항목으로 남는다.
3. **숨어 있으면 layout 전환을 못 따라갔다.** Wayland 의 group 전환은 **포커스한 client
   에게만** 간다. 드롭다운은 대개 숨어 있고, **그 hotkey 가 창을 부르는 유일한 수단**이라
   스스로 빠져나올 수 없다. `org.kde.KeyboardLayouts.layoutChanged` 를 구독해 풀었고, 그
   시그널의 index 를 `active_group` 에 쓰는 것까지 필요했다.

**COSMIC 에서 하나** (`6b5bb7f`)

4. **dead key 로 바뀔 때 직전 등록을 안 거뒀다.** KDE 의 ②와 같은 결함이 COSMIC 경로에만
   남아 있었다 — fr → de 로 바꾸면 `key: "twosuperior"` 가 사용자 RON 에 죽은 채로 남는다
   (독일어에서 `Ctrl+AltGr+2` 를 눌러도 발동하지는 않는 것까지 확인했다). 쓰는 쪽과 지우는
   쪽을 `renderCosmicPositionRon(key_name: ?[]const u8)` 한 함수로 묶었다 — 갈라 두면 같은
   map 키가 둘 생기고, 중복 키가 있는 RON 은 COSMIC 이 파일 전체를 버린다 (#484 의 기전).
   `cosmic_position_keysym` 을 보지 않고 **항상** 거두는 이유는 부팅 경로다: 그 값은 매 실행
   0 에서 시작하는데 RON 은 파일이라 지난 실행의 줄이 남아 있다.

**GNOME · Cinnamon 확장에서 셋** (`f5b1dcf` · `3802e95`)

5. **확장이 위치 표기를 몰랐다.** GNOME 의 hotkey 주인은 gsettings 가 아니라 확장이다 —
   tildaz 가 부팅 때 확장을 스스로 켜고, 켜져 있으면 gsettings 등록을 건너뛴다. 그 확장의
   `_toAccel` 이 `[Backquote]` 를 그대로 흘려 `grab_accelerator` 가 0 을 냈고, **실패 로그도
   없어서** 위치 표기가 조용히 아무 데도 안 걸렸다.
6. **확장이 `config_N.json` 을 읽고 있었다** (#493 TOML 이관 누락). 확장은 zig 를 안 거치고
   config 를 직접 읽으므로 (config = source of truth 계약) 이관 뒤로 **등록 대상 0 개**였다.
   실기에서 눈에 안 띈 이유는 이관 전의 `config_0.json` 이 디스크에 남아 있었기 때문이다.
   GJS 에 TOML 파서가 없어 좁은 부분집합을 뒀다 — **주석은 문자열 밖에서만** 자른다
   (`dock_position = "top"   # top | bottom | …` 처럼 우리가 읽는 줄에 뒤 주석이 실제로 붙어
   있다).
7. **모르는 자리가 기본값으로 떨어졌다.** `_toAccel` 이 null 을 내는 경로가 6 번 고침으로
   처음 생겼는데, GNOME 의 `_readConfig` 는 `if (a) out.accel = a` 라 실패하면 기본값
   `<Super>grave` 가 남았다 — **사용자가 적지 않은 조합**이 걸린다. 실기에서 `ctrl+[Nope]` 가
   `<Super>grave` 로 등록을 시도하는 것을 보고 고쳤다.

## 표가 JS 에 한 벌 더 생기므로 test 로 묶었다

확장은 zig 를 안 거치므로 `physical_key.zig` 의 표(117 행)를 JS 에도 둬야 한다. 두 벌이
갈리면 **조용히 옆 키에 붙는다** (Mutter · Muffin 은 틀린 keycode 를 거부하지 않는다).
`physical_key.zig` 와 `paths.zig` 의 새 test 가 두 확장 파일을 `@embedFile` 로 읽어 위치
표(양방향)와 config 파일명을 견준다. `@embedFile` 이 package path 를 못 벗어나서
`build.zig` 가 익명 import 로 넘긴다.

## 검증 도구 — 어디서든 같은 절차로

```sh
./dist/hotkey/position-hotkey-check.sh            # 기본 ctrl+[Backquote]
./dist/hotkey/position-hotkey-check.sh --keep     # 남겨 두고 직접 눌러 볼 때
```

`--instance 9` 로만 돌고, 끝나면 만든 것을 스스로 지운다 — config · 로그 · KDE (D-Bus) ·
GNOME/Cinnamon (dconf **항목과 목록**) · COSMIC (RON 줄). 실기로 돌리며 도구 자체의 결함
셋도 고쳤다 (`073f3df`): 조회 경로가 인스턴스를 안 따랐고, 로그 grep 이 `gnome` · `cinnamon`
카테고리를 빠뜨렸고, 정리가 KDE 만 거뒀다.

`AGENTS.md` 에 사용법 · 환경별 기대값 · **손으로 잴 때 걸리는 함정 일곱** · 데스크톱별
layout 전환 방법 · nested 실행 방법을 적었다. 함정 중 이번에 는 것들:

- **Cinnamon 의 layout 스키마는 `org.cinnamon.desktop.input-sources` 다** —
  `org.gnome.desktop.input-sources` 도 `org.gnome.libgnomekbd.keyboard layouts` 도 값만
  바뀌고 아무 일도 안 일어난다. 이것 때문에 한 라운드를 "Cinnamon 은 layout 을 못 바꾼다"
  로 잘못 결론냈다.
- **layout 이 적용됐는지는 `setxkbmap -query` 로 못 본다** — Cinnamon · COSMIC 둘 다
  Xwayland 에 layout 을 안 내려서 늘 `us` 로 보인다. 앱 로그의 `[keys] latin fallback
  active for N binding(s)` 를 오라클로 쓴다 (`ru` 로 바꾸면 뜬다).
- **확장 경로는 `TILDAZ_VERBOSE=1` 로 계측 없이 관측한다** — `[wayland]
  drainSurfaceOutputs entered=[] …` (숨김) ↔ `entered=[11 ] …` (복귀).
- **uinput 으로 가상 키보드를 새로 꽂으면 keymap 이 잠깐 바뀐다** — 그 사이에 키를 보내면
  발동하지 않아 **거짓 실패**가 난다. 장치를 만든 뒤 5 초쯤 두고 눌러야 한다.
- **GNOME 확장은 파일을 고쳐도 `disable`/`enable` 로 다시 안 읽는다** (ESM import 캐시).
  계측을 심어 재려면 nested 로 새로 띄운다.
- **GNOME 50 은 `--nested` 가 없다** — `--wayland` 만 주면 native backend 를 골라
  `Failed to take control of the session: EBUSY` 로 끝난다. 지금 이름은 `--devkit` 이다.
- **GNOME 대조군은 layout 을 하나만 켜고 재야 한다** — 둘 이상 켜면 Mutter 가 keysym 을 모든
  group 에서 찾아 걸어 주므로 라벨 표기도 되는 것처럼 보인다.

## 남은 것

- **Windows · macOS 는 미검증이다.** Windows 는 `WM_INPUTLANGCHANGE` 재등록 경로가,
  macOS 는 회귀만 남았다 (이번 변경이 닿지 않는다).
- 재검증에서 나온 **COSMIC keymap 재전송** 과 **RON 중복 항목**은 이 PR 범위 밖이라 별도
  이슈로 뒀다.

## 자동 검증

`zig build check` (6 타깃) · `zig build test` 통과. 새 test 넷이 **실제로 도는지** 기대값을
깨뜨려 확인했다 (`b262f59` 때의 집계 누락과 같은 구멍을 피하려고).

문서는 `CONFIG.md` · `KEYBINDINGS.md` · `SPEC.md` · `AGENTS.md` 를 같이 고쳤고, 거짓이 된
안내 메시지 (`config_hotkey_position_*`) 와 `physical_key.zig` 헤더의 낡은 서술도 걷었다.

검증에 쓴 config · 로그 · dconf · RON 은 매번 지웠고, 세 세션 모두 설정이 백업과 동일한
것을 `diff` 로 확인했다.
