### PR TITLE
build: 안 그리는 이미지 프로토콜을 ghostty-vt 에서 뺀다 — 2.23 MiB (#554)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,27 @@ fn preserveResolvedWindowsAbi(target: std.Build.ResolvedTarget) std.Build.Resolv
     return explicit_target;
 }
 
+/// ghostty-vt 에서 끄는 기능 (#554). 네 곳의 의존성 선언이 **같은 값을 써야** 하므로
+/// 상수 하나로 둔다 — 인라인으로 네 번 적으면 어긋난다 (#534 에서 실제로 겪었다).
+///
+/// **왜 끄나.** 우리는 이미지를 그리지 않는다 (`src/` 에 kitty graphics 를 다루는 코드가
+/// 없다). 그런데 켜 두면 ghostty 의 stream 이 APC 로 온 명령을 파싱해 **이미지 데이터를
+/// 페이지에 저장하고**, `write_pty` 로 **"지원한다" 는 응답까지 보낸다**
+/// (`stream_terminal.zig` 의 `apcEnd`). 앱은 그 응답을 믿고 이미지를 보내는데 화면에는
+/// 아무것도 안 나온다. 끄면 앱이 텍스트 대체 경로로 정상 폴백한다.
+///
+/// **절감** (2026-08-30 · ReleaseFast · simd=true · x86_64-linux):
+/// 17,549,928 → 15,209,024 바이트, **2.23 MiB (13.3 %)**. 그중 89 % 가 kitty-graphics 다
+/// (이미지 저장 구조가 `Screen` · `PageList` · `page` 에 박혀 있다).
+///
+/// **나머지 일곱 기능은 꺼도 0 바이트다.** `snapshot` · `formatter` · `selection` ·
+/// `render_state` · `input_encode` · `color` · `grid_introspection` 은 C API export 에만
+/// 걸리는데, 그 블록이 `lib_vt.zig` 의 `if (@import("root") == lib)` 안이라 Zig 모듈로
+/// 쓰는 우리 바이너리에는 애초에 들어오지 않는다.
+///
+/// 이미지를 그리기로 하면 이 줄을 지우면 된다.
+const vt_features_disabled = "-kitty-graphics,-glyph-protocol";
+
 // 빌드:
 //   zig build                       -- 기본 빌드 (Debug, SIMD 비활성, #200)
 //   zig build -Doptimize=ReleaseFast -Dsimd=true -- 릴리즈 최적화 + SIMD (#19)
@@ -100,6 +121,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .@"emit-lib-vt" = true,
         .@"font-backend" = .freetype,
+        .@"vt-features" = @as([]const u8, vt_features_disabled),
     })) |dep| {
         exe_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
@@ -331,6 +353,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .@"emit-lib-vt" = true,
         .@"font-backend" = .freetype,
+        .@"vt-features" = @as([]const u8, vt_features_disabled),
     })) |dep| {
         test_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
@@ -443,6 +466,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .@"emit-lib-vt" = true,
         .@"font-backend" = .freetype,
+        .@"vt-features" = @as([]const u8, vt_features_disabled),
     })) |dep| {
         stress_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
     }
@@ -581,6 +605,7 @@ pub fn build(b: *std.Build) void {
                 // libxml2 회피 — 위 메인 빌드의 `font-backend` 주석 참고. check 는 linux
                 // 타겟도 도는데, linux 기본 font_backend 는 fontconfig_freetype 이라 더더욱 필요.
                 .@"font-backend" = .freetype,
+                .@"vt-features" = @as([]const u8, vt_features_disabled),
             })) |dep| {
                 check_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
             }


### PR DESCRIPTION
`-Dvt-features=-kitty-graphics,-glyph-protocol` 을 ghostty 의존성 **네 곳** (메인 · test · stress · check) 에 넣습니다. `font-backend` 와 같은 이유로 네 곳 모두입니다.

