### PR TITLE
fix(cosmic): 단축키 항목의 writer 를 앱 하나로 모은다 (#514)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -250,7 +250,8 @@ Linux 지원 수준은 desktop 이름이 아니라 실제 capability + 검증 �
 - **COSMIC (smithay).** layer-shell drop-down. hotkey 는 RON custom shortcut
   (`~/.config/cosmic/.../custom`) 의 TildaZ 전용 항목을 config_N 전체에 맞춰
   `Spawn("tildaz --toggle N")`로 원자적 갱신하되, 기존 bytes 와 같으면 write/rename 을
-  생략한다. XDG autostart는 지원.
+  생략한다. XDG autostart는 지원. **`install.sh` 는 COSMIC 항목을 쓰지 않는다** — writer 는
+  이 경로 하나다 ([#514](https://github.com/ensky0/tildaz/issues/514), Hyprland 와 같은 규칙).
   - **"TildaZ 전용 항목" 의 판정 근거는 우리가 쓰는 description 표식
     (`description: Some("TildaZ_<index>")`) 하나다** — 명령 문자열이 아니다
     ([#484](https://github.com/ensky0/tildaz/issues/484)). 이 파일에는 사용자가 만든
@@ -259,6 +260,12 @@ Linux 지원 수준은 desktop 이름이 아니라 실제 capability + 검증 �
     사라진다), 남의 항목을 자기 것으로 착각하면 **조용히 지운다**. 명령에는 바이너리
     경로와 이름이 들어가 사용자가 바꿀 수 있으므로 판정 근거가 될 수 없다. 표식 뒤의
     번호가 정수인지도 확인한다.
+  - **예외는 하나뿐이다 — 예전 `install.sh` 가 표식 없이 쓴 줄을 흡수한다**
+    ([#514](https://github.com/ensky0/tildaz/issues/514)). 그 시절엔 writer 가 둘이었고
+    스크립트 쪽이 표식을 안 붙여, 같은 hotkey 가 RON 에 두 번 남았다. 흡수 조건은 **완전
+    일치**다: `description` 이 아예 없고, `Spawn` 명령이 *지금 실행 파일 경로* +
+    `--toggle <index>` 와 바이트까지 같으며, 그 index 를 우리가 실제로 관리할 때. 셋 중
+    하나라도 어긋나면 사용자 항목으로 보고 남긴다.
 - **GNOME / Cinnamon (mutter / muffin).** layer-shell 미지원이라 TildaZ 본체는 평범한
   xdg-shell client (`app_id="tildaz.instanceN"`) 로 두고, **Shell extension** 이 창을 잡아
   drop-down 배치 + 토글 + 창 목록 숨김(Alt-Tab / taskbar / window-list / Expo)을

--- a/dist/linux/install.sh
+++ b/dist/linux/install.sh
@@ -158,42 +158,6 @@ HYPR_CONF="$HYPR_DIR/hyprland.conf"
 HYPR_LUA="$HYPR_DIR/hyprland.lua"
 TILDAZ_MARKER_LUA="-- tildaz autostart (added by install.sh — uninstall.sh removes this)"
 
-# tildaz config.hotkey → COSMIC RON 바인딩 키 `(modifiers: [..], key: "..")`.
-#   modifiers: Super/Ctrl/Alt/Shift, key: xkb keysym 이름(KEY_ prefix 없이) —
-#   letter 소문자("a"), 함수키 "F1", "grave"/"space"(소문자), "Tab"/"Escape"/"Return".
-#   (cosmic-comp 은 keysym 이름을 case-insensitive 로도 매칭하므로 casing 은 best-effort.)
-cosmic_translate_hotkey() {
-    local cfg="$TILDAZ_CONFIG_DIR/config_0.json" hk="f1" v=""
-    if [[ -f "$cfg" ]]; then
-        v="$(grep -oE '"hotkey"[[:space:]]*:[[:space:]]*"[^"]*"' "$cfg" 2>/dev/null | head -1 | sed -E 's/.*"([^"]*)"$/\1/' || true)"
-        [[ -n "$v" ]] && hk="$v"
-    fi
-    local -a parts=() mods=(); local key="" tok ckey m
-    IFS='+' read -ra parts <<< "$hk"
-    for tok in "${parts[@]}"; do
-        case "${tok,,}" in
-            ctrl|control) mods+=("Ctrl") ;;
-            shift) mods+=("Shift") ;;
-            alt) mods+=("Alt") ;;
-            super|meta|logo|win) mods+=("Super") ;;
-            "") ;;
-            *) key="$tok" ;;
-        esac
-    done
-    case "${key,,}" in
-        f1|f2|f3|f4|f5|f6|f7|f8|f9|f10|f11|f12) ckey="${key^^}" ;;
-        grave|'`') ckey="grave" ;;
-        space) ckey="space" ;;
-        tab) ckey="Tab" ;;
-        escape|esc) ckey="Escape" ;;
-        enter|return) ckey="Return" ;;
-        *) if [[ "$key" =~ ^[a-zA-Z]$ ]]; then ckey="${key,,}"; else ckey="$key"; fi ;;
-    esac
-    local mods_csv=""
-    for m in "${mods[@]}"; do mods_csv+="${mods_csv:+, }$m"; done
-    COSMIC_BINDING="(modifiers: [${mods_csv}], key: \"${ckey}\")"
-}
-
 # config 에 marker+line 을 idempotent append (needle 정규식이 이미 있으면 skip → return 1).
 append_marked() {
     local cfg="$1" marker="$2" needle="$3" line="$4"
@@ -263,42 +227,15 @@ elif [[ -f "$HYPR_LUA" ]]; then
     if [[ ${#hypr_added[@]} -gt 0 ]]; then HYPR_MSG="$HYPR_LUA  (Lua ${hypr_added[*]} 추가)"; else HYPR_MSG="$HYPR_LUA  (이미 설정됨 — 변경 없음)"; fi
 fi
 
-# ~/.config/cosmic/...Shortcuts/v1/custom — COSMIC hotkey. COSMIC(smithay 기반
-# cosmic-comp)은 wlr-layer-shell 지원(drop-down 그대로 동작)이지만
-# compositor 단축키→`tildaz --toggle N`으로 건다.
-# COSMIC 단축키는 RON map 파일(`{ (modifiers:[..], key:".."): Spawn("..") }`).
-# 자동실행은 COSMIC 가 XDG user autostart를 지원하므로 tildaz 의
-# autostart 모듈(config.auto_start)이 담당 — 여기선 hotkey 만 등록.
-# 본문 보존: 기존 tildaz --toggle Spawn 줄만 제거 후 config_0 hotkey 로 재삽입(멱등 +
-# config=source of truth). RON 형태가 예상(닫는 '}' 독립 줄)과 다르면 안 건드림.
-cosmic_translate_hotkey
-COSMIC_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
-COSMIC_CUSTOM="$COSMIC_DIR/custom"
-COSMIC_ENTRY="    ${COSMIC_BINDING}: Spawn(\"$TILDAZ_EXE --toggle 0\"),"
-COSMIC_MSG=""
-if [[ "${XDG_CURRENT_DESKTOP:-}" == *[Cc][Oo][Ss][Mm][Ii][Cc]* ]] || command -v cosmic-comp >/dev/null 2>&1 || [[ -f "$COSMIC_CUSTOM" ]]; then
-    mkdir -p "$COSMIC_DIR"
-    if [[ ! -f "$COSMIC_CUSTOM" ]]; then
-        printf '{\n%s\n}\n' "$COSMIC_ENTRY" > "$COSMIC_CUSTOM"
-        COSMIC_MSG="$COSMIC_CUSTOM  (생성 — hotkey shortcut 등록)"
-    elif grep -qE '^[[:space:]]*\}[[:space:]]*$' "$COSMIC_CUSTOM"; then
-        # pretty multi-line RON map(닫는 '}' 가 독립 줄) — 안전하게 마지막 '}' 직전 삽입.
-        cosmic_tmp="$(mktemp)"
-        grep -vE 'Spawn\("[^"]*tildaz --toggle( [0-9]+)?"\)' "$COSMIC_CUSTOM" > "$cosmic_tmp"
-        awk -v entry="$COSMIC_ENTRY" '
-            { lines[NR] = $0 }
-            END {
-                last = 0
-                for (i = NR; i >= 1; i--) if (lines[i] ~ /^[[:space:]]*}[[:space:]]*$/) { last = i; break }
-                for (i = 1; i <= NR; i++) { if (i == last) print entry; print lines[i] }
-            }' "$cosmic_tmp" > "$COSMIC_CUSTOM"
-        rm -f "$cosmic_tmp"
-        COSMIC_MSG="$COSMIC_CUSTOM  (hotkey shortcut 등록/갱신)"
-    else
-        COSMIC_MSG="$COSMIC_CUSTOM  (형식이 예상과 달라 안 건드림 — 수동 추가: ${COSMIC_BINDING}: Spawn(\"$TILDAZ_EXE --toggle 0\"),)"
-    fi
-fi
-
+# COSMIC hotkey 는 여기서 등록하지 않는다 — TildaZ 가 실행될 때 등록한다.
+# 예전에는 이 자리에서 RON custom shortcut(`~/.config/cosmic/...Shortcuts/v1/custom`)
+# 을 직접 썼는데, 그 줄에는 우리 표식(`description: Some("TildaZ_<index>")`)이 없어서
+# launcher 가 자기 항목으로 알아보지 못하고 하나 더 썼다 — 같은 hotkey 가 두 번
+# 등록됐다 ([#514](https://github.com/ensky0/tildaz/issues/514)). writer 를 둘 두면
+# 표식이 갈라지고, 갈라지면 중복 맵 키로 COSMIC 이 파일을 통째로 버린다(#484).
+# Hyprland 도 같은 이유로 hotkey 를 런타임 등록으로 옮겼다(위 `remove_legacy_hypr_hotkey`).
+# 이 스크립트가 예전에 남긴 줄은 TildaZ 가 처음 실행될 때 흡수한다
+# (`src/shortcut_sync/linux.zig` 의 `legacyInstallScriptEntryIndex`).
 # GNOME Shell extension — GNOME(mutter) 은 wlr-layer-shell 미지원이라 drop-down
 # placement / lifecycle(launch·show·hide) 을 extension 이 담당한다 (#228). GNOME
 # 환경에서만 의미(다른 DE 는 gnome-shell 이 없어 무시). 복사는 항상, enable 은
@@ -371,7 +308,6 @@ echo "  $ICON_OUT"
 echo "  $BIN_LINK -> $TILDAZ_EXE"
 echo "  $SWAY_MSG"
 [[ -n "$HYPR_MSG" ]] && echo "  $HYPR_MSG"
-[[ -n "$COSMIC_MSG" ]] && echo "  $COSMIC_MSG"
 [[ -n "$EXT_MSG" ]] && echo "  $EXT_MSG"
 [[ -n "$CIN_MSG" ]] && echo "  $CIN_MSG"
 echo ""
@@ -385,10 +321,10 @@ echo "  - sway: ~/.config/sway/config 의 exec 로 자동실행(없으면 위에
 echo "          로그인 후 hotkey(기본 F1) 토글. exit 후 재실행은 launcher 에서 'tildaz'."
 echo "  - Hyprland: layer-shell drop-down. hotkey 는 실행 시 config_N별 hyprctl bind→'tildaz --toggle N'."
 echo "          위에서 hyprland.lua/.conf 에 자동실행 추가 → 적용하려면 'hyprctl reload' 또는 재로그인."
-echo "  - COSMIC: layer-shell drop-down. hotkey 는 RON shortcut→'tildaz --toggle N'(portal 우회)."
-echo "          위에서 ~/.config/cosmic/...Shortcuts/v1/custom 에 등록 → cosmic-comp 가 live 반영(안 되면 재로그인)."
+echo "  - COSMIC: layer-shell drop-down. hotkey 는 실행 시 config_N별 RON shortcut→'tildaz --toggle N'(portal 우회)."
+echo "          TildaZ 를 한 번 띄우면 ~/.config/cosmic/...Shortcuts/v1/custom 에 등록됨 → cosmic-comp 가 live 반영(안 되면 재로그인)."
 echo "          자동실행은 config.auto_start=true 면 XDG autostart 로 동작."
 echo "  - 기타 wlroots: layer-shell drop-down. 자동실행은 compositor 의 exec 류로 직접."
-echo "  - config: $TILDAZ_CONFIG_DIR/config_N.json (instance별 auto_start/hidden_start/hotkey/위치)"
+echo "  - config: $TILDAZ_CONFIG_DIR/config_N.toml (instance별 auto_start/hidden_start/hotkey/위치)"
 echo "  - autostart: 비-GNOME 은 config.auto_start=true 면 $CONFIG_HOME/autostart/"
 echo "    tildaz.desktop 자동 생성. GNOME 은 NotShowIn으로 건너뛰고 extension이 담당."

--- a/dist/linux/uninstall.sh
+++ b/dist/linux/uninstall.sh
@@ -13,11 +13,13 @@
 #   KDE ~/.config/kglobalshortcutsrc 의 [tildaz.instanceN] 그룹
 #   ~/.config/sway/config 의 tildaz 블록 (install.sh 가 넣은 marker+exec 2줄만.
 #     파일/본문은 보존, marker 없는 사용자 작성 줄은 안 건드림)
+#   ~/.config/cosmic/...Shortcuts/v1/custom 의 TildaZ 단축키 줄 (표식 있는 줄 +
+#     예전 install.sh 가 쓴 표식 없는 줄. 사용자가 이름 붙인 줄은 보존)
 #   ~/.config/hypr/{hyprland.conf,hyprland.lua} 의 tildaz 블록 (marker + 다음 줄
 #     2줄만. .conf=exec-once / .lua=hl.on, 동일 규칙. 본문 보존)
 #
 # 보존:
-#   $XDG_CONFIG_HOME/tildaz/config_N.json  (fallback: ~/.config, 사용자 설정)
+#   $XDG_CONFIG_HOME/tildaz/config_N.toml  (fallback: ~/.config, 사용자 설정)
 #   $XDG_STATE_HOME/tildaz/               (fallback: ~/.local/state, log)
 #
 # 사용법:
@@ -220,16 +222,31 @@ remove_tildaz_block "$SWAY_CFG"  "$TILDAZ_MARKER"     "marker + exec 2줄"
 remove_tildaz_block "$HYPR_CONF" "$TILDAZ_MARKER"     "marker + exec-once 2줄"
 remove_tildaz_block "$HYPR_LUA"  "$TILDAZ_MARKER_LUA" "marker + hl.on 2줄"
 
-# COSMIC RON custom shortcut — marker 블록이 아니라 단일 라인이라 `Spawn("..tildaz
-# --toggle N")` 매칭으로 그 줄만 제거(구형 번호 없는 항목도 포함, 다른 단축키 + 바깥 '{ }' 보존). 바이너리 경로
-# 무관하게 매칭(uninstall 시 binary 가 이미 없을 수 있음).
+# COSMIC RON custom shortcut — marker 블록이 아니라 단일 라인이라 줄 단위로 지운다.
+# 지우는 것은 둘뿐이다.
+#   ① 우리 표식이 붙은 줄 — `description: Some("TildaZ_<index>")`. 바이너리 경로 · 이름과
+#      무관하게 우리 것이다.
+#   ② 표식이 아예 없고 명령이 `tildaz --toggle[ N]` 인 줄 — 예전 install.sh 가 쓴 것
+#      (#514). 지금 install.sh 는 COSMIC 항목을 쓰지 않는다.
+# 사용자가 이름을 붙인 줄(`description: Some("My wrapper")`)은 명령이 겹쳐도 보존한다 —
+# 명령 문자열로 판정하면 남의 항목을 지운다(#484). 바깥 '{ }' 와 다른 단축키도 보존.
+# 경로를 안 보는 이유는 uninstall 시점엔 binary 가 이미 없을 수 있어서다.
 COSMIC_CUSTOM="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom"
-if [[ -f "$COSMIC_CUSTOM" ]] && grep -qE 'Spawn\("[^"]*tildaz --toggle( [0-9]+)?"\)' "$COSMIC_CUSTOM"; then
+if [[ -f "$COSMIC_CUSTOM" ]]; then
     tmp="$COSMIC_CUSTOM.tildaz-uninstall-tmp"
-    grep -vE 'Spawn\("[^"]*tildaz --toggle( [0-9]+)?"\)' "$COSMIC_CUSTOM" > "$tmp"
-    mv "$tmp" "$COSMIC_CUSTOM"
-    echo "Removed: tildaz hotkey shortcut in $COSMIC_CUSTOM"
-    removed=$((removed + 1))
+    awk '
+        /description: Some\("TildaZ_[0-9]+"\)/ { next }
+        /description:/ { print; next }
+        /Spawn\("[^"]*tildaz --toggle( [0-9]+)?"\)/ { next }
+        { print }
+    ' "$COSMIC_CUSTOM" > "$tmp"
+    if cmp -s "$tmp" "$COSMIC_CUSTOM"; then
+        rm -f "$tmp"
+    else
+        mv "$tmp" "$COSMIC_CUSTOM"
+        echo "Removed: tildaz hotkey shortcut in $COSMIC_CUSTOM"
+        removed=$((removed + 1))
+    fi
 fi
 
 if [[ "$removed" -eq 0 ]]; then

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -402,6 +402,11 @@ fn syncCosmic(rt: Runtime, allocator: std.mem.Allocator, indices: []const u32) !
     };
     defer allocator.free(content);
 
+    var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    // #451 — `fs.selfExePath` ➡️ `std.process.executablePath` (길이를 돌려준다).
+    const exe_len = try std.process.executablePath(rt.io, &exe_buf);
+    const exe = exe_buf[0..exe_len];
+
     const close_offset = findClosingMapLine(content) orelse return error.UnsupportedCosmicShortcutFormat;
     var output: std.ArrayList(u8) = .empty;
     defer output.deinit(allocator);
@@ -409,12 +414,17 @@ fn syncCosmic(rt: Runtime, allocator: std.mem.Allocator, indices: []const u32) !
     while (offset < content.len) {
         const end = std.mem.findScalarPos(u8, content, offset, '\n') orelse content.len;
         const line = content[offset..end];
-        if (offset == close_offset) try appendCosmicEntries(rt, &output, allocator, indices);
+        if (offset == close_offset) try appendCosmicEntries(rt, &output, allocator, indices, exe);
         // #496 1-c — 우리 줄은 지우고 다시 쓰는 구조다. 그런데 **위치 표기 인스턴스의
         // 줄은 워커가 쓴 것**이라 여기서 지우면 launcher 가 돌 때마다 사라진다. 그래서
         // 그 인스턴스의 줄만 남긴다.
+        //
+        // #514 — 표식 없는 옛 `install.sh` 줄은 **우리가 그 index 를 실제로 관리할 때만**
+        // 흡수한다. config 를 지운 인스턴스의 줄까지 지우면 판정 근거가 다시 넓어진다.
         const keep = if (tildazCosmicEntryIndex(line)) |idx|
             cosmicDeferredToWorker(rt, allocator, idx)
+        else if (legacyInstallScriptEntryIndex(line, exe)) |idx|
+            std.mem.findScalar(u32, indices, idx) == null
         else
             true;
         if (keep) {
@@ -477,6 +487,117 @@ fn tildazCosmicEntryIndex(line: []const u8) ?u32 {
     return std.fmt.parseInt(u32, rest[0..end], 10) catch null;
 }
 
+/// #514 — 예전 [`dist/linux/install.sh`](../../dist/linux/install.sh) 가 쓴 **표식 없는**
+/// COSMIC 항목이면 그 instance index.
+///
+/// 그 스크립트는 `description` 을 안 붙이고 자기 항목을 썼다. 그래서 launcher 가 자기
+/// 것으로 못 알아보고 하나 더 썼고, 같은 hotkey 가 RON 에 두 번 남았다. 지금 install.sh 는
+/// COSMIC 항목을 아예 쓰지 않으므로 (writer 는 이 파일 하나다), 남아 있는 옛 줄을 여기서
+/// 흡수한다.
+///
+/// **완전 일치만 본다.** #484 의 교훈이 "명령 문자열의 *부분* 일치로 판정하지 말라" 였다.
+/// 조건이 하나라도 어긋나면 남의 항목으로 본다.
+///
+/// - `description` 이 **아예 없다.** 사용자가 이름을 붙인 줄은 명령이 겹쳐도 남긴다.
+/// - `Spawn` 명령이 *지금 실행 파일 경로* + `--toggle <index>` 와 **바이트까지 같다.**
+///   경로가 다르면 (사용자가 옮겼거나 다른 빌드면) 건드리지 않는다. 래퍼 스크립트처럼
+///   명령이 더 붙은 줄도 여기서 걸린다.
+/// - 번호 없는 `--toggle` 도 받는다 — #230 의 첫 형태다 (인스턴스 번호가 생기기 전).
+///
+/// 그래도 위험이 하나 남는다: 사용자가 **같은 명령으로 두 번째 단축키**를 손수 만들어
+/// 뒀다면 그것도 지워진다. 호출부 (`syncCosmic`) 가 "우리가 그 index 를 실제로 관리할
+/// 때만" 으로 한 번 더 좁힌다.
+fn legacyInstallScriptEntryIndex(line: []const u8, exe: []const u8) ?u32 {
+    if (std.mem.find(u8, line, "description:") != null) return null;
+    const open = "): Spawn(\"";
+    const start = std.mem.find(u8, line, open) orelse return null;
+    var buf: [std.Io.Dir.max_path_bytes + 64]u8 = undefined;
+    const command = ronStringUnescape(line[start + open.len ..], &buf) orelse return null;
+    if (!std.mem.startsWith(u8, command, exe)) return null;
+    const tail = command[exe.len..];
+    // #230 의 첫 형태 — 인스턴스 번호가 없던 때라 0 번이다.
+    if (std.mem.eql(u8, tail, " --toggle")) return 0;
+    const numbered = " --toggle ";
+    if (!std.mem.startsWith(u8, tail, numbered)) return null;
+    return std.fmt.parseInt(u32, tail[numbered.len..], 10) catch null;
+}
+
+test "#514 legacy install.sh entries are absorbed only on an exact command match" {
+    const exe = "/home/u/.local/bin/tildaz";
+    // 옛 install.sh 가 쓴 형태 — 표식이 없고 명령이 정확히 우리 것이다.
+    try std.testing.expectEqual(@as(?u32, 0), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/.local/bin/tildaz --toggle 0\"),",
+        exe,
+    ));
+    try std.testing.expectEqual(@as(?u32, 3), legacyInstallScriptEntryIndex(
+        "    (modifiers: [Ctrl, Shift], key: \"grave\"): Spawn(\"/home/u/.local/bin/tildaz --toggle 3\"),",
+        exe,
+    ));
+    // #230 의 첫 형태 — 번호가 없던 때. 0 번이다.
+    try std.testing.expectEqual(@as(?u32, 0), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/.local/bin/tildaz --toggle\"),",
+        exe,
+    ));
+
+    // 표식이 있으면 여기 소관이 아니다 — 우리 줄이든 사용자가 이름 붙인 줄이든.
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\", description: Some(\"TildaZ_0\")): Spawn(\"/home/u/.local/bin/tildaz --toggle 0\"),",
+        exe,
+    ));
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\", description: Some(\"My toggle\")): Spawn(\"/home/u/.local/bin/tildaz --toggle 0\"),",
+        exe,
+    ));
+
+    // 경로가 다르면 우리 것이 아니다 — 부분 일치로 떨어지지 않는다 (#484).
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/usr/bin/tildaz --toggle 0\"),",
+        exe,
+    ));
+    // 명령 **앞**에 뭔가 붙은 줄 — 경로가 안에 들어 있을 뿐 우리 명령이 아니다.
+    // 부분 일치로 판정하면 이 줄이 통과한다 (#484 가 그랬다).
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/opt/wrap /home/u/.local/bin/tildaz --toggle 0\"),",
+        exe,
+    ));
+    // 래퍼 — 명령이 더 붙었다.
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"sh -c '/home/u/.local/bin/tildaz --toggle 0; notify-send hi'\"),",
+        exe,
+    ));
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/.local/bin/tildaz --toggle 0 --extra\"),",
+        exe,
+    ));
+    // 명령이 우리 것으로 시작하지만 다른 하위 명령이다.
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/.local/bin/tildaz --autostart\"),",
+        exe,
+    ));
+    // 번호 자리가 정수가 아니다.
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/.local/bin/tildaz --toggle x\"),",
+        exe,
+    ));
+    // 우리 항목이 아닌 남의 단축키.
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex(
+        "    (modifiers: [Super], key: \"e\"): Spawn(\"nautilus\"),",
+        exe,
+    ));
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex("{", exe));
+    try std.testing.expectEqual(@as(?u32, null), legacyInstallScriptEntryIndex("}", exe));
+}
+
+test "#514 escaped paths in a legacy entry are matched after unescaping" {
+    // `appendRonString` 이 `\\` 와 `"` 를 escape 한다. 읽는 쪽이 같은 규칙을 풀어야
+    // 따옴표가 든 경로에서 판정이 갈리지 않는다.
+    const exe = "/home/u/my \"odd\" dir/tildaz";
+    try std.testing.expectEqual(@as(?u32, 2), legacyInstallScriptEntryIndex(
+        "    (modifiers: [], key: \"F1\"): Spawn(\"/home/u/my \\\"odd\\\" dir/tildaz --toggle 2\"),",
+        exe,
+    ));
+}
+
 /// #496 1-c — 이 인스턴스의 hotkey 가 **위치 표기**인가.
 ///
 /// 그렇다면 launcher 는 COSMIC 항목을 쓰지 못한다. COSMIC 의 RON `key:` 는 글자만 받는데
