### PR TITLE
fix(pane): 분할 거부를 로그에 남기고, 단축키 0 개 조건을 문서에서 바로잡는다 (#483)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -773,22 +773,29 @@ echo -e "\n🎉❤️🌈🎨🌞🍎🚀💎✨\n👋🏻👋🏼👋🏽👋�
 chcp 65001 >nul && echo. && echo 🎉❤️🌈🎨🌞🍎🚀💎✨ && echo 👋🏻👋🏼👋🏽👋🏾👋🏿 && echo 👨‍👩‍👧👨‍👨‍👦‍👦 && echo ABCDEFG abcdefg 0123456789 && echo 한글 ABC 가나다라마바사 && echo ▀▁▂▃▄▅▆▇█▉▊▋▌▍▎▏ && echo ▐░▒▓▔▕ && echo.
 ```
 
-# 측정 인스턴스 (`-e`) 에는 창 안 단축키가 없어요
+# `config_N.toml` 이 없는 실행에는 창 안 단축키가 하나도 없어요
 
-`-e <셸경로>` 로 띄운 측정 인스턴스는 **`Ctrl+Shift+T` · `Ctrl+Shift+W` · `Cmd+T` 같은 창 안
-단축키가 하나도 안 먹어요.** 세 platform 공통이고, 버그가 아니라 두 규칙이 맞물린 결과예요.
+**조건은 `-e` 가 아니라 "그 회차가 뜰 때 config 파일이 없었다" 예요.** `Ctrl+Shift+T` ·
+`Ctrl+Shift+W` · `Cmd+T` 같은 창 안 단축키가 **0 개**인 채로 돌아요. 세 platform 공통이고,
+버그가 아니라 두 규칙이 맞물린 결과예요.
 
-- 측정 인스턴스는 **일부러 config 를 만들지 않아요** ([#382](https://github.com/ensky0/tildaz/issues/382)
-  — *"측정이 사용자 설정을 만드는 주체가 되면 안 된다"*). `config.zig` 의 `Config.load` 주석에
-  적혀 있어요.
-- 그런데 **config 파일이 없는 경로가 `[keys]` 를 채우지 않아요.** `Config.load` 는 파일이 없으면
+- **config 파일이 없는 경로가 `[keys]` 를 채우지 않아요.** `Config.load` 는 파일이 없으면
   `defaultOwned` 로 가는데 그 함수가 `key_bindings` · `key_binding_count` 를 건드리지 않아서
   `Config{}` 의 기본값 `key_binding_count = 0` 이 그대로 남아요. 바인딩을 채우는 것은 `parse`
   안의 루프뿐이고, 그 안의 `defaultBindings(action)` fallback 도 **파일을 파싱하는 경로에만**
   있어요.
+- **측정 인스턴스 (`-e`) 가 대표 사례일 뿐이에요.** 그쪽은 *일부러* config 를 만들지 않아서
+  ([#382](https://github.com/ensky0/tildaz/issues/382) — *"측정이 사용자 설정을 만드는 주체가 되면
+  안 된다"*, `config.zig` 의 `Config.load` 주석) 매번 걸려요.
 
-그래서 그 기계에 `config_N.toml` 이 **없으면** 단축키가 0 개인 채로 돌아요. 있으면 정상이에요 —
-`-e` 가 config 를 *읽는* 것은 막지 않아요.
+**⚠️ `-e` 없이 새 인스턴스를 처음 띄우는 회차도 그대로 걸려요.** 앱이 파일을 *만들기는* 하지만
+**그 회차의 메모리 config 는 이미 빈 채**예요. 그래서 **한 번 띄웠다 내리고 다시 띄우면** 그때부터
+정상이에요. 2026-08-29 [#483](https://github.com/ensky0/tildaz/issues/483) macOS 회차에서 이것으로
+걸렸어요 — `⌘T` 조차 안 먹는데 문자 키 (`h` → `ㅗ`) 는 정상이라 포커스 문제도 아니어서 한참 갈랐어요.
+그 전까지 이 절의 제목이 `-e` 로 좁혀져 있어서 해당 없다고 읽혔던 것이 원인이에요.
+
+**그래서 단축키를 쓰는 검증은 config 를 먼저 만들어 두고 시작해요** (아래 `# 실행 환경` 의 `--instance 9`
+절차). 파일이 있으면 `-e` 여도 정상이에요 — `-e` 가 config 를 *읽는* 것은 막지 않아요.
 
 **합성 입력 문제로 오진하기 쉬워요.** 2026-08-26 [#506](https://github.com/ensky0/tildaz/issues/506)
 Windows 검증에서 VK-only · VK+scancode · scancode-only 세 방식으로 `SendInput` 을 보내도
@@ -877,7 +884,7 @@ tildaz --instance 1 -e <zig-out/bin/render-test> -size 88x33 &
   그래서 출력할 내용을 담은 **스크립트 파일**을 만들어 넘겨요. 스크립트 끝에 `sleep` 을 둬야
   창이 남아요 (`-e` 로 띄운 프로세스가 끝나면 앱도 끝나요).
 - **`--instance 1` 을 써요.** 평소 쓰는 daily 인스턴스 (`--instance 0`) 를 건드리지 않아요.
-- **단축키는 안 먹어요** — 위 `# 측정 인스턴스 (-e) 에는 창 안 단축키가 없어요` 절. 탭을
+- **단축키는 안 먹어요** — 위 `# config_N.toml 이 없는 실행에는 창 안 단축키가 하나도 없어요` 절. 탭을
   만들거나 닫아야 하면 컨트롤 스트립의 `+` / `×` 를 클릭해요.
 - 입력은 **`printf` 로 UTF-8 byte 를 직접** 내요 — 편집기 · 클립보드가 cluster 를 정규화해
   버리는 것을 피해요.

--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -382,6 +382,9 @@ pub const App = struct {
         if (!shell_validate.checkForNewTab(self.rt, self.allocator, self.shell)) return;
         self.session.splitActive(dir, self.paneArea(), self.paneMetrics()) catch |err| switch (err) {
             error.TooSmall => {
+                // #483 — 거부도 로그를 남긴다. 다이얼로그는 사용자에게만 보이므로, 로그로 판정하는
+                // 검증 회차에서는 *거부* 와 *액션 미발동* 이 구분되지 않았다 (2026-08-29 macOS 회차).
+                log.appendLine("pane", "split {s} rejected: pane would be under {d}x{d}", .{ @tagName(dir), pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS });
                 var buf: [160]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.pane_too_small_format, .{ pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS }) catch
                     messages.pane_too_small_format;
@@ -389,6 +392,7 @@ pub const App = struct {
                 return;
             },
             error.TooManyPanes => {
+                log.appendLine("pane", "split {s} rejected: tab already has {d} panes", .{ @tagName(dir), pane_layout.MAX_PANES_PER_TAB });
                 var buf: [128]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.pane_limit_format, .{pane_layout.MAX_PANES_PER_TAB}) catch
                     messages.pane_limit_format;

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -5580,6 +5580,9 @@ const Client = struct {
         if (!shell_validate.checkForNewTab(self.rt, self.allocator, self.config.shell)) return;
         self.session.?.splitActive(dir, self.paneArea(), self.paneMetrics()) catch |err| switch (err) {
             error.TooSmall => {
+                // #483 — 거부도 로그를 남긴다. 다이얼로그는 사용자에게만 보이므로, 로그로 판정하는
+                // 검증 회차에서는 *거부* 와 *액션 미발동* 이 구분되지 않았다 (2026-08-29 macOS 회차).
+                log.appendLine("pane", "split {s} rejected: pane would be under {d}x{d}", .{ @tagName(dir), pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS });
                 var buf: [160]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.pane_too_small_format, .{ pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS }) catch
                     messages.pane_too_small_format;
@@ -5587,6 +5590,7 @@ const Client = struct {
                 return;
             },
             error.TooManyPanes => {
+                log.appendLine("pane", "split {s} rejected: tab already has {d} panes", .{ @tagName(dir), pane_layout.MAX_PANES_PER_TAB });
                 var buf: [128]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.pane_limit_format, .{pane_layout.MAX_PANES_PER_TAB}) catch
                     messages.pane_limit_format;

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -3368,6 +3368,9 @@ fn handleSplit(dir: pane_layout.Direction) void {
     if (!@import("../shell_validate.zig").checkForNewTab(g_rt, g_gpa.allocator(), g_config.shell)) return;
     g_session.splitActive(dir, paneAreaMac(), paneMetricsMac()) catch |err| switch (err) {
         error.TooSmall => {
+            // #483 — 거부도 로그를 남긴다. 다이얼로그는 사용자에게만 보이므로, 로그로 판정하는
+            // 검증 회차에서는 *거부* 와 *액션 미발동* 이 구분되지 않았다 (2026-08-29 macOS 회차).
+            log.appendLine("pane", "split {s} rejected: pane would be under {d}x{d}", .{ @tagName(dir), pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS });
             var buf: [160]u8 = undefined;
             const msg = std.fmt.bufPrint(&buf, messages.pane_too_small_format, .{ pane_layout.MIN_PANE_COLS, pane_layout.MIN_PANE_ROWS }) catch
                 messages.pane_too_small_format;
@@ -3375,6 +3378,7 @@ fn handleSplit(dir: pane_layout.Direction) void {
             return;
         },
         error.TooManyPanes => {
+            log.appendLine("pane", "split {s} rejected: tab already has {d} panes", .{ @tagName(dir), pane_layout.MAX_PANES_PER_TAB });
             var buf: [128]u8 = undefined;
             const msg = std.fmt.bufPrint(&buf, messages.pane_limit_format, .{pane_layout.MAX_PANES_PER_TAB}) catch
                 messages.pane_limit_format;


### PR DESCRIPTION
[#483](https://github.com/ensky0/tildaz/issues/483) macOS 회차가 남긴 후속 둘입니다. 둘 다 **진단 자료의 공백**이고, 그 회차가 실제로 둘 다에 걸려 시간을 썼습니다.

## 1. `docs(agents)` — 단축키가 0 개인 조건은 `-e` 가 아니다

절 제목이 `# 측정 인스턴스 (-e) 에는 창 안 단축키가 없어요` 라서, `-e` 를 안 쓰는 회차는 **해당 없다고 읽혔습니다.**

실제 조건은 **그 회차가 뜰 때 config 파일이 없었는지**입니다 — `Config.load` 가 파일을 못 찾으면 `defaultOwned` 로 빠지는데 그 함수가 `key_bindings` · `key_binding_count` 를 채우지 않기 때문이고, `-e` 는 *일부러 config 를 만들지 않는* 대표 사례일 뿐입니다.

그래서 **`-e` 없이 새 인스턴스를 처음 띄우는 회차도 그대로 걸립니다.** 앱이 파일을 *만들기는* 하지만 그 회차의 메모리 config 는 이미 빈 채라, 한 번 내렸다 다시 띄워야 정상입니다.

[#506](https://github.com/ensky0/tildaz/issues/506) Windows 회차에 이어 **두 번째**로 같은 데서 시간을 썼으므로 제목과 첫 문단을 조건 중심으로 다시 쓰고, 재발 사례와 회복 방법을 함께 적었습니다.

## 2. `fix(pane)` — 분할 거부도 로그에 남긴다

`TooSmall` · `TooManyPanes` 는 **다이얼로그만 띄우고 조용히 `return`** 했습니다. 로그를 남기는 것은 `else` 갈래 (`split failed: …`) 뿐이라, 로그로 판정하는 검증 회차에서 **거부와 액션 미발동이 구분되지 않았습니다.** macOS 회차가 그것을 "단축키가 안 먹는다" 로 오독했고, 캡처를 보고서야 `Not enough room to split` 다이얼로그를 발견했습니다.

세 host 가 같은 모양이라 세 곳 모두에 한 줄씩 넣었습니다. 사용자에게는 이미 다이얼로그가 보이므로 **사용자 대상 결함이 아니라 진단 자료의 공백**입니다.

## 검증

- `zig build check` (6 타깃) · `zig build test` · ReleaseFast 전부 통과 (파이프 없이 종료 코드 확인).
- **Linux 실기** (미니PC Firebat ZY-A8 · CachyOS · KDE Plasma 6.7.4 / KWin Wayland) — 좁아질 때까지 `Ctrl+Shift+←` 를 반복하니 로그가 이렇게 남았습니다.

```
[pane] split left — tab 0 has 2 panes, active pane 1
[pane] split left — tab 0 has 3 panes, active pane 2
[pane] split left rejected: pane would be under 20x5
```

- macOS · Windows 는 같은 코드 모양이고 `zig build check` 가 컴파일을 보장합니다.
