### PR TITLE
fix(pane): `-size` 인스턴스도 분할되면 pane 격자를 layout 으로 받는다 (#555)

### DIFF
--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -215,14 +215,18 @@ pub const App = struct {
         self.syncPaneGrids();
     }
 
-    /// #483 5단계 — 모든 탭의 pane 격자를 layout 에 맞춘다 (`applyLayouts`, 같은 격자면 건너뜀). `-size` 측정
-    /// 인스턴스는 창 안 단축키가 없어 분할이 없으므로 pane 하나에 요청 격자 그대로 (#382 — 이전의 `resizeAll`).
+    /// #483 5단계 — 모든 탭의 pane 격자를 layout 에 맞춘다 (`applyLayouts`, 같은 격자면 건너뜀).
+    ///
+    /// #555 — 예전에는 `-size` 측정 인스턴스만 `resizeAll` 로 갈랐다 (#382). 근거가 *"측정
+    /// 인스턴스에는 창 안 단축키가 없어 분할이 일어나지 않는다"* 였는데 **그 전제가 거짓이다** —
+    /// 단축키 유무를 정하는 것은 `-size` 가 아니라 그 회차가 뜰 때 config 파일이 있었는지다
+    /// (AGENTS.md `# config_N.toml 이 없는 실행에는 창 안 단축키가 하나도 없어요`). config 가
+    /// 있으면 `-size` 인스턴스도 분할되고, 그때 `resizeAll` 이 모든 pane 에 **창 전체 격자**를
+    /// 줘서 pane 이 분할선을 넘어 그려졌다.
+    ///
+    /// 갈래를 없애도 측정은 그대로다 — pane 하나면 `applyLayouts` 가 `getTerminalGridSize()` 와
+    /// 같은 값을 낸다. `pane_layout.zig` 의 단일 pane 테스트가 그 등식을 단언한다.
     fn syncPaneGrids(self: *App) void {
-        if (self.grid != null) {
-            const grid = self.getTerminalGridSize();
-            self.session.resizeAll(grid.cols, grid.rows);
-            return;
-        }
         self.session.applyLayouts(self.paneArea(), self.paneMetrics());
     }
 

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -3578,9 +3578,20 @@ const Client = struct {
             const tab = session.activeTab() orelse return;
             const before_cols = tab.terminal.cols;
             const before_rows = tab.terminal.rows;
-            if (self.run_opts.grid != null) {
-                // #382 — 측정 격자는 창이 아니라 `-size` 가 정한다. 측정 인스턴스에는 창 안 단축키가
-                // 없어 분할이 일어나지 않으므로 pane 하나에 그 격자를 그대로 준다.
+            // #555 — `-size` 의 격자 고정은 **pane 이 하나일 때만** 뜻이 있다. 예전에는 `-size`
+            // 이기만 하면 `resizeAll` 로 모든 pane 에 창 전체 격자를 줬는데, 근거가 *"측정
+            // 인스턴스에는 창 안 단축키가 없어 분할이 일어나지 않는다"* (#382) 였고 **그 전제가
+            // 거짓이다** — 단축키 유무는 `-size` 가 아니라 그 회차가 뜰 때 config 파일이 있었는지가
+            // 정한다 (AGENTS.md `# config_N.toml 이 없는 실행에는 창 안 단축키가 하나도 없어요`).
+            // 분할된 채 그 갈래를 타면 pane 이 분할선을 넘어 그려진다.
+            //
+            // Windows · macOS 는 창 자체를 요청 격자에 맞추므로 이 갈래가 아예 없다. Linux 만
+            // 위에서 `grid` 를 요청값으로 덮어쓰기 때문에 (측정 중 격자가 흔들리는 것을 막는 #382)
+            // 여기서 조건을 둔다.
+            const has_split = session.totalPaneCount() > session.count();
+            if (self.run_opts.grid != null and !has_split) {
+                // #382 — 격자가 측정 중에 움직이면 producer 가 SIGWINCH 를 더 받아 측정이 오염된다.
+                // pane 이 하나인 동안에는 창이 아니라 `-size` 가 격자를 정한다.
                 if (before_cols != grid.cols or before_rows != grid.rows) session.resizeAll(grid.cols, grid.rows);
             } else {
                 // #483 4b — pane 마다 격자가 다르다. 창 · 탭바 · metrics 로 layout 을 다시 펴서 모든 탭의

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -2425,17 +2425,16 @@ fn syncGeometryAfterScreenChange() void {
 
     // 4. 새 viewport 에 맞춰 cols/rows 재계산. cell 크기 같으면 viewport 만
     //    변경. ghostty Terminal + PTY 도 같은 cols/rows 로 resize.
-    const grid = terminalGrid(vp_w_px, vp_h_px, @floatCast(scale_pt));
     const before_cols = tab.terminal.cols;
     const before_rows = tab.terminal.rows;
-    if (g_run_opts.grid != null) {
-        // #382 — 측정 격자는 창이 아니라 `-size` 가 정한다. 측정 인스턴스에는 창 안 단축키가 없어 분할이
-        // 없으므로 pane 하나에 그 격자를 그대로 준다.
-        if (grid.cols != before_cols or grid.rows != before_rows) g_session.resizeAll(grid.cols, grid.rows);
-    } else {
-        // #483 5단계 — pane 마다 격자가 다르다 (`applyLayouts`, 같은 격자면 건너뜀).
-        g_session.applyLayouts(paneAreaMac(), paneMetricsMac());
-    }
+    // #483 5단계 — pane 마다 격자가 다르다 (`applyLayouts`, 같은 격자면 건너뜀).
+    //
+    // #555 — 예전에는 `-size` 측정 인스턴스만 `resizeAll` 로 갈랐다 (#382). 근거가 *"측정
+    // 인스턴스에는 창 안 단축키가 없어 분할이 일어나지 않는다"* 였는데 그 전제가 거짓이라
+    // (AGENTS.md `# config_N.toml 이 없는 실행에는 …`) 분할된 상태에서 pane 이 분할선을 넘어
+    // 그려졌다. pane 하나면 `applyLayouts` 가 `terminalGrid` 와 같은 값을 내므로 (그 등식은
+    // `pane_layout.zig` 의 단일 pane 테스트가 단언한다) 갈래를 없애도 측정은 그대로다.
+    g_session.applyLayouts(paneAreaMac(), paneMetricsMac());
     if (tab.terminal.cols != before_cols or tab.terminal.rows != before_rows) {
         log.appendLine("geom", "screen changed: vp={d}x{d}px scale={d:.2} cols={d} rows={d}", .{
             vp_w_px, vp_h_px, scale_pt, tab.terminal.cols, tab.terminal.rows,


### PR DESCRIPTION
`-size` 로 띄운 인스턴스에서 pane 을 분할한 뒤 창 크기가 바뀌면, 모든 pane 이 **창 전체 격자**를 받아 왼쪽 pane 이 분할선을 넘어 오른쪽 pane 글자 위에 겹쳤습니다.

## 전제가 거짓이 된 특수 케이스였습니다

세 host 가 같은 갈래를 갖고 있었고 근거도 같았습니다 ([#382](https://github.com/ensky0/tildaz/issues/382)).

> 측정 인스턴스에는 창 안 단축키가 없어 분할이 일어나지 않으므로 pane 하나에 그 격자를 그대로 준다

**그 전제가 거짓입니다.** 단축키 유무를 정하는 것은 `-size` 가 아니라 **그 회차가 뜰 때 config 파일이 있었는지**입니다 (AGENTS.md 의 `# config_N.toml 이 없는 실행에는 창 안 단축키가 하나도 없어요`). config 가 있으면 `-size` 인스턴스도 분할되고, [#550](https://github.com/ensky0/tildaz/issues/550) 의 측정 런북은 단축키를 쓰는 검증을 위해 config 를 먼저 만들라고 지시하므로 그 조건이 실제로 만들어집니다.

## host 마다 처방이 다릅니다

| host | 처방 | 왜 |
|---|---|---|
| **Windows · macOS** | 갈래를 **지웠습니다** | 창 자체를 요청 격자에 맞추므로, pane 하나면 `applyLayouts` 가 `getTerminalGridSize()` / `terminalGrid` 와 **같은 값**을 냅니다 |
| **Linux** | pane 이 **하나일 때만** 고정 | 그쪽만 `grid` 를 요청값으로 덮어씁니다 — 측정 중 격자가 흔들리면 producer 가 SIGWINCH 를 더 받아 측정이 오염되기 때문입니다 (#382 의 `120x40 → 139x41 → 120x40` 왕복) |

Windows · macOS 의 등가성은 추론이 아니라 **`pane_layout.zig` 의 단일 pane 테스트가 이미 단언하는 등식**입니다.

```zig
p[0].cols == ui_metrics.terminalCols(w, pad, scrollbar_w, cell_w)
p[0].rows == ui_metrics.terminalRows(h, tab_bar_h, pad, cell_h)
```

`paneArea()` 가 넘기는 rect 모양도 그 테스트가 쓰는 것과 같습니다. 그래서 지우는 것이 동작을 바꾸지 않습니다.

Linux 는 `totalPaneCount() > count()` 로 갈랐습니다 — 분할되면 pane 이 창을 나눠 갖는 것이 맞습니다.

## 검증

- `zig build check` 6 타겟 · `zig build test` 415 전부 통과.
- **Linux 실기로 1 pane 회귀를 봤습니다** — 제가 건드린 것 중 깨질 수 있는 것이 *"`-size` 인스턴스가 여전히 정확히 요청 격자를 받는가"* 라서, `-size 88x33` 로 띄워 `terminal session created cols=88 rows=33` 을 확인했습니다.
- 분할 상태의 시연은 단축키 주입이 필요해 다음 Linux 회차에 묶습니다. 이 결함을 처음 만난 #550 Windows 회차의 시나리오가 그대로 재현 절차입니다.

## 릴리즈 노트

넣지 않습니다 — `-size` 는 검증용 플래그라 사용자가 겪지 않습니다. 실제 비용은 **우리 검증 도구가 거짓 신호를 낸다**는 쪽이었습니다 (#550 Windows 회차가 이것을 pin 회귀인지 따지느라 시간을 썼습니다).
