### PR TITLE
fix(build): zig build 가 Shell extension 리소스를 exe 옆에 깐다 (#520)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -253,6 +253,28 @@ pub fn build(b: *std.Build) void {
         b.installArtifact(exe);
     }
 
+    // #520 — Linux 는 Shell extension 리소스를 exe 옆 `share/tildaz/` 에도 깐다.
+    //
+    // worker 가 부팅할 때 `shell_extension.syncForCurrentUser` 가 그 경로에서 GNOME ·
+    // Cinnamon extension 을 사용자 홈으로 복사하는데 (`<exe_dir>/../share/tildaz/`),
+    // 여기가 비어 있으면 **설치본을 그대로 두고 조용히 넘어간다.** 그래서 `zig build` 로
+    // 개발하는 동안에는 레포의 extension 을 고쳐도 셸에는 옛 파일이 남았다 — 게다가
+    // 로그는 성공처럼 찍혀서 (`Shell extension synchronized and enabled`) 그 사실을
+    // 알아챌 근거가 없었다.
+    //
+    // 경로 · 파일 구성은 `dist/linux/package.sh` 의 `install_extension_resources` 와
+    // 같다. 그쪽이 패키지에 넣는 것을 여기서는 `zig-out` 에 넣을 뿐이라, dev 빌드와
+    // 패키지가 같은 배치를 갖는다.
+    if (is_linux_target) {
+        for ([_][]const u8{ "gnome-extension", "cinnamon-extension" }) |family| {
+            b.installDirectory(.{
+                .source_dir = b.path(b.fmt("dist/linux/{s}", .{family})),
+                .install_dir = .{ .custom = "share/tildaz" },
+                .install_subdir = family,
+            });
+        }
+    }
+
     // stress 하네스도 같은 런타임을 exe 옆에 두고 실행해야 하므로 (아래 stress 단계)
     // install step 을 붙잡아 둡니다. Windows 아닌 target 에선 null 입니다.
     var conpty_dll_install: ?*std.Build.Step.InstallFile = null;

--- a/src/host/linux/gsettings_hotkey.zig
+++ b/src/host/linux/gsettings_hotkey.zig
@@ -115,13 +115,24 @@ pub fn ensureShellExtensionReady(rt: Runtime, allocator: std.mem.Allocator) void
     const target = currentShellExtensionTarget(rt) orelse return;
     const label = target.owner.logCategory();
 
-    const extension_available = shell_extension.syncForCurrentUser(rt, allocator, target.kind) catch |err| {
+    const outcome = shell_extension.syncForCurrentUser(rt, allocator, target.kind) catch |err| {
         log.appendLine(label, "Shell extension resource sync failed: {s}", .{@errorName(err)});
         return;
     };
-    if (!extension_available) {
-        log.appendLine(label, "Shell extension resources not installed — enable skipped", .{});
-        return;
+    switch (outcome) {
+        .synced => {},
+        // #520 — 진행은 하지만 **동기화한 것이 아니다.** 예전에는 이 경우도 아래의
+        // "synchronized and enabled" 로 찍혀서, dev 빌드로 extension 을 고치는 사람이
+        // 자기 변경이 반영되지 않은 것을 알 방법이 없었다.
+        .kept_installed => log.appendLine(
+            label,
+            "Shell extension resources not found next to the executable — kept the installed copy (it may be older than this build)",
+            .{},
+        ),
+        .unavailable => {
+            log.appendLine(label, "Shell extension resources not installed — enable skipped", .{});
+            return;
+        },
     }
     const api = Api.load() orelse return;
     const source = api.schema_source_get_default() orelse return;
@@ -134,7 +145,9 @@ pub fn ensureShellExtensionReady(rt: Runtime, allocator: std.mem.Allocator) void
         return;
     };
     api.settings_sync();
-    log.appendLine(label, "Shell extension synchronized and enabled", .{});
+    log.appendLine(label, "Shell extension {s} and enabled", .{
+        if (outcome == .synced) "synchronized" else "left as installed",
+    });
 }
 
 /// GSettings custom-keybinding 등록의 DE별 차이를 담는 descriptor. GNOME 과

--- a/src/host/linux/shell_extension.zig
+++ b/src/host/linux/shell_extension.zig
@@ -24,12 +24,27 @@ const cinnamon_resources = [_]Resource{
     .{ .relative_path = "metadata.json" },
 };
 
+/// #520 — 동기화 결과. 예전에는 `bool` 이라 **"복사했다" 와 "소스가 없어 손대지 않았다"
+/// 가 같은 값**이었고, 호출자가 둘 다 `Shell extension synchronized and enabled` 로
+/// 찍었다. 그래서 dev 빌드에서 extension 이 갱신되지 않는 것을 로그로 알아챌 수 없었다.
+pub const SyncOutcome = enum {
+    /// 소스에서 대상으로 반영했다 (내용이 같아 실제 쓰기가 없었던 경우도 포함).
+    synced,
+    /// **소스가 없어 손대지 않았다.** 설치본이 이미 있어서 진행은 가능하지만, 지금 레포의
+    /// extension 이 아닐 수 있다.
+    kept_installed,
+    /// 소스도 설치본도 없다.
+    unavailable,
+};
+
 /// Package resources live at <prefix>/share/tildaz. AppImage uses the same
 /// layout below AppDir/usr, so every packaged Linux format follows this path.
