### PR TITLE
fix(cosmic): 받은 keymap 의 정체와 안 쓴 경우를 로그에 남긴다 (#513)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -5650,7 +5650,18 @@ const Client = struct {
         defer posix.munmap(memory);
 
         try self.keyboard.setKeymap(self.allocator, memory);
-        log.appendLineVerbose("wayland", "keyboard keymap loaded size={}", .{size});
+        // #513 — **받은 keymap 이 어느 layout 인지 남긴다.** COSMIC 에서 키보드를 꽂으면
+        // 위치 표기 hotkey 가 직전 layout 의 글자로 재등록되는데, 로그만 봐서는
+        // *compositor 가 옛 keymap 을 보낸 것*인지 *우리가 잘못 읽은 것*인지 구분할 수
+        // 없었다. 아래 `writeCosmicPositionHotkey` 가 남기는 `key=` 와 나란히 읽으면
+        // 그 자리에서 갈린다 — 이름이 직전 layout 이면 compositor 쪽, 지금 layout 인데
+        // 글자가 엉뚱하면 우리 쪽이다.
+        var layout_buf: [256]u8 = undefined;
+        if (self.keyboard.layoutNames(&layout_buf)) |names| {
+            log.appendLine("wayland", "keyboard keymap loaded size={} layouts=[{s}]", .{ size, names });
+        } else {
+            log.appendLineVerbose("wayland", "keyboard keymap loaded size={}", .{size});
+        }
         // #496 1-a — layout 이 바뀌면 이 event 가 다시 온다. 그래서 매번 다시 푼다.
         self.resolveBindingFallbacks();
         self.refreshKdePositionHotkey();

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -49,6 +49,13 @@ const XkbStateModNameIsActive = *const fn (
     component: c_uint,
 ) callconv(.c) c_int;
 
+// #513 — 진단용. **받은 keymap 이 어느 layout 인지**를 로그에 남긴다. COSMIC 에서
+// 키보드를 꽂으면 위치 표기 hotkey 가 직전 layout 의 글자로 재등록되는데, 로그만으로는
+// *compositor 가 옛 keymap 을 보낸 것*인지 *우리가 잘못 읽은 것*인지 구분할 수 없었다
+// ([#513](https://github.com/ensky0/tildaz/issues/513)).
+const XkbKeymapNumLayouts = *const fn (keymap: *xkb_keymap) callconv(.c) c_uint;
+const XkbKeymapLayoutGetName = *const fn (keymap: *xkb_keymap, layout: c_uint) callconv(.c) ?[*:0]const u8;
+
 // #496 1-a — keymap 전수 조회용. **비라틴 layout 에서 "이 문자를 낼 수 있는 키가
 // 하나도 없다" 를 판정**하는 데 쓴다. state 가 아니라 keymap 을 보는 이유는 현재
 // modifier / layout 과 무관하게 물어야 하기 때문이다 — `xkb_state_key_get_one_sym`
@@ -103,6 +110,8 @@ const Api = struct {
     // #496 1-a — optional. 하나라도 없으면 `keymapScan` 이 null 이 되고 fallback 이
     // 꺼진다 (위 주석 참고).
     keymap_scan: ?KeymapScan = null,
+    // #513 — optional. 진단 로그 전용이라 없으면 그 줄에서 layout 이름만 빠진다.
+    layout_names: ?LayoutNames = null,
 
     fn load() !Api {
         const handle = std.c.dlopen("libxkbcommon.so.0", .{ .LAZY = true }) orelse return error.XkbLibraryMissing;
@@ -121,6 +130,7 @@ const Api = struct {
             .state_key_get_one_sym = lookup(handle, XkbStateKeyGetOneSym, "xkb_state_key_get_one_sym") orelse return error.XkbSymbolMissing,
             .state_mod_name_is_active = lookup(handle, XkbStateModNameIsActive, "xkb_state_mod_name_is_active") orelse return error.XkbSymbolMissing,
             .keymap_scan = KeymapScan.load(handle),
+            .layout_names = LayoutNames.load(handle),
         };
     }
 
@@ -156,6 +166,21 @@ const KeymapScan = struct {
             .num_layouts_for_key = lookup(handle, XkbKeymapNumLayoutsForKey, "xkb_keymap_num_layouts_for_key") orelse return null,
             .num_levels_for_key = lookup(handle, XkbKeymapNumLevelsForKey, "xkb_keymap_num_levels_for_key") orelse return null,
             .key_get_syms_by_level = lookup(handle, XkbKeymapKeyGetSymsByLevel, "xkb_keymap_key_get_syms_by_level") orelse return null,
+        };
+    }
+};
+
+/// #513 — keymap 의 layout 이름 조회. `KeymapScan` 과 갈라 두는 이유는 **쓰임이 다르기
+/// 때문**이다 — 그쪽은 없으면 라틴 fallback 기능이 꺼지지만, 이쪽은 진단 로그 한 줄이
+/// 짧아질 뿐이다. 한 묶음으로 합치면 없는 쪽 하나가 다른 쪽 기능까지 끈다.
+const LayoutNames = struct {
+    num_layouts: XkbKeymapNumLayouts,
+    layout_get_name: XkbKeymapLayoutGetName,
+
+    fn load(handle: *anyopaque) ?LayoutNames {
+        return .{
+            .num_layouts = lookup(handle, XkbKeymapNumLayouts, "xkb_keymap_num_layouts") orelse return null,
+            .layout_get_name = lookup(handle, XkbKeymapLayoutGetName, "xkb_keymap_layout_get_name") orelse return null,
         };
     }
 };
