### PR TITLE
fix(linux): dead key 를 Compose 로 조합한다 — AZERTY 의 ^ 가 글자가 된다 (#494)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -599,13 +599,15 @@ xkbcli dump-keymap --raw | wc -c           # 연결 시점 keymap 의 크기 (wl
 
 **GNOME 은 gsettings 가 주 경로가 아니에요.** tildaz 가 부팅 때 Shell extension 을 스스로 켜고 (`ensureShellExtensionReady`), 켜져 있으면 gsettings 등록을 건너뛰어요 (`extension active — gsettings hotkey skipped`). 그래서 **스크립트의 GSettings 조회가 `''` 인 것이 정상**이고, 그때의 근거는 셸 로그예요 (`journalctl --user -b -o cat | grep tildaz`). gsettings 값을 직접 보려면 확장을 끄고 `~/.local/share/gnome-shell/extensions/tildaz@ensky0.github.io` 를 옮겨 둬야 해요 (설치돼 있으면 tildaz 가 다시 켜요).
 
-**함정 일곱 — 앞의 넷은 스크립트가 이미 피하고, 뒤의 셋은 손으로 잴 때 걸려요.**
+**함정 아홉 — 앞의 넷은 스크립트가 이미 피하고, 뒤의 다섯은 손으로 잴 때 걸려요.**
 
 - **`XDG_CURRENT_DESKTOP` 이 비면 등록 경로를 통째로 건너뛰어요.** tty · ssh 셸에는 대개 없고, 그러면 로그가 `de=(unset)` 이 되며 아무 데도 등록하지 않아요 — "등록이 안 된다" 로 오해하기 쉬워요.
-- **config 를 만들려고 그냥 띄우면 기본값 `F1` 이 사용자의 instance 0 과 충돌해요.** 그 충돌 다이얼로그는 **모달이라 부팅을 막고** 로그가 빈 채로 남아요. `env -u XDG_CURRENT_DESKTOP` 으로 한 번 띄워 config 만 만든 뒤 hotkey 를 바꿔요.
+- **config 를 만들려고 그냥 띄우면 기본값 `F1` 이 사용자의 instance 0 과 충돌해요.** 그 충돌 다이얼로그는 **모달이라 부팅을 막고** 로그가 빈 채로 남아요. `env -u XDG_CURRENT_DESKTOP` 으로 한 번 띄워 config 만 만든 뒤 hotkey 를 바꿔요. **`config_N.toml` 을 손으로 쓸 때는 `[keys]` 를 빼먹지 않아요** — 없으면 `missing required key "keys"` 로 같은 모달이 떠서 똑같이 부팅이 막혀요. `config_0.toml` 을 복사해 `hotkey` · `shell` · `auto_start` 만 바꾸는 게 안전해요.
 - **`pkill -f 'instance 9'` 는 자기 명령줄을 매치해 셸을 죽여요** (그 문자열이 명령에도 들어 있어서요). `pgrep -x tildaz` 로 좁히고 `/proc/PID/cmdline` 에서 인자를 확인해요.
 - **layout 전환은 창을 띄우지 않고 해요.** Wayland 의 group 전환은 *포커스한 client* 에게만 가므로, 창을 띄우면 그 경로로 통과해 버려 D-Bus 통지 경로 (#496 1-c 의 ③) 가 검증되지 않아요.
 - **uinput 으로 가상 키보드를 새로 꽂으면 keymap 이 잠깐 바뀌어요.** cosmic-comp 실측에서 장치를 만든 직후 client 가 받은 keymap 이 `grave` → `twosuperior` 로 두 번 왔고, 그 사이에 키를 보내면 **발동하지 않아 거짓 실패**가 나요. 장치를 만든 뒤 **5 초쯤 두고** 눌러요 (`SETTLE`).
+- **`fcitx5` 같은 text-input-v3 IME 가 떠 있으면 키가 앱의 xkb 경로로 오지 않아요.** IME 가 가로채 **자기 구현으로 조합한 뒤 commit** 하므로, 재고 있는 것이 앱 코드가 아니에요. **`fcitx5-remote -c` 로 영문 모드로 바꿔도 경로에서 빠지지 않아요** (fcitx5 에도 자체 Compose 가 있어요). 결과가 우연히 같아 보이는 케이스가 많아 눈치채기 어려워요 — [#494](https://github.com/ensky0/tildaz/issues/494) dead key 검증에서 이 때문에 세 케이스가 거짓 FAIL 로 나왔고, `pkill -x fcitx5` 뒤 전부 통과했어요 (끝나면 `setsid nohup fcitx5 -d &` 로 되돌려요). 판정은 앱 로그의 **`text_input preedit` · `text_input commit` 줄 개수**예요 — 케이스 구간에서 **0 이어야** 앱 자신의 경로를 잰 것이에요. IME 공존 자체를 보는 케이스는 반대로 띄운 채 재고, *조합 주체가 누구인지* 를 결과에 같이 적어요.
+- **`xkbcli interactive-wayland` 는 포커스를 훔치고 안 돌려줘요.** 그 자체가 Wayland client 라, 측정 중에 띄우면 tildaz 의 **layer-shell 표면으로 포커스가 돌아오지 않아** 이후 케이스가 전부 "바이트 없음" 이 돼요 (dead key 가 아니라 평범한 문자 키까지요). 받은 keymap 을 밖에서 확인하는 데는 좋은 도구지만 **tildaz 를 띄우기 전에만** 써요. 띄운 뒤에는 앱 로그의 `keyboard keymap loaded … layouts=[…]` 와 **인앱 가드 키**로 확인해요 — `KEY_Q` 는 fr 에서 `a`, us 에서 `q` 라 한 키로 layout 이 되돌아갔는지 케이스마다 갈려요. 이미 걸렸으면 `tildaz --toggle 9` 두 번으로 회복돼요.
 - **GNOME 확장은 파일을 고쳐도 `disable`/`enable` 로 다시 안 읽어요.** ESM import 캐시라 셸이 새로 떠야 해요. 계측 로그를 심어 재려면 **nested 로 새로 띄워요** — 로그인 세션을 건드리지 않아요.
 - **GNOME 50 은 `--nested` 가 없어요.** `gnome-shell --nested` 가 `Unknown option` 이고, 그냥 `--wayland` 만 주면 native backend 를 골라 `Failed to take control of the session: EBUSY` 로 끝나요. 지금 이름은 **`--devkit`** 이에요.
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -132,6 +132,32 @@ digit bindings ignore Shift, on every layout. Nothing to change.
 **The extra ISO key.** AZERTY has a `<>` key that US keyboards do not have. It
 is `[IntlBackslash]` if you want to bind it.
 
+### Dead keys
+
+On layouts with dead keys — French, German, Spanish, Italian and most other
+European layouts — `^`, `¨`, `´`, `` ` `` and `~` do not print by themselves; they
+wait for the next key and combine with it. TildaZ combines them the same way GTK
+and Qt applications do, using the system Compose table:
+
+| You type | You get |
+|---|---|
+| `^` `e` | `ê` |
+| `^` `Space`, or `^` `^` | `^` |
+| `^` `x` (no such combination) | nothing — both keys are dropped |
+| `^` then `Enter`, `Ctrl+C`, or a shortcut | the pending `^` is dropped; the key itself works normally |
+
+On German and Spanish layouts this is also the only way to type a backtick
+(`` ` ``): dead grave, then `Space`.
+
+The combinations come from the Compose file of your locale (`LC_ALL`, `LC_CTYPE`,
+or `LANG`), falling back to `en_US.UTF-8`; your own `~/.XCompose` is honoured
+too. If no Compose file is installed at all (the `libx11-data` package on Debian
+and Ubuntu), dead keys stay silent and the log says so: `compose table
+unavailable`.
+
+macOS and Windows are not affected — the OS combines dead keys before TildaZ
+sees the text.
+
 ### macOS
 
 **Letter shortcuts match the letter printed on the key**, the same way Safari and

--- a/SPEC.md
+++ b/SPEC.md
@@ -829,7 +829,7 @@ Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496
 - **locale** 은 `LC_ALL` → `LC_CTYPE` → `LANG` (libxkbcommon 규약). 그 표가 없으면 `en_US.UTF-8` 로 한 번 더 시도한다 — X11 `compose.dir` 이 거의 모든 UTF-8 locale 을 그 파일로 보낸다. libxkbcommon 1.12+ 의 자체 fallback 은 C 라이브러리가 아는 locale 에만 적용된다 (실측 1.13.1: 미설치 `xx_XX.UTF-8` 은 `XKB-679` 에러 + `NULL` — 우리 재시도가 있어야 조합이 살았다). 둘 다 없으면 (Compose 파일 미설치 — Debian 계열 `libx11-data`) 로그 한 줄 (`compose table unavailable`) 을 남기고 종전처럼 동작한다. 사용자 `~/.XCompose` · `$XDG_CONFIG_HOME/XCompose` 도 libxkbcommon 이 읽는다.
 - Compose 심볼 8 개는 **optional** (`ComposeApi`, all-or-nothing) — 없으면 조합만 꺼지고 키보드는 그대로다.
 
-검증 상태 (2026-08-26): lima VM (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway · `wtype` keysym 주입) 에서 위 규칙 전부 통과 — 조합 8 종, `^` 뒤 Enter · Ctrl+C 가 삼켜지지 않음, 없는 locale 의 `en_US.UTF-8` fallback (#494 댓글에 바이트 기록). **실기 (COSMIC · KDE, 실제 AZERTY 자판, fcitx5 공존) 는 확인 필요.**
+검증 상태 (2026-08-26): lima VM (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway · `wtype` keysym 주입 — [`dist/linux/dead-key-compose-check.sh`](dist/linux/dead-key-compose-check.sh)) 에서 위 규칙 전부 통과 — 조합 8 종, `^` 뒤 Enter · Ctrl+C 가 삼켜지지 않음, 없는 locale 의 `en_US.UTF-8` fallback (#494 댓글에 바이트 기록). **실기 (COSMIC · KDE, 실제 AZERTY 자판, fcitx5 공존) 는 확인 필요.**
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -808,6 +808,29 @@ emoji picker 는 **OS 제공 도구를 그대로 쓴다** — tildaz 는 picker 
 | tildaz 안 동작 | ✅ OS 가 focused 앱에 직접 입력 | ✅ cursor 에 anchored 된 popover — focus loss 자동 dismiss / `Esc` 닫힘 / emoji 클릭 즉시 입력 (2026-07-13 macOS 26.5.2 + v0.6.1 실기 시연) | emoji 입력은 paste (`Ctrl+Shift+V` / 우클릭) 또는 `echo` / `printf` 로 |
 | 참고 | | 과거 "floating panel + no auto-dismiss" quirk 기록 (2026-05-06, [bc9aa0b](https://github.com/ensky0/tildaz/commit/bc9aa0b) 시점) 은 현재 환경에서 재현 안 됨 — 원인 미확정 (후보: #166/#190 의 NSTextInputClient 표면 확장 또는 macOS 업데이트). Esc dismiss 보강 코드 (`isEmojiPickerOpen()`) 는 무해해서 유지. | *미실측 (DE / 버전 따라 다를 수 있음)*: KDE Plasma `Meta+.` 는 클립보드 복사 방식, GNOME `Ctrl+.` 은 IBus 경유 GTK 앱 전용이라 tildaz (비-GTK Wayland client) 안에서 미동작 |
 
+### 5.3 Dead key 조합 — Linux 는 앱이 Compose 로 한다 ([#494](https://github.com/ensky0/tildaz/issues/494))
+
+dead key (`^` `¨` `´` `` ` `` `~` — 프랑스어 · 독일어 · 스페인어 · 이탈리아어 등 대부분의 유럽 layout) 는 키 하나로 글자가 되지 않고 **다음 키와 조합**된다 (`^`+`e` → `ê`, `^`+space → `^`). 세 platform 이 같은 결과를 내야 하고, 다른 것은 **누가 조합하는가**뿐이다.
+
+| platform | 조합 주체 | 경로 |
+|---|---|---|
+| macOS | OS | `interpretKeyEvents:` — AppKit 텍스트 입력 시스템이 dead key 상태를 든다 |
+| Windows | OS | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
+| **Linux** | **tildaz** | libxkbcommon **Compose** (`xkb_compose_state_feed`) — [`xkb.zig`](src/host/linux/xkb.zig) `Keyboard.composeFeed`. #494 전에는 `xkb_state_key_get_utf8` 만 있어 dead key 가 **빈 문자열** = 아무것도 보내지 않았다 |
+
+Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496 과 같은 뿌리). 규칙:
+
+- **글자가 될 키만 compose 를 거친다.** 단축키 · 다이얼로그 · 메뉴 · scrollback · nav 키 (`terminalSequenceForKeysym`) 는 그 앞에서 끝난다.
+- **Ctrl / Alt 가 눌린 키는 거치지 않는다** (GTK 와 같다). `^` 다음 `Ctrl+C` 는 `\x03` 이 그대로 나간다. AltGr (`Mod5`) 은 해당 없음 — AltGr 로 내는 dead key 도 조합된다.
+- **IME preedit 이 있으면 IME 가 주인** — compose 를 건너뛴다.
+- **compose 를 거치지 않은 키가 끼면 조합을 버린다** (`composeReset`). `^` → Enter → `e` 는 `\r` `e` 다. modifier 키 자체 (Shift 를 누르는 것) 는 libxkbcommon 이 IGNORED 로 받아 상태를 지킨다 — `^` → Shift+`e` → `Ê`.
+- 상태별 동작: `NOTHING` → 기존 utf8 경로 · `COMPOSING` → 아무것도 안 보냄 · `COMPOSED` → 결과 바이트 · `CANCELLED` (`^` 다음 `x`) → **둘 다 버림**. X11 · xterm 관례다 — GTK 만 `^x` 를 내는데 Compose 표 밖의 별도 규칙이라 채택하지 않았다.
+- key repeat 은 press 와 같은 경로라 `^` 를 누르고 있으면 `<dead_circumflex><dead_circumflex>` → `^` 가 두 번마다 하나 — X 앱과 같다.
+- **locale** 은 `LC_ALL` → `LC_CTYPE` → `LANG` (libxkbcommon 규약). 그 표가 없으면 `en_US.UTF-8` 로 한 번 더 시도한다 — X11 `compose.dir` 이 거의 모든 UTF-8 locale 을 그 파일로 보낸다. libxkbcommon 1.12+ 의 자체 fallback 은 C 라이브러리가 아는 locale 에만 적용된다 (실측 1.13.1: 미설치 `xx_XX.UTF-8` 은 `XKB-679` 에러 + `NULL` — 우리 재시도가 있어야 조합이 살았다). 둘 다 없으면 (Compose 파일 미설치 — Debian 계열 `libx11-data`) 로그 한 줄 (`compose table unavailable`) 을 남기고 종전처럼 동작한다. 사용자 `~/.XCompose` · `$XDG_CONFIG_HOME/XCompose` 도 libxkbcommon 이 읽는다.
+- Compose 심볼 8 개는 **optional** (`ComposeApi`, all-or-nothing) — 없으면 조합만 꺼지고 키보드는 그대로다.
+
+검증 상태 (2026-08-26): lima VM (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway · `wtype` keysym 주입) 에서 위 규칙 전부 통과 — 조합 8 종, `^` 뒤 Enter · Ctrl+C 가 삼켜지지 않음, 없는 locale 의 `en_US.UTF-8` fallback (#494 댓글에 바이트 기록). **실기 (COSMIC · KDE, 실제 AZERTY 자판, fcitx5 공존) 는 확인 필요.**
+
 ---
 
 ## 6. 다이얼로그

--- a/SPEC.md
+++ b/SPEC.md
@@ -814,8 +814,8 @@ dead key (`^` `¨` `´` `` ` `` `~` — 프랑스어 · 독일어 · 스페인�
 
 | platform | 조합 주체 | 경로 |
 |---|---|---|
-| macOS | OS | `interpretKeyEvents:` — AppKit 텍스트 입력 시스템이 dead key 상태를 든다 |
-| Windows | OS | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
+| macOS | OS (코드 판정 — 실기 미확인) | `interpretKeyEvents:` — AppKit 텍스트 입력 시스템이 dead key 상태를 든다 |
+| Windows | OS (코드 판정 — 실기 미확인) | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
 | **Linux** | **tildaz** | libxkbcommon **Compose** (`xkb_compose_state_feed`) — [`xkb.zig`](src/host/linux/xkb.zig) `Keyboard.composeFeed`. #494 전에는 `xkb_state_key_get_utf8` 만 있어 dead key 가 **빈 문자열** = 아무것도 보내지 않았다 |
 
 Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496 과 같은 뿌리). 규칙:
@@ -829,7 +829,13 @@ Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496
 - **locale** 은 `LC_ALL` → `LC_CTYPE` → `LANG` (libxkbcommon 규약). 그 표가 없으면 `en_US.UTF-8` 로 한 번 더 시도한다 — X11 `compose.dir` 이 거의 모든 UTF-8 locale 을 그 파일로 보낸다. libxkbcommon 1.12+ 의 자체 fallback 은 C 라이브러리가 아는 locale 에만 적용된다 (실측 1.13.1: 미설치 `xx_XX.UTF-8` 은 `XKB-679` 에러 + `NULL` — 우리 재시도가 있어야 조합이 살았다). 둘 다 없으면 (Compose 파일 미설치 — Debian 계열 `libx11-data`) 로그 한 줄 (`compose table unavailable`) 을 남기고 종전처럼 동작한다. 사용자 `~/.XCompose` · `$XDG_CONFIG_HOME/XCompose` 도 libxkbcommon 이 읽는다.
 - Compose 심볼 8 개는 **optional** (`ComposeApi`, all-or-nothing) — 없으면 조합만 꺼지고 키보드는 그대로다.
 
-검증 상태 (2026-08-26): lima VM (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway · `wtype` keysym 주입 — [`dist/linux/dead-key-compose-check.sh`](dist/linux/dead-key-compose-check.sh)) 에서 위 규칙 전부 통과 — 조합 8 종, `^` 뒤 Enter · Ctrl+C 가 삼켜지지 않음, 없는 locale 의 `en_US.UTF-8` fallback (#494 댓글에 바이트 기록). **실기 (COSMIC · KDE, 실제 AZERTY 자판, fcitx5 공존) 는 확인 필요.**
+검증 상태 (2026-08-26 · 27): lima VM (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway · `wtype` keysym 주입 — [`dist/linux/dead-key-compose-check.sh`](dist/linux/dead-key-compose-check.sh)) 통과에 이어, **실기 두 DE 에서 13 케이스 전부 일치** — 노트북 i5-1240P (CachyOS · libxkbcommon 1.13.2), COSMIC (cosmic-comp 1.6.0) 과 KDE Plasma (KWin 6.7.4), 실제 `fr` · `de` layout 에 `/dev/uinput` scancode 주입, 두 DE 가 같은 바이트 ([COSMIC](https://github.com/ensky0/tildaz/issues/494#issuecomment-5427290965) · [KDE](https://github.com/ensky0/tildaz/issues/494#issuecomment-5427566292)). 실기에서 확인된 사실:
+
+- **text-input-v3 IME (fcitx5) 가 떠 있으면 영문 모드여도 IME 가 자기 Compose 로 조합해 commit 한다.** 위 경계 규칙은 IME 없는 세션에서만 관측된다 (`^`+`x` 가 IME 경로에서는 `^x`). 한글 모드에서는 IME 가 전부 소유한다 — "IME 가 주인" 규칙 그대로. 검증 결과에는 *조합 주체가 누구였는지* 를 함께 적어야 한다.
+- 대조군 foot 1.27.0 은 `^` 뒤 Enter 를 삼키고 (`65` 만 나옴) `^`+Ctrl+C 를 `ĉ` 로 조합해 **SIGINT 를 삼킨다** — "Ctrl/Alt 제외 · 조합 버림" 두 규칙의 근거가 실기로 재현됐다.
+- `ko_KR.UTF-8` 의 Compose 파일은 `en_US.UTF-8` 을 include 하는 한 줄이라 fallback 없이 바로 로드된다.
+
+**macOS · Windows 는 코드 판정이고 실기 미확인**이다 — OS 가 조합 주체라 코드 리뷰로는 드러나지 않으므로 따로 재야 한다.
 
 ---
 

--- a/dist/linux/dead-key-compose-check.sh
+++ b/dist/linux/dead-key-compose-check.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# dead-key-compose-check.sh — #494 dead key (Compose) 조합 자동 검증.
+#
+# headless sway 를 격리된 XDG 경로로 띄우고, tildaz 를 `--instance 9 -e <수신자>` 로 실행한 뒤
+# wtype 으로 keysym 을 직접 주입한다 (layout 무관 — 가상 키보드가 자기 keymap 을 올린다).
+# 판정은 PTY 로 실제 흘러간 바이트 (raw tty · 바이트 단위 기록) 와 앱 로그의 compose 줄이다.
+#
+#   ./dist/linux/dead-key-compose-check.sh --bin ./zig-out/bin/tildaz                     # LANG 은 현재 값
+#   ./dist/linux/dead-key-compose-check.sh --bin ./zig-out/bin/tildaz --lang xx_XX.UTF-8  # 없는 locale → en_US.UTF-8 fallback
+#   ./dist/linux/dead-key-compose-check.sh --bin ./zig-out/bin/tildaz --strace            # tildaz 의 write() 까지 기록
+#
+# 필요: sway · wtype · python3 · xxd (grim 은 있으면 스크린샷). 사용자의 세션은 건드리지 않는다 —
+# headless 백엔드라 화면이 없고, XDG_RUNTIME_DIR 을 /tmp 아래로 돌려 lock · 소켓을 격리한다.
+# 실행 중인 sway 세션이 있어도 죽이지 않는다 (자기 sway 는 timeout 으로 끝난다).
+#
+# 함정 (실측 — #494 댓글):
+#   - 수신자를 bash `read -rN1` 로 두면 PTY 가 raw 여도 CR 이 LF 로 오고 0x03 이 사라진다 →
+#     python `tty.setraw` + `os.read` 로 받는다.
+#   - wtype 은 세션당 첫 프로세스만 유효하다 → 입력 전체를 단일 호출의 -s 타임라인에 넣는다.
+#   - cat 은 파일 출력 시 버퍼링한다 → 수신자는 무버퍼로 쓴다.
+#   - `-e` 인스턴스는 로그를 `tildaz_stress.log` 에 쓴다 → `*.log` 로 찾는다.
+set -uo pipefail
+
+BIN=""
+LANG_VALUE="${LANG:-C.UTF-8}"
+USE_STRACE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bin) BIN="$2"; shift 2 ;;
+        --lang) LANG_VALUE="$2"; shift 2 ;;
+        --strace) USE_STRACE=1; shift ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$BIN" && -x "$BIN" ]] || { echo "--bin <tildaz 실행 파일> 이 필요해요 (예: --bin ./zig-out/bin/tildaz)" >&2; exit 2; }
+BIN="$(realpath "$BIN")"
+for tool in sway wtype python3 xxd; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "$tool 이 없어요 — 설치 후 다시 실행해요" >&2; exit 2; }
+done
+if [[ $USE_STRACE = 1 ]] && ! command -v strace >/dev/null 2>&1; then echo "strace 가 없어요" >&2; exit 2; fi
+
+T=/tmp/tildaz-compose-check
+rm -rf "$T"
+mkdir -p "$T/home" "$T/xdg" "$T/state" "$T/run"
+chmod 700 "$T/run"
+
+# ── 수신자 (python): raw 로 두고 바이트 단위로 기록. termios 플래그를 시점별로 남긴다 ──
+cat > "$T/rec.sh" <<EOF
+#!/bin/bash
+exec python3 $T/rec.py
+EOF
+chmod +x "$T/rec.sh"
+cat > "$T/rec.py" <<EOF
+import os, termios, threading, time, tty
+T = "$T"
+def flags(tag):
+    a = termios.tcgetattr(0)
+    with open(T + "/rec.diag", "a") as d:
+        d.write(f"{tag}: ICRNL={bool(a[0] & termios.ICRNL)} ISIG={bool(a[3] & termios.ISIG)} ICANON={bool(a[3] & termios.ICANON)}\\n")
+with open(T + "/rec.diag", "w") as d:
+    d.write(f"tty={os.ttyname(0)}\\n")
+flags("before  ")
+tty.setraw(0)
+flags("after   ")
+threading.Thread(target=lambda: (time.sleep(3), flags("t+3s    ")), daemon=True).start()
+out = open(T + "/pty.bin", "wb", buffering=0)
+first = True
+while True:
+    b = os.read(0, 1)
+    if not b:
+        break
+    out.write(b)
+    if first:
+        first = False
+        flags("1st-byte")
+EOF
+
+# ── 드라이버: sway 가 exec 한다 (WAYLAND_DISPLAY 상속). tildaz 를 띄우고 키를 넣고 sway 를 끝낸다 ──
+STRACE_PREFIX=""
+[[ $USE_STRACE = 1 ]] && STRACE_PREFIX="strace -f -e trace=write -xx -s 64 -o $T/strace.log"
+cat > "$T/drive.sh" <<EOF
+#!/bin/bash
+set -u
+exec > "$T/drive.log" 2>&1
+echo "drive start: WAYLAND_DISPLAY=\${WAYLAND_DISPLAY:-} LANG=\${LANG:-}"
+# XDG_CURRENT_DESKTOP 을 비워 전역 hotkey 등록 경로를 건너뛴다 (비면 어디에도 등록하지 않는다).
+env -u XDG_CURRENT_DESKTOP TILDAZ_VERBOSE=1 HOME=$T/home XDG_CONFIG_HOME=$T/xdg XDG_STATE_HOME=$T/state \\
+    $STRACE_PREFIX "$BIN" --instance 9 -e $T/rec.sh &
+TZ_PID=\$!
+sleep 4
+echo "tildaz pid=\$TZ_PID alive=\$(kill -0 \$TZ_PID 2>/dev/null && echo yes || echo no)"
+# 단일 wtype 타임라인 — 기대 바이트는 아래 EXPECT.
+#   Ctrl+C (기준선) · ^e · ^space · ^^ · ^x (버림) · a · ^ Enter e (조합 버림) · ^ Ctrl+C e (조합 버림, 03 보존)
+#   dead_grave space · dead_acute e · dead_diaeresis u · Enter
+wtype -s 500 \\
+  -M ctrl -k c -m ctrl -s 300 \\
+  -k dead_circumflex -k e -s 300 \\
+  -k dead_circumflex -k space -s 300 \\
+  -k dead_circumflex -k dead_circumflex -s 300 \\
+  -k dead_circumflex -k x -s 300 \\
+  -k a -s 300 \\
+  -k dead_circumflex -k Return -k e -s 300 \\
+  -k dead_circumflex -M ctrl -k c -m ctrl -k e -s 300 \\
+  -k dead_grave -k space -s 300 \\
+  -k dead_acute -k e -s 300 \\
+  -k dead_diaeresis -k u -s 300 \\
+  -k Return
+echo "wtype exit=\$?"
+sleep 2
+command -v grim >/dev/null 2>&1 && { grim "$T/shot.png" && echo "grim ok" || echo "grim failed"; }
+sleep 1
+swaymsg exit
+EOF
+chmod +x "$T/drive.sh"
+printf 'exec %s/drive.sh\n' "$T" > "$T/sway.cfg"
+
+echo "=== LANG=$LANG_VALUE bin=$BIN — headless sway 시작 (최대 40 s)"
+env -i PATH="$PATH" HOME="$T/home" LANG="$LANG_VALUE" \
+    XDG_RUNTIME_DIR="$T/run" WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman \
+    timeout 40 sway -c "$T/sway.cfg" > "$T/sway.log" 2>&1
+echo "sway exit=$?"
+
+echo "--- drive.log"; cat "$T/drive.log" 2>/dev/null
+echo "--- rec.diag (PTY termios)"; cat "$T/rec.diag" 2>/dev/null || echo "(no rec.diag — 수신자가 뜨지 않았어요)"
+if [[ $USE_STRACE = 1 ]]; then
+    echo "--- strace: tildaz write() of key bytes"
+    grep -E 'write\([0-9]+, "(\\x03|\\x0d|\\xc3|\\x5e|\\x61|\\x60|\\x65)' "$T/strace.log" 2>/dev/null | sed 's/^[0-9]* *//' | head -24
+fi
+echo "--- compose lines in app log"
+grep -h -i 'compose\|keyboard keymap loaded' "$T"/state/tildaz/*.log 2>/dev/null || echo "(no compose line — 앱 로그가 없거나 compose 초기화 전에 끝났어요)"
+echo "--- PTY bytes (hex)"
+GOT=$(xxd -p "$T/pty.bin" 2>/dev/null | tr -d '\n')
+EXPECT="03c3aa5e5e610d65036560c3a9c3bc0d"
+echo "EXPECT $EXPECT"
+echo "GOT    ${GOT:-(empty)}"
+if [[ "$GOT" == "$EXPECT" ]]; then
+    echo "##### PASS #####"
+    exit 0
+else
+    echo "##### FAIL ##### (산출물: $T — drive.log · rec.diag · sway.log · pty.bin)"
+    exit 1
+fi

--- a/dist/linux/dead-key-compose-check.sh
+++ b/dist/linux/dead-key-compose-check.sh
@@ -19,6 +19,10 @@
 #   - wtype 은 세션당 첫 프로세스만 유효하다 → 입력 전체를 단일 호출의 -s 타임라인에 넣는다.
 #   - cat 은 파일 출력 시 버퍼링한다 → 수신자는 무버퍼로 쓴다.
 #   - `-e` 인스턴스는 로그를 `tildaz_stress.log` 에 쓴다 → `*.log` 로 찾는다.
+#   - text-input-v3 IME (fcitx5 등) 가 떠 있으면 키가 앱의 xkb 경로로 오지 않고 IME 가 자기 Compose 로
+#     조합해 commit 한다 — 그러면 재는 것이 앱 코드가 아니다 (실기: 케이스 1~3 은 결과가 같아 구별이
+#     안 되고 `^`+`x` 만 `^x` 로 갈린다). nested headless sway 에는 IME 가 없다는 것이 이 스크립트의
+#     전제이고, 그 전제를 앱 로그의 `text_input preedit/commit` 줄 수 == 0 으로 판정에 넣는다.
 set -uo pipefail
 
 BIN=""
@@ -128,15 +132,19 @@ if [[ $USE_STRACE = 1 ]]; then
 fi
 echo "--- compose lines in app log"
 grep -h -i 'compose\|keyboard keymap loaded' "$T"/state/tildaz/*.log 2>/dev/null || echo "(no compose line — 앱 로그가 없거나 compose 초기화 전에 끝났어요)"
+echo "--- composition owner (text_input lines in app log — must be 0: an IME in the path means we did not measure tildaz)"
+IME_LINES=$(grep -h 'text_input \(preedit\|commit\)' "$T"/state/tildaz/*.log 2>/dev/null | wc -l | tr -d ' ')
+echo "text_input preedit/commit lines: $IME_LINES"
 echo "--- PTY bytes (hex)"
 GOT=$(xxd -p "$T/pty.bin" 2>/dev/null | tr -d '\n')
 EXPECT="03c3aa5e5e610d65036560c3a9c3bc0d"
 echo "EXPECT $EXPECT"
 echo "GOT    ${GOT:-(empty)}"
-if [[ "$GOT" == "$EXPECT" ]]; then
+if [[ "$GOT" == "$EXPECT" && "$IME_LINES" == "0" ]]; then
     echo "##### PASS #####"
     exit 0
 else
+    [[ "$IME_LINES" != "0" ]] && echo "an IME composed instead of tildaz (text_input lines=$IME_LINES) — this run does not measure the app path"
     echo "##### FAIL ##### (산출물: $T — drive.log · rec.diag · sway.log · pty.bin)"
     exit 1
 fi

--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -23,4 +23,5 @@ _(empty — folded into `v0.9.0.md`)_
 
 ## Body candidates
 
-_(empty)_
+- Dead keys combine on Linux — `^` then `e` gives `ê`, and German and Spanish
+  layouts can type a backtick. ([#494](https://github.com/ensky0/tildaz/issues/494))

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -5767,8 +5767,11 @@ const Client = struct {
         self.compose_setup_done = true;
         var locale_buf: [128]u8 = undefined;
         const locale = self.composeLocale(&locale_buf);
+        // 네 갈래 모두 항상 남긴다 — 성공 줄만 verbose 로 두면 "dead key 가 안 된다" 는 제보에서
+        // 평소 로그로는 성공/실패를 가를 수 없다 (실기 검증에서 실제로 한 번 헛돌았다, #494).
+        // 부팅에 한 줄이고 `keyboard keymap loaded` 도 같은 자리에 항상 남는다.
         switch (self.keyboard.setComposeLocale(locale)) {
-            .ready => log.appendLineVerbose("wayland", "compose table loaded locale={s}", .{locale}),
+            .ready => log.appendLine("wayland", "compose table loaded locale={s}", .{locale}),
             .fallback_locale => log.appendLine("wayland", "compose table for locale={s} not found -- using en_US.UTF-8", .{locale}),
             .unavailable => log.appendLine("wayland", "compose table unavailable locale={s} -- dead keys will not combine", .{locale}),
             .no_symbols => log.appendLine("wayland", "libxkbcommon has no compose symbols -- dead keys will not combine", .{}),

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1406,6 +1406,9 @@ const Client = struct {
     pointer_id: u32 = 0,
     seat_capabilities: u32 = 0,
     keyboard: xkb.Keyboard = .{},
+    /// #494 — Compose 표를 올리는 시도는 한 번이다 (첫 keymap 뒤). 실패해도 다시 하지 않는다 —
+    /// locale 과 Compose 파일은 프로세스 수명 동안 바뀌지 않는다.
+    compose_setup_done: bool = false,
     pointer_x_px: i32 = -1,
     pointer_y_px: i32 = -1,
     pointer_inside: bool = false,
@@ -5752,6 +5755,39 @@ const Client = struct {
         self.needs_redraw = true;
     }
 
+    /// #494 — Compose 표를 한 번 올린다. dead key (`^` `¨` `´` `` ` `` …) 는 keymap 만으로는 글자가
+    /// 되지 않고 (`xkb_state_key_get_utf8` 이 빈 문자열), 다음 키와의 조합은 locale 의 Compose
+    /// 파일이 정한다. GTK · Qt 가 같은 표를 쓴다.
+    ///
+    /// locale 은 libxkbcommon 규약대로 `LC_ALL` → `LC_CTYPE` → `LANG` 순으로 읽고, 다 비어 있으면
+    /// `C` 다 — 그러면 `setComposeLocale` 안에서 `en_US.UTF-8` 로 떨어진다. 결과는 로그 한 줄로
+    /// 남긴다: dead key 가 조합되지 않는다는 신고가 오면 이 줄이 첫 갈림길이다.
+    fn ensureCompose(self: *Client) void {
+        if (self.compose_setup_done) return;
+        self.compose_setup_done = true;
+        var locale_buf: [128]u8 = undefined;
+        const locale = self.composeLocale(&locale_buf);
+        switch (self.keyboard.setComposeLocale(locale)) {
+            .ready => log.appendLineVerbose("wayland", "compose table loaded locale={s}", .{locale}),
+            .fallback_locale => log.appendLine("wayland", "compose table for locale={s} not found -- using en_US.UTF-8", .{locale}),
+            .unavailable => log.appendLine("wayland", "compose table unavailable locale={s} -- dead keys will not combine", .{locale}),
+            .no_symbols => log.appendLine("wayland", "libxkbcommon has no compose symbols -- dead keys will not combine", .{}),
+        }
+    }
+
+    /// `LC_ALL` → `LC_CTYPE` → `LANG` 중 첫 비어 있지 않은 값을 NUL 종단으로 `buf` 에 담는다.
+    /// 없으면 `"C"`. 버퍼를 넘는 값은 건너뛴다 — locale 이름은 길어도 수십 바이트다.
+    fn composeLocale(self: *Client, buf: []u8) [:0]const u8 {
+        for ([_][]const u8{ "LC_ALL", "LC_CTYPE", "LANG" }) |key| {
+            const value = self.rt.environ.getPosix(key) orelse continue;
+            if (value.len == 0 or value.len >= buf.len) continue;
+            @memcpy(buf[0..value.len], value);
+            buf[value.len] = 0;
+            return buf[0..value.len :0];
+        }
+        return "C";
+    }
+
     fn handleKeyboardKeymap(self: *Client, payload: []const u8) !void {
         if (payload.len < 8) return error.WaylandBadMessage;
         const format = readU32(payload[0..4]);
@@ -5777,6 +5813,9 @@ const Client = struct {
         defer posix.munmap(memory);
 
         try self.keyboard.setKeymap(self.allocator, memory);
+        // #494 — dead key 조합 (Compose). `xkb_context` 가 첫 keymap 에서 생기므로 여기서 올린다.
+        // 두 번째 keymap 부터는 아무 일도 안 한다 — 표는 layout 이 아니라 locale 의 것이다.
+        self.ensureCompose();
         // #513 — **받은 keymap 이 어느 layout 인지 남긴다.** COSMIC 에서 키보드를 꽂으면
         // 위치 표기 hotkey 가 직전 layout 의 글자로 재등록되는데, 로그만 봐서는
         // *compositor 가 옛 keymap 을 보낸 것*인지 *우리가 잘못 읽은 것*인지 구분할 수
@@ -5833,6 +5872,14 @@ const Client = struct {
     /// 자신에게 보관 (matchClipboardSerial 같은 path 에서 사용).
     fn processKeyEvent(self: *Client, serial: u32, key: u32) !void {
         self.last_serial = serial;
+
+        // #494 — compose 를 거치지 않고 끝난 키 (다이얼로그 · 메뉴 · 단축키 · nav 키 · Ctrl/Alt
+        // 조합 · IME preedit 중) 가 끼면 조합 중이던 dead key 를 버린다. `^` 를 누른 뒤 Enter 나
+        // Ctrl+C 를 쳤으면 조합 의도는 끝난 것이고, 그 뒤 `e` 에서 `ê` 가 튀어나오면 더 놀랍다.
+        // modifier 키 자체 (Shift 를 누르는 것) 는 `composeFeed` 가 IGNORED 로 받아 상태를 지키므로
+        // `^` → Shift+`e` → `Ê` 는 그대로 된다.
+        var fed_compose = false;
+        defer if (!fed_compose) self.keyboard.composeReset();
 
         // #203 Phase C — dialog 활성 시 모든 키 dialog 로 라우팅 (Enter / Esc /
         // Tab 만 의미). modal — 다른 키 swallow. preedit / 단축키 모두
@@ -5942,7 +5989,34 @@ const Client = struct {
             }
         }
 
+        // #494 — dead key 조합 (Compose). `^` (`dead_circumflex`) 는 아래 `utf8()` 이 빈 문자열이라
+        // 지금까지는 아무것도 보내지 않고 끝났다 — 그래서 AZERTY 에서 `^` 를 칠 수 없었고, 독일어 ·
+        // 스페인어 자판은 backtick 을 아예 낼 수 없었다. 여기서 keysym 을 Compose 상태 기계에 먹여
+        // `^`+`e` → `ê`, `^`+space → `^`, `^`+`^` → `^` 를 만든다.
+        //
+        // **글자가 될 키만 지나간다.** 단축키 · 다이얼로그 · 메뉴 · scrollback · nav 키는 위에서 이미
+        // 돌아갔다. 남은 둘은 여기서 가른다:
+        //   - **IME 가 preedit 을 들고 있으면 IME 가 주인이다.** compose 를 건너뛴다 (위 defer 가
+        //     상태를 비운다). IME 가 키를 가로채는 세션에서는 이 함수까지 키가 오지 않으므로 둘이
+        //     동시에 조합할 일은 원래 없고, 이 조건은 preedit 이 있는 채로 키가 온 경계를 막는다.
+        //   - **Ctrl / Alt 가 눌린 키는 compose 를 거치지 않는다.** `^` 다음 `Ctrl+C` 를 feed 하면
+        //     `c` 가 시퀀스를 깨며 (`CANCELLED`) `\x03` 까지 삼킨다. GTK 도 modifier 가 붙은 키는
+        //     compose 에 넣지 않는다. AltGr 은 `Mod5` 라 여기에 걸리지 않는다 — AltGr 로 내는 dead
+        //     key (fr 의 `dead_grave` 등) 도 조합된다.
         var buf: [64]u8 = undefined;
+        if (sym_opt) |sym| {
+            if (self.preedit_text.items.len == 0 and !ctrl and !alt) {
+                fed_compose = true;
+                switch (self.keyboard.composeFeed(sym, &buf)) {
+                    .passthrough => {},
+                    .swallow => return,
+                    .composed => |text| {
+                        self.queueInput(text);
+                        return;
+                    },
+                }
+            }
+        }
         const bytes = self.keyboard.utf8(xkb_key, &buf);
         if (bytes.len > 0) self.queueInput(bytes);
     }

--- a/src/host/linux/xkb.zig
+++ b/src/host/linux/xkb.zig
@@ -11,10 +11,24 @@ const log = @import("../../log.zig");
 const xkb_context = opaque {};
 const xkb_keymap = opaque {};
 const xkb_state = opaque {};
+const xkb_compose_table = opaque {};
+const xkb_compose_state = opaque {};
 
 const XKB_CONTEXT_NO_FLAGS: c_uint = 0;
 const XKB_KEYMAP_FORMAT_TEXT_V1: c_uint = 1;
 const XKB_KEYMAP_COMPILE_NO_FLAGS: c_uint = 0;
+
+// #494 — libxkbcommon Compose (`xkbcommon-compose.h`). 값은 헤더의 enum 순서 그대로다.
+const XKB_COMPOSE_COMPILE_NO_FLAGS: c_uint = 0;
+const XKB_COMPOSE_STATE_NO_FLAGS: c_uint = 0;
+/// `enum xkb_compose_status`
+const XKB_COMPOSE_NOTHING: c_int = 0;
+const XKB_COMPOSE_COMPOSING: c_int = 1;
+const XKB_COMPOSE_COMPOSED: c_int = 2;
+const XKB_COMPOSE_CANCELLED: c_int = 3;
+/// `enum xkb_compose_feed_result`
+const XKB_COMPOSE_FEED_IGNORED: c_int = 0;
+const XKB_COMPOSE_FEED_ACCEPTED: c_int = 1;
 
 const XkbContextNew = *const fn (flags: c_uint) callconv(.c) ?*xkb_context;
 const XkbContextUnref = *const fn (context: ?*xkb_context) callconv(.c) void;
@@ -90,6 +104,28 @@ const XkbKeysymGetName = *const fn (
     size: usize,
 ) callconv(.c) c_int;
 
+// #494 — Compose. dead key (`dead_circumflex` 0xfe52 등) 는 `xkb_state_key_get_utf8` 이 빈
+// 문자열을 내고, 다음 키와의 조합 (`^`+`e` → `ê`, `^`+space → `^`) 은 이 상태 기계가 한다 —
+// GTK · Qt 가 쓰는 것과 같은 경로다. **여덟 개는 optional 이다.** 없으면 compose 만 꺼지고
+// 키보드는 지금처럼 동작한다 (#496 1-a 의 `KeymapScan` 과 같은 이유 — 오래된 libxkbcommon
+// 에서 키보드가 통째로 죽을 일이 아니다).
+const XkbComposeTableNewFromLocale = *const fn (
+    context: *xkb_context,
+    locale: [*:0]const u8,
+    flags: c_uint,
+) callconv(.c) ?*xkb_compose_table;
+const XkbComposeTableUnref = *const fn (table: ?*xkb_compose_table) callconv(.c) void;
+const XkbComposeStateNew = *const fn (table: *xkb_compose_table, flags: c_uint) callconv(.c) ?*xkb_compose_state;
+const XkbComposeStateUnref = *const fn (state: ?*xkb_compose_state) callconv(.c) void;
+const XkbComposeStateFeed = *const fn (state: *xkb_compose_state, keysym: c_uint) callconv(.c) c_int;
+const XkbComposeStateReset = *const fn (state: *xkb_compose_state) callconv(.c) void;
+const XkbComposeStateGetStatus = *const fn (state: *xkb_compose_state) callconv(.c) c_int;
+const XkbComposeStateGetUtf8 = *const fn (
+    state: *xkb_compose_state,
+    buffer: [*]u8,
+    size: usize,
+) callconv(.c) c_int;
+
 // libxkbcommon `enum xkb_state_component`. MODS_EFFECTIVE = (1 << 3).
 // 처음에 (1 << 7) = LAYOUT_EFFECTIVE 로 잘못 적어 mod_name_is_active 가
 // modifier component 를 안 보고 항상 0 반환 → 단축키 분기 fail (1차 시연 발견).
@@ -112,6 +148,8 @@ const Api = struct {
     keymap_scan: ?KeymapScan = null,
     // #513 — optional. 진단 로그 전용이라 없으면 그 줄에서 layout 이름만 빠진다.
     layout_names: ?LayoutNames = null,
+    // #494 — optional. 없으면 dead key 조합만 꺼진다 (`Keyboard.composeFeed` 가 passthrough).
+    compose: ?ComposeApi = null,
 
     fn load() !Api {
         const handle = std.c.dlopen("libxkbcommon.so.0", .{ .LAZY = true }) orelse return error.XkbLibraryMissing;
@@ -131,6 +169,7 @@ const Api = struct {
             .state_mod_name_is_active = lookup(handle, XkbStateModNameIsActive, "xkb_state_mod_name_is_active") orelse return error.XkbSymbolMissing,
             .keymap_scan = KeymapScan.load(handle),
             .layout_names = LayoutNames.load(handle),
+            .compose = ComposeApi.load(handle),
         };
     }
 
@@ -185,6 +224,32 @@ const LayoutNames = struct {
     }
 };
 
+/// #494 — Compose 상태 기계 심볼 묶음. **all-or-nothing** — `feed` 는 있는데 `get_utf8` 이
+/// 없으면 조합은 되는데 결과를 못 꺼내 글자가 사라지므로, 하나라도 없으면 통째로 끈다.
+const ComposeApi = struct {
+    table_new_from_locale: XkbComposeTableNewFromLocale,
+    table_unref: XkbComposeTableUnref,
+    state_new: XkbComposeStateNew,
+    state_unref: XkbComposeStateUnref,
+    state_feed: XkbComposeStateFeed,
+    state_reset: XkbComposeStateReset,
+    state_get_status: XkbComposeStateGetStatus,
+    state_get_utf8: XkbComposeStateGetUtf8,
+
+    fn load(handle: *anyopaque) ?ComposeApi {
+        return .{
+            .table_new_from_locale = lookup(handle, XkbComposeTableNewFromLocale, "xkb_compose_table_new_from_locale") orelse return null,
+            .table_unref = lookup(handle, XkbComposeTableUnref, "xkb_compose_table_unref") orelse return null,
+            .state_new = lookup(handle, XkbComposeStateNew, "xkb_compose_state_new") orelse return null,
+            .state_unref = lookup(handle, XkbComposeStateUnref, "xkb_compose_state_unref") orelse return null,
+            .state_feed = lookup(handle, XkbComposeStateFeed, "xkb_compose_state_feed") orelse return null,
+            .state_reset = lookup(handle, XkbComposeStateReset, "xkb_compose_state_reset") orelse return null,
+            .state_get_status = lookup(handle, XkbComposeStateGetStatus, "xkb_compose_state_get_status") orelse return null,
+            .state_get_utf8 = lookup(handle, XkbComposeStateGetUtf8, "xkb_compose_state_get_utf8") orelse return null,
+        };
+    }
+};
+
 fn lookup(handle: *anyopaque, comptime T: type, name: [*:0]const u8) ?T {
     const symbol = std.c.dlsym(handle, name) orelse return null;
     return @ptrCast(@alignCast(symbol));
@@ -202,9 +267,14 @@ pub const Keyboard = struct {
     context: ?*xkb_context = null,
     keymap: ?*xkb_keymap = null,
     state: ?*xkb_state = null,
+    /// #494 — Compose. `setComposeLocale` 이 만든다. **keymap 이 바뀌어도 그대로 둔다** —
+    /// 표는 layout 이 아니라 locale 의 것이고, 조합 중 상태가 layout 전환에 끊길 이유도 없다.
+    compose_table: ?*xkb_compose_table = null,
+    compose_state: ?*xkb_compose_state = null,
 
     pub fn deinit(self: *Keyboard) void {
         self.clearKeymap();
+        self.clearCompose();
         if (self.api) |*api| {
             if (self.context) |context| {
                 api.context_unref(context);
@@ -433,6 +503,117 @@ pub const Keyboard = struct {
         return buf[0..wanted];
     }
 
+    /// #494 — `setComposeLocale` 의 결과. 호출자가 로그 한 줄로 남긴다.
+    pub const ComposeSetup = enum {
+        /// 요청한 locale 의 Compose 표가 올라갔다 (이미 올라가 있던 경우도 포함).
+        ready,
+        /// 요청한 locale 에는 표가 없어 `en_US.UTF-8` 로 올라갔다.
+        fallback_locale,
+        /// 둘 다 실패 — dead key 는 지금처럼 조합되지 않는다.
+        unavailable,
+        /// libxkbcommon 이 compose 심볼을 내주지 않거나 아직 context 가 없다.
+        no_symbols,
+    };
+
+    /// #494 — 이 locale 의 Compose 표를 올린다. 호출 시점은 **첫 keymap 이 온 뒤**다 —
+    /// `xkb_context` 가 그때 생긴다. 이미 올라가 있으면 다시 만들지 않는다.
+    ///
+    /// `locale` 이 가리키는 Compose 파일이 없으면 (`C` · compose.dir 에 없는 locale) `en_US.UTF-8`
+    /// 로 한 번 더 시도한다. X11 의 `compose.dir` 에서 거의 모든 UTF-8 locale 이 그 파일을
+    /// 가리킨다. libxkbcommon 1.12+ 도 fallback 을 하지만 **C 라이브러리가 아는 locale 에만**
+    /// 이다 — 실측 (lima VM · 1.13.1) 에서 설치되지 않은 `xx_XX.UTF-8` 은 `XKB-679` 에러와 함께
+    /// `NULL` 을 냈고, 이 재시도가 있어야 조합이 살았다.
+    pub fn setComposeLocale(self: *Keyboard, locale: [:0]const u8) ComposeSetup {
+        const api = if (self.api) |*a| a else return .no_symbols;
+        const compose = api.compose orelse return .no_symbols;
+        const context = self.context orelse return .no_symbols;
+        if (self.compose_state != null) return .ready;
+
+        var setup: ComposeSetup = .ready;
+        var table = compose.table_new_from_locale(context, locale.ptr, XKB_COMPOSE_COMPILE_NO_FLAGS);
+        if (table == null) {
+            table = compose.table_new_from_locale(context, "en_US.UTF-8", XKB_COMPOSE_COMPILE_NO_FLAGS);
+            setup = .fallback_locale;
+        }
+        const table_ptr = table orelse return .unavailable;
+        const state = compose.state_new(table_ptr, XKB_COMPOSE_STATE_NO_FLAGS) orelse {
+            compose.table_unref(table_ptr);
+            return .unavailable;
+        };
+        self.compose_table = table_ptr;
+        self.compose_state = state;
+        return setup;
+    }
+
+    /// #494 — `composeFeed` 의 결과.
+    pub const ComposeResult = union(enum) {
+        /// compose 가 없거나 이 keysym 이 시퀀스와 무관하다 — 호출자가 기존 utf8 경로로 간다.
+        passthrough,
+        /// 조합 중 (`COMPOSING`) 이거나 조합이 깨졌다 (`CANCELLED`) — 아무것도 보내지 않는다.
+        swallow,
+        /// 조합이 끝났다 — 이 바이트를 보낸다. `buf` 안을 가리킨다.
+        composed: []const u8,
+    };
+
+    /// #494 — 눌린 키의 keysym 을 Compose 상태 기계에 먹이고 무엇을 할지 돌려준다.
+    /// 호출자는 **글자가 될 키만** 넘긴다 — 단축키 · nav 키 · Ctrl/Alt 조합은 넘기지 않는다
+    /// (`wayland_minimal.zig` `processKeyEvent` 의 주석).
+    pub fn composeFeed(self: *Keyboard, keysym: u32, buf: []u8) ComposeResult {
+        const api = if (self.api) |*a| a else return .passthrough;
+        const compose = api.compose orelse return .passthrough;
+        const state = self.compose_state orelse return .passthrough;
+        const fed = compose.state_feed(state, @intCast(keysym));
+        const status = compose.state_get_status(state);
+        switch (composeDecision(fed, status)) {
+            .passthrough => return .passthrough,
+            .swallow => return .swallow,
+            .composed => {
+                const n = compose.state_get_utf8(state, buf.ptr, buf.len);
+                if (n <= 0) return .swallow;
+                const len: usize = @intCast(n);
+                // 버퍼가 모자라면 (libxkbcommon 은 필요한 길이를 돌려준다) 잘린 글자를 보내는
+                // 대신 버린다. 64 바이트면 Compose 표의 어떤 결과도 담긴다.
+                if (len >= buf.len) return .swallow;
+                return .{ .composed = buf[0..len] };
+            },
+        }
+    }
+
+    /// #494 — 조합 중이던 것을 버린다. compose 를 거치지 않은 키 (단축키 · Enter · Ctrl 조합 ·
+    /// IME preedit 중의 키) 가 끼면 호출자가 부른다 — 그 뒤에 예상 못 한 `ê` 가 튀어나오지 않게.
+    pub fn composeReset(self: *Keyboard) void {
+        const api = if (self.api) |*a| a else return;
+        const compose = api.compose orelse return;
+        const state = self.compose_state orelse return;
+        compose.state_reset(state);
+    }
+
+    pub const ComposeDecision = enum { passthrough, swallow, composed };
+
+    /// #494 — feed 결과와 상태를 동작으로 옮기는 표. 순수 함수라 libxkbcommon 없이 테스트한다.
+    ///
+    /// | feed | status | 동작 | 뜻 |
+    /// |---|---|---|---|
+    /// | IGNORED | (무엇이든) | passthrough | modifier 키 같은 무시 keysym — 상태가 안 바뀌었다 |
+    /// | ACCEPTED | NOTHING | passthrough | 시퀀스 시작이 아니다 — 보통 글자, 기존 utf8 경로 |
+    /// | ACCEPTED | COMPOSING | swallow | 시퀀스 진행 중 (`^` 를 누른 직후) |
+    /// | ACCEPTED | COMPOSED | composed | 끝났다 — `get_utf8` 결과를 보낸다 |
+    /// | ACCEPTED | CANCELLED | swallow | 이어지지 않는 키 (`^` 다음 `x`) — X11 · xterm 관례대로 둘 다 버린다 |
+    ///
+    /// `CANCELLED` 에서 GTK 만 `^x` 처럼 둘 다 내는데, 그건 Compose 표 밖의 별도 규칙이라
+    /// 넣지 않는다. 다음 feed 는 헤더 문서대로 `NOTHING` 과 같이 새 시퀀스 판정을 시작한다.
+    fn composeDecision(fed: c_int, status: c_int) ComposeDecision {
+        if (fed == XKB_COMPOSE_FEED_IGNORED) return .passthrough;
+        return switch (status) {
+            XKB_COMPOSE_NOTHING => .passthrough,
+            XKB_COMPOSE_COMPOSING => .swallow,
+            XKB_COMPOSE_COMPOSED => .composed,
+            XKB_COMPOSE_CANCELLED => .swallow,
+            // 모르는 상태값 — 헤더에 없는 값이 오면 글자를 삼키는 쪽보다 보내는 쪽이 낫다.
+            else => .passthrough,
+        };
+    }
+
     pub fn ctrlActive(self: *Keyboard) bool {
         return self.modActive("Control");
     }
@@ -477,7 +658,51 @@ pub const Keyboard = struct {
             }
         }
     }
+
+    fn clearCompose(self: *Keyboard) void {
+        const api = if (self.api) |*a| a else return;
+        const compose = api.compose orelse return;
+        if (self.compose_state) |state| {
+            compose.state_unref(state);
+            self.compose_state = null;
+        }
+        if (self.compose_table) |table| {
+            compose.table_unref(table);
+            self.compose_table = null;
+        }
+    }
 };
+
+test "#494 composeDecision — feed 결과 × 상태 → 동작 표" {
+    const D = Keyboard.ComposeDecision;
+    // modifier 키처럼 무시된 keysym 은 상태를 안 바꿨으니 그대로 지나간다 — 상태값과 무관하다.
+    try std.testing.expectEqual(D.passthrough, Keyboard.composeDecision(XKB_COMPOSE_FEED_IGNORED, XKB_COMPOSE_NOTHING));
+    try std.testing.expectEqual(D.passthrough, Keyboard.composeDecision(XKB_COMPOSE_FEED_IGNORED, XKB_COMPOSE_COMPOSING));
+    // 보통 글자 — 시퀀스 시작이 아니다.
+    try std.testing.expectEqual(D.passthrough, Keyboard.composeDecision(XKB_COMPOSE_FEED_ACCEPTED, XKB_COMPOSE_NOTHING));
+    // `^` 를 누른 직후 — 아무것도 보내지 않는다. 지금까지 dead key 가 조용했던 것과 겉보기가
+    // 같지만 이유가 다르다 (조합을 기다리는 중).
+    try std.testing.expectEqual(D.swallow, Keyboard.composeDecision(XKB_COMPOSE_FEED_ACCEPTED, XKB_COMPOSE_COMPOSING));
+    // `^` 다음 `e` — 결과 (`ê`) 를 보낸다.
+    try std.testing.expectEqual(D.composed, Keyboard.composeDecision(XKB_COMPOSE_FEED_ACCEPTED, XKB_COMPOSE_COMPOSED));
+    // `^` 다음 `x` — 이어지는 시퀀스가 없다. 둘 다 버린다 (X11 · xterm 관례).
+    try std.testing.expectEqual(D.swallow, Keyboard.composeDecision(XKB_COMPOSE_FEED_ACCEPTED, XKB_COMPOSE_CANCELLED));
+    // 헤더에 없는 상태값 — 삼키지 않는다.
+    try std.testing.expectEqual(D.passthrough, Keyboard.composeDecision(XKB_COMPOSE_FEED_ACCEPTED, 99));
+}
+
+test "#494 compose 가 없으면 전부 passthrough — 키보드는 지금처럼 동작한다" {
+    // libxkbcommon 이 없거나 (이 테스트 환경) compose 심볼이 없으면 `composeFeed` 는 항상
+    // passthrough 라 호출자가 기존 `utf8()` 경로를 탄다. 삼키면 글자가 사라진다.
+    var kb: Keyboard = .{};
+    defer kb.deinit();
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqual(Keyboard.ComposeResult.passthrough, kb.composeFeed(0xfe52, &buf));
+    try std.testing.expectEqual(Keyboard.ComposeSetup.no_symbols, kb.setComposeLocale("fr_FR.UTF-8"));
+    // reset 도 아무 일 없이 돌아온다.
+    kb.composeReset();
+    try std.testing.expectEqual(@as(?*xkb_compose_state, null), kb.compose_state);
+}
 
 test "#496 1-a canProduceKeysym 은 활성 group 만 본다 — 기본 group 은 0" {
     // 이 결함을 두 번 내지 않기 위한 못이다. keymap 이 없으면 판정 자체가 불가라


### PR DESCRIPTION
Linux 텍스트 입력 경로가 `xkb_state_key_get_utf8` 하나여서 dead key (`dead_circumflex` 등) 는 빈 문자열이 되어 아무것도 보내지 않았다. 프랑스어 AZERTY 에서 `^` 를 칠 수 없었고 (#494 신고), 독일어 · 스페인어 자판은 backtick 을 아예 낼 수 없었다. macOS · Windows 는 OS 가 조합해 주므로 **Linux 전용** 결함이다 (세 platform 표는 SPEC §5.3).

## 무엇을 넣었나

| 곳 | 내용 |
|---|---|
| `src/host/linux/xkb.zig` | libxkbcommon Compose 심볼 8 개를 `KeymapScan` 과 같은 **all-or-nothing optional 묶음** (`ComposeApi`) 으로 — 없으면 조합만 꺼지고 키보드는 그대로다. `setComposeLocale` (locale 표가 없으면 `en_US.UTF-8` 재시도) · `composeFeed` → `passthrough / swallow / composed` · `composeReset`. 판정은 순수 함수 `composeDecision` 으로 갈라 libxkbcommon 없이 테스트한다 |
| `src/host/linux/wayland_minimal.zig` | 첫 keymap 뒤 `ensureCompose` (`Runtime.environ` 으로 `LC_ALL → LC_CTYPE → LANG`), `processKeyEvent` 끝의 `utf8()` 앞에서 compose 통과. 성공 · 실패 네 갈래 모두 로그에 남긴다 |
| 문서 | `SPEC.md` §5.3 (세 platform 표 · 경계 규칙 · 실기 결과), `KEYBINDINGS.md` "Dead keys", `UNRELEASED.md` 본문 후보, `AGENTS.md` 실기 키 입력 검증 함정 둘 |
| `dist/linux/dead-key-compose-check.sh` | headless sway + `wtype` 자동 검증. 어느 Linux 머신에서든 DE 무관 · 사용자 세션을 건드리지 않는다. 앱 로그의 `text_input` 줄 수 0 판정으로 "IME 가 대신 조합한" 회차를 걸러 낸다 |

## 경계 규칙 — 대조군 foot 이 갈리는 지점

| 상황 | 동작 | foot 1.27.0 (대조군, 실기) |
|---|---|---|
| Ctrl / Alt 가 눌린 키 | compose 를 **거치지 않는다** (GTK 와 같다) | `^`+Ctrl+C 를 `ĉ` 로 조합해 **SIGINT 를 삼킨다** |
| compose 를 거치지 않은 키가 끼면 (Enter · 단축키 · Ctrl 조합 · 다이얼로그 · 메뉴) | 조합 중이던 것을 **버린다** | Enter 를 feed 해 `0d` 까지 삼킨다 |
| IME preedit 중 | 건너뛴다 — IME 가 주인 | — |
| `CANCELLED` (`^` 다음 `x`) | 둘 다 버린다 (X11 · xterm 관례) | 같다 |
| locale 표 없음 | `en_US.UTF-8` 로 한 번 더 — **libxkbcommon 1.13.x 는 미설치 locale 에 스스로 fallback 하지 않는다** (실측) | — |

## 검증

- **lima VM** (Ubuntu aarch64 · libxkbcommon 1.13.1 · headless sway): 자동 스크립트 PASS (현재 locale · 없는 locale 두 회차 — PTY 바이트 `03 c3aa 5e 5e 61 0d 65 03 65 60 c3a9 c3bc 0d` 일치), Linux 단위 테스트 **351 passed · 3 skipped · 0 failed** (cross-build 바이너리를 VM 에서 실행), `zig build check` 6 target.
- **실기 — COSMIC (cosmic-comp 1.6.0) · KDE Plasma (KWin 6.7.4)**, 노트북 i5-1240P · CachyOS · libxkbcommon 1.13.2, 실제 `fr` · `de` layout 에 `/dev/uinput` scancode 주입: **13 케이스 전부 일치, 두 DE 가 같은 바이트.** text-input-v3 IME (fcitx5) 가 떠 있으면 영문 모드여도 IME 가 조합하는 것까지 확인 — 그래서 결과에는 조합 주체를 함께 적는다. 기록: [COSMIC](https://github.com/ensky0/tildaz/issues/494#issuecomment-5427290965) · [KDE](https://github.com/ensky0/tildaz/issues/494#issuecomment-5427566292) · [덧](https://github.com/ensky0/tildaz/issues/494#issuecomment-5427581702).
- **미검증**: macOS · Windows 의 dead key 는 코드 판정 (OS 가 조합) 이고 실기로 재지 않았다. 이 PR 은 그 두 platform 의 코드를 건드리지 않으므로 회귀 위험은 없다.

## 범위 밖

- **조합 중 화면 표시** (macOS `setMarkedText:` 동등 — `^` 를 누른 직후 보여 주기) — 결함이 아니라 UX 결정이 필요해 #530 로 분리.
- compositor 가 먼저 끝날 때 `TildaZ failed to start` 문구 (#494 댓글의 부수 발견) — 별 이슈 후보.

Closes #494
