### PR TITLE
fix(ime): GL 경로에서도 cursor rectangle 을 보낸다 — 후보창이 pane 원점에 고정 (#535)

### DIFF
--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -38,3 +38,6 @@ Internal changes belong in neither.
 - Alt combinations now reach the program on non-Latin keyboard layouts too — `Alt+n` sends
   `ESC n` on a Russian layout or a Korean input source instead of the layout's own letter.
   ([#483](https://github.com/ensky0/tildaz/issues/483))
+- On Linux, the IME candidate window for Hanja, Kanji and Hanzi follows the terminal cursor
+  again on the default GPU render path, instead of staying pinned to the corner of the pane.
+  ([#535](https://github.com/ensky0/tildaz/issues/535))

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1420,7 +1420,8 @@ const Client = struct {
     pending_commit: std.ArrayList(u8) = .empty,
     preedit_text: std.ArrayList(u8) = .empty,
     // L10-γ — 마지막으로 server 에 알린 cursor rect (pixel, surface-relative).
-    // paint 끝마다 비교해 변경 시만 set_cursor_rectangle + commit 보내 spam 회피.
+    // #535 — `redraw` 가 paint 를 마친 뒤 비교해 변경 시만 set_cursor_rectangle +
+    // commit 보내 spam 회피 (그리기 경로마다가 아니라 프레임마다 한 번).
     last_cursor_rect_x: i32 = -1,
     last_cursor_rect_y: i32 = -1,
     last_cursor_rect_w: i32 = 0,
@@ -3579,6 +3580,20 @@ const Client = struct {
             perf.addTimed(&perf.onrender, onrender_t0);
             if (!painted_frame) perf.incExtra(&perf.onrender);
         }
+        // #535 — IME cursor rectangle 은 **paint 를 마친 뒤 여기서 한 번** 보낸다.
+        // 예전엔 `paintBuffer` 안에 있었는데, #277 이 GL 분기를 `paintIntoBuffer` 에
+        // 만들면서 그 분기가 `paintBuffer` 를 지나치게 됐다. 기본 경로 (`gpu-gl`) 에서만
+        // rect 가 `enableTextInput` 때 보낸 값 (활성 pane 의 격자 원점) 에 멈춰, 한자
+        // 후보창이 cursor 를 안 따라왔다. 경로가 또 갈려도 프레임 부수 효과가 떨어지지
+        // 않도록 세 경로 (GL · dma-buf CPU 매핑 · shm) 의 공통 상위에 둔다.
+        //
+        // **paint 뒤여야 한다.** rect 가 읽는 `render_state.cursor.viewport` 를 채우는
+        // 것이 paint 자신이라 (`buildGlFrame` · `paint` 의 `state.update`), 앞에 두면
+        // 한 프레임 낡은 자리를 보낸다. `painted_frame` 게이트 — 그리지 못한 frame 은
+        // 보낼 새 값이 없다. error 는 main loop 를 멈추지 않게 swallow.
+        defer {
+            if (painted_frame) self.updateCursorRectangle() catch {};
+        }
         // L9-γ hide / show — layer-shell spec 의 re-map sequence 준수:
         // 1. hide path 가 `surface_hidden=true` set → 어떤 attach 도 skip.
         // 2. show path 가 `surface_hidden=false` + `configured=false` + commit
@@ -4737,10 +4752,6 @@ const Client = struct {
                 var sep_storage: [pane_layout.MAX_PANES_PER_TAB]pane_layout.Separator = undefined;
                 const in = self.frameInputs(session, width, height, &titles_storage, &hotkey_hint_buf, &pane_storage, &sep_storage);
                 self.renderer.paint(self.allocator, memory, stride, in);
-                // L10-γ — cursor 위치가 변했으면 server 에 알린다. fcitx5
-                // popover (한자 후보, 확장 candidate window 등) 가 우리 cursor
-                // 근처에 정렬되도록. error 는 main loop 멈추지 않게 swallow.
-                self.updateCursorRectangle() catch {};
                 return;
             }
         }


### PR DESCRIPTION
## 무엇

Linux 의 기본 렌더 경로 (`render_path=gpu-gl`) 에서 IME cursor rectangle 이 갱신되지 않아, 한자 · 후보창이 커서를 따라오지 않고 pane 원점에 고정되던 것을 고친다.

## 왜 그랬나

`updateCursorRectangle` 호출이 `paintBuffer` 한 곳뿐이었다. #189 (L10-γ) 이 거기에 넣었는데, **#277 이 GL 분기를 `paintIntoBuffer` 에 만들면서 그 분기가 `paintBuffer` 를 지나치게 됐다.** shm 경로가 영구 fallback 으로 남아 계속 정상이라, 두 경로를 나란히 두고 보지 않으면 드러나지 않았다.

## 어떻게 고쳤나

GL 분기에 호출을 하나 더 넣지 않고 **`redraw` 로 올렸다.** 세 경로 (GL · dma-buf CPU 매핑 · shm) 가 한 자리로 모이고, 경로가 또 갈려도 프레임 부수 효과가 떨어지지 않는다.

호출은 paint *뒤*여야 한다 — rect 가 읽는 `render_state.cursor.viewport` 를 채우는 것이 paint 자신이라 (`buildGlFrame` · `paint` 의 `state.update`), 앞에 두면 한 프레임 낡은 자리를 보낸다. `painted_frame` 게이트가 그것과 "그리지 못한 frame 은 보낼 새 값이 없다" 를 함께 만족한다.

## 범위 — Linux 전용

macOS 는 `firstRectForCharacterRange` 로 OS 가 물어보는 pull 구조이고, Windows 는 `WM_IME_*` 응답으로 `ImmSetCompositionWindow` 를 부른다. 둘 다 프레임마다 밀 것이 없어 같은 구멍이 없다.

## 부수 효과

rect 전송 비용이 `perf.render` 에서 빠지고 `perf.onrender` 에만 남는다. GL 경로는 원래 `perf.render` 에 안 들어가 있었으니 두 경로의 의미가 오히려 같아진다.

## 검증

- `zig build -Doptimize=ReleaseFast -Dsimd=true` · `zig build check` (6 타깃) · `zig build test` — 통과
- 실기: 미니PC Firebat ZY-A8 (Ryzen 7 8845HS · Radeon 780M · CachyOS) · KDE Plasma 6.7.4 (KWin Wayland) · fcitx5 5.1.21 (`hangul`) · `render_path=gpu-gl`
  - pane 1 개 — 화면 오른쪽 아래 끝에서 조합해도 후보창이 커서에 붙는다
  - pane 3 개 — 가장 오른쪽 아래 pane 에서도 같다

## 문서

`SPEC.md` 의 IME 표는 Linux 를 "`set_cursor_rectangle` 매 redraw (L10-γ)" 로 적어 뒀다. 지금까지 사실이 아니었고 이 PR 로 그대로 참이 된다 — 고칠 서술이 없다. `dist/release-notes/UNRELEASED.md` 의 본문 후보에 한 줄 넣었다.

Closes #535
