### PR TITLE
fix(render): macOS atlas 의 cluster 를 별도 맵 · u64 키로 옮긴다 (#529)

### DIFF
--- a/src/renderer/glyph_atlas_common.zig
+++ b/src/renderer/glyph_atlas_common.zig
@@ -26,6 +26,26 @@ pub const GlyphKey = struct {
     index: u16,
 };
 
+/// cluster cache key — 글리프 여러 개를 한 비트맵으로 합성하는 cluster 용.
+///
+/// **`GlyphKey` 와 반드시 다른 맵에 산다** ([#529](https://github.com/ensky0/tildaz/issues/529)).
+/// 한 맵을 나눠 쓰면 cluster 해시가 *진짜* glyph index 와 겹쳐 남의 그림이 나온다 — macOS 가
+/// 64비트 해시를 `u16` 으로 잘라 같은 맵에 넣다가 실측으로 걸렸다 (같은 화면 200 회 중 21 회
+/// 겹침, 실기에서 `a̸` 자리에 `U` 가 그려졌다). 그래서 해시를 **자르지 않고** (`u64`) 맵도 따로 둔다.
+///
+/// **폰트를 함께 본다 (#401).** glyph index 는 폰트 안에서만 뜻이 있어서 `Cascadia Code` 의
+/// 3054 번과 `Segoe UI Symbol` 의 3054 번은 전혀 다른 글리프다. 예전에는 인덱스 해시만 키로
+/// 썼는데, cluster 경로에 컬러 emoji 만 들어오던 동안에는 face 가 사실상 하나라 드러나지
+/// 않다가 결합 기호까지 이 경로를 타면서 mono face 여럿이 같은 캐시를 공유하게 됐다.
+///
+/// miss 걱정은 없다 — cluster 캐시가 폰트를 **소유한 채 재사용**하므로 같은 cluster 에 대해
+/// 포인터가 안정적이다 (#578 뒤로도 캐시가 자기 몫을 들고 있다).
+pub const ClusterKey = struct {
+    font_ptr: usize,
+    /// 자르지 않는다 — 자르면 `GlyphKey.index` 대역과 겹칠 여지가 생긴다 (#529).
+    indices_hash: u64,
+};
+
 /// 단순 row-based atlas packing. cursor / row_height 상태를 포인터로 받아
 /// 갱신하고 배치 좌표 (x, y) 를 반환. 현재 row 에 안 들어가면 다음 row 로,
 /// atlas 가 가득 차면 null (caller 가 reset 후 재시도).

--- a/src/renderer/macos/glyph_atlas.zig
+++ b/src/renderer/macos/glyph_atlas.zig
@@ -22,10 +22,16 @@ pub const ATLAS_SIZE: u32 = 2048;
 // #282 G5 — AtlasEntry / GlyphKey / packing 은 Windows atlas 와 공통(라인 동일).
 pub const AtlasEntry = atlas_common.AtlasEntry;
 const GlyphKey = atlas_common.GlyphKey;
+/// #529 — cluster 는 **일반 글리프와 다른 맵**에 산다. 근거는 공용 파일의 정의에 있다.
+const ClusterKey = atlas_common.ClusterKey;
 
 pub const GlyphAtlas = struct {
     alloc: std.mem.Allocator,
+    /// 단일 글리프 + 탭 아이콘. 키가 **진짜 glyph index** 다.
     cache: std.AutoHashMap(GlyphKey, AtlasEntry),
+    /// 여러 글리프를 합성한 cluster (#401). **위 맵과 반드시 갈라 둔다** (#529) —
+    /// 한 맵을 쓰면 cluster 해시가 진짜 glyph index 와 겹쳐 남의 그림이 나온다.
+    cluster_cache: std.AutoHashMap(ClusterKey, AtlasEntry),
 
     // 단순 row-based packing 상태.
     cursor_x: u32 = 0,
@@ -65,6 +71,7 @@ pub const GlyphAtlas = struct {
         return .{
             .alloc = alloc,
             .cache = std.AutoHashMap(GlyphKey, AtlasEntry).init(alloc),
+            .cluster_cache = std.AutoHashMap(ClusterKey, AtlasEntry).init(alloc),
             .font_size = font_size,
             .scale = scale,
             .pixels = pixels,
@@ -76,6 +83,7 @@ pub const GlyphAtlas = struct {
         self.alloc.free(self.temp_buf);
         self.alloc.free(self.pixels);
         self.cache.deinit();
+        self.cluster_cache.deinit();
     }
 
     /// 글리프 lookup or rasterize. 라스터 실패 시 null.
@@ -114,6 +122,10 @@ pub const GlyphAtlas = struct {
         // 키는 글리프 인덱스들의 해시다. 같은 인덱스 조합이면 결과가 같다 (positions 는 그
         // 조합에서 결정되므로 키에 안 넣는다). **폰트도 전부 넣는다** — 같은 인덱스가 폰트마다
         // 다른 글리프를 가리키므로, 갈린 cluster 를 인덱스만으로 구분하면 남의 그림을 준다.
+        //
+        // ⚠️ **해시를 자르지 않고, 일반 글리프와 다른 맵에 넣는다** (#529). 예전에는 `u16` 으로
+        // 잘라 `cache` 에 넣었는데, 그 대역이 *진짜* glyph index 와 같은 자리라 값이 겹치면 먼저
+        // 들어간 쪽의 비트맵이 나왔다 — 실기에서 `a̸` 자리에 `U` 가 그려졌다.
         var h = std.hash.Wyhash.init(0xC1_05_7E_47);
         for (glyphs) |g| h.update(std.mem.asBytes(&g));
         if (fonts.len == glyphs.len) {
@@ -122,11 +134,11 @@ pub const GlyphAtlas = struct {
                 h.update(std.mem.asBytes(&p));
             }
         }
-        const key = GlyphKey{ .font_ptr = @intFromPtr(font), .index = @truncate(h.final()) };
-        if (self.cache.get(key)) |entry| return entry;
+        const key = ClusterKey{ .font_ptr = @intFromPtr(font), .indices_hash = h.final() };
+        if (self.cluster_cache.get(key)) |entry| return entry;
 
         const entry = self.rasterizeCluster(font, glyphs, positions, fonts, cluster_advance_pt) orelse return null;
-        self.cache.put(key, entry) catch return null;
+        self.cluster_cache.put(key, entry) catch return null;
         return entry;
     }
 
@@ -190,6 +202,8 @@ pub const GlyphAtlas = struct {
     /// 아틀라스 reset (cache + packing 상태 + 픽셀 모두 클리어).
     pub fn reset(self: *GlyphAtlas) void {
         self.cache.clearRetainingCapacity();
+        // cluster 맵도 함께 비운다 — 빠뜨리면 폰트 · scale 이 바뀐 뒤 죽은 좌표가 남는다.
+        self.cluster_cache.clearRetainingCapacity();
         self.cursor_x = 0;
         self.cursor_y = 0;
         self.row_height = 0;

--- a/src/renderer/windows/glyph_atlas.zig
+++ b/src/renderer/windows/glyph_atlas.zig
@@ -32,22 +32,9 @@ const MAX_CLUSTER_GLYPHS = dwrite_font.MAX_CLUSTER_GLYPHS;
 pub const AtlasEntry = atlas_common.AtlasEntry;
 const GlyphKey = atlas_common.GlyphKey;
 
-/// Multi-glyph cluster (#139) cache key.
-///
-/// **face 를 함께 본다 (#401).** 예전에는 `indices_hash` 만 썼고, 근거는 *"system
-/// fallback 의 face 는 매번 새 instance 라 key 에 넣으면 항상 miss"* + *"같은 glyph
-/// index 시퀀스면 같은 그림"* 이었다. 앞의 것은 지금도 사실이 아니고 (아래), **뒤의 것이
-/// 틀렸다** — glyph index 는 폰트 안에서만 의미가 있어서 `Cascadia Code` 의 3054 번과
-/// `Segoe UI Symbol` 의 3054 번은 전혀 다른 글리프다. cluster 경로에 컬러 emoji 만 들어오던
-/// 동안에는 face 가 사실상 `Segoe UI Emoji` 하나라 드러나지 않았지만, 결합 기호까지 이
-/// 경로를 타면서 mono face 여럿이 같은 캐시를 공유하게 됐다.
-///
-/// miss 걱정도 없다 — `resolveGrapheme` 의 cluster 캐시가 face 를 **소유한 채 재사용**하므로
-/// (`releaseCluster` 는 퇴출 시에만 부른다) 같은 cluster 에 대해 포인터가 안정적이다.
-const ClusterKey = struct {
-    font_ptr: usize,
-    indices_hash: u64,
-};
+/// Multi-glyph cluster (#139) cache key — 정의와 근거는 `glyph_atlas_common.zig` 에 있다
+/// (#529 에서 macOS 와 공용으로 올렸다).
+const ClusterKey = atlas_common.ClusterKey;
 
 fn hashIndices(indices: []const u16) u64 {
     var h: u64 = 0xcbf29ce484222325; // FNV-1a 64-bit offset basis


### PR DESCRIPTION
## 무엇을 고쳤나

macOS glyph atlas 에서 **cluster 키가 일반 글리프와 같은 맵 · 같은 16비트 자리**를 나눠 썼다.

`getOrInsertCluster` 는 64비트 해시를 `@truncate` 로 `GlyphKey.index` (`u16`) 에 밀어 넣었는데, 그 대역은 `getOrInsert` 가 **진짜 glyph index** 로 쓰는 자리다. 값이 겹치면 먼저 들어간 쪽의 비트맵이 그대로 나온다.

게다가 해시 입력에 `CTFontRef` **포인터 값**이 들어가고 그 주소는 실행마다 달라서, **같은 바이너리 · 같은 글자라도 회차마다 겹침이 갈렸다.**

## 실기에서 잡은 모습

같은 바이너리를 24 회 띄웠더니 한 회차에서 (I) 절이 이렇게 갈렸다.

| 정상 23 회 | 갈린 회차 |
|---|---|
| `a+U+0338 사선   [a̸]\| base [a]\|` | `a+U+0338 사선   [U]\| base [a]\|` |

cluster 자리에 상관없는 글자 `U` 가 또렷하게 그려졌다. 숫자로도 맞췄다 — `U` 의 glyph index 는 **56** 이고, `a̸` (글리프 `[68, 701]`) 의 키는 폰트 포인터가 `0x10000DB80` 같은 값일 때 **정확히 56** 이 된다. 그리는 순서도 맞는다: (I) 절의 줄은 `k+U+0336 긴취소선 …` 처럼 **글자 `U` 가 cluster 보다 앞에** 있어서 `U` 가 atlas 에 먼저 들어간다.

## 어떻게 고쳤나

Windows 가 이미 쓰던 모양으로 맞춘다.

| 자리 | 바뀐 것 |
|---|---|
| `renderer/glyph_atlas_common.zig` | `ClusterKey{font_ptr, indices_hash: u64}` 를 **공용으로** 올렸다. 왜 자르면 안 되는지 · 왜 폰트를 키에 넣는지를 그 자리에 적었다 |
| `renderer/macos/glyph_atlas.zig` | `cluster_cache` 맵을 따로 두고 `getOrInsertCluster` 가 그것을 본다. `@truncate` 를 없앴다. `init` · `deinit` · **`reset`** 이 두 맵을 함께 다룬다 |
| `renderer/windows/glyph_atlas.zig` | 공용 `ClusterKey` alias 한 줄 (동작 변화 없음) |

`reset` 에 cluster 맵을 빠뜨리면 폰트 · scale 이 바뀐 뒤 **죽은 좌표가 남는다.**

**다른 안을 안 고른 이유** — `GlyphKey.index` 만 `u64` 로 넓히면 자르는 문제는 없어지지만 *자리를 나눠 쓰는 것*은 그대로다. 해시에서 폰트 포인터를 빼는 것은 반대로 틀렸다 (같은 인덱스를 쓰는 다른 폰트의 cluster 가 한 키가 된다, #401).

## 영향 범위 — macOS 만

| platform | cluster 키 | 저장 위치 | 판정 |
|---|---|---|---|
| **macOS** | 64비트 해시를 `u16` 으로 **잘라** 넣었다 | 일반 글리프와 **같은 맵** | **영향 있음** |
| Windows | `indices_hash: u64` — 자르지 않는다 | **별도 맵** | 구조적으로 불가능 ([#483 A/B](https://github.com/ensky0/tildaz/issues/483#issuecomment-5427870032) 도 전 회차 `AE 0`) |
| Linux | — | GPU atlas 자체가 없다 | 해당 없음 |

## 검증

기기는 MacBook Pro (M5 Pro) · **내장 120 Hz** (`period=8.333ms`) · `vp=1716x1312px scale=2.00 cell=19x39px` · `-size 88x33` 이다. 재현이 실제로 관측된 조건이 120 Hz 24 회라 **같은 조건으로** 다시 쟀다.

| 무엇 | 결과 |
|---|---|
| `render-test` 24 회 (수정 전) | 24 회 중 **1 회 갈림** |
| `render-test` 24 회 (이 PR) | **전부 바이트 동일** (고유 1 종) |
| `render-test` 24 회 (이 PR + #578 합산, rebase 후) | **전부 바이트 동일** |
| 수정 전 **정상 회차**와 대조 | **AE 0** — 그림은 그대로다 (회귀 없음) |
| `zig build test` · `zig build check` (6 타겟) · `zig fmt --check` | rebase 후 다시 돌려 통과 |

> **주의로 남겨 둔다** — 같은 화면이라도 **내장 120 Hz 캡처와 외장 60 Hz 캡처는 서로 `AE 168466`** 이 나온다. `color-capture` 가 출력 색공간을 sRGB 로 잡아도 디스플레이가 다르면 값이 갈리므로, **A/B 는 반드시 같은 화면에서** 찍어야 한다.

## 이슈는 닫지 않는다

원 관측인 `d̅` **빈 칸**이 이 결함 탓인지는 [조사 댓글](https://github.com/ensky0/tildaz/issues/529#issuecomment-5487963308) 대로 아직 미확정이다 (확률이 300 배 안 맞고, 40 회를 돌려도 빈 칸은 안 나왔다). 이 수정 뒤에도 다시 보이면 원인이 따로 있다는 뜻이므로 #529 는 `long-term watch` 로 **열어 둔다.**

Refs #529