### PR TITLE
chore(deps): ghostty pin 을 83c5671 로 올린다 — cluster 처리량 ~2x · print 경로 use-after-free (#550)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,8 +35,8 @@
         .ghostty = .{
             // 특정 커밋으로 고정. `refs/heads/main.tar.gz` 는 upstream main 이
             // 움직이면 CI 프리페치가 해시 불일치로 실패 (c41a9ef 참고).
-            .url = "https://github.com/ghostty-org/ghostty/archive/94d775fefc21f74d9cc85a46b34c4e1d85318fd0.tar.gz",
-            .hash = "ghostty-1.3.2-dev-5UdBCyCSPwV-Pp82UMGLutqeo0gckMrI0GfbUbUY0-Jt",
+            .url = "https://github.com/ghostty-org/ghostty/archive/83c56715773d2b5f0e8b1d5bee68424514bb43e3.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBC6RsYAWcESTAM9Ox27DitklgKczL7uwQxNUcNkA3",
         },
         // TOML config 파서 (#493). MIT.
         //

--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -21,6 +21,12 @@ Internal changes belong in neither.
 
 ## Body candidates
 
+- Heavy output lands faster. Emoji, ZWJ sequences and CJK text parse roughly twice as
+  fast, and ANSI-heavy output about 1.5x, measured on Linux, macOS and Windows.
+  ([#550](https://github.com/ensky0/tildaz/issues/550))
+- Fixed a crash that could corrupt memory while printing grapheme clusters when a
+  program emits OSC 8 hyperlinks.
+  ([#550](https://github.com/ensky0/tildaz/issues/550))
 - Linux: windows and dialogs are no longer resampled at fractional display scales, so
   text and lines stay sharp at 1.7x and other fractional factors.
   ([#539](https://github.com/ensky0/tildaz/issues/539))

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -386,7 +386,11 @@ pub const Tab = struct {
     /// 등) 을 PTY 로 송신. stream 파싱은 main thread 의 drainOutput 에서
     /// 일어나므로 blocking 가능한 backend.write 직접 호출 대신 키 입력과 같은
     /// write_queue 경로로 (순서 보존 + push 가 복사라 data lifetime 무관).
-    fn vtWritePty(handler: *ghostty.TerminalStream.Handler, data: [:0]const u8) void {
+    ///
+    /// #550 — 인자가 `[:0]const u8` 이었다가 upstream 이 `[]const u8` 로 바꿨다.
+    /// 본문이 널 종단을 쓰지 않고 `queueWrite` 도 평범한 slice 를 받으므로 타입만
+    /// 넓히면 되고 동작은 그대로다.
+    fn vtWritePty(handler: *ghostty.TerminalStream.Handler, data: []const u8) void {
         const tab: *Tab = @alignCast(@fieldParentPtr("terminal", handler.terminal));
         tab.queueWrite(data);
     }
@@ -639,7 +643,9 @@ test "#451 ghostty pin answers DECRQSS and XTGETTCAP with grapheme mode enabled"
             calls = 0;
         }
 
-        fn writePty(_: *ghostty.TerminalStream.Handler, data: [:0]const u8) void {
+        // #550 — upstream 이 `Effects.write_pty` 의 인자를 `[:0]const u8` 에서
+        // `[]const u8` 로 바꿨다. 여기도 길이만 쓰므로 타입만 맞춘다.
+        fn writePty(_: *ghostty.TerminalStream.Handler, data: []const u8) void {
             @memcpy(response[0..data.len], data);
             len = data.len;
             calls += 1;


### PR DESCRIPTION
ghostty pin 을 [`94d775fe`](https://github.com/ghostty-org/ghostty/commit/94d775fefc21f74d9cc85a46b34c4e1d85318fd0) (2026-08-11) → [`83c5671`](https://github.com/ghostty-org/ghostty/commit/83c56715773d2b5f0e8b1d5bee68424514bb43e3) (2026-08-30, upstream main HEAD) 로 올립니다. 명분은 **성능과 crash fix** 입니다.

## API 파손이 하나 있었고 `zig build check` 가 잡았습니다

`Effects.write_pty` 의 인자가 `[:0]const u8` → `[]const u8` 로 바뀌었습니다. 본체 (`vtWritePty`) 와 테스트 헬퍼 (`Capture.writePty`) 둘 다 길이만 쓰고 널 종단에 의존하지 않아 타입만 넓혔습니다 — 동작 변화는 없습니다.

이슈 본문은 `Effects` 를 *"필드 개별 대입이라 필드 추가는 무해"* 로 봤는데, 이건 **추가가 아니라 시그니처 변경**이라 소스 대조로는 보이지 않았습니다. 본문이 *"중첩 struct 의 필드 모양은 `zig build check` 로만 확정된다"* 고 적어 둔 그대로였습니다.

## 세 platform 실기 — 이득은 실측되고 회귀는 0

| | `ansi` | `hangul` | `cjk` | `emoji_vs16` | `zwj` |
|---|---|---|---|---|---|
| macOS (M5 Pro) | 1.61x | 2.21x | 1.14x | **2.78x** | **2.75x** |
| Windows (i5-1240P) | 1.48x | 1.94x | — | 1.89x | 1.98x |
| Linux (같은 기기) | ~1.5x | ~1.9x | — | ~1.9x | ~1.9x |

- **회귀 시연은 세 회차 모두 A/B 픽셀 대조**로 했습니다. macOS 회차는 두 빌드에 같은 합성 입력을 넣고 창을 캡처해 **다른 픽셀 0** 을 확인했고, 각 단계가 화면을 6~10 % 실제로 바꿨다는 것을 함께 적어 *"조작이 헛돌아 두 화면이 같았던 것"* 과 구분했습니다.
- **`cjk` 가 기대(3~5x)와 다른 것은 어긋남이 아니라 측정 층입니다.** `d760ee9` 가 고치는 것은 *버퍼 resize 시의 reflow* 인데 `stress.zig` 의 `runParser` 는 resize 를 한 번도 부르지 않습니다. 그래서 그 몫은 이 숫자에 원리상 들어올 수 없고, reflow 는 pane 리사이즈 시연으로 따로 확인했습니다.
- Windows 는 `windows-fetch-check` 와 `zig build package` 도 통과했습니다.

상세는 [macOS](https://github.com/ensky0/tildaz/issues/550#issuecomment-5467271947) · [Windows](https://github.com/ensky0/tildaz/issues/550#issuecomment-5467286712) · [Linux](https://github.com/ensky0/tildaz/issues/550#issuecomment-5467772352) 회차 코멘트에 있습니다.

## 전제 재확인

- `font-backend = .freetype` 명시 **네 곳** 그대로. 새 pin 도 `SharedDeps` 의 `font_backend.hasFontconfig()` 게이팅을 유지해 libxml2 lazy 의존성 차단 전제가 깨지지 않습니다.
- `minimum_zig_version` 양쪽 다 `0.16.0` — Zig 전환 없음.
- 이슈가 분석한 `4540d499` (8/28) 와 이 HEAD 사이 **14 커밋도 읽었습니다.** gtk · ghostty 렌더러 · ghostty 실행파일 쪽이거나 lazy 의존성 갱신이고, `lib_vt.zig` · `src/build/` 는 하나도 바뀌지 않았습니다.

## 검증

`zig build check` 6 타겟 · `zig build test` 407 (bump 전과 같은 수) · `zig build probe-check` 전부 통과. 파이프 없이 종료 코드로 확인했습니다.
