### PR TITLE
feat(input): kitty keyboard protocol 의 뗌 · 반복을 세 platform 에서 보고한다 (#538)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -95,6 +95,7 @@ const max_dmabuf_tranches: usize = 16;
 const wl_seat_capability_pointer: u32 = 1;
 const wl_seat_capability_keyboard: u32 = 2;
 const wl_keyboard_keymap_format_xkb_v1: u32 = 1;
+const wl_keyboard_key_state_released: u32 = 0;
 const wl_keyboard_key_state_pressed: u32 = 1;
 const wl_keyboard_key_state_repeated: u32 = 2;
 const wayland_xkb_keycode_offset: u32 = 8;
@@ -6242,7 +6243,7 @@ const Client = struct {
         if (state == wl_keyboard_key_state_pressed) {
             self.key_repeat_keycode = key;
             self.key_repeat_next_ms = self.rt.nowMs() + @as(i64, self.key_repeat_delay_ms);
-        } else if (state == 0 and self.key_repeat_keycode == key) {
+        } else if (state == wl_keyboard_key_state_released and self.key_repeat_keycode == key) {
             // released — same key disarm.
             //
             // #546 — 이 disarm 이 `maybeRepeatKey` 의 스테일 발동 방어의 전제다. 그 함수가
@@ -6252,8 +6253,22 @@ const Client = struct {
             // 한 번에 탭 둘이 닫히는 증상이 조용히 되돌아온다.
             self.key_repeat_keycode = 0;
         }
+        // #538 — 뗌(release) 은 **`processKeyEvent` 를 타지 않는다.** 그 함수는 다이얼로그
+        // 라우팅 · 커맨드 메뉴 · compose · 단축키 분류가 전부 엮여 있어서, 뗌을 흘리면
+        // 단축키가 두 번 발동하고 compose 상태가 깨진다. 뗌에 필요한 것은 인코딩뿐이라
+        // `sendEncodedKey` 로 직행한다.
+        //
+        // 모드 검사는 하지 않는다 — 인코더가 거른다 (`key_encode.Event.action` 주석).
+        // 다만 **다이얼로그 · 메뉴가 떠 있으면 보내지 않는다.** 그때 press 는 PTY 로
+        // 가지 않았으므로 뗌만 가면 앱이 짝 없는 release 를 본다.
+        if (state == wl_keyboard_key_state_released) {
+            if (self.dialog.active() or self.command_menu_open) return;
+            self.last_serial = serial;
+            self.sendEncodedKey(key, key + wayland_xkb_keycode_offset, "", .release);
+            return;
+        }
         if (state != wl_keyboard_key_state_pressed and state != wl_keyboard_key_state_repeated) return;
-        try self.processKeyEvent(serial, key);
+        try self.processKeyEvent(serial, key, if (state == wl_keyboard_key_state_repeated) .repeat else .press);
     }
 
     /// L12-γ-5 — main loop 의 매 iteration 에서 repeat timer 검사. timer 가
@@ -6291,7 +6306,7 @@ const Client = struct {
 
         const now = self.rt.nowMs();
         if (now < self.key_repeat_next_ms) return; // 새 press 가 arm 을 다시 잡았다
-        try self.processKeyEvent(self.last_serial, self.key_repeat_keycode);
+        try self.processKeyEvent(self.last_serial, self.key_repeat_keycode, .repeat);
         self.key_repeat_next_ms = now + @divTrunc(1000, @as(i64, self.key_repeat_rate_hz));
     }
 
@@ -6319,7 +6334,7 @@ const Client = struct {
     /// L12-γ-5 — keyboard.key 의 실제 처리 (byte parsing 분리 후). pressed /
     /// repeated 둘 다 같은 path. serial 은 clipboard 등 시점 기록용으로 자기
     /// 자신에게 보관 (matchClipboardSerial 같은 path 에서 사용).
-    fn processKeyEvent(self: *Client, serial: u32, key: u32) !void {
+    fn processKeyEvent(self: *Client, serial: u32, key: u32, action: key_encode.Action) !void {
         self.last_serial = serial;
 
         // #494 — compose 를 거치지 않고 끝난 키 (다이얼로그 · 메뉴 · 단축키 · nav 키 · Ctrl/Alt
@@ -6481,14 +6496,14 @@ const Client = struct {
         // #533 — 여기서 PTY 로 나가는 바이트가 정해진다. 예전엔 `utf8()` 결과를 그대로
         // 보냈고 (그래서 Alt 가 사라졌다) 그 위에 `terminalSequenceForKeysym` 이 특수키를
         // 따로 적고 있었다. 이제 둘 다 인코더 한 곳으로 모은다 — modifier 가 실린다.
-        self.sendEncodedKey(key, xkb_key, self.keyboard.utf8(xkb_key, &buf));
+        self.sendEncodedKey(key, xkb_key, self.keyboard.utf8(xkb_key, &buf), action);
     }
 
     /// #533 — 키 하나를 `key_encode` 로 인코딩해 PTY 로 보낸다.
     ///
     /// `key` 는 wl_keyboard 가 준 raw evdev keycode, `xkb_key` 는 거기에 8 을 더한 xkb 값이다
     /// (둘 다 필요하다 — 물리 위치는 evdev 로, xkb 조회는 xkb 값으로 한다).
-    fn sendEncodedKey(self: *Client, key: u32, xkb_key: u32, utf8_in: []const u8) void {
+    fn sendEncodedKey(self: *Client, key: u32, xkb_key: u32, utf8_in: []const u8, action: key_encode.Action) void {
         const consumed = self.keyboard.consumedMods(xkb_key);
 
         // #533 — **제어문자는 Ctrl 을 뺀 글자로 바꿔서 넘긴다.** xkb 의 `utf8()` 은 Ctrl
@@ -6551,6 +6566,7 @@ const Client = struct {
             },
             .utf8 = utf8,
             .unshifted_codepoint = unshifted,
+            .action = action,
         }, self.keyEncodeOptions()) catch return;
         const bytes = writer.buffered();
         if (bytes.len > 0) self.queueInput(bytes);

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -948,6 +948,15 @@ fn firstCodepoint(text: []const u8) u21 {
 ///
 /// `utf8` 은 이 키가 만든 문자다 — 특수키 경로는 빈 문자열을 준다. 제어문자는
 /// `key_encode` 가 걸러 내므로 (`textForEncoding`) 호출부가 신경 쓰지 않아도 된다.
+/// #538 — `NSEvent.isARepeat`. 길게 눌러 OS 가 만든 반복이면 `.repeat` 이다.
+///
+/// 뗌에는 쓰지 않는다 — `keyUp:` 의 이벤트에는 의미가 없다. 호출처가 누름 갈래에서만 쓴다.
+fn macKeyAction(event: objc.id) key_encode.Action {
+    if (event == null) return .press;
+    const is_repeat = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) bool);
+    return if (is_repeat(event, objc.sel("isARepeat"))) .repeat else .press;
+}
+
 fn sendEncodedKeyMac(tab: anytype, event: objc.id, utf8: []const u8, action: key_encode.Action) bool {
     if (event == null) return false;
     const get_flags = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) c_ulong);
@@ -1488,7 +1497,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                 // #533 — 인코더가 code + mods 로 제어문자를 만든다. `characters` 를
                 // 그대로 넘겨도 `textForEncoding` 이 제어문자를 걸러 내므로 이중으로
                 // 나가지 않는다. Ctrl+C 의 큐 우회도 인코더 결과를 보고 판정한다.
-                if (!sendEncodedKeyMac(tab, event, cstr[0..len], .press)) {
+                if (!sendEncodedKeyMac(tab, event, cstr[0..len], macKeyAction(event))) {
                     // 인코더가 낼 것이 없으면 예전 경로 그대로 — 우리가 모르는 keycode 의
                     // Ctrl 조합이 조용히 사라지지 않게 한다.
                     if (ctrl_c) {
@@ -1540,7 +1549,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
         // 집합은 그대로다 — `isNavOrFunction` 이 글자 키를 걸러, 문자 입력이
         // `interpretKeyEvents:` 를 건너뛰어 한글 조합이 깨지는 일을 막는다.
         if (physical_key.fromMacKeyCode(keycode)) |code| {
-            if (key_encode.isNavOrFunction(code) and sendEncodedKeyMac(tab, event, "", .press)) return;
+            if (key_encode.isNavOrFunction(code) and sendEncodedKeyMac(tab, event, "", macKeyAction(event))) return;
         }
 
         // #533 — `[input] macos_option_as_alt` 가 Option 을 Alt 로 쓰라고 하면 **글자
@@ -1563,7 +1572,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                     plain = us[0..1];
                 }
             }
-            if (sendEncodedKeyMac(tab, event, plain, .press)) return;
+            if (sendEncodedKeyMac(tab, event, plain, macKeyAction(event))) return;
         }
     }
 
@@ -1581,7 +1590,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                     return;
                 }
                 commitPreeditToPty(self_view);
-                _ = sendEncodedKeyMac(tab, event, "", .press);
+                _ = sendEncodedKeyMac(tab, event, "", macKeyAction(event));
                 return;
             }
         }

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -948,7 +948,7 @@ fn firstCodepoint(text: []const u8) u21 {
 ///
 /// `utf8` 은 이 키가 만든 문자다 — 특수키 경로는 빈 문자열을 준다. 제어문자는
 /// `key_encode` 가 걸러 내므로 (`textForEncoding`) 호출부가 신경 쓰지 않아도 된다.
-fn sendEncodedKeyMac(tab: anytype, event: objc.id, utf8: []const u8) bool {
+fn sendEncodedKeyMac(tab: anytype, event: objc.id, utf8: []const u8, action: key_encode.Action) bool {
     if (event == null) return false;
     const get_flags = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) c_ulong);
     const get_keycode = objc.objcSend(fn (objc.id, objc.SEL) callconv(.c) c_ushort);
@@ -993,6 +993,7 @@ fn sendEncodedKeyMac(tab: anytype, event: objc.id, utf8: []const u8) bool {
         .consumed_mods = .{ .shift = shift, .alt = option and !option_as_alt },
         .utf8 = text,
         .unshifted_codepoint = unshifted,
+        .action = action,
     }, keyEncodeOptionsMac(option_as_alt)) catch return false;
 
     const bytes = writer.buffered();
