### PR TITLE
fix(keys): 반복은 발동 전에 입력 큐를 비운다 — 이미 뗀 키로 탭이 둘 닫히던 문제 (#546)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -625,7 +625,7 @@ Windows 실측).
 
 | 항목 | Windows | macOS | Linux | Win | Mac | Linux |
 |---|---|---|---|---|---|---|
-| 영어/숫자/기호 길게 누름 → 반복 입력 | OS default | `ApplePressAndHoldEnabled = false` 우리 앱 도메인에 등록 — 안 등록하면 system 이 accent picker (à á â) 띄우려 repeat 막음 | client-side timer (compositor `wl_keyboard.repeat_info` 의 rate / delay 따름, [5455d54](https://github.com/ensky0/tildaz/commit/5455d54), L12-γ-5). focus 떠날 때 / key release 시 즉시 disarm | ✅ | ✅ | ✅ |
+| 영어/숫자/기호 길게 누름 → 반복 입력 | OS default | `ApplePressAndHoldEnabled = false` 우리 앱 도메인에 등록 — 안 등록하면 system 이 accent picker (à á â) 띄우려 repeat 막음 | client-side timer (compositor `wl_keyboard.repeat_info` 의 rate / delay 따름, [5455d54](https://github.com/ensky0/tildaz/commit/5455d54), L12-γ-5). focus 떠날 때 / key release 시 즉시 disarm. 반복을 내보내기 전에 입력 큐를 한 번 비워, 오래 걸린 핸들러 (pane 마다 500 ms 유예가 쌓이는 탭 닫기 등) 동안 도착한 release 를 먼저 반영한다 — 그래서 *이미 뗀 키* 로 반복이 나가지 않는다 ([#546](https://github.com/ensky0/tildaz/issues/546)) | ✅ | ✅ | ✅ |
 | 한글 자모 길게 누름 → 반복 입력 | (해당 없음) | IME 경로라 PressAndHold 영향 없음 (자동) | `wl_keyboard.key` 가 IME 로 라우팅됨 — fcitx5 / ibus 자체 key repeat 동작 (compositor `repeat_info` 가 IME 측에 적용). 사용자 일상 사용 OK 확인 (Cinnamon Wayland + fcitx5-hangul, KDE Plasma 6 + KWin). | — | ✅ | ✅ |
 
 ### 2.8 전체화면 토글 (윈도우 단위)

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -6214,6 +6214,12 @@ const Client = struct {
             self.key_repeat_next_ms = self.rt.nowMs() + @as(i64, self.key_repeat_delay_ms);
         } else if (state == 0 and self.key_repeat_keycode == key) {
             // released — same key disarm.
+            //
+            // #546 — 이 disarm 이 `maybeRepeatKey` 의 스테일 발동 방어의 전제다. 그 함수가
+            // 발동 전에 큐를 비우는 목적이 *여기서* disarm 이 걸리게 하는 것이라서,
+            // #538 이 release 를 `processKeyEvent` 로 흘리려고 아래 조기 반환을 없앨 때도
+            // 이 disarm 은 그 자리에 그대로 남아야 한다. 옮기거나 순서를 바꾸면 `Ctrl+Shift+W`
+            // 한 번에 탭 둘이 닫히는 증상이 조용히 되돌아온다.
             self.key_repeat_keycode = 0;
         }
         if (state != wl_keyboard_key_state_pressed and state != wl_keyboard_key_state_repeated) return;
@@ -6223,13 +6229,61 @@ const Client = struct {
     /// L12-γ-5 — main loop 의 매 iteration 에서 repeat timer 검사. timer 가
     /// arm 되어 있고 (`key_repeat_keycode != 0`) 현재 시간이 next_ms 넘으면
     /// `processKeyEvent` 를 simulated `repeated` state 로 재호출.
+    ///
+    /// #546 — 발동 전에 소켓 큐를 한 번 비운다. 반복을 내보내는 근거는 *키가 아직
+    /// 눌려 있다* 는 것인데, 그 근거는 우리가 마지막으로 읽은 이벤트까지만 유효하다.
+    /// 오래 걸린 핸들러 (탭을 닫으면 pane 마다 `Pty.deinit` 의 500 ms 유예가 직렬로
+    /// 쌓인다 — `terminal/posix/pty.zig`) 동안 도착한 release 는 아직 큐에 있어서,
+    /// 그대로 발동하면 **이미 뗀 키로** 반복이 한 번 더 나간다. `Ctrl+Shift+W` 한 번이
+    /// 탭 둘을 닫은 것이 그 결과였다 (2 pane 탭 = 약 1 초 블록 > KDE 기본 반복 지연
+    /// 600 ms). 큐를 먼저 비우면 `handleKeyboardKey` 의 disarm 이 걸려 발동이 취소된다.
+    ///
+    /// 문턱 상수를 두지 않은 이유는 블록 시간이 pane 수 · 자식 프로그램에 따라 달라서
+    /// 어떤 값도 근거가 없기 때문이다. 대신 *사실을 다시 읽어* 판단한다.
+    ///
+    /// 비용은 타이머가 만료된 순간에만 든다 (평소에는 위 두 early return 에서 끝난다).
+    /// 재진입 안전 — 이 함수의 호출처 셋 (main loop · confirm pump · prompt pump) 이
+    /// 모두 `pollAndDispatch` 가 *반환한 뒤* 라, #213 의 `dispatchBuffered` 중첩이 아니다.
     fn maybeRepeatKey(self: *Client) !void {
         if (self.key_repeat_keycode == 0) return;
         if (self.key_repeat_rate_hz <= 0) return;
+        if (self.rt.nowMs() < self.key_repeat_next_ms) return;
+
+        // 밀린 입력을 먼저 반영한다. 오류는 삼킨다 — 이 드레인은 발동 여부를 가리기 위한
+        // 기회적 확인이고, 진짜 dispatch 경로는 루프 자신의 `pollAndDispatch` 라서 연결이
+        // 끊겼으면 다음 iteration 이 같은 오류를 제대로 올린다.
+        self.drainInputBeforeRepeat() catch {};
+
+        if (self.key_repeat_keycode == 0) return; // release 가 disarm 했다
+        if (self.key_repeat_rate_hz <= 0) return; // repeat_info 가 그 사이에 바뀌었다
+        // 드레인이 앱을 끝냈으면 (마지막 탭이 닫혔다 등) 단축키를 한 번 더 태우지 않는다.
+        if (!self.running or self.shell_exited.load(.acquire)) return;
+
         const now = self.rt.nowMs();
-        if (now < self.key_repeat_next_ms) return;
+        if (now < self.key_repeat_next_ms) return; // 새 press 가 arm 을 다시 잡았다
         try self.processKeyEvent(self.last_serial, self.key_repeat_keycode);
         self.key_repeat_next_ms = now + @divTrunc(1000, @as(i64, self.key_repeat_rate_hz));
+    }
+
+    /// #546 — 반복 발동 전에 wayland 입력을 논블로킹으로 한 번 비운다.
+    ///
+    /// `pollAndDispatch(0)` 을 쓰지 않는 이유는 그 함수가 buffer 에 partial message 가
+    /// 남아 있으면 **소켓을 아예 읽지 않고** 돌아오기 때문이다 (`input_len > 0` early
+    /// return). 이 자리가 봐야 하는 것은 *블록 동안 새로 도착한* release 라서 그 경로로는
+    /// 부족하다. `readAndDispatch` 는 받은 바이트를 `input_len` 뒤에 이어 붙이므로
+    /// partial message 도 이 호출로 완성된다.
+    ///
+    /// `readAndDispatch` 는 EAGAIN 을 `n == 0` 으로 받아 `WaylandConnectionClosed` 로
+    /// 올리므로, **poll 로 읽을 것이 있음을 확인한 뒤에만** 부른다.
+    fn drainInputBeforeRepeat(self: *Client) !void {
+        if (self.input_len > 0) try self.dispatchBuffered();
+        var fds = [_]posix.pollfd{.{
+            .fd = self.wayland_fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        if (try posix.poll(&fds, 0) == 0) return;
+        if ((fds[0].revents & posix.POLL.IN) != 0) try self.readAndDispatch();
     }
 
     /// L12-γ-5 — keyboard.key 의 실제 처리 (byte parsing 분리 후). pressed /


### PR DESCRIPTION
`Ctrl+Shift+W` 한 번이 탭 **둘**을 닫던 문제를 고칩니다 ([#546](https://github.com/ensky0/tildaz/issues/546)).

## 무엇이 문제였나

`maybeRepeatKey` 는 "키가 아직 눌려 있다" 를 **마지막으로 읽은 이벤트로만** 판단합니다. 그런데
탭을 닫으면 pane 마다 `Pty.deinit` 의 `SIGHUP` → 500 ms 유예가 **직렬로** 쌓여서 (2 pane ≈ 1 초),
그 동안 도착한 release 가 소켓 큐에 남습니다. 메인 루프는 `pollAndDispatch` → 드레인 →
`maybeRepeatKey` 순서라 **소켓을 다시 읽기 전에** 반복이 발동하고, 그래서 *이미 뗀 키*로 닫기가
한 번 더 나갑니다 (KDE 기본 반복 지연 600 ms < 1 초).

이슈 본문 로그의 시각이 이 모델과 산술까지 맞아 **계측 없이 원인을 확정**했습니다. 발동이 정확히
한 번인 이유까지 설명됩니다 — 다음 iteration 의 `pollAndDispatch` 가 release 를 읽어 disarm 합니다.

## 무엇을 고쳤나

발동 직전에 wayland 입력을 **논블로킹으로 한 번 비웁니다.** 그러면 큐에 release 가 있을 때
`handleKeyboardKey` 의 disarm 이 먼저 걸려 발동이 취소됩니다.

- `pollAndDispatch(0)` 이 아니라 **전용 helper** 를 둔 이유는 그 함수가 buffer 에 partial message 가
  남아 있으면 (`input_len > 0` early return) **소켓을 아예 읽지 않고** 돌아오기 때문입니다.
- **문턱 상수를 두지 않았습니다.** 블록 시간이 pane 수와 자식 프로그램에 따라 달라 어떤 값도 근거가
  없습니다. 대신 *사실을 다시 읽어* 판단합니다.
- 비용은 타이머가 만료된 순간에만 듭니다. 재진입도 안전합니다 — `maybeRepeatKey` 의 호출처 셋이
  모두 `pollAndDispatch` 가 반환한 뒤라 #213 의 `dispatchBuffered` 중첩이 아닙니다.

## 키를 길게 누르면 탭이 줄줄이 닫히는 동작은 그대로입니다

이슈 본문의 3 안(파괴적 액션을 반복 대상에서 제외)은 **철회했습니다.** 같은 기기에서 kitty 0.48.2 ·
Ghostty 1.3.1 · WezTerm 20260716 · Konsole 26.08.0 을 각자 기본 설정으로 재 보니 넷 다 셸만 있는
탭 5 개를 전부 닫고 종료했습니다. **반복 키를 거르는 터미널은 없었습니다.** 그들이 파괴적 닫기를
막는 수단은 확인 다이얼로그이고, 그 게이트는 "셸만 있는 탭이냐, 프로그램이 돌고 있는 탭이냐" 입니다
([#546 코멘트](https://github.com/ensky0/tildaz/issues/546#issuecomment-5461090465) 4 절).

## 검증

- `zig build check` (6 타깃) · `zig build test` · `-Doptimize=ReleaseFast -Dsimd=true` 전부 통과.
- **Linux 실기 A/B** (미니PC Firebat ZY-A8 · CachyOS · KDE Plasma 6.7.4 / KWin 6.7.4 Wayland) —
  2 pane 짜리 탭 둘에서 `Ctrl+Shift+W` 를 0.25 초 눌렀다 떼면 **수정 전은 앱 종료**(남은 탭까지),
  **수정 후는 활성 탭만** 닫히고 pane 둘이 남습니다. 2 초 누른 채 두면 수정 후에도 줄줄이 닫힙니다.
  절차 · 로그 · 오독 주의는 [결과 코멘트](https://github.com/ensky0/tildaz/issues/546#issuecomment-5461164125).
- **macOS · Windows 는 이 수정의 대상이 아닙니다.** Linux host 파일 하나만 바뀌었고, 짧게 한 번
  누른 키로 반복이 나가는 것은 client 가 타이머를 직접 드는 Linux 만의 구조입니다.

## 릴리즈 노트에는 넣지 않습니다

이 증상의 노출을 만든 #483(pane) 과 #545(`close_tab` = 탭 통째로) 가 **둘 다 미출시**라, 기본
설정의 v0.9.2 사용자는 이것을 본 적이 없습니다 = 이전 버전 대비 변화가 없습니다. `AGENTS.md`
릴리즈 노트 절의 *"브랜치 안에서 만든 퇴행을 고친 것"* 판례와 같은 경우입니다.

## 함께 담은 것

- `SPEC.md` 의 Linux key repeat 서술에 이 동작을 한 줄 추가했습니다.
- `handleKeyboardKey` 의 disarm 자리에 **인계 주석**을 남겼습니다 —
  [#538](https://github.com/ensky0/tildaz/issues/538) 이 release 를 인코더로 흘리려고 조기 반환을
  없앨 때 그 disarm 을 유지해야 합니다. 옮기면 이 수정이 조용히 되돌아갑니다.
