### PR TITLE
fix(font): cluster 캐시가 담을 때 자기 몫을 따로 retain 한다 (#578)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -427,12 +427,18 @@ Two consequences worth knowing before touching this code:
   simple policy: if any cluster in the run fails, the whole run falls back to the
   per-cluster path.
 - **Ownership is the trap.** Where the cached value owns a font handle (macOS, Windows),
-  the cache takes ownership and hands callers `owned = false` — otherwise the cell
-  loop's per-frame release kills the cached font. And since `ClusterCache.put` frees
-  values it cannot store (over the 8-codepoint key limit), callers must check
-  *before* handing ownership over. macOS needs that check in the run path too, because
-  it retains per cluster there; Windows does not, because its run results are chain
-  faces it never owned.
+  the cache and the caller each hold their **own** reference: on insert the cache
+  retains its share, and the caller keeps whatever `owned` it already had, releasing
+  it per frame as usual. Handing the caller's reference over instead — the old macOS
+  policy — breaks as soon as the cache empties mid-insert (capacity eviction, or the
+  same key overwritten): the run path collects a whole run before feeding it to the
+  atlas one cluster at a time, so the caller is still using fonts the cache just freed
+  ([#578](https://github.com/ensky0/tildaz/issues/578)). Values read back *out* of the
+  cache stay `owned = false` — those live in the cache while the caller uses them.
+  Clusters over the 8-codepoint key limit are never inserted, since `ClusterCache.put`
+  frees what it cannot store and that value is now the cache's share. Windows sidesteps
+  all of this because its run results are chain faces it never owned; Linux stores
+  indices with no ownership at all.
 
 ### Result
 

--- a/src/font/macos/font.zig
+++ b/src/font/macos/font.zig
@@ -229,9 +229,9 @@ pub const CoreTextFontContext = struct {
     ///
     /// **macOS 값에는 소유권이 있다** (Linux 의 face index 와 다르고 Windows 와 같다).
     /// `resolveGrapheme` 은 CT 가 fallback 으로 고른 폰트를 `CFRetain` 해서 돌려주고
-    /// (`owned = true`) 셀 루프가 매 프레임 `CFRelease` 한다. 캐시에 담은 폰트를 그대로
-    /// `owned = true` 로 주면 그 release 가 캐시 안의 폰트를 죽인다. 그래서 캐시가 소유권을
-    /// 가져가고 caller 에게는 `owned = false` 로 준다.
+    /// (`owned = true`) 셀 루프가 매 프레임 `CFRelease` 한다. **캐시는 담을 때 자기 몫을
+    /// 따로 `CFRetain` 한다** ([#578](https://github.com/ensky0/tildaz/issues/578)) — 참조를
+    /// 호출자에게서 넘겨받으면 캐시가 비워지는 순간 호출자가 아직 쓸 폰트까지 풀려 죽는다.
     ///
     /// negative 도 담는다 — CT 가 못 만든 cluster 를 안 담으면 매 프레임 `CTLine` 을 헛 만든다.
     cluster_cache: cluster_cache.ClusterCache(GlyphResult, releaseCluster),
@@ -768,16 +768,19 @@ pub const CoreTextFontContext = struct {
 
         // #399 (B) — 다음 런이 shape 를 건너뛸 수 있게 담는다.
         //
-        // ⚠️ **Windows 와 다른 자리다.** 거기는 런 결과가 전부 chain face (`owned = false`) 라
-        // 소유권 문제가 없었지만, macOS 는 위에서 cluster 마다 `CFRetain` 했다. 그래서 담을 수
-        // 있는 것만 담고 소유권을 캐시에 넘기며 (`owned = false`), **키 상한을 넘어 못 담는
-        // cluster 는 `owned = true` 그대로 둬서** 호출자가 release 하게 한다. `put` 이 못 담는
-        // 값을 그 자리에서 해제하기 때문에 (`cluster_cache.zig:78`) 이 판정을 건너뛰면 caller 가
-        // 죽은 폰트를 쓴다.
+        // **캐시 몫을 따로 retain 한다** ([#578](https://github.com/ensky0/tildaz/issues/578)).
+        // 예전에는 호출자의 참조를 캐시에 넘기고 (`owned = false`) 그것을 캐시 몫으로 삼았는데,
+        // 그러면 담는 도중 캐시가 비워질 때 (`CAPACITY` 초과 · 같은 키 덮어쓰기) **호출자가
+        // 아직 쓸 폰트가 풀려** 죽는다 — 셀 루프는 런을 통째로 받아 놓고 뒤에서 하나씩 atlas
+        // 에 넣기 때문이다. 각자 자기 몫을 소유하면 담는 순서에 기대지 않아도 된다.
+        //
+        // 키 상한을 넘는 cluster 는 애초에 담지 않는다 — `put` 은 못 담는 값을 그 자리에서
+        // 해제하는데 (`cluster_cache.zig`), 그 값이 이제 *캐시 몫*이라 짝이 맞는다.
         for (0..clusters.len) |i| {
             if (clusters[i].len <= cluster_cache.MAX_KEY_CPS) {
-                self.cluster_cache.put(clusters[i], out[i]);
-                out[i].owned = false;
+                var cached = out[i];
+                for (cached.fonts[0..cached.count]) |f| _ = ct.CFRetain(f);
+                self.cluster_cache.put(clusters[i], cached);
             }
         }
         return count;
@@ -785,16 +788,16 @@ pub const CoreTextFontContext = struct {
 
     /// #399 (B) — 캐시를 씌운 층. shape 자체는 `resolveGraphemeUncached` 가 한다.
     ///
-    /// **소유권이 이 함수의 핵심이다.** 셀 루프는 `result.owned` 면 매 프레임 `CFRelease` 하는데,
-    /// 캐시에 담은 폰트를 `owned = true` 로 돌려주면 그 release 가 캐시 안의 폰트를 죽인다
-    /// (use-after-free). 그래서 **캐시가 소유권을 가져가고 caller 에게는 `owned = false`** 로
-    /// 준다. 해제는 `releaseCluster` 가 퇴출 · 무효화 때 한다.
+    /// **소유권이 이 함수의 핵심이다.** 캐시와 호출자가 **각자 자기 몫을 소유**한다
+    /// ([#578](https://github.com/ensky0/tildaz/issues/578)) — 담을 때 캐시 몫을 따로
+    /// `CFRetain` 하고, 호출자에게는 `owned` 를 그대로 돌려줘서 셀 루프가 매 프레임
+    /// `CFRelease` 하게 둔다. 참조를 넘겨 주던 예전 방식은 캐시가 비워지는 순간 호출자가
+    /// 쓰던 폰트까지 풀어 버렸다 (배칭 경로에서 실제로 죽었다).
     ///
-    /// ⚠️ **담지 못하는 cluster 는 소유권을 넘기면 안 된다.** `ClusterCache.put` 은 키 상한
-    /// (`MAX_KEY_CPS` = 8) 을 넘으면 담지 않고 **그 자리에서 값을 해제**한다 (소유권을 받았다고
-    /// 보기 때문이다). 그때도 `owned = false` 로 바꿔 주면 caller 가 이미 죽은 폰트를 쓴다.
-    /// 그래서 담을 수 있는지 **먼저 판정**하고, 못 담으면 원래 소유권 그대로 돌려준다
-    /// (Windows 에서 실제로 걸린 함정이다, 1c1a5d1).
+    /// 키 상한 (`MAX_KEY_CPS` = 8) 을 넘는 cluster 는 담지 않는다 — `ClusterCache.put` 이
+    /// 못 담는 값을 그 자리에서 해제하는데, 그 값이 캐시 몫이라 짝이 맞는다.
+    ///
+    /// **캐시에서 꺼내 주는 값은 `owned = false`** 다. 그 폰트는 캐시가 소유한 채 살아 있다.
     fn resolveGraphemeInner(self: *CoreTextFontContext, cps: []const u21) ?GlyphResult {
         if (self.cluster_cache.get(cps)) |cached| {
             const c = cached orelse return null; // negative hit — CTLine 을 다시 헛 만들지 않는다
@@ -806,11 +809,15 @@ pub const CoreTextFontContext = struct {
         const result = self.resolveGraphemeUncached(cps);
         if (cps.len == 0 or cps.len > cluster_cache.MAX_KEY_CPS) return result;
 
-        self.cluster_cache.put(cps, result);
-        const r = result orelse return null;
-        var out = r;
-        out.owned = false;
-        return out;
+        if (result) |r| {
+            var cached = r;
+            for (cached.fonts[0..cached.count]) |f| _ = ct.CFRetain(f);
+            self.cluster_cache.put(cps, cached);
+        } else {
+            // negative 도 담는다 — 안 담으면 매 프레임 `CTLine` 을 헛 만든다.
+            self.cluster_cache.put(cps, null);
+        }
+        return result;
     }
 
     fn resolveGraphemeUncached(self: *CoreTextFontContext, cps: []const u21) ?GlyphResult {


### PR DESCRIPTION
## 무엇을 고쳤나

결합 문자 cluster 가 **2048 종을 넘는 화면**에서 앱이 그리다가 `SIGSEGV` 로 죽었다. 원인은 **캐시가 값을 버리는데 호출부가 그 값을 계속 쓰는 것** 이다.

`ClusterCache.put` 은 가득 차면 통째로 비우면서 담긴 값의 폰트를 `CFRelease` 한다. 그런데 배칭 경로는 런의 cluster 를 **차례로** 담으면서 호출자의 참조를 캐시에 넘겼고 (`owned = false`), 셀 루프는 런을 **통째로 받아 놓고 뒤에서 하나씩** atlas 에 넣는다. 그래서 담는 도중 캐시가 비워지면 호출자가 아직 쓸 폰트가 풀려 `rasterizeCluster` 의 `CTFontGetBoundingRectsForGlyphs` 에서 죽는다.

**캐시가 담을 때 자기 몫을 따로 `CFRetain`** 하고 호출자의 `owned` 는 건드리지 않는다. 각자 자기 몫을 소유하므로 담는 순서에 기대지 않는다. 같은 키를 덮어쓰는 경로(한 런에 같은 cluster 가 두 번)도 함께 막힌다.

개별 경로(`resolveGraphemeInner`)도 같은 모양으로 맞췄다 — 지금은 안 터지지만 규칙이 한 가지여야 다음 사람이 헷갈리지 않는다. 캐시에서 **꺼내 주는** 값은 그대로 `owned = false` 다 (그 폰트는 캐시가 소유한 채 살아 있다).

## 영향 범위 — macOS 만

| platform | 값의 소유권 | 판정 |
|---|---|---|
| **macOS** | 배칭이 cluster 마다 `CFRetain` 하고 소유권을 넘겼다 | **영향 있음** |
| Windows | 런 결과가 전부 chain face (`owned = false`) — 캐시가 놓을 것이 없다 | 없음 |
| Linux | `ClusterCache(ClusterGlyph, **null**)` — release 함수를 아예 안 준다 | 없음 |

## 검증

| 무엇 | 결과 |
|---|---|
| cluster **2816 종** 화면 10 회 (`-e`, `-size 88x33`) | **수정 전 0/10 정상 → 수정 후 10/10 정상** |
| cluster 1800 종 화면 | 그대로 정상 (회귀 없음) |
| `zig build test` | 통과 |
| `zig build check` (6 타겟) | 통과 |
| `zig fmt --check` | 통과 |

기기는 MacBook Pro (M5 Pro) · 외장 60 Hz · `vp=1716x1312px scale=2.00 cell=19x39px` 이다.

## 문서

[`ARCHITECTURE.md`](https://github.com/ensky0/tildaz/blob/main/ARCHITECTURE.md) 의 *Ownership is the trap* 절이 옛 규칙(소유권을 넘긴다)을 서술하고 있어 같은 커밋에서 새 규칙으로 갱신했다.

Closes #578