@@ -1314,6 +1315,26 @@ fn runKeyAction(action: config.KeyAction) bool {
     return true;
 }
 
+/// #538 — `keyUp:`. kitty keyboard protocol 의 `report_events` 를 켠 앱에만 의미가 있다.
+///
+/// **`keyDown:` 의 경로를 재사용하지 않는다.** 그쪽은 커맨드 메뉴 · Cmd 단축키 · IME
+/// (`interpretKeyEvents:`) 가 엮여 있어서 뗌을 흘리면 단축키가 두 번 발동한다. 뗌에
+/// 필요한 것은 인코딩뿐이라 `sendEncodedKeyMac` 으로 직행한다.
+///
+/// 모드 검사는 하지 않는다 — 인코더가 거른다 (`key_encode.Event.action` 주석).
+/// 대신 **press 가 PTY 로 가지 않은 상황**에서는 보내지 않는다.
+///
+///   * 커맨드 메뉴가 열려 있을 때 — 그때 press 는 메뉴가 삼킨다.
+///   * IME 조합 중 (`g_marked_len > 0`) — 그때 글자는 `insertText:` 로 확정되지
+///     `keyDown:` 의 인코더 경로로 나가지 않는다. 뗌만 내보내면 짝이 안 맞는다.
+fn tildazKeyUp(_: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void {
+    if (event == null) return;
+    if (g_command_menu_open) return;
+    if (g_marked_len > 0) return;
+    const tab = g_session.activeTab() orelse return;
+    _ = sendEncodedKeyMac(tab, event, "", .release);
+}
+
 fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) void {
     perf.markInput(); // #441 축 ② — 응답 지연은 여기서 시작한다.
     requestRender(); // #255 Phase2 — 키 입력 → 렌더 (스크롤백/탭조작 등 출력 없는 변화 포함).
@@ -1467,7 +1488,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                 // #533 — 인코더가 code + mods 로 제어문자를 만든다. `characters` 를
                 // 그대로 넘겨도 `textForEncoding` 이 제어문자를 걸러 내므로 이중으로
                 // 나가지 않는다. Ctrl+C 의 큐 우회도 인코더 결과를 보고 판정한다.
-                if (!sendEncodedKeyMac(tab, event, cstr[0..len])) {
+                if (!sendEncodedKeyMac(tab, event, cstr[0..len], .press)) {
                     // 인코더가 낼 것이 없으면 예전 경로 그대로 — 우리가 모르는 keycode 의
                     // Ctrl 조합이 조용히 사라지지 않게 한다.
                     if (ctrl_c) {
@@ -1519,7 +1540,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
         // 집합은 그대로다 — `isNavOrFunction` 이 글자 키를 걸러, 문자 입력이
         // `interpretKeyEvents:` 를 건너뛰어 한글 조합이 깨지는 일을 막는다.
         if (physical_key.fromMacKeyCode(keycode)) |code| {
-            if (key_encode.isNavOrFunction(code) and sendEncodedKeyMac(tab, event, "")) return;
+            if (key_encode.isNavOrFunction(code) and sendEncodedKeyMac(tab, event, "", .press)) return;
         }
 
         // #533 — `[input] macos_option_as_alt` 가 Option 을 Alt 로 쓰라고 하면 **글자
@@ -1542,7 +1563,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                     plain = us[0..1];
                 }
             }
-            if (sendEncodedKeyMac(tab, event, plain)) return;
+            if (sendEncodedKeyMac(tab, event, plain, .press)) return;
         }
     }
 