@@ -496,11 +617,13 @@ fn cosmicDeferredToWorker(rt: Runtime, allocator: std.mem.Allocator, index: u32)
 /// 그래서 명령 문자열 매칭으로 떨어졌다.
 const cosmic_entry_marker = "description: Some(\"TildaZ_";
 
-fn appendCosmicEntries(rt: Runtime, output: *std.ArrayList(u8), allocator: std.mem.Allocator, indices: []const u32) !void {
-    var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    // #451 — `fs.selfExePath` ➡️ `std.process.executablePath` (길이를 돌려준다).
-    const exe_len = try std.process.executablePath(rt.io, &exe_buf);
-    const exe = exe_buf[0..exe_len];
+fn appendCosmicEntries(
+    rt: Runtime,
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    indices: []const u32,
+    exe: []const u8,
+) !void {
     for (indices) |index| {
         const text = try instances.configHotkeyText(rt, allocator, index);
         defer allocator.free(text);
@@ -718,4 +841,27 @@ fn appendRonString(output: *std.ArrayList(u8), allocator: std.mem.Allocator, val
         if (byte == '\\' or byte == '"') try output.append(allocator, '\\');
         try output.append(allocator, byte);
     }
+}
+
+/// `appendRonString` 의 역이다. `escaped` 는 여는 `"` **다음**부터이고, 닫는 `"` 까지를
+/// escape 를 풀어 `buf` 에 담아 돌려준다. 버퍼가 모자라거나 문자열이 닫히지 않으면 `null`.
+///
+/// 읽는 쪽과 쓰는 쪽을 붙여 둔다 — 규칙이 갈리면 따옴표 · 역슬래시가 든 경로에서 자기
+/// 항목을 못 알아본다. 그 갈라짐이 #484 의 기전이었다.
+fn ronStringUnescape(escaped: []const u8, buf: []u8) ?[]const u8 {
+    var out: usize = 0;
+    var i: usize = 0;
+    while (i < escaped.len) : (i += 1) {
+        var byte = escaped[i];
+        if (byte == '"') return buf[0..out];
+        if (byte == '\\') {
+            i += 1;
+            if (i >= escaped.len) return null;
+            byte = escaped[i];
+        }
+        if (out >= buf.len) return null;
+        buf[out] = byte;
+        out += 1;
+    }
+    return null;
 }


### PR DESCRIPTION
Closes #514

## 문제

`dist/linux/install.sh` 가 COSMIC RON 에 자기 항목을 **표식 없이** 썼다. 우리 matcher 는
`description: Some("TildaZ_<index>")` 표식만 보므로 (#484) 그 줄을 사용자 항목으로 보존했고,
launcher 는 자기 항목을 하나 더 썼다 — 같은 hotkey 가 RON 에 두 줄로 남고 tildaz 는 앞의 것을
영영 못 지웠다.

이슈 본문의 전제가 사실과 달랐다 ([근거](https://github.com/ensky0/tildaz/issues/514#issuecomment-5419013510)).
본체 writer 는 생긴 날부터 표식을 썼고 (9d5e355, #267), #484 가 고친 것은 matcher 였다. 표식
없는 줄의 유일한 출처는 install.sh 이고, 그 줄은 c1c925b (#230) 부터 지금까지 그대로였다 —
**옛 사용자만의 문제가 아니라 새 설치에도 그대로 생긴다.**

## 고친 것

writer 를 앱 하나로 모은다. Hyprland 가 같은 이유로 이미 옮긴 자리다 (`remove_legacy_hypr_hotkey`).

- `install.sh` 의 COSMIC 등록 블록과 `cosmic_translate_hotkey` 제거. 등록은 launcher 의
  `syncCosmic` 이 한다.
- 남은 옛 줄은 `legacyInstallScriptEntryIndex` 가 흡수한다. **완전 일치**만 본다 —
  `description` 이 아예 없고, `Spawn` 명령이 지금 실행 파일 경로 + `--toggle <index>` 와
  바이트까지 같고, 그 index 를 우리가 실제로 관리할 때.
- `uninstall.sh` 의 제거 판정을 명령 문자열 → 표식으로. 예전에는 사용자가 이름 붙인 줄도
  명령이 겹치면 지웠다 (#484 와 같은 부류).

곁가지 둘: `install.sh` 가 `config_0.json` 을 읽던 것 (#493 TOML 이관 누락), `uninstall.sh`
머리말의 삭제 대상 목록에 COSMIC 줄이 빠져 있던 것.

## 검증 (노트북 i5-1240P · CachyOS · COSMIC · cosmic-comp 1.0.0)

- `zig build test` · `zig build check` (6 타깃) 통과.
- 새 테스트가 실제로 잡는지 확인 — 판정을 부분 일치로 되돌리니 `/opt/wrap <exe> --toggle 0`
  케이스가 `expected null, found 0` 으로 실패한다.
- 가짜 HOME 왕복 실기:

  ```
  실행 전                                          실행 후
  (key: "F1"): Spawn("<exe> --toggle 0")           ← 흡수됨
  (key: "F1", TildaZ_0): Spawn("<exe> --toggle 0") (key: "F1", TildaZ_0): …  ← 하나만 남음
  (key: "t", "My wrapper"): Spawn("<exe> --toggle 0")  그대로 보존
  (key: "z"): Spawn("<exe> --toggle 7")                그대로 보존 (관리 안 하는 index)
  (key: "e"): Spawn("nautilus")                        그대로 보존
  ```

  두 번째 실행은 변화 없음 (`numbered hotkeys already synchronized`). `install.sh` 는 RON 을
  안 건드리고, `uninstall.sh` 는 우리 줄과 옛 줄만 지우며 래퍼는 남긴다.