@@ -343,6 +368,33 @@ pub const Keyboard = struct {
 
     /// #496 1-c — keysym → xkb 이름 (`twosuperior` · `Cyrillic_io` · `grave`).
     /// COSMIC RON 의 `key:` 가 이 이름을 받는다. 버퍼에 담아 slice 로 돌려준다.
+    /// #513 — 지금 keymap 이 담고 있는 layout 이름들을 `", "` 로 이어 돌려준다
+    /// (`"English (US), Korean"`). 심볼이 없거나 keymap 이 없으면 `null`.
+    ///
+    /// **어느 keymap 을 받았는지가 곧 판정 근거다.** 위치 표기 hotkey 가 엉뚱한 글자로
+    /// 등록될 때, 이 이름이 직전 layout 이면 compositor 가 옛 keymap 을 보낸 것이고 지금
+    /// layout 이면 우리 쪽 처리가 틀린 것이다.
+    pub fn layoutNames(self: *Keyboard, buf: []u8) ?[]const u8 {
+        const api = self.api orelse return null;
+        const names = api.layout_names orelse return null;
+        const keymap = self.keymap orelse return null;
+        const count = names.num_layouts(keymap);
+        var out: usize = 0;
+        var layout: c_uint = 0;
+        while (layout < count) : (layout += 1) {
+            const name = names.layout_get_name(keymap, layout) orelse continue;
+            const text = std.mem.span(name);
+            const separator: []const u8 = if (out == 0) "" else ", ";
+            // 버퍼가 모자라면 거기서 끊는다 — 진단 줄이라 자르는 편이 낫다.
+            if (out + separator.len + text.len > buf.len) break;
+            @memcpy(buf[out..][0..separator.len], separator);
+            out += separator.len;
+            @memcpy(buf[out..][0..text.len], text);
+            out += text.len;
+        }
+        return buf[0..out];
+    }
+
     pub fn keysymName(self: *Keyboard, keysym: u32, buf: []u8) ?[]const u8 {
         const api = if (self.api) |*a| a else return null;
         const scan = api.keymap_scan orelse return null;

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -737,12 +737,19 @@ fn rewriteCosmicPositionEntry(
     defer output.deinit(allocator);
     try renderCosmicPositionRon(&output, allocator, content, exe, index, key_name, modifiers);
 
+    // #513 — **안 쓴 경우에도 남긴다.** 예전엔 `writeFileIfChanged` 가 false 면 아무
+    // 로그도 없어서, 로그만 보면 "이미 맞아서 안 씀" 과 "이 경로를 아예 안 탐" 이
+    // 구분되지 않았다. keymap 재전송을 쫓을 때 특히 걸린다.
     if (try paths.writeFileIfChanged(rt, allocator, path, output.items)) {
         if (key_name) |name| {
             log.appendLine("cosmic", "position hotkey entry written key={s}", .{name});
         } else {
             log.appendLine("cosmic", "position hotkey entry withdrawn", .{});
         }
+    } else if (key_name) |name| {
+        log.appendLine("cosmic", "position hotkey entry already current key={s}", .{name});
+    } else {
+        log.appendLine("cosmic", "position hotkey entry already absent", .{});
     }
 }
 


### PR DESCRIPTION
> [!WARNING]
> **정정 (2026-08-26).** 이 PR 본문이 근거로 든 두 관측 — layout 전환 시 중간 `English (US)`
> keymap, 키보드 핫플러그 때의 낡은 keymap — 은 **측정 인공물이었다.** `cat > xkb_config` 가
> truncate 후 write 라 cosmic-comp 이 빈 파일을 읽고 기본 `us` 로 떨어진 것이다. 원자적으로
> (`temp` + `mv`) 쓰자 4/4 재현이 0/2 로 사라졌다. **머지된 코드(진단 로그)는 그대로 유효하고**
> 오히려 그 로그가 이 인공물을 잡아냈다. 자세한 정정은
> [#513 코멘트](https://github.com/ensky0/tildaz/issues/513#issuecomment-5419454452),
> 문서 정정은 [4484c52](https://github.com/ensky0/tildaz/commit/4484c52) 이다.

Refs #513 (닫지 않음 — upstream 제기와 KDE 측정이 남았다)

## 왜

#513 은 *"compositor 가 옛 keymap 을 보낸 것인지, 앱이 재전송을 잘못 처리한 것인지"* 를 가르지
못한 채 열려 있었다. 이슈는 `wl_keyboard.keymap` 을 덤프하는 최소 Wayland client 를 새로 두자고
했는데, `handleKeyboardKeymap` 이 **이미 그 텍스트를 mmap 하고 있다.** 거기서 받은 keymap 의
정체를 남기면 그 자리에서 갈린다.

## 넣은 것

- `[wayland] keyboard keymap loaded size=… layouts=[…]` — `xkb_keymap_num_layouts` ·
  `xkb_keymap_layout_get_name` 을 **optional** 로 `dlsym`. 없으면 그 줄에서 이름만 빠지고
  키보드는 그대로 동작한다. `KeymapScan` 과 갈라 둔 이유는 쓰임이 달라서다 — 그쪽은 없으면
  라틴 fallback 이 꺼지지만 이쪽은 진단 줄이 짧아질 뿐이다.
- `[cosmic] position hotkey entry already current key=…` / `already absent` — 이슈가 적은
  "곁가지". `writeFileIfChanged` 가 false 면 아무 로그도 안 남아 **"이미 맞아서 안 씀"** 과
  **"경로를 아예 안 탐"** 이 구분되지 않았다.

## 이 두 줄로 갈린 것

노트북 i5-1240P · CachyOS · cosmic-comp 1.0.0 (`314fc670`) · 2026-08-26 · 3 회차
([측정 전문](https://github.com/ensky0/tildaz/issues/513#issuecomment-5419454452)).

| 시점 | `xkb_config` 실제 상태 | 받은 keymap |
|---|---|---|
| 기동 | `kr` + 원래 options | `size=35707` `layouts=[Korean]` |
| layout 왕복 뒤 | `kr` + `options: None` | `size=35566` `layouts=[Korean]` |
| **장치를 꽂은 뒤** | 그대로 | **`size=35707`** `layouts=[Korean]` |

**cosmic-comp 은 키보드가 새로 붙으면 낡은 keymap 을 보낸다.** 이름은 셋 다 `Korean` 이라
**크기를 함께 남겼기에** 드러났다. 덤으로 layout 을 바꿀 때마다 중간에 `English (US)` keymap 이
한 번 끼어드는 것도 3 회차 전부 재현됐다.

## 앱 쪽 수정이 없는 이유

원인이 compositor 다. 핫플러그 건은 뒤따르는 정정 이벤트가 없어 debounce 로도 못 막고, 받은
keymap 이 최신인지 검증할 근거가 우리에겐 없다. 억지로 막으면 증상 가리기가 된다.

영향 범위는 소스로 판정했다 — `positionHotkeyKeysym` 을 부르는 곳은 셋뿐이고 전부 COSMIC 아니면
KDE 분기 안이다. GNOME · Cinnamon (`evdev + 8`) · sway (`bindcode`) · Hyprland (`keycode=`) 는
**자리를 그대로 받으므로 구조적으로 무관**하다.

## 검증

`zig build test` · `zig build check` (6 타깃) 통과.

