### PR TITLE
fix(exit): 다이얼로그 펌프가 SIGTERM 을 삼키지 않는다 (#521)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -9020,6 +9020,27 @@ const Client = struct {
         return self.runConfirmDialog(.confirm, title, message);
     }
 
+    /// [#521](https://github.com/ensky0/tildaz/issues/521) — 다이얼로그 펌프가 `SIGTERM` 을
+    /// 삼키지 않게 하는 공통 판정.
+    ///
+    /// 아래 펌프들은 사용자가 버튼을 누를 때까지 돈다. **기다리는 것 자체는 의도다** —
+    /// 안내를 읽지 않고 사라지면 안 된다. 문제는 그 사이 세션 로그아웃 · 재부팅이 보낸
+    /// `SIGTERM` 이다. 핸들러는 플래그만 세우는데 (`signal_exit`) 펌프가 그것을 보지 않으면
+    /// **신호가 무시된다** — 기본 동작 (즉시 종료) 을 없앤 셈이라 고치기 전보다 나쁘고,
+    /// `signal_exit.zig` 의 주석이 정확히 이 함정을 경고한다. main loop 는 이미 보고 있었지만
+    /// 펌프가 도는 동안에는 main loop 가 돌지 않는다.
+    ///
+    /// `running` 을 함께 내려서 **바깥 loop 도 같이 빠져나오게** 한다. 그 전이가 한 번뿐이라
+    /// 펌프가 매 바퀴 불러도 로그는 한 줄만 남는다.
+    fn signalExitRequested(self: *Client) bool {
+        if (!signal_exit.requested()) return false;
+        if (self.running) {
+            self.running = false;
+            log.appendLine("exit", "SIGTERM received while a dialog pump was running — leaving the pump", .{});
+        }
+        return true;
+    }
+
     fn runConfirmDialog(self: *Client, kind: DialogOverlay.Kind, title: []const u8, message: []const u8) bool {
         // Confirm dialog 띄움. 실패 시 안전 default Cancel.
         std.debug.assert(kind == .confirm);
@@ -9033,6 +9054,12 @@ const Client = struct {
         // 의 그것과 일치 (dispatch / drain dismiss / drain exited tabs / dbus /
         // key repeat / redraw).
         while (self.running and self.pending_confirm_result == null) {
+            // #521 — 신호가 오면 안전 default (Cancel) 로 빠진다. main loop 의 기존 검사가
+            // 뒤이어 평소의 종료 경로를 태운다.
+            if (self.signalExitRequested()) {
+                self.pending_confirm_result = false;
+                break;
+            }
             self.pollAndDispatch(frame_poll_ms) catch |err| {
                 log.appendLine("dialog", "confirm inner pump pollAndDispatch failed: {s} — break + Cancel", .{@errorName(err)});
                 self.pending_confirm_result = false;
@@ -9073,6 +9100,10 @@ const Client = struct {
         // dialog.kind 가 .none 이 되면(= dismiss 처리 완료) 종료. running=false(외부
         // 종료 신호)면 무한 대기 방지로 함께 탈출.
         while (self.running and self.dialog.kind != .none) {
+            // #521 — 신호가 오면 안내를 접고 빠진다. 세 호출처 모두 이 함수 직후가
+            // `std.process.exit(1)` 이라 그대로 종료된다. 그 시점엔 세션이 아직 없어서
+            // (`ensureSessionGrid` 는 더 뒤) `deinit` 을 건너뛰어도 거둘 PTY 자식이 없다.
+            if (self.signalExitRequested()) break;
             self.pollAndDispatch(frame_poll_ms) catch |err| {
                 log.appendLine("dialog", "fatal dialog pump pollAndDispatch failed: {s} — break", .{@errorName(err)});
                 break;
@@ -9091,6 +9122,11 @@ const Client = struct {
         // 이전엔 key repeat / PTY drain / redraw 를 생략해 캡처 dialog 동안
         // 배경 터미널이 정지했다 (Windows GetMessageW / macOS runModal 은 계속 그림).
         while (self.running and self.pending_prompt_result == null) {
+            // #521 — 신호가 오면 취소로 빠진다 (`accepted = false` → 호출처가 `null` 을 받는다).
+            if (self.signalExitRequested()) {
+                self.pending_prompt_result = false;
+                break;
+            }
             self.pollAndDispatch(frame_poll_ms) catch {
                 self.pending_prompt_result = false;
                 break;
@@ -9143,6 +9179,10 @@ const Client = struct {
 
         var timer: Timer = .start(self.rt);
         while (self.running and !self.mapped and timer.read() < 5 * std.time.ns_per_s) {
+            // #521 — 여기는 5 초 상한이 있어 신호를 영원히 삼키지는 않지만, 로그아웃을
+            // 최대 5 초 늦출 이유가 없다. 빠져나가면 아래 `!self.mapped` 가 걸려 새 instance
+            // prompt 를 접는다 — `running` 이 이미 false 라 곧 종료 경로로 간다.
+            if (self.signalExitRequested()) break;
             try self.pollAndDispatch(frame_poll_ms);
             self.drainPendingDialogDismiss();
             self.drainExitedTabs();


### PR DESCRIPTION
fatal · confirm · prompt 다이얼로그가 떠 있는 동안 **`SIGTERM` 이 무시돼** 프로세스가 `SIGKILL` 로만 정리됐다. 세션 로그아웃 · 재부팅이 보내는 신호라, 그때 다이얼로그가 떠 있으면 로그아웃이 지연되거나 세션 관리자가 강제 종료하게 된다.

## 원인

이 펌프들은 사용자가 버튼을 누를 때까지 돈다 — **기다리는 것 자체는 의도다.** 안내를 읽지 않고 사라지면 안 된다. 문제는 그 루프가 `signal_exit.requested()` 를 보지 않는 것이었다. 핸들러는 플래그만 세우는데 아무도 보지 않으면 **기본 동작 (즉시 종료) 을 없앤 셈**이라 고치기 전보다 나쁘다 — [`signal_exit.zig`](../blob/main/src/signal_exit.zig) 의 주석이 정확히 이 함정을 경고하고 있었다.

main loop 는 이미 보고 있었지만, **펌프가 도는 동안에는 main loop 가 돌지 않는다.**

## 무엇을 바꿨나

판정을 `signalExitRequested` 하나로 모으고 네 펌프가 각자의 뒷정리를 하게 했다. 그 함수가 `running` 도 함께 내려서 바깥 loop 가 같이 빠져나오고, 전이가 한 번뿐이라 로그는 한 줄만 남는다.

| 펌프 | 빠져나온 뒤 |
|---|---|
| **fatal** | 호출처 셋이 곧바로 `std.process.exit(1)` |
| **confirm** | 안전 default 인 Cancel |
| **prompt** | 취소 → 호출처가 `null` 을 받는다 |
| **map 대기** (새 instance) | `!mapped` 로 prompt 를 접는다. 5 초 상한이 있어 신호를 영원히 삼키진 않았지만 로그아웃을 늦출 이유가 없다 |

confirm · prompt 는 main loop 의 기존 검사가 뒤이어 평소의 종료 경로를 태우므로 `deinit` 이 돌아 PTY 자식 정리 ([#129](https://github.com/ensky0/tildaz/issues/129)) 도 실행된다.

## 이슈 본문의 "추가 확인 필요" 는 전제가 틀렸다

본문은 *"fatal 세 경로가 `Client.init` 안이라 아직 핸들러가 없는 구간"* 이라 적고 왜 안 죽는지 모르겠다고 남겼다. 세 경로는 모두 **`Client.run()` 안**이고 `runBaselineWindow` 의 순서가 `Client.init` → `signal_exit.install()` → `client.run()` 이라, **어떤 fatal 이 뜨든 핸들러는 이미 설치돼 있다.** 주 진단만으로 실측이 전부 설명되고 `install()` 시점을 앞당길 필요가 없다.

## Linux 전용이 맞다

`signal_exit.install()` 은 Linux 에서만 부른다. macOS · Windows 는 `SIGTERM` 기본 동작 (즉시 종료) 이 그대로 살아 있어 이 증상이 없다.

## 검증

**실기** (CachyOS · KDE Plasma 6 / KWin · 미니PC Firebat ZY-A8) — 없는 폰트 이름을 넣은 격리 config 로 fatal 다이얼로그를 띄우고 `kill -TERM` → **3 초 안에 종료**됐다.

```
[dialog] configured logical=511x528 physical=868x897 wrap_px=766 rows=11/11 …
[exit] SIGTERM received while a dialog pump was running — leaving the pump
```

이 시점엔 핸들러가 이미 걸려 있으므로 기본 동작이 아니라 **새로 넣은 검사로 펌프를 빠져나가 종료**한 것이 확정된다. 상세는 [검증 코멘트](https://github.com/ensky0/tildaz/issues/521#issuecomment-5420654236).

confirm · prompt · map 대기 셋은 **실측하지 않았다** — 같은 헬퍼 한 줄을 쓰지만 띄우는 것 자체에 상호작용이 필요하다 (Alt+F4 · 새 instance 흐름).

**자동** — `zig build check` (6 타겟 compile-only) · `zig build test` 통과.

## 문서

이 동작을 서술한 문서는 없다 (`SPEC.md` · `AGENTS.md` 등에 `SIGTERM` 서술 없음 — grep 확인).

Closes #521