근거와 실측 상세는 [#554 의 조사 코멘트](https://github.com/ensky0/tildaz/issues/554#issuecomment-5468954886)에 있고, 여기서는 요약합니다.

## 크기만의 문제가 아니었습니다

우리는 이미지를 그리지 않습니다 — `src/` 전체에 kitty graphics 를 다루는 코드가 없습니다. 그런데 켜 두면 [`stream_terminal.zig`](https://github.com/ghostty-org/ghostty/blob/main/src/terminal/stream_terminal.zig) 의 `apcEnd` 가

1. APC 로 온 kitty graphics 명령을 파싱하고,
2. `terminal.kittyGraphics(...)` 로 **이미지 데이터를 페이지에 저장하고**,
3. `write_pty` 로 **"지원한다" 는 응답까지 보냅니다** — `if (self.effects.write_pty == null) break :resp;` 로 막혀 있지만 우리는 `vtWritePty` 를 연결해 두었으므로 이 경로가 살아 있습니다.

즉 앱에게 지원한다고 답한 뒤 아무것도 그리지 않습니다. 앱은 그 말을 믿고 이미지를 보내고 사용자는 빈 화면을 봅니다. 끄면 앱이 텍스트 대체 경로로 정상 폴백합니다.

## 아홉 기능 중 일곱은 꺼도 0 바이트입니다

`snapshot` · `formatter` · `selection` · `render_state` · `input_encode` · `color` · `grid_introspection` 은 **C API export 에만** 걸립니다. 그 블록이 `lib_vt.zig` 의 `if (@import("root") == lib)` 안에 있어서, Zig 모듈로 쓰는 우리 바이너리에는 애초에 들어오지 않습니다.

`terminal/` 안에서 `comptime build_options.<기능>` 으로 실제 코드를 가리는 것은 `kitty_graphics` (145 곳) 와 `glyph_protocol` (14 곳) 둘뿐입니다. 이슈 본문이 후보로 적었던 `snapshot` · `formatter` · `search` 는 그래서 대상이 아닙니다.

## 절감 실측

`ReleaseFast` · `simd=true` · x86_64-linux · main `5775e4f` 기준입니다.

| 설정 | 크기 | 절감 |
|---|---:|---:|
| 기준선 | 17,549,928 | — |
| `-glyph-protocol` 만 | 17,281,824 | 268 KB · 1.5 % |
| `-kitty-graphics` 만 | 15,456,216 | 2.00 MiB · 11.9 % |
| **둘 다** | **15,209,024** | **2.23 MiB · 13.3 %** |

절감의 89 % 가 kitty-graphics 입니다 — 이미지 저장 구조가 `Screen` · `PageList` · `page` 에 박혀 있습니다.

컴파일 시간은 재지 않았습니다 (반복 측정이 필요해 조용한 기기가 있어야 하는데, 크기만으로 판단이 섰습니다).

## 값은 상수 하나로 둡니다

네 곳이 같은 값을 써야 하므로 `vt_features_disabled` 하나를 참조하게 했습니다. 인라인으로 네 번 적으면 어긋납니다 — [#534](https://github.com/ensky0/tildaz/issues/534) 에서 세 renderer 가 코드포인트 범위를 각자 적어 두어 고칠 자리가 넷이 됐던 것과 같은 자리입니다.

이미지를 그리기로 하면 그 한 줄을 지우면 됩니다.

## 릴리즈 노트에는 넣지 않습니다

체감하는 사람이 적습니다. 2.2 MB 는 다운로드에서 느껴지지 않고, 폴백 개선은 이미지 출력 도구를 쓰는 소수만 닿습니다 (그들도 전에는 "이미지가 안 된다" 로 알았을 것입니다). AGENTS.md 의 *"체감하는 사람이 적은 항목은 아예 빼요"* 를 따릅니다.

## 검증

`zig build test` 414 전부 통과 · `zig build check` 6 타겟 · `zig build probe-check` · ReleaseFast 빌드 크기가 측정값과 일치합니다.
