### PR TITLE
fix(wayland): `wl_seat` 을 v10 으로 bind 한다 — fcitx5 가 뜨면 반복 보고가 사라졌다 (#562)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -2041,7 +2041,32 @@ const Client = struct {
         }
         if (self.caps.seat.name != 0) {
             self.seat_id = self.allocId();
-            try self.bind(self.caps.seat.name, "wl_seat", @min(self.caps.seat.version, 7), self.seat_id);
+            // #562 — v10 이 필요하다. `wl_keyboard.key_state.repeated` (값 2) 가 v10 부터라,
+            // 그 아래로 bind 하면 compositor 가 반복을 알려 줄 수 없어 **Linux 의 반복 보고는
+            // 전부 우리 자체 타이머**가 만든다. 그런데 fcitx5 처럼 자동반복을 낱개
+            // press/release 쌍으로 재생하는 IME 가 떠 있으면 그 release 가 매번 타이머를
+            // disarm 해서 (`handleKeyboardKey` 의 disarm) 타이머가 영영 못 뛴다. 한국어
+            // 사용자는 fcitx5 를 상시 띄우므로 실사용에서 만나는 조합이다.
+            //
+            // **이중 반복은 규격이 배제한다.** `wl_keyboard.key` 서술이 *"compositors may
+            // send key events with the repeated key state **when a repeat_info event with a
+            // rate argument of 0 has been received**"* 로, `rate = 0` 을 전제 조건으로
+            // 못박는다. 그래서 두 경우뿐이고 우리는 둘 다 이미 갖고 있다 —
+            // `rate = 0` 이면 `maybeRepeatKey` 의 `if (self.key_repeat_rate_hz <= 0) return`
+            // 이 물러나고, `rate > 0` 이면 compositor 가 `repeated` 를 보낼 수 없어 타이머가
+            // 지금처럼 반복한다.
+            //
+            // **올려도 새로 오는 이벤트는 pointer 둘뿐이다** — v8 `axis_value120` ·
+            // v9 `axis_relative_direction`. 둘 다 `handlePointerEvent` 의 `else => {}` 가
+            // 무시한다. v10 은 새 이벤트가 아니라 기존 `key` 이벤트의 새 `state` 값이다.
+            //
+            // v10 을 내주지 않는 compositor 는 `@min` 이 예전 동작을 그대로 유지한다.
+            const seat_version = @min(self.caps.seat.version, 10);
+            try self.bind(self.caps.seat.name, "wl_seat", seat_version, self.seat_id);
+            // 데스크톱마다 내주는 버전이 갈리므로 판정 근거를 남긴다. `bound=10` 이면
+            // compositor 가 반복을 맡을 수 있고 (그때 `repeat rate=0` 이 뒤따른다),
+            // 그보다 낮으면 우리 타이머가 반복을 만든다.
+            log.appendLineVerbose("wayland", "wl_seat bound version={} (advertised {}) (#562)", .{ seat_version, self.caps.seat.version });
         }
         if (self.caps.data_device_manager.name != 0) {
             self.data_device_manager_id = self.allocId();


### PR DESCRIPTION
`wl_seat` bind 를 v7 → **v10** 으로 올립니다. 한 줄이지만 근거가 길어 요약합니다 — 상세는 [#562](https://github.com/ensky0/tildaz/issues/562) 에 있습니다.

## 무엇이 문제였나

`wl_keyboard.key_state.repeated` (값 2) 가 **v10 부터**인데 우리는 v7 로 cap 하고 있었습니다 (근거 주석 없이). 그래서 compositor 가 반복을 알려 줄 수 없어 **Linux 의 반복 보고는 전부 우리 자체 타이머**가 만들고 있었습니다.

그런데 **fcitx5 는 자동반복을 낱개 press/release 쌍으로 재생합니다.** 그 release 가 매번 `handleKeyboardKey` 의 disarm 을 때려서 타이머가 영영 못 뜁니다. 결과적으로 `report_events` 를 켠 TUI 가 "눌러 둔 키"를 "빠른 연타"로 봅니다. **한국어 사용자는 fcitx5 를 상시 띄우므로 실사용에서 만나는 조합입니다.**

| KWin 6.7.4 · ← 2~3 초 | `:1` | `:2` | `:3` |
|---|---:|---:|---:|
| v7 · fcitx5 없음 | 1 | 48 | 2 |
| v7 · fcitx5 있음 | 62 | **0** | 99 |
| **v10 · fcitx5 있음** | 1 | **36** | — |

## 이중 반복은 규격이 배제합니다 — KWin 의 성질이 아닙니다

`wl_keyboard.key` 의 서술입니다.

> Since version 10, compositors may send key events with the "repeated" key state **when a wl_keyboard.repeat_info event with a rate argument of 0 has been received.**

`rate = 0` 이 `repeated` 를 보낼 수 있는 **전제 조건**입니다. 그래서 경우가 둘뿐이고 우리 코드는 둘 다 이미 갖고 있습니다.

| compositor | 우리 |
|---|---|
| `rate = 0` | `maybeRepeatKey` 의 `if (self.key_repeat_rate_hz <= 0) return` 이 물러남 |
| `rate > 0` | compositor 가 `repeated` 를 **보낼 수 없음** → 타이머가 지금처럼 반복 |

## 올려도 새로 오는 이벤트는 pointer 둘뿐입니다

`wayland.xml` 에서 `since="8"` · `"9"` · `"10"` 을 전수로 뽑았습니다.

| 버전 | 새로 생긴 것 | 우리 |
|---|---|---|
| v8 | `wl_pointer.axis_value120` | `handlePointerEvent` 의 `else => {}` 가 무시 |
| v9 | `wl_pointer.axis_relative_direction` | 같음 |
| v10 | **새 이벤트 없음** — 기존 `key` 이벤트의 새 `state` 값 | `wl_keyboard_key_state_repeated` 로 이미 다룸 |

keyboard · touch 에 새 이벤트는 하나도 생기지 않습니다.

## 여섯 데스크톱 실기 — 위험 조합이 한 곳도 없습니다

| 데스크톱 | advertised | bound | `repeat rate` | 갈래 |
|---|---:|---:|---:|---|
| KDE Plasma (KWin 6.7.4) | 10 | 10 | **0** | compositor 가 반복 → 이득 |
| GNOME Shell 50.4 | 10 | 10 | **0** | compositor 가 반복 → 이득 |
| sway 1.12 | 9 | 9 | 25 | `@min` → 동작 변화 0 |
| Hyprland 0.56.2 | 9 | 9 | 25 | 동일 |
| cosmic-comp 1.0.0 | 9 | 9 | 25 | 동일 |
| Cinnamon 6.6.9 | 5 | 5 | 33 | 동일 |

v10 을 내주는 둘은 규격대로 정확히 `rate = 0` 을 보내고, 나머지 넷은 v10 미만이라 예전 경로 그대로입니다. 즉 **동작이 바뀌는 곳은 KDE 와 GNOME 뿐이고, 둘 다 바뀌는 방향이 의도한 것**입니다.

nested 실행 시 tildaz 는 config · 로그를 격리하고 `XDG_CURRENT_DESKTOP` 을 비워 띄웠습니다 — 그래야 GNOME · Cinnamon 의 dconf 쓰기가 실제 세션으로 새지 않습니다 (AGENTS.md `# 실행 환경`).

**한계**: 각 데스크톱에서 키를 눌러 `:2` 를 세지는 않았고 로그 두 줄로 갈래만 확정했습니다. v10 미만 넷은 경로가 완전히 같아 셀 것이 없고, GNOME 은 두 조각 (`rate<=0` 물러남 · `repeated` → `.repeat`) 이 모두 KDE 에서 실측된 경로라 같게 동작한다고 봅니다 (`추정`).

## 판정 근거를 로그에 남깁니다

데스크톱마다 갈리므로 `wl_seat bound version=N (advertised M)` 을 찍습니다. `keyboard repeat rate=` 와 나란히 읽으면 그 환경이 어느 갈래인지 자명해지고, 새 데스크톱을 만나도 두 줄로 바로 갈립니다.

## 검증

`zig build test` · `zig build check` 6 타겟. 릴리즈 노트 본문 후보는 [#538](https://github.com/ensky0/tildaz/issues/538) 과 같은 이유로 넣지 않습니다 (`report_events` 를 켜는 앱이 드물어 체감하는 사람이 적습니다).
