### PR TITLE
fix(wayland): fractional 배율에서 창이 리샘플되고 포인터가 밀린다 (#539 · #552)

### DIFF
--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -20,3 +20,10 @@ Internal changes belong in neither.
 ## Upgrade notes
 
 ## Body candidates
+
+- Linux: windows and dialogs are no longer resampled at fractional display scales, so
+  text and lines stay sharp at 1.7x and other fractional factors.
+  ([#539](https://github.com/ensky0/tildaz/issues/539))
+- Linux: mouse input lands where you point at fractional display scales; it was biased
+  by up to two pixels toward the top-left.
+  ([#552](https://github.com/ensky0/tildaz/issues/552))

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -3248,14 +3248,25 @@ const Client = struct {
         return id;
     }
 
-    /// fractional scaling 변환. 우리 코드 내부 단위 = physical pixel. compositor
-    /// 와 I/O 시 logical 단위로 변환 / 역변환. KDE Plasma 6 의 170% 환경에서
-    /// preferred_scale=204 (= 120×1.7) → logical_w × 204 / 120 = physical_w.
-    /// fallback (advertise 안 된 compositor): preferred_scale=120 → no-op.
-    fn logicalToPhysical(self: *const Client, logical: i32) i32 {
-        const num: i32 = @intCast(self.preferred_scale);
-        const den: i32 = @intCast(fractional_scale_denominator);
-        return @divFloor(logical * num, den);
+    // fractional scaling 변환. 우리 코드 내부 단위 = physical pixel. compositor
+    // 와 I/O 시 logical 단위로 변환 / 역변환. KDE Plasma 6 의 170% 환경에서
+    // preferred_scale=204 (= 120×1.7) → logical × 204 / 120 = physical.
+    // fallback (advertise 안 된 compositor): preferred_scale=120 → no-op.
+    //
+    // **좌표와 크기는 반올림 규칙이 다르다.** 하나로 합치지 않는다 — 아래 두
+    // 함수의 주석이 각각 이유를 적는다.
+
+    /// **좌표** (포인터 위치) 전용 변환.
+    ///
+    /// `wl_fixed` (24.8 고정소수점) 를 논리 정수로 **먼저 자르지 않는다.** 자른 뒤에
+    /// 배율을 곱하면 버린 소수부 × 배율만큼 (1.7x 에서 최대 2 px) 항상 작아지는 쪽으로
+    /// 치우쳤다 (#552). 고정소수점 상태에서 곱하고 마지막에 한 번만 내린다.
+    ///
+    /// 내림인 것은 크기와 달리 **의도한 것**이다 — 좌표는 "이 점이 몇 번 픽셀 안에
+    /// 있는가" 라서, 반올림하면 히트테스트가 반 픽셀 밀린다. 크기 (`logicalToPhysicalSize`)
+    /// 쪽이 반올림인 이유는 그쪽 주석에 있다.
+    fn fixedLogicalToPhysicalPx(self: *const Client, fixed: i32) i32 {
+        return physicalPxForFixedLogical(fixed, self.preferred_scale);
     }
 
     /// **크기** (buffer / surface 크기) 전용 변환 — 위 좌표용과 반올림 규칙이 다르다.
@@ -6785,8 +6796,8 @@ const Client = struct {
         self.last_pointer_enter_surface_id = readU32(payload[4..8]);
         const sx = readI32(payload[8..12]);
         const sy = readI32(payload[12..16]);
-        self.pointer_x_px = self.logicalToPhysical(wlFixedToPx(sx));
-        self.pointer_y_px = self.logicalToPhysical(wlFixedToPx(sy));
+        self.pointer_x_px = self.fixedLogicalToPhysicalPx(sx);
+        self.pointer_y_px = self.fixedLogicalToPhysicalPx(sy);
         self.pointer_inside = true;
         // #193 — enter 시 우리 surface 가 받는 첫 serial. 이 시점에 cursor 첫
         // 송신해야 compositor 의 default cursor 가 우리 의도 (cell I-beam 또는
@@ -6830,8 +6841,8 @@ const Client = struct {
         // payload[0..4]=time.
         const sx = readI32(payload[4..8]);
         const sy = readI32(payload[8..12]);
-        self.pointer_x_px = self.logicalToPhysical(wlFixedToPx(sx));
-        self.pointer_y_px = self.logicalToPhysical(wlFixedToPx(sy));
+        self.pointer_x_px = self.fixedLogicalToPhysicalPx(sx);
+        self.pointer_y_px = self.fixedLogicalToPhysicalPx(sy);
         // #193 — region 변경 시만 set_shape (캐시 hit 시 no-op).
         self.updateCursorShape() catch {};
 
@@ -10282,11 +10293,47 @@ fn isAcceptableTextMime(mime: []const u8) bool {
         std.mem.eql(u8, mime, clipboard_mime_text_plain);
 }
 
-/// wl_fixed_t (signed 24.8 fixed-point packed in i32) → integer pixel.
-/// surface 좌표는 음수가 정상 흐름엔 안 들어오지만, leave 직후 등 edge case 대비
-/// `@divTrunc` 로 0 방향 정수 변환 — pixelToCell 의 범위 검사가 음수 reject.
-fn wlFixedToPx(value: i32) i32 {
-    return @divTrunc(value, 256);
+/// wl_fixed_t (signed 24.8 fixed-point packed in i32) 논리 좌표 → 물리 픽셀 인덱스.
+/// `Client.fixedLogicalToPhysicalPx` 의 계산부로, Client 없이 검증할 수 있게
+/// file-scope 순수 함수로 둔다.
+///
+/// 나눗셈이 한 번뿐인 것이 핵심이다 — `wl_fixed` 를 논리 정수로 자른 뒤 배율을
+/// 곱하면 정밀도를 먼저 버려 결과가 한쪽으로 치우친다 (#552).
+///
+/// surface 좌표는 음수가 정상 흐름엔 안 들어오지만 leave 직후 등 edge case 가 있다.
+/// `@divFloor` 라 바깥 점이 음수로 남고, pixelToCell 의 범위 검사가 그것을 reject
+/// 한다 (예전 `@divTrunc` 는 논리 -0.5 를 0 으로 만들어 안쪽으로 보이게 했다).
+fn physicalPxForFixedLogical(fixed: i32, scale_num: u32) i32 {
+    const num: i64 = @intCast(scale_num);
+    const den: i64 = @as(i64, fractional_scale_denominator) * 256;
+    return @intCast(@divFloor(@as(i64, fixed) * num, den));
+}
+
+test "#552 포인터 좌표는 논리 정수로 자르지 않고 고정소수점에서 곱한다" {
+    const s17: u32 = 204; // 1.7x
+    const fx = struct {
+        fn v(whole: i32, two_fifty_sixths: i32) i32 {
+            return whole * 256 + two_fifty_sixths;
+        }
+    };
+
+    // 논리 100.996 → 171.69 → 171. 논리 정수로 먼저 자르면 170 이었다.
+    try std.testing.expectEqual(@as(i32, 171), physicalPxForFixedLogical(fx.v(100, 255), s17));
+    // 논리 10.996 → 18.69 → 18. 자르면 17 이었다.
+    try std.testing.expectEqual(@as(i32, 18), physicalPxForFixedLogical(fx.v(10, 255), s17));
+    // 논리 정수 자리는 자르던 때와 같아야 한다 — 회귀 가드.
+    try std.testing.expectEqual(@as(i32, 170), physicalPxForFixedLogical(fx.v(100, 0), s17));
+
+    // 내림이다 (반올림 아님) — 점이 들어 있는 픽셀 인덱스라서.
+    try std.testing.expectEqual(@as(i32, 1), physicalPxForFixedLogical(fx.v(1, 0), s17)); // 1.7 → 1
+
+    // fractional 미advertise (120) 는 논리 = 물리.
+    try std.testing.expectEqual(@as(i32, 100), physicalPxForFixedLogical(fx.v(100, 0), 120));
+    try std.testing.expectEqual(@as(i32, 100), physicalPxForFixedLogical(fx.v(100, 255), 120));
+
+    // surface 바깥 (음수) 은 음수로 남아야 한다 — `@divTrunc` 는 -0.5 를 0 으로 만들어
+    // 바깥 점을 안쪽으로 보이게 했다.
+    try std.testing.expectEqual(@as(i32, -1), physicalPxForFixedLogical(-128, s17)); // 논리 -0.5
 }
 
 /// logical 크기 → physical buffer 크기. `Client.logicalToPhysicalSize` 의 계산부로,

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -3258,6 +3258,20 @@ const Client = struct {
         return @divFloor(logical * num, den);
     }
 
+    /// **크기** (buffer / surface 크기) 전용 변환 — 위 좌표용과 반올림 규칙이 다르다.
+    ///
+    /// `fractional-scale-v1` 은 버퍼 크기를 *"surface 크기 × 배율, 0 에서 먼 쪽으로
+    /// 반올림"* 으로 규정한다 (protocol description: *"the size is rounded halfway
+    /// away from zero"*). 내림하면 버퍼가 compositor 의 목적지 사각형보다 최대 1 px
+    /// 짧아지고, compositor 가 그 축으로 창 전체를 늘려 **글자까지 번진다** (#539 —
+    /// scale 1.7 · 논리 높이 735 에서 1249.5 를 1249 로 버려 발생).
+    ///
+    /// 어긋남은 소수부가 0.5 이상일 때만 생기므로 배율과 창 크기의 조합에 따라
+    /// 나타났다 사라진다 — "이 배율에서는 괜찮더라" 로 판정하면 안 된다.
+    fn logicalToPhysicalSize(self: *const Client, logical: i32) i32 {
+        return physicalSizeForLogical(logical, self.preferred_scale);
+    }
+
     fn physicalToLogical(self: *const Client, physical: i32) i32 {
         const num: i32 = @intCast(self.preferred_scale);
         const den: i32 = @intCast(fractional_scale_denominator);
@@ -3271,8 +3285,9 @@ const Client = struct {
     }
 
     /// dialog surface 요청은 계산한 physical content보다 작아지면 마지막 glyph가
-    /// 잘릴 수 있으므로 positive ceil을 쓴다. configure의 logical→physical floor와
-    /// 짝을 이뤄 요청한 buffer 크기를 보존한다 (#306).
+    /// 잘릴 수 있으므로 positive ceil을 쓴다. configure의 `logicalToPhysicalSize`와
+    /// 짝을 이뤄 요청한 buffer 크기를 보존한다 (#306). 그쪽이 내림에서 반올림으로
+    /// 바뀌어도(#539) 보존은 유지된다 — 반올림은 내림보다 작아지지 않는다.
     fn physicalToLogicalCeil(self: *const Client, physical: i32) i32 {
         if (physical <= 0) return 0;
         const num: i64 = @intCast(self.preferred_scale);
@@ -5302,8 +5317,8 @@ const Client = struct {
                 // 이면 실제 layout 의 크기가 초기 안전 commit 과 같아 compositor 가 두
                 // 번째 configure 를 안 보낼 수 있으므로, 이 configure 를 boot 진행
                 // 신호로 계속 써야 한다 (안 그러면 그 config 에서 boot 가 멈춘다).
-                if (w > 0) self.pending_width = self.logicalToPhysical(w_logical);
-                if (h > 0) self.pending_height = self.logicalToPhysical(h_logical);
+                if (w > 0) self.pending_width = self.logicalToPhysicalSize(w_logical);
+                if (h > 0) self.pending_height = self.logicalToPhysicalSize(h_logical);
                 self.applyPendingSize();
                 // viewport.set_destination — compositor 가 우리 buffer (physical)
                 // 를 logical surface size 안에 1:1 매핑하게. 호출 안 하면 buffer
@@ -7708,8 +7723,8 @@ const Client = struct {
         if (payload.len < 12) return error.WaylandBadMessage;
         // xdg-shell configure 의 width/height = *logical pixel* (compositor 단위).
         // 우리 내부 단위는 physical 이라 변환.
-        self.pending_width = self.logicalToPhysical(readI32(payload[0..4]));
-        self.pending_height = self.logicalToPhysical(readI32(payload[4..8]));
+        self.pending_width = self.logicalToPhysicalSize(readI32(payload[0..4]));
+        self.pending_height = self.logicalToPhysicalSize(readI32(payload[4..8]));
     }
 
     fn handleBufferEvent(self: *Client, id: u32, opcode: u16) bool {
@@ -9421,8 +9436,8 @@ const Client = struct {
                 const w_clamped: i32 = @intCast(@min(w_logical, @as(u32, std.math.maxInt(i32))));
                 const h_clamped: i32 = @intCast(@min(h_logical, @as(u32, std.math.maxInt(i32))));
                 const configured = dialog_layout.Size{
-                    .w = self.logicalToPhysical(w_clamped),
-                    .h = self.logicalToPhysical(h_clamped),
+                    .w = self.logicalToPhysicalSize(w_clamped),
+                    .h = self.logicalToPhysicalSize(h_clamped),
                 };
                 const configured_layout = self.applyCurrentDialogLayoutForSurface(configured);
                 if (!configured_layout.fits) {
@@ -10272,6 +10287,46 @@ fn isAcceptableTextMime(mime: []const u8) bool {
 /// `@divTrunc` 로 0 방향 정수 변환 — pixelToCell 의 범위 검사가 음수 reject.
 fn wlFixedToPx(value: i32) i32 {
     return @divTrunc(value, 256);
+}
+
+/// logical 크기 → physical buffer 크기. `Client.logicalToPhysicalSize` 의 계산부로,
+/// Client 없이 검증할 수 있게 file-scope 순수 함수로 둔다.
+///
+/// 반올림은 **0 에서 먼 쪽** (half away from zero) 이다 — `fractional-scale-v1` 의
+/// 규정이자 compositor 가 목적지 사각형을 잡는 방식이라, 이것과 어긋나면 창이
+/// 그 축으로 리샘플된다 (#539).
+fn physicalSizeForLogical(logical: i32, scale_num: u32) i32 {
+    const num: i64 = @intCast(scale_num);
+    const den: i64 = fractional_scale_denominator;
+    const scaled: i64 = @as(i64, logical) * num;
+    const half: i64 = @divFloor(den, 2);
+    const rounded: i64 = if (scaled >= 0)
+        @divFloor(scaled + half, den)
+    else
+        -@divFloor(-scaled + half, den);
+    return @intCast(rounded);
+}
+
+test "#539 buffer 크기는 0 에서 먼 쪽으로 반올림한다 (내림이 아니다)" {
+    const s17: u32 = 204; // 1.7x
+    // 이슈의 실측 조합 — 논리 735 는 1249.5 라 내림하면 1 px 짧아진다.
+    try std.testing.expectEqual(@as(i32, 1250), physicalSizeForLogical(735, s17));
+    // 같은 화면의 논리 폭 2259 는 3840.3 이라 반올림해도 그대로 — 가로가 또렷했던 이유.
+    try std.testing.expectEqual(@as(i32, 3840), physicalSizeForLogical(2259, s17));
+    // 로그에서 확인한 dialog 값들 (내림일 때 897 / 545 였다).
+    try std.testing.expectEqual(@as(i32, 898), physicalSizeForLogical(528, s17)); // 897.6
+    try std.testing.expectEqual(@as(i32, 546), physicalSizeForLogical(321, s17)); // 545.7
+    try std.testing.expectEqual(@as(i32, 476), physicalSizeForLogical(280, s17)); // 476.0 정확
+    // 정확히 .5 는 0 에서 먼 쪽 = 올림 (5 × 1.7 = 8.5).
+    try std.testing.expectEqual(@as(i32, 9), physicalSizeForLogical(5, s17));
+
+    // 정수 배율과 fractional 미advertise (120) 는 내림과 결과가 같아야 한다 — 회귀 가드.
+    try std.testing.expectEqual(@as(i32, 1271), physicalSizeForLogical(1271, 120));
+    try std.testing.expectEqual(@as(i32, 2542), physicalSizeForLogical(1271, 240));
+
+    // 0 과 음수 (compositor 가 0 을 보내는 경로가 있다).
+    try std.testing.expectEqual(@as(i32, 0), physicalSizeForLogical(0, s17));
+    try std.testing.expectEqual(@as(i32, -1250), physicalSizeForLogical(-735, s17));
 }
 
 fn readU32(bytes: *const [4]u8) u32 {


### PR DESCRIPTION
## 왜 한 브랜치인가

`logicalToPhysical` 한 함수가 **크기**와 **좌표** 양쪽에 쓰이고 있었습니다. 둘은 올바른 반올림이 다릅니다 — 크기는 "픽셀이 몇 개냐" 라서 반올림이고, 좌표는 "이 점이 몇 번 픽셀 안이냐" 라서 내림입니다. **한 함수로 둔 것 자체가 원인**이라 함수를 갈랐고, 그래서 두 이슈가 같은 두 줄을 만집니다. 커밋은 나눴습니다.

| 커밋 | |
|---|---|
| 3c2e654 | 크기 변환을 스펙(`fractional-scale-v1`)대로 반올림 ([#539](https://github.com/ensky0/tildaz/issues/539)) |
| 173a521 | 좌표를 고정소수점에서 곱하고 한 번만 내림 ([#552](https://github.com/ensky0/tildaz/issues/552)) |
| 06d12b7 | 릴리즈 노트 본문 후보 운반 |

## 1. `#539` — 창이 세로로 리샘플돼 번집니다

`fractional-scale-v1` 이 버퍼 크기를 *"the size is rounded halfway away from zero"* 로 규정하는데 `logicalToPhysical` 이 `@divFloor` 였습니다. 내림한 버퍼는 compositor 의 목적지 사각형보다 최대 1 px 짧아서, compositor 가 그 축으로 창 전체를 늘립니다. 분할선만이 아니라 **글자까지** 번진 이유입니다.

같은 화면에서 세로만 번진 것도 이것으로 설명됩니다. 논리 폭 2259 는 `× 1.7 = 3840.3` 이라 내림과 반올림이 둘 다 3840 이고, 높이만 소수부가 0.5 를 넘었습니다.

## 2. `#552` — 포인터 좌표가 한쪽으로 밀립니다

`wl_pointer` 좌표는 `wl_fixed` (24.8) 라 논리 픽셀의 1/256 까지 담는데, `wlFixedToPx` 가 논리 정수로 **먼저 자르고** 그 뒤에 배율을 곱했습니다. 버린 소수부 × 배율만큼 (1.7x 에서 최대 2 px) **항상 작아지는 쪽으로만** 치우쳤습니다. 고정소수점 상태에서 곱하고 마지막에 한 번만 내리도록 바꿨습니다.

`@divTrunc` 도 `@divFloor` 로 바꿨습니다. 0 방향 절단은 surface 바깥의 논리 −0.5 를 0 (= 안쪽) 으로 만들어 `pixelToCell` 의 음수 범위 검사를 우회시켰습니다.

## 검증

- `zig build test` 405 → 407, 전부 통과 · `zig build check` 6 타겟 통과.
- **#539 실기 A/B** — 미니PC Firebat ZY-A8 · CachyOS · KDE Plasma 6 (KWin Wayland) · 3840×2160 @ 60 Hz · **scale 1.7**. 로그가 `logical_h=735`, `scale=204/120` 으로 두 회차가 같은 조건임을 확인해 줍니다 (`735 × 1.7 = 1249.5`).

  | | 밴드 전이 행의 밝기 |
  |---|---|
  | main `911c685` | **13 종**, 58..137 — 창 위에서 아래로 단조 증가 후 1 회 wrap |
  | 이 브랜치 | **1 종**, `61` — 18 곳 전부 동일 |

  A 의 드리프트가 창 높이 전체에 걸친 1 px 선형 리샘플의 서명이고, B 에서 사라졌습니다. 상세는 [#539 코멘트](https://github.com/ensky0/tildaz/issues/539#issuecomment-5466078017)에 있습니다.

- **#552 실기는 아직입니다.** 경계 1 px 을 정확히 집으려면 절대좌표 uinput 장치가 필요해 준비가 큽니다. 같은 Linux 실기가 필요한 다른 작업과 한 회차에 몰아서 재기로 했고, 그래서 #552 는 열어 둡니다.

## 영향 범위

fractional scale 을 내주는 compositor 전부입니다 — KDE Plasma · COSMIC · Hyprland. GNOME · Cinnamon 은 `preferred_scale` 을 안 내줘 기본값 120 (no-op) 이라 해당 없고, 정수 배율도 소수부가 0 이라 해당 없습니다. main 창뿐 아니라 dialog 도 같은 헬퍼를 써서 함께 고쳐집니다. macOS · Windows 는 이 경로가 없습니다.