-/// A repository/portable install may not have this directory next to the
-/// executable; install.sh already copied those resources and this becomes a
-/// graceful no-op.
-pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind) !bool {
+/// `zig build` 도 #520 이후 같은 배치를 `zig-out/share/tildaz` 에 만든다.
+///
+/// 그래도 그 디렉터리가 없을 수 있다 — 레포에서 바이너리만 옮겨 쓰거나, install.sh 가
+/// 이미 복사해 둔 portable 설치가 그렇다. 그때는 설치본을 그대로 두고 `kept_installed`
+/// 를 돌려준다.
+pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind) !SyncOutcome {
     var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     // #451 — `fs.selfExePath` ➡️ `std.process.executablePath` (길이를 돌려준다).
     const exe_len = try std.process.executablePath(rt.io, &exe_buf);
@@ -57,8 +72,8 @@ pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind)
         error.FileNotFound => {
             const installed_entry = try std.Io.Dir.path.join(allocator, &.{ destination_dir, "extension.js" });
             defer allocator.free(installed_entry);
-            std.Io.Dir.accessAbsolute(rt.io, installed_entry, .{}) catch return false;
-            return true;
+            std.Io.Dir.accessAbsolute(rt.io, installed_entry, .{}) catch return .unavailable;
+            return .kept_installed;
         },
         else => return err,
     };
@@ -89,7 +104,7 @@ pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind)
         };
         if (changed or !compiled_exists) try compileGnomeSchemas(rt, allocator, destination_dir);
     }
-    return true;
+    return .synced;
 }
 
 fn syncFile(rt: Runtime, allocator: std.mem.Allocator, source_path: []const u8, destination_path: []const u8) !bool {


### PR DESCRIPTION
`zig build` 로 개발할 때 Shell extension 이 갱신되지 않던 것을 고칩니다 (#520).

## 원인

worker 는 부팅할 때 `shell_extension.syncForCurrentUser` 로 GNOME · Cinnamon extension 을
사용자 홈에 복사합니다. 소스는 **`<exe_dir>/../share/tildaz/`** 인데 `zig build` 는 그
디렉터리를 만들지 않았습니다. 그러면 그 함수는 **설치본을 그대로 두고 조용히 넘어갑니다**
(portable 설치를 덮지 않으려는 의도된 fallback).

결과가 나빴습니다. 레포의 extension 을 고쳐도 셸에는 **영원히 옛 파일**이 남는데, 로그는
성공처럼 찍혀서 알아챌 근거가 없었습니다.

```
[gnome] Shell extension synchronized and enabled     ← 실제로는 아무것도 동기화하지 않음
```

#510 의 GNOME · Cinnamon 검증에서 실제로 걸렸습니다 — 새 코드가 설치본에 없는 것을 손으로
확인하고서야 알았습니다.

## 고친 것 둘

**1. `zig build` (Linux target) 가 `zig-out/share/tildaz/` 를 만듭니다.**

경로 · 파일 구성은 `dist/linux/package.sh` 의 `install_extension_resources` 와 같아서 dev
빌드와 패키지가 같은 배치를 갖습니다.

```
zig-out/share/tildaz/gnome-extension/tildaz@ensky0.github.io/{extension.js,metadata.json,schemas/*.xml}
zig-out/share/tildaz/cinnamon-extension/tildaz@ensky0.github.io/{extension.js,metadata.json}
```

`package.sh` 는 `zig-out/bin` 만 읽고 extension 은 `dist/` 원본에서 따로 스테이징하므로
간섭하지 않습니다.

**2. 로그가 "동기화했다" 와 "손대지 않았다" 를 구분합니다.**

`syncForCurrentUser` 의 반환을 `bool` → `SyncOutcome` (`synced` / `kept_installed` /
`unavailable`) 로 바꿨습니다. 예전에는 앞의 둘이 같은 `true` 라 호출자가 가를 수 없었습니다.

디렉터리가 없는 경우는 여전히 남습니다 (바이너리만 옮겨 쓰거나 install.sh 로 이미 깔아 둔
portable 설치). 그때는 진행하되 **오래됐을 수 있다고 말합니다.**

## 검증

`zig build check` (6 타겟) · `test` · `probe-check`.

**Linux 실기** (CachyOS) — 두 갈래를 모두 태웠습니다.

| 조건 | 결과 |
|---|---|
| 설치본을 옛 상태로 위조 → dev 빌드로 실행 | 설치본이 **갱신됨** (`writeHotkeyState` 0 → 1), 로그 `synchronized and enabled` |
| `share/tildaz` 없는 위치로 exe 만 복사해 실행 | `resources not found next to the executable — kept the installed copy (it may be older than this build)` + `left as installed and enabled` |

Windows · macOS 는 이 경로가 **Linux 전용**이라 (GNOME · Cinnamon Shell extension) 해당하지
않습니다. `zig build` 변경도 Linux target 에만 걸립니다.

Closes #520