@@ -1560,7 +1581,7 @@ fn tildazKeyDown(self_view: objc.id, _: objc.SEL, event: objc.id) callconv(.c) v
                     return;
                 }
                 commitPreeditToPty(self_view);
-                _ = sendEncodedKeyMac(tab, event, "");
+                _ = sendEncodedKeyMac(tab, event, "", .press);
                 return;
             }
         }
@@ -3614,6 +3635,8 @@ fn registerTildazViewClass() !objc.Class {
         return error.ViewSubclassAddMethodFailed;
     // "v@:@" = void 반환, self + _cmd + 한 인자 (NSEvent id).
     if (!objc.class_addMethod(cls, objc.sel("keyDown:"), @ptrCast(&tildazKeyDown), "v@:@"))
+        return error.ViewSubclassAddMethodFailed;
+    if (!objc.class_addMethod(cls, objc.sel("keyUp:"), @ptrCast(&tildazKeyUp), "v@:@"))
         return error.ViewSubclassAddMethodFailed;
     if (!objc.class_addMethod(cls, objc.sel("scrollWheel:"), @ptrCast(&tildazScrollWheel), "v@:@"))
         return error.ViewSubclassAddMethodFailed;

--- a/src/key_encode.zig
+++ b/src/key_encode.zig
@@ -35,6 +35,10 @@ const physical_key = @import("physical_key.zig");
 /// (`mouse_report.zig` 와 달리) 같은 shape 를 다시 정의하지 않는다.
 pub const Mods = ghostty.input.KeyMods;
 
+/// 눌림 · 반복 · 뗌. #538 — 그 전에는 `repeat: bool` 뿐이었고 그마저 세팅하는 자리가
+/// 없어서 **세 갈래가 전부 `.press` 로** 인코딩됐다.
+pub const Action = ghostty.input.KeyAction;
+
 /// 인코딩 옵션. 8 개 중 7 개는 `fromTerminal` 이 터미널 상태에서 뽑아 주고,
 /// `macos_option_as_alt` 만 앱 config 가 정한다 (터미널이 알 수 없는 값).
 pub const Options = ghostty.input.KeyEncodeOptions;
@@ -70,9 +74,17 @@ pub const Event = struct {
     /// 되고 `Alt+n` 이 `ESC` 없이 `n` 으로 나간다.
     unshifted_codepoint: u21 = 0,
 
-    /// 길게 눌러 반복 중인가. 뗌(release) 은 아직 보내지 않는다 — kitty protocol 의
-    /// release 보고는 후속 작업이다 (#533 코멘트의 결정).
-    repeat: bool = false,
+    /// 눌림 · 반복 · 뗌 (#538).
+    ///
+    /// **`.release` 를 모드와 무관하게 넘겨도 된다.** 인코더가 알아서 거른다 — kitty
+    /// flags 가 없으면 legacy 경로가 `.press` · `.repeat` 만 내보내고, flags 가 있어도
+    /// `report_events` 가 꺼져 있으면 `kitty()` 앞부분에서 돌아간다. 그래서 host 가
+    /// "지금 kitty 모드인가" 를 판정할 필요가 없다.
+    ///
+    /// 다만 **`.release` 를 인코더까지 흘리기 전에 host 가 걸러야 하는 것**은 있다.
+    /// 다이얼로그 · 메뉴가 떠 있어 press 가 PTY 로 가지 않은 경우다 — 그때 뗌만 가면
+    /// 앱이 짝 없는 release 를 본다.
+    action: Action = .press,
 };
 
 /// #533 — **글자를 만들지 않는 키**인가 (화살표 · nav · F-key).
@@ -146,7 +158,7 @@ pub fn encode(
     opts: Options,
 ) std.Io.Writer.Error!void {
     return ghostty.input.encodeKey(writer, .{
-        .action = if (event.repeat) .repeat else .press,
+        .action = event.action,
         .key = toGhosttyKey(event.code),
         .mods = event.mods,
         .consumed_mods = event.consumed_mods,
@@ -467,4 +479,77 @@ test "② kitty keyboard protocol — 수식키 없는 글자는 그대로" {
         .unshifted_codepoint = 'a',
     }, .{ .kitty_flags = .{ .disambiguate = true } });
     try testing.expectEqualStrings("a", out);
+}
+
+test "#538 release 는 report_events + report_all 에서만 나간다" {
+    var buf: [32]u8 = undefined;
+    var ev: Event = .{ .code = .enter };
+    ev.action = .release;
+
+    // upstream 이 스스로 단언하는 값이다 — enter · backspace · tab 은 `report_all`
+    // 이 있어야 뗌을 낸다. 마지막 `:3` 이 event type = release 다.
+    try testing.expectEqualStrings("\x1b[13;1:3u", try encodeToBuf(&buf, ev, .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true, .report_all = true },
+    }));
+
+    // `report_all` 이 없으면 그 셋은 뗌을 안 낸다.
+    try testing.expectEqualStrings("", try encodeToBuf(&buf, ev, .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true },
+    }));
+}
+
+test "#538 report_events 가 없으면 release 는 바이트를 내지 않는다 — 회귀 가드" {
+    var buf: [32]u8 = undefined;
+    var release: Event = .{ .code = .key_a, .utf8 = "a", .unshifted_codepoint = 'a' };
+    release.action = .release;
+
+    // kitty flags 자체가 없는 흔한 경우 — legacy 경로가 press · repeat 만 낸다.
+    try testing.expectEqualStrings("", try encodeToBuf(&buf, release, .{}));
+
+    // `disambiguate` 만 켠 경우 (#533 에서 fish · neovim · zellij 로 검증한 그 모드).
+    // **이 줄이 핵심 회귀 가드다** — 여기서 바이트가 나오면 흔한 앱에 입력이 두 배로 간다.
+    try testing.expectEqualStrings("", try encodeToBuf(&buf, release, .{
+        .kitty_flags = .{ .disambiguate = true },
+    }));
+
+    // 화살표처럼 kitty 표에 항목이 있는 키도 마찬가지여야 한다.
+    var arrow: Event = .{ .code = .arrow_left };
+    arrow.action = .release;
+    try testing.expectEqualStrings("", try encodeToBuf(&buf, arrow, .{
+        .kitty_flags = .{ .disambiguate = true },
+    }));
+}
+
+test "#538 repeat 는 press 와 갈린다 — 그 전에는 둘 다 press 로 나갔다" {
+    var buf: [32]u8 = undefined;
+    const opts: Options = .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true, .report_all = true },
+    };
+    var press: Event = .{ .code = .enter };
+    press.action = .press;
+    var repeat: Event = .{ .code = .enter };
+    repeat.action = .repeat;
+
+    // press 는 수식키가 기본값이면 `;1` 을 생략한다 (event 항목이 뒤에 붙는
+    // repeat · release 는 자리를 채워야 해서 `;1` 이 남는다).
+    try testing.expectEqualStrings("\x1b[13u", try encodeToBuf(&buf, press, opts));
+    var buf2: [32]u8 = undefined;
+    try testing.expectEqualStrings("\x1b[13;1:2u", try encodeToBuf(&buf2, repeat, opts));
+}
+
+test "#538 report_events 를 켜도 press 는 그대로다 — 기존 동작 회귀 가드" {
+    var buf: [32]u8 = undefined;
+    var press: Event = .{
+        .code = .key_c,
+        .mods = .{ .ctrl = true },
+        .utf8 = "c",
+        .unshifted_codepoint = 'c',
+    };
+    press.action = .press;
+    const with = try encodeToBuf(&buf, press, .{
+        .kitty_flags = .{ .disambiguate = true, .report_events = true },
+    });
+    var buf2: [32]u8 = undefined;
+    const without = try encodeToBuf(&buf2, press, .{ .kitty_flags = .{ .disambiguate = true } });
+    try testing.expectEqualStrings(without, with);
 }

--- a/src/window.zig
+++ b/src/window.zig
@@ -88,6 +88,7 @@ const PM_REMOVE: UINT = 0x0001;
 /// `messageLoop`) 직접 비교한다.
 const WM_QUIT: UINT = 0x0012;
 const WM_SYSKEYDOWN: UINT = 0x0104;
+const WM_SYSKEYUP: UINT = 0x0105;
 const WM_LBUTTONDBLCLK: UINT = 0x0203;
 const WM_LBUTTONDOWN: UINT = 0x0201;
 const WM_LBUTTONUP: UINT = 0x0202;
@@ -2183,7 +2184,7 @@ pub const Window = struct {
                 const kd_scan: u32 = @intCast((@as(usize, @bitCast(lParam)) >> 16) & 0xFF);
                 const kd_extended = ((@as(usize, @bitCast(lParam)) >> 24) & 1) != 0;
                 if (physical_key.fromScanCode(kd_scan, kd_extended)) |code| {
-                    if (key_encode.isNavOrFunction(code)) _ = self.sendEncodedKeyWin(@intCast(wParam), lParam, "");
+                    if (key_encode.isNavOrFunction(code)) _ = self.sendEncodedKeyWin(@intCast(wParam), lParam, "", .press);
                 }
 
                 // #533 — kitty protocol 이 켜져 있을 때만 `Ctrl`+글자도 인코더로 보낸다.
@@ -2204,7 +2205,7 @@ pub const Window = struct {
                         GetKeyState(VK_SHIFT) < 0,
                         &ctrl_chars,
                     );
-                    if (ctrl_text.len > 0 and self.sendEncodedKeyWin(@intCast(wParam), lParam, ctrl_text)) {
+                    if (ctrl_text.len > 0 and self.sendEncodedKeyWin(@intCast(wParam), lParam, ctrl_text, .press)) {
                         // TranslateMessage 가 큐에 넣을 짝꿍 `WM_CHAR`(제어문자) 를 삼킨다 —
                         // 그러지 않으면 `CSI u` 와 `\x03` 이 둘 다 나간다.
                         self.swallow_next_wm_char = true;
@@ -2213,14 +2214,25 @@ pub const Window = struct {
                 }
                 return 0;
             },
-            WM_KEYUP => {
+            WM_KEYUP, WM_SYSKEYUP => {
                 // preserve 요청 뒤 IME result가 전혀 오지 않은 IME에서는 chord가
                 // 끝날 때 요청만 해제. 예상 read-only result가 보류됐는데 action이
                 // 소비하지 못한 예외에는 결과를 확정해 입력 손실/가짜 overlay 방지.
-                if (GetKeyState(VK_CONTROL) >= 0 and GetKeyState(VK_SHIFT) >= 0) {
+                if (msg == WM_KEYUP and GetKeyState(VK_CONTROL) >= 0 and GetKeyState(VK_SHIFT) >= 0) {
                     self.ime_preserve_requested = false;
                     if (self.ime_deferred_result != null) _ = self.imeDispatchDeferredResult();
                 }
+                // #538 — kitty keyboard protocol 의 뗌(release) 보고. `report_events` 를
+                // 켠 앱에만 바이트가 나간다 (인코더가 거른다 — `key_encode.Event.action`).
+                //
+                // **`WM_KEYDOWN` 의 경로를 재사용하지 않는다.** 그쪽은 단축키 · 커맨드 메뉴 ·
+                // IME 가 엮여 있어서 뗌을 흘리면 단축키가 두 번 발동한다. 뗌에 필요한 것은
+                // 인코딩뿐이라 `sendEncodedKeyWin` 으로 직행한다.
+                //
+                // IME 조합 중에는 보내지 않는다 — 그때 글자는 `WM_IME_COMPOSITION` 경로로
+                // 확정되지 이 인코더로 나가지 않아서, 뗌만 가면 짝이 안 맞는다.
+                // (macOS 의 `g_marked_len > 0` 과 같은 판정이다.)
+                if (self.preedit_len == 0) _ = self.sendEncodedKeyWin(@intCast(wParam), lParam, "", .release);
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
             },
             WM_SIZE => {
@@ -2391,7 +2403,7 @@ pub const Window = struct {
                         GetKeyState(VK_SHIFT) < 0,
                         &char_buf,
                     );
-                    if (self.sendEncodedKeyWin(@intCast(wParam), lParam, text)) return 0;
+                    if (self.sendEncodedKeyWin(@intCast(wParam), lParam, text, .press)) return 0;
                 }
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
             },
@@ -2949,7 +2961,7 @@ pub const Window = struct {
     ///
     /// `utf8` 은 이 키가 만든 글자다. Windows 는 그것을 `WM_CHAR` 로 따로 주므로 이
     /// 경로는 대개 빈 문자열이고, 인코더가 `code` 와 `mods` 로 바이트를 만든다.
-    fn sendEncodedKeyWin(self: *Window, vk: UINT, lParam: LPARAM, utf8: []const u8) bool {
+    fn sendEncodedKeyWin(self: *Window, vk: UINT, lParam: LPARAM, utf8: []const u8, action: key_encode.Action) bool {
         const write_fn = self.write_fn orelse return false;
 
         // scan code 는 lParam 16~23 비트, extended 는 24 비트. 둘을 함께 봐야
@@ -2992,6 +3004,7 @@ pub const Window = struct {
             .consumed_mods = .{},
             .utf8 = text,
             .unshifted_codepoint = unshifted,
+            .action = action,
         }, self.keyEncodeOptions()) catch return false;
 
         const bytes = writer.buffered();

--- a/src/window.zig
+++ b/src/window.zig
@@ -2184,7 +2184,7 @@ pub const Window = struct {
                 const kd_scan: u32 = @intCast((@as(usize, @bitCast(lParam)) >> 16) & 0xFF);
                 const kd_extended = ((@as(usize, @bitCast(lParam)) >> 24) & 1) != 0;
                 if (physical_key.fromScanCode(kd_scan, kd_extended)) |code| {
-                    if (key_encode.isNavOrFunction(code)) _ = self.sendEncodedKeyWin(@intCast(wParam), lParam, "", .press);
+                    if (key_encode.isNavOrFunction(code)) _ = self.sendEncodedKeyWin(@intCast(wParam), lParam, "", keyActionFromLParam(lParam));
                 }
 
                 // #533 — kitty protocol 이 켜져 있을 때만 `Ctrl`+글자도 인코더로 보낸다.
@@ -2205,7 +2205,7 @@ pub const Window = struct {
                         GetKeyState(VK_SHIFT) < 0,
                         &ctrl_chars,
                     );
-                    if (ctrl_text.len > 0 and self.sendEncodedKeyWin(@intCast(wParam), lParam, ctrl_text, .press)) {
+                    if (ctrl_text.len > 0 and self.sendEncodedKeyWin(@intCast(wParam), lParam, ctrl_text, keyActionFromLParam(lParam))) {
                         // TranslateMessage 가 큐에 넣을 짝꿍 `WM_CHAR`(제어문자) 를 삼킨다 —
                         // 그러지 않으면 `CSI u` 와 `\x03` 이 둘 다 나간다.
                         self.swallow_next_wm_char = true;
@@ -2403,7 +2403,7 @@ pub const Window = struct {
                         GetKeyState(VK_SHIFT) < 0,
                         &char_buf,
                     );
-                    if (self.sendEncodedKeyWin(@intCast(wParam), lParam, text, .press)) return 0;
+                    if (self.sendEncodedKeyWin(@intCast(wParam), lParam, text, keyActionFromLParam(lParam))) return 0;
                 }
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
             },
@@ -2961,6 +2961,16 @@ pub const Window = struct {
     ///
     /// `utf8` 은 이 키가 만든 글자다. Windows 는 그것을 `WM_CHAR` 로 따로 주므로 이
     /// 경로는 대개 빈 문자열이고, 인코더가 `code` 와 `mods` 로 바이트를 만든다.
+    /// #538 — `WM_KEYDOWN` · `WM_SYSKEYDOWN` 의 `lParam` 30 번 비트가 **직전 키 상태**다.
+    /// 1 이면 이미 눌려 있던 키라 OS 가 만든 반복이다.
+    ///
+    /// 뗌에는 쓸 수 없다 — `WM_KEYUP` 의 그 비트는 늘 1 이다 (직전에 눌려 있었으니까).
+    /// 그래서 호출처가 누름 갈래에서만 이 함수를 쓴다.
+    fn keyActionFromLParam(lParam: LPARAM) key_encode.Action {
+        const bits: usize = @bitCast(lParam);
+        return if ((bits >> 30) & 1 != 0) .repeat else .press;
+    }
+
     fn sendEncodedKeyWin(self: *Window, vk: UINT, lParam: LPARAM, utf8: []const u8, action: key_encode.Action) bool {
         const write_fn = self.write_fn orelse return false;
 


### PR DESCRIPTION
kitty keyboard protocol 의 **뗌(release)** 과 **반복(repeat)** 을 세 platform 에서 보고합니다. `report_events` (`CSI > 2 u`) 를 켠 앱이 키를 뗀 것을 알 수 없었고, 이는 SPEC §0 #1 (세 platform 동등) 미달이었습니다.

## 본문의 정정을 소스로 확인했습니다

`Event.repeat` 을 `true` 로 세팅하는 자리가 `src/` 전체에 **없어서** (grep 0 건) press 와 repeat 도 갈리지 않고 있었습니다. 그래서 이 PR 은 release 만이 아니라 **세 갈래를 처음으로 갖춥니다.** `repeat: bool` 을 `action: press/repeat/release` 로 넓혔습니다 (`ghostty.input.KeyAction` 별칭).

## host 쪽에 모드 검사를 두지 않았습니다

ghostty `src/input/key_encode.zig` 를 읽어 확인했습니다 — release 는 인코더가 알아서 거릅니다. kitty flags 가 없으면 legacy 경로가 press · repeat 만 내보내고, flags 가 있어도 `report_events` 가 꺼져 있으면 `kitty()` 앞부분에서 돌아가며, 평문 경로와 무항목 경로도 release 를 명시적으로 배제합니다. 그래서 host 는 넘기기만 합니다.

## release 는 세 host 모두 press 경로를 재사용하지 않습니다

Linux 의 `processKeyEvent`, macOS 의 `keyDown:`, Windows 의 `WM_KEYDOWN` 은 다이얼로그 · 커맨드 메뉴 · compose · 단축키 분류 · IME 가 엮여 있어서, 뗌을 흘리면 **단축키가 두 번 발동**하고 조합 상태가 깨집니다. 뗌에 필요한 것은 인코딩뿐이라 각 host 의 순수 인코딩 함수로 직행합니다.

**press 가 PTY 로 가지 않은 상황에서는 뗌도 보내지 않습니다** — 짝 없는 release 를 앱이 보게 되기 때문입니다. 다이얼로그 · 커맨드 메뉴가 떠 있을 때, IME 조합 중 (macOS `g_marked_len > 0` · Windows `preedit_len > 0`) 이 그 경우입니다.

⚠️ **[#546](https://github.com/ensky0/tildaz/issues/546) 의 disarm 은 그 자리 그대로 뒀습니다.** `handleKeyboardKey` 에서 release 가 조기 반환되던 자리를 열면서도 그 위의 disarm 은 옮기지 않았습니다 — 코드에 인계 주석이 있고, 순서를 바꾸면 `Ctrl+Shift+W` 한 번에 탭 둘이 닫히는 증상이 조용히 되돌아옵니다.

## 세 platform 실기 — release 는 확인됐고, repeat 은 그 뒤에 마저 배선했습니다

| | release `:3` | repeat `:2` | 회귀 |
|---|---|---|---|
| [Linux](https://github.com/ensky0/tildaz/issues/538#issuecomment-5467822169) | ✅ 실측 | ✅ 실측 (49 회) | 4 종 통과 |
| [macOS](https://github.com/ensky0/tildaz/issues/538#issuecomment-5467243560) | ✅ 실측 | ❌ 0 건 → **이 PR 에서 배선** | 3 종 통과 |
| [Windows](https://github.com/ensky0/tildaz/issues/538#issuecomment-5467419276) | ✅ 실측 | ❌ 0 건 → **이 PR 에서 배선** | 3 종 통과 |

세 회차가 같은 결론을 냈습니다 — `.repeat` 을 흘리는 host 가 Linux 뿐이었습니다. 두 번째 커밋이 그것을 마저 합니다.

- **Windows** — `WM_KEYDOWN` · `WM_SYSKEYDOWN` 의 `lParam` 30 번 비트 (직전 키 상태) 가 1 이면 반복입니다.
- **macOS** — `NSEvent.isARepeat` 를 읽습니다.
- 둘 다 **뗌에는 쓰지 않습니다** — `WM_KEYUP` 의 그 비트는 늘 1 이고 `keyUp:` 의 `isARepeat` 은 의미가 없습니다.

**회귀는 세 회차 모두 깨끗했습니다** — `disambiguate` 만 켠 흔한 모드에서 뗌이 0 건 (main 과 바이트 동일), `Ctrl+Shift+W` / `⌘W` 가 탭 하나만 닫음, 한글 IME 조합 정상, key repeat 자체 정상.

## ⚠️ 아직 실기로 못 본 것

**Windows · macOS 의 repeat 배선은 그 회차가 끝난 뒤에 넣었습니다.** 두 기기에서 `:2` 가 실제로 나오는지는 확인되지 않았습니다. 인코더 쪽은 단위 테스트가 `\x1b[13;1:2u` 를 단언하고 Linux 실기가 그 경로를 확인했으므로, 남은 것은 *두 host 가 판정을 제대로 넘기는지* 하나입니다.

## 검증

`zig build test` 407 → 411 전부 통과 · `zig build check` 6 타겟 · `zig build probe-check`. 새 pin ([#550](https://github.com/ensky0/tildaz/issues/550), `b53c383`) 위로 rebase 한 뒤 다시 돌렸습니다 — 이 PR 의 테스트가 인코더 바이트를 정확히 단언하므로 pin 이 인코딩을 바꾸지 않았다는 것도 함께 확인됩니다.

새 테스트는 ① release 가 `report_events` + `report_all` 에서만 나가고 ② `disambiguate` 만 켠 흔한 모드에서는 **바이트가 0 개**이며 (입력이 두 배로 가는 것을 막는 회귀 가드) ③ repeat 이 press 와 갈리고 ④ press 자체는 `report_events` 를 켜도 그대로인지를 봅니다.
