### PR TITLE
fix(session): pane 드레인 라운드를 호출 사이에 잇는다 (#574)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -751,7 +751,7 @@ terminal preedit(조합 중 자모) 활성 중에 어떤 focus_loss (마우스 �
 | 분할선 드래그 | 회색 선 ±4 pt (`PANE_SEPARATOR_HIT_SLOP_PT`) 누름 → 드래그. 드래그 중엔 셀 경계에 스냅된 amber 고스트만 그리고 (`Tree.setSeparatorPx` 를 트리 복사본에 적용해 자리를 얻는다) **놓을 때 한 번만** 트리 갱신 + PTY resize (확정 설계 축 2 — Konsole 방식, SIGWINCH 폭풍 방지). 최소 크기 (20×5 셀) 에 닿으면 **거기서 멈춘다** (clamp, 2026-08-27 결정 — 고스트가 한계에 서고 놓으면 거기까지만; 예전엔 드래그 전체를 거부해 "끌다가 취소됨" 으로 보였다). **선에 붙은 칸만 변한다** — 선 너머가 같은 축으로 또 갈려 있어도 먼 칸은 px 그대로 (`Tree.keepFarFixed` 가 안쪽 같은-축 분할의 비율을 다시 놓는다; 예전엔 비율이 그대로라 안쪽 분할선까지 비례해 밀렸다). 위아래로 쌓인 칸은 둘 다 선의 이웃이라 같이 변한다. 한계도 먼 칸을 고정한 채 잰다 (`Tree.minExtentKeepFar`). 커서는 분할선 위에서 `col_resize` / `row_resize` | `App.sep_drag` · `finishSeparatorDrag`, 커서는 `WM_SETCURSOR` 의 `IDC_SIZEWE` / `IDC_SIZENS` (`CursorRegion.separator_*`) | `g_sep_drag` · `finishSeparatorDrag`, 커서는 `resetCursorRects` 의 `resizeLeftRight/UpDownCursor` | `sep_drag` · `finishSeparatorDrag` | ✅ | ✅ | ✅ |
 | 최소 크기 20 열 × 5 행 | `MIN_PANE_COLS` / `MIN_PANE_ROWS` (열 × 행 — 터미널 `80x24` 표기 순서). **분할은 갈라지는 두 조각을, 가르는 축만** 검사한다 (2026-08-28 결정 — 좌우 분할은 `cols`, 위아래 분할은 `rows`. 반대 축은 이 분할이 건드리지 않는다: 창이 줄어 19 열이 된 pane 을 위아래로 가르는 것이 "20 열 미만" 으로 거부되던 것이 실기에서 걸렸다). 거부는 `TooSmall` → 대화상자 "Each pane needs at least 20 columns × 5 rows". 창이 줄면 (drop-down 은 커서가 있는 모니터 크기를 따르고 pane 은 비율 유지) pane 이 최소 아래로 **갈 수 있다** — 막지 않는다 (tmux 도 같다). 그 뒤 크기 조절 · 드래그는 그 pane 을 **더 줄이지만 않고** (한계 = 지금 크기, `minExtentKeepFar`), 뒤 검사는 "새로 최소 아래로 떨어지는 pane 이 없다" (`noPaneNewlyBelowMin`) 다. 2026-08-27 macOS 실기: 큰 모니터에서 가른 뒤 작은 모니터로 돌아오니 B · C 가 17 열이 됐고, 예전의 탭 전체 검사 (`allPanesAtLeastMin`, 삭제) 가 A 의 위아래 분할과 B 키우기까지 막았다 | 공통 `pane_layout` | 동일 | 동일 | ✅ | ✅ | ✅ |
 | 마우스 경로 | `…` 메뉴 *Split Right* / *Split Down* (`command_menu.Command.split_right/horizontal`, 순수 모듈이라 세 host 에 같이 뜬다 — 실행은 배선된 host 만) · `+` **Alt+클릭** = 활성 pane 분할 (Windows Terminal 선례; 방향은 pane 이 넓으면 오른쪽, 높으면 아래 — WT `auto`) | `executeCommandMenu` · `handlePlusClick` (Alt+클릭, `Window.isAltDown`) | `executeCommandMenu` · `handlePlusClick` (Option+클릭) | `executeCommandMenu` · `handlePlusClick` | ✅ | ✅ | ✅ |
-| 출력 드레인 | 예산 4 ms 하나를 보이는 pane 이 나눠 씀 — 활성 pane 먼저, pane 사이에도 예산 검사 (§13.3.1, 세 platform 실측 표). **코드는 공통이지만 실측은 갈린다** — Linux 만 16 pane 에서 상한이 깨지고, 공정성은 pane 2 개부터 host 마다 크게 다르다 (§13.3.1) | 공통 `SessionCore.drainFrame` | 동일 | 동일 | ✅ | ✅ | ✅ |
+| 출력 드레인 | 예산 4 ms 하나를 활성 `TabGroup`의 pane 이 나눠 쓴다. 호출 경계를 넘는 **논리 라운드**마다 active pane 을 먼저, 나머지 존재 pane 을 안정된 `PaneId` 순서로 각각 한 번, 마지막에 숨은 탭 한 슬롯을 처리한다 (§13.3.1). 예산이 끝나면 다음 호출이 중단 지점부터 이어서, 매 호출 처음 pane 으로 돌아가던 starvation 을 막는다 ([#574](https://github.com/ensky0/tildaz/issues/574)) | 공통 `SessionCore.drainFrame` | 동일 | 동일 | ✅ | ✅ | ✅ |
 | 비활성 pane 스크롤바 | 클릭 = 그 pane 포커스 뒤 그 pane 의 scrollbar 로 (좌클릭 경로가 포커스를 먼저 옮긴다) | 동일 | 동일 | 동일 | ✅ | ✅ | ✅ |
 
 ---
@@ -1786,14 +1786,26 @@ AC · CPU `performance` · 64 MiB · 120x40 · scrollback 32,767 · `ReleaseFast
 상한에 붙어 처리량이 반토막난다 (Windows ② 60 Hz 실측: 29.3~30.2 → 15.1~15.2 MiB/s, ×0.50). 즉 예산은
 사양 A 아래에서 **응답성 손잡이**, 사양 A 없이는 **처리량 손잡이**다.
 
-### 13.3.1 pane 수 축 — 예산은 하나, 보이는 pane 이 나눠 쓴다 ([#483](https://github.com/ensky0/tildaz/issues/483) 6단계, 2026-08-27 · 세 platform 재측정 [#551](https://github.com/ensky0/tildaz/issues/551), 2026-08-31)
+### 13.3.1 pane 수 축 — 예산은 하나, 논리 라운드는 호출을 넘어 이어진다 ([#483](https://github.com/ensky0/tildaz/issues/483) 6단계, 2026-08-27 · 세 platform 재측정 [#551](https://github.com/ensky0/tildaz/issues/551), 2026-08-31 · 공정성 수정 [#574](https://github.com/ensky0/tildaz/issues/574), 2026-09-01)
 
-화면 분할로 "활성/비활성" 2 분법이 "보임/안 보임" 이 됐다. `drainFrame` 은 **활성 pane 을 먼저**, 그다음 보이는
-pane 을 화면 순서로 한 청크씩 돌리고, **pane 사이에서도 예산을 검사**한다 — 검사 없이 N 청크를 돌면 최악 점유가
-`예산 + N 청크` 로 pane 수에 비례해 커진다. 예산 자체는 **4 ms 하나**다 — 보이는 pane 이 몇이든 UI 스레드가 한
-번에 붙잡히는 상한은 같고, pane 들은 청크를 번갈아 받아 같은 프레임에 함께 나아간다. "pane 마다 1 ms" 나
-"pane 수 × 4 ms" 는 택하지 않았다 — 전자는 처리량을 pane 수로 나누고 (사양 A 가 있어 어차피 프레임 사이에 더
-드레인한다), 후자는 최악 입력 지연을 pane 수에 비례해 늘린다.
+화면 분할 뒤 `drainFrame` 은 현재 활성 `TabGroup`의 pane 과 숨은 탭을 다음 **논리 라운드**로 스케줄한다.
+
+1. 라운드 시작 시 존재하는 pane 을 `PaneId` 집합으로 고정한다.
+2. 그때의 active pane 을 첫 토큰으로 처리한다.
+3. 나머지 존재 pane 을 안정된 `PaneId` 순서로 각각 한 번 처리한다. 이 순서는 분할 트리의 화면 배치 순서라는
+   뜻이 아니다.
+4. 활성 그룹을 모두 처리한 뒤 기존 hidden round-robin 한 슬롯을 처리한다.
+5. 공통 **4 ms** 예산이 끝나면 아직 처리하지 않은 `PaneId`와 hidden 차례를 보존해 다음 호출에서 이어 간다.
+
+따라서 active-first는 **매 호출**이 아니라 **매 논리 라운드**의 시작 우선권이다. 구성과 포커스가 안정되고 출력이
+계속 밀린 동안 각 활성 그룹 pane 의 처리 청크 수 차이는 최대 하나다. 포커스가 바뀌면 새 active를 다음 차례로
+당긴다. 이미 이번 라운드에서 처리한 pane 은 입력 반응을 위해 한 번 더 처리할 수 있지만, 다른 pane 의 남은 차례는
+지우지 않는다. split · close · active tab 변경처럼 구성 자체가 바뀌면 새 집합으로 라운드를 다시 시작한다. zoom은
+렌더 표시만 바꾸므로 라운드를 버리지 않고, 그 뒤에 가려진 같은 그룹 pane 도 기존과 같이 계속 드레인한다.
+
+예산 자체는 **pane마다가 아니라 4 ms 하나**다. "pane마다 1 ms"는 처리량을 pane 수로 나누고, "pane 수 × 4 ms"는
+최악 입력 지연을 pane 수에 비례해 늘리므로 채택하지 않는다. 예산 검사는 청크 사이에서만 가능해 마지막 청크 하나가
+4 ms를 넘길 수 있다. 이 비선점 청크 초과는 라운드 공정성과 별개이며 #574가 해결하는 범위가 아니다.
 
 **실측 — 세 platform** (`zig build stress -- throughput --layer frame --panes N --cols 120 --rows 40`,
 `plain` · pane 마다 producer 하나 · **64 MiB/pane** · 합계 격자를 **120×40 으로 고정** · 조건별 5 회 절사평균).
@@ -1806,7 +1818,7 @@ pane 을 화면 순서로 한 청크씩 돌리고, **pane 사이에서도 예산
 | **Windows** · Lenovo 83JY · Ryzen AI 7 350 · 120 Hz | 4.16 → **4.55** ms | 161 → 79 MiB/s |
 | **Linux** · Ryzen AI 7 350 · 120 Hz | 4.32 → **7.93** ms | 101 → 46 MiB/s |
 
-producer 종료 퍼짐 (pane 간 공정성) 을 모사 프레임으로 환산한 값 — 120 fps 기준:
+**수정 전** producer 종료 퍼짐을 모사 프레임으로 환산한 값 — 120 fps 기준:
 
 | pane | macOS | Windows | Linux |
 |---:|---:|---:|---:|
@@ -1822,7 +1834,7 @@ producer 종료 퍼짐 (pane 간 공정성) 을 모사 프레임으로 환산한
   초과 폭이 0.6 ms 안 (청크 하나) 에 머문다.
 - **Linux 만 16 pane 에서 상한이 깨진다** (6.98~11.27 ms). 원인 코드는 공통 `drainFrame` 이지만
   **발현은 host 에서 갈린다** — macOS · Windows 는 같은 조건에서 묶였다. Linux host 의 드레인 구조로 따로 추적한다.
-- **공정성은 pane 2 개부터 나빠지고 host 마다 크게 다르다.** `drainFrame` 이 매 호출 `group.panes` 를
+- **수정 전 공정성은 pane 2 개부터 나빠지고 host 마다 크게 달랐다.** `drainFrame` 이 매 호출 `group.panes` 를
   **처음부터** 도는데 (숨은 탭에는 `inactive_drain_cursor` 가 있지만 **보이는 pane 에는 커서가 없다**)
   예산이 한 바퀴를 못 채우면 뒤 pane 이 다음 프레임에도 계속 뒤로 밀린다. 한 프레임에 한 바퀴를 도는
   host 에서는 드러나지 않아, 같은 코드가 macOS 0.9 프레임 · Linux 125 프레임으로 갈린다 (8 pane).
@@ -1834,6 +1846,31 @@ producer 종료 퍼짐 (pane 간 공정성) 을 모사 프레임으로 환산한
 
 합계 처리량은 격자를 고정했는데도 pane 수가 늘면 내려간다 (pane 하나의 몫이 아니라 합계다) — 격자 변화가 아니라
 producer · PTY · ring 경쟁 때문이다. `frame` 층은 프레임마다 한 번만 드레인해 (사양 A 없음) 앱의 하한이다.
+
+위 종료 퍼짐은 #574 수정 전 원인을 찾은 역사적 자료다. 당시 producer는 동시에 시작하지 않았고, 종료 시점도
+각 pane의 VT parser가 마지막 바이트를 반영한 시점이 아니라 자식 process 종료 callback이었다. 따라서 수치 자체를
+화면 완료 지연으로 해석하지 않는다. #574부터 `frame --panes N`은 모든 producer가 준비 barrier에 모인 뒤 함께
+시작하고, pane별 마지막 OSC title marker가 실제 `Terminal`에 반영된 시점을 `PaneId`별로 기록한다. 리포트는
+pane별 drain 청크·바이트, 최장 service gap, 청크 수 skew, marker 완료 퍼짐을 함께 내며 process 종료는 보조 진단으로만
+남긴다.
+
+**#574 보강 하네스의 Linux 수정 전/후 실측** — AMD Ryzen AI 7 350, ReleaseFast + SIMD, `plain`, 120 fps,
+120×40, pane마다 64 MiB, 조건별 5회 절사평균 ([전체 결과와 quantum 실험](https://github.com/ensky0/tildaz/issues/574#issuecomment-5488591291)):
+
+| pane | 마지막 VT marker 퍼짐: 수정 전 → 후 | 최대 chunk skew: 수정 전 → 후 | 합계 처리량: 수정 전 → 후 |
+|---:|---:|---:|---:|
+| 2 | 61.3 → **0.0 ms** | 103.7 → **1** | 68.4 → 68.1 MiB/s (−0.5%) |
+| 4 | 397.3 → **1.6 ms** | 346.7 → **1** | 56.1 → 56.3 MiB/s (+0.2%) |
+| 8 | 1,409.8 → **3.3 ms** | 991.3 → **1** | 53.0 → 48.1 MiB/s (−9.2%) |
+| 16 | 16,507.6 → **2.0 ms** | 1,037 → **1** | 41.3 → 33.8 MiB/s (−18.1%) |
+
+2·4 pane 은 처리량 변화 없이 공정성 오류가 사라졌다. 8·16 pane 이 **모두 계속 대용량 출력하는** 조건에서는
+동시에 활동하는 producer · PTY · read thread 경쟁이 끝까지 유지돼 합계 처리량이 낮아진 것으로 *추정*한다
+(hardware counter 미확인). pane 이 16개여도 backlog pane 이 하나면 나머지는 빈 ring 확인만 하므로 이 비용은
+거의 없다. pane당 연속 quantum 을 2·4청크로 늘려도 16 pane 처리량은 각각 33.6 MiB/s로 회복되지 않고 skew만
+2·4로 늘었다. 따라서 가장 단순하고 강한 strict round-robin (quantum 1)을 사양으로 유지한다. 이 새 전후 실측은
+Linux에서만 했으며, 공통 코드의 Windows · macOS compile check는 통과했지만 두 platform의 새 처리량은 아직 실기
+측정하지 않았다.
 
 ### 13.4 렌더 게이트는 "화면이 바뀌었나" 하나다 ([#388](https://github.com/ensky0/tildaz/issues/388))
 

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -102,6 +102,7 @@ dist/stress/measure-repeat.sh --phase after --workloads zwj,plain
 | `--cols` / `--rows` | 그리드 | `120` × `40` |
 | `--scrollback` | scrollback 줄 수 | config 기본값 (100,000) |
 | `--fps` | `frame` 층이 모사할 프레임 주기 | `60` |
+| `--panes` | `frame` 층의 활성 `TabGroup`에 만들 producer/pane 수 (`1`–`16`) | `1` |
 | `--segments` | `scrollback` 이 나눠 볼 구간 수 | `8` |
 
 ### 층
@@ -117,6 +118,12 @@ dist/stress/measure-repeat.sh --phase after --workloads zwj,plain
 
 `frame` 층은 `drainOutputForRender` 를 `--fps` 주기로 **한 번씩** 부르고, 그 안의 `drainFrame`
 이 `SessionCore.DRAIN_FRAME_BUDGET_NS` (현재 **4 ms**) 만 파싱해요.
+
+`--panes N`이면 N producer가 각 준비 파일을 만든 뒤 하나의 start barrier에서 함께 풀려요. 각 producer는
+payload 끝에 pane별 OSC title marker를 쓰고, 하네스가 그 marker를 해당 `PaneId`의 `Terminal`에서 확인할 때까지
+process를 살려 둬요. 그래서 리포트의 `parsed done`은 process 종료나 PTY read 완료가 아니라 **마지막 marker를 VT
+parser가 실제 반영한 시점**이에요. 함께 나오는 pane별 drain 청크·바이트, 최장 service gap, 청크 수 skew와 완료
+퍼짐으로 스케줄러 공정성을 봐요. process 종료 시점은 marker 확인 뒤의 보조 진단일 뿐이에요 ([#574](https://github.com/ensky0/tildaz/issues/574)).
 
 ⚠️ **이 층은 더 이상 앱과 같지 않아요.** 사양 A ([#387](https://github.com/ensky0/tildaz/issues/387),
 SPEC §13) 이후 세 host 는 **프레임 사이에도** 드레인해서 실제 앱의 duty 가 훨씬 높아요 — Windows ②
@@ -355,7 +362,9 @@ perf 스냅숏에 답이 있어요 (측정 인스턴스는 종료할 때 자동�
 
 현재는 [#572](https://github.com/ensky0/tildaz/issues/572) / [PR #575](https://github.com/ensky0/tildaz/pull/575)에서
 `closePane`도 제거 전에 남은 출력을 끝까지 드레인하도록 고쳤어요. 실제 앱의 Windows pane 4 · 8을
-각 5회 다시 측정해 모두 `push − drain = 0`을 확인했으므로, 다중 pane producer 종료도 그대로 써도 돼요.
+각 5회 다시 측정해 모두 `push − drain = 0`을 확인했어요. 다만 scheduler 공정성 측정은 종료 callback을 완료
+시점으로 쓰지 않아요. `frame --panes N` producer는 마지막 OSC marker가 모든 pane에서 파싱될 때까지 살아 있고,
+그 marker의 `PaneId`별 반영 시점을 비교해 close-time drain이 측정 꼬리를 가리는 일을 막아요 (#574).
 
 | 지표 | 정상 (4 회차) | **오염 (5 회차)** |
 |---|---|---|

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -260,6 +260,10 @@ pub const Tab = struct {
     /// — 이전 공유 state 가 탭 전환마다 전체 재구축하던 것과 같은 비용이다.
     render_state: ghostty.RenderState = .empty,
     output_ring: RingBuffer = .{},
+    /// stress 하네스가 pane별 공정성을 직접 재는 누적값. `drainOutputChunk`를 호출하는
+    /// UI thread 하나만 쓰고 하네스가 같은 thread에서 읽으므로 atomic이 필요 없다.
+    stress_drain_chunks: u64 = 0,
+    stress_drain_bytes: u64 = 0,
     /// #451 — `Io` 를 담아야 해서 기본값이 없다. `Tab.init` 이 `rt.io` 로 채운다.
     write_queue: WriteQueue,
     write_thread: ?std.Thread = null,
@@ -378,7 +382,7 @@ pub const Tab = struct {
         if (!instance_context.isStress()) return;
         // drainOutputChunk 는 ring 이 비면 false 라 그 자체가 종료 조건이다. producer
         // PTY exit 통보 뒤에는 EOF 에 도달했으므로 새 payload 는 더 오지 않는다.
-        while (tab.drainOutputChunk()) {}
+        while (tab.drainOutputChunk() > 0) {}
     }
 
     /// #483 — 이 탭이 화면에서 사라졌다. 스냅숏 메모리를 돌려주고 `.empty` 로 되돌린다.
@@ -463,11 +467,11 @@ pub const Tab = struct {
 
     /// 한 번에 최대 64KiB만 파싱한다. frame 전체 예산과 탭 간 순서는
     /// SessionCore가 관리하고, 이 함수는 한 탭의 원자적인 drain 단위만 담당한다.
-    fn drainOutputChunk(tab: *Tab) bool {
+    fn drainOutputChunk(tab: *Tab) usize {
         const drain_t0 = perf.now();
         var buf: [65536]u8 = undefined;
         const n = tab.output_ring.pop(&buf);
-        if (n == 0) return false;
+        if (n == 0) return 0;
 
         const parse_t0 = perf.now();
         tab.stream.nextSlice(buf[0..n]);
@@ -477,7 +481,12 @@ pub const Tab = struct {
         if (comptime builtin.os.tag == .windows) tab.syncTerminalTitle();
         perf.addTimed(&perf.parse, parse_t0);
         perf.addTimedBytes(&perf.drain, drain_t0, @intCast(n));
-        return true;
+        // 평소 앱의 hot path에는 측정용 누적 연산도 넣지 않는다.
+        if (instance_context.isStress()) {
+            tab.stress_drain_chunks += 1;
+            tab.stress_drain_bytes += n;
+        }
+        return n;
     }
 
     fn writeLoop(tab: *Tab) void {
@@ -582,7 +591,7 @@ pub const Tab = struct {
     /// 를 지키는 경로다. 단 **프레임당 1 회로 부르면 앱과 다르다** — 사양 A (#387) 이후
     /// host 는 프레임 사이에도 부른다 (SPEC §13.1).
     pub fn drainChunkForStress(tab: *Tab) bool {
-        return tab.drainOutputChunk();
+        return tab.drainOutputChunk() > 0;
     }
 };
 
@@ -778,6 +787,107 @@ fn flushAutomaticTitle(
 /// 안내 (cross-platform 동등).
 pub const MAX_TABS: usize = 32;
 
+const VisiblePaneMask = u16;
+
+comptime {
+    if (pane_layout.MAX_PANES_PER_TAB > @bitSizeOf(VisiblePaneMask))
+        @compileError("VisiblePaneMask cannot represent every pane slot");
+}
+
+const VisibleDrainStep = union(enum) {
+    pane: pane_layout.PaneId,
+    hidden,
+};
+
+/// [#574](https://github.com/ensky0/tildaz/issues/574) — 활성 `TabGroup`의 pane을 한 번씩
+/// 처리하는 논리 라운드. 4 ms `drainFrame` 호출이 라운드 중간에서 끝나도 `pending`과 다음
+/// 위치를 보존하므로 다음 호출이 활성 pane부터 다시 시작하지 않는다.
+const VisibleDrainRound = struct {
+    const Phase = enum { visible, hidden };
+
+    members: VisiblePaneMask = 0,
+    pending: VisiblePaneMask = 0,
+    next_index: usize = 0,
+    phase: Phase = .visible,
+    round_did_work: bool = false,
+    /// 포커스만 바뀌었고 새 활성 pane이 이번 라운드 몫을 이미 썼을 때의 1회 우선권.
+    /// `pending`은 그대로 두므로 사용자 동작이 남은 pane의 라운드를 폐기하지 않는다.
+    focus_priority: ?pane_layout.PaneId = null,
+
+    fn paneBit(id: pane_layout.PaneId) VisiblePaneMask {
+        std.debug.assert(id < pane_layout.MAX_PANES_PER_TAB);
+        return @as(VisiblePaneMask, 1) << @intCast(id);
+    }
+
+    fn reset(round: *VisibleDrainRound, members: VisiblePaneMask, active: pane_layout.PaneId) void {
+        round.* = .{
+            .members = members,
+            .pending = members,
+            .next_index = @intCast(active),
+        };
+    }
+
+    fn ensure(round: *VisibleDrainRound, members: VisiblePaneMask, active: pane_layout.PaneId) void {
+        if (round.members != members) round.reset(members, active);
+    }
+
+    /// 새 활성 pane을 남은 라운드 안에서 먼저 처리한다. 아직 `pending`이면 순서만 당기고,
+    /// 이미 처리했으면 정확히 한 번의 우선권만 더한다.
+    fn prioritize(round: *VisibleDrainRound, members: VisiblePaneMask, active: pane_layout.PaneId) void {
+        round.ensure(members, active);
+        if (round.pending & paneBit(active) != 0) {
+            round.next_index = @intCast(active);
+            round.focus_priority = null;
+        } else {
+            round.focus_priority = active;
+        }
+    }
+
+    fn next(round: *VisibleDrainRound, members: VisiblePaneMask, active: pane_layout.PaneId) VisibleDrainStep {
+        round.ensure(members, active);
+
+        if (round.focus_priority) |id| {
+            round.focus_priority = null;
+            if (members & paneBit(id) != 0) return .{ .pane = id };
+        }
+
+        if (round.phase == .visible) {
+            var scanned: usize = 0;
+            while (scanned < pane_layout.MAX_PANES_PER_TAB) : (scanned += 1) {
+                const i = (round.next_index + scanned) % pane_layout.MAX_PANES_PER_TAB;
+                const id: pane_layout.PaneId = @intCast(i);
+                const bit = paneBit(id);
+                if (round.pending & bit == 0) continue;
+                round.pending &= ~bit;
+                round.next_index = (i + 1) % pane_layout.MAX_PANES_PER_TAB;
+                return .{ .pane = id };
+            }
+            round.phase = .hidden;
+        }
+        return .hidden;
+    }
+
+    /// hidden 단계가 끝나면 라운드를 마치고 그 라운드에 실제 출력이 있었는지를 돌려준다.
+    /// pane 단계면 아직 라운드 중이므로 null.
+    fn complete(
+        round: *VisibleDrainRound,
+        step: VisibleDrainStep,
+        did_work: bool,
+        members: VisiblePaneMask,
+        active: pane_layout.PaneId,
+    ) ?bool {
+        round.round_did_work = round.round_did_work or did_work;
+        return switch (step) {
+            .pane => null,
+            .hidden => finished: {
+                const result = round.round_did_work;
+                round.reset(members, active);
+                break :finished result;
+            },
+        };
+    }
+};
+
 /// [#483](https://github.com/ensky0/tildaz/issues/483) 3단계 — 탭바의 탭 하나 = 화면 하나.
 /// pane (`Tab`, 터미널 하나) 들을 분할 트리 (`pane_layout.Tree`) 로 배치한다. 지금은 항상
 /// leaf 하나다 — 4단계가 `split` 을 부르기 전까지 host 가 보는 동작은 이전의 "탭 = 터미널
@@ -795,6 +905,8 @@ pub const TabGroup = struct {
     /// 않는다 (셸은 계속 돈다). 그 pane 이 닫히거나 pane 이 하나가 되면 풀린다 (`closePane`). 분할 ·
     /// 포커스 이동 · 크기 조절 · 균등은 먼저 푼다 (`unzoom`) — tmux 의 zoom 과 같은 규칙.
     zoomed: ?pane_layout.PaneId = null,
+    /// #574 — 4 ms 호출 경계 밖까지 이어지는 활성 그룹 pane 드레인 라운드.
+    visible_drain_round: VisibleDrainRound = .{},
 
     fn initSingle(alloc: std.mem.Allocator, tab: *Tab) !*TabGroup {
         const group = try alloc.create(TabGroup);
@@ -815,6 +927,22 @@ pub const TabGroup = struct {
 
     pub fn paneCount(group: *const TabGroup) usize {
         return group.tree.count();
+    }
+
+    fn drainMembers(group: *const TabGroup) VisiblePaneMask {
+        var members: VisiblePaneMask = 0;
+        for (group.panes, 0..) |pane, i| {
+            if (pane != null) members |= VisibleDrainRound.paneBit(@intCast(i));
+        }
+        return members;
+    }
+
+    fn resetVisibleDrainRound(group: *TabGroup) void {
+        group.visible_drain_round.reset(group.drainMembers(), group.active_pane);
+    }
+
+    fn prioritizeActiveDrain(group: *TabGroup) void {
+        group.visible_drain_round.prioritize(group.drainMembers(), group.active_pane);
     }
 
     /// 이 그룹의 pane 배치 — 최대화 중이면 그 pane 하나가 `rect` 전체 (`pane_layout.leafRect`), 아니면
@@ -869,6 +997,7 @@ pub const TabGroup = struct {
         if (group.active_pane == id) group.active_pane = next;
         // 최대화된 pane 이 닫혔거나 pane 이 하나만 남으면 최대화는 뜻이 없다.
         if (group.zoomed == id or group.paneCount() < 2) group.zoomed = null;
+        group.resetVisibleDrainRound();
         return true;
     }
 };
@@ -1047,7 +1176,7 @@ pub const SessionCore = struct {
         errdefer self.allocator.destroy(group);
         try self.tabs.append(self.allocator, group);
         self.active_tab = self.tabs.items.len - 1;
-        self.releaseHiddenRenderStates();
+        self.finishActiveGroupChange();
     }
 
     /// 터미널 하나 (pane) 를 만들어 셸을 띄운다 — 탭 (`createTab`) 과 분할 (`splitActive`) 의
@@ -1094,7 +1223,7 @@ pub const SessionCore = struct {
 
         if (next_active) |active| {
             self.active_tab = active;
-            self.releaseHiddenRenderStates();
+            self.finishActiveGroupChange();
             return .changed;
         }
         self.active_tab = 0;
@@ -1139,6 +1268,7 @@ pub const SessionCore = struct {
         const tab = try self.spawnTab(pr.cols, pr.rows);
         group.panes[new_id] = tab;
         group.active_pane = new_id;
+        group.resetVisibleDrainRound();
         self.applyGroupLayout(group, lay);
     }
 
@@ -1168,6 +1298,7 @@ pub const SessionCore = struct {
         const lay = group.layout(rect, m, &buf);
         const anchor = cursorAnchor(group, lay, dir, m);
         group.active_pane = pane_layout.neighbor(lay, group.active_pane, dir, anchor) orelse return was_zoomed;
+        group.prioritizeActiveDrain();
         return true;
     }
 
@@ -1246,6 +1377,7 @@ pub const SessionCore = struct {
         const group = self.activeGroup() orelse return false;
         if (id >= group.panes.len or group.panes[id] == null or group.active_pane == id) return false;
         group.active_pane = id;
+        group.prioritizeActiveDrain();
         return true;
     }
 
@@ -1312,7 +1444,7 @@ pub const SessionCore = struct {
     pub fn setActiveTab(self: *SessionCore, index: usize) bool {
         if (index >= self.tabs.items.len or index == self.active_tab) return false;
         self.active_tab = index;
-        self.releaseHiddenRenderStates();
+        self.finishActiveGroupChange();
         return true;
     }
 
@@ -1321,7 +1453,7 @@ pub const SessionCore = struct {
     pub fn activateNext(self: *SessionCore) bool {
         if (self.tabs.items.len <= 1) return false;
         self.active_tab = (self.active_tab + 1) % self.tabs.items.len;
-        self.releaseHiddenRenderStates();
+        self.finishActiveGroupChange();
         return true;
     }
 
@@ -1329,8 +1461,15 @@ pub const SessionCore = struct {
     pub fn activatePrev(self: *SessionCore) bool {
         if (self.tabs.items.len <= 1) return false;
         self.active_tab = if (self.active_tab == 0) self.tabs.items.len - 1 else self.active_tab - 1;
-        self.releaseHiddenRenderStates();
+        self.finishActiveGroupChange();
         return true;
+    }
+
+    /// 활성 그룹이 바뀐 뒤 새 그룹은 활성 pane에서 논리 라운드를 시작하고, 다른 그룹의
+    /// 렌더 스냅숏은 비운다. 활성 탭을 바꾸는 모든 진입점이 이 한 함수를 쓴다.
+    fn finishActiveGroupChange(self: *SessionCore) void {
+        if (self.activeGroup()) |group| group.resetVisibleDrainRound();
+        self.releaseHiddenRenderStates();
     }
 
     /// #483 2단계 ① · 3단계 — 활성 그룹에 없는 (보이지 않는) pane 의 렌더 스냅숏을 비운다
@@ -1572,48 +1711,45 @@ pub const SessionCore = struct {
                 if (!in_range) continue;
                 if (e.tab.output_ring.isEmpty()) continue;
                 self.inactive_drain_cursor = (e.flat + 1) % total;
-                return e.tab.drainOutputChunk();
+                return e.tab.drainOutputChunk() > 0;
             }
         }
         self.inactive_drain_cursor = (start + 1) % total;
         return false;
     }
 
-    /// 활성 탭 한 chunk와 다음 비활성 탭 한 chunk를 번갈아 처리한다. 활성 탭은
-    /// 매 frame 첫 순서를 보장하되, 모든 탭이 하나의 `DRAIN_FRAME_BUDGET_NS` 예산을 공유해 탭 수가
-    /// 늘어나도 UI thread 점유 시간이 비례해 늘지 않는다.
+    /// 활성 `TabGroup`의 pane을 논리 라운드당 한 chunk씩 처리한 뒤 숨은 pane 하나를 처리한다.
+    /// 라운드는 `drainFrame` 호출 경계를 넘어 이어지고, 활성 pane은 **매 호출**이 아니라 **매
+    /// 논리 라운드**의 첫 순서다. 모든 탭은 하나의 `DRAIN_FRAME_BUDGET_NS` 예산을 공유한다.
     fn drainFrame(self: *SessionCore) DrainFrameResult {
         const group = self.activeGroup() orelse return .{};
         const active = group.activeTab();
         const started_ns = active.title_clock.read();
         var result: DrainFrameResult = .{};
+        const members = group.drainMembers();
 
         while (active.title_clock.read() - started_ns < DRAIN_FRAME_BUDGET_NS) {
-            // #483 3단계 — "활성 탭" 은 활성 그룹의 pane 전부다 (보이는 것은 모두 지연 민감).
-            // leaf 하나면 이전의 활성 탭 한 chunk 와 같다.
-            //
-            // #483 6단계 — 키보드가 가는 활성 pane 을 먼저, 그다음 나머지 보이는 pane 을 화면 순서로. pane
-            // 사이에서도 예산을 검사한다 — 검사 없이 N 청크를 돌면 최악 점유가 `예산 + N 청크` 로 pane 수에
-            // 비례해 커진다 (측정: 4 pane 에서 4.3 ms 로 1 pane 의 4.0~4.4 와 같았지만 16 pane 은 보장이 없다).
-            // 예산 자체 (4 ms) 는 pane 수와 무관하게 하나다 — 보이는 pane 이 몇이든 UI 스레드가 한 번에
-            // 붙잡히는 상한은 같고, pane 들은 청크를 번갈아 받아 같은 프레임에 함께 나아간다 (측정: 2 · 4 pane
-            // 의 producer 가 같은 프레임에 끝났다).
-            var drained_visible = active.drainOutputChunk();
-            var over_budget = false;
-            for (group.panes) |p| {
-                const tab = p orelse continue;
-                if (tab == active) continue;
-                if (active.title_clock.read() - started_ns >= DRAIN_FRAME_BUDGET_NS) {
-                    over_budget = true;
-                    break;
-                }
-                drained_visible = tab.drainOutputChunk() or drained_visible;
-            }
-            result.active_output = result.active_output or drained_visible;
+            // #574 — pane 사이에서 예산이 끝나도 `next`가 pending 위치를 보존한다. 마지막
+            // 활성 그룹 pane 뒤에서 끝나면 hidden 단계 역시 다음 호출로 이월된다.
+            const step = group.visible_drain_round.next(members, group.active_pane);
+            const did_work = switch (step) {
+                .pane => |id| pane: {
+                    const tab = group.panes[id] orelse break :pane false;
+                    const drained = tab.drainOutputChunk() > 0;
+                    result.active_output = result.active_output or drained;
+                    break :pane drained;
+                },
+                .hidden => self.drainNextInactiveChunk(),
+            };
+            const completed_round = group.visible_drain_round.complete(
+                step,
+                did_work,
+                members,
+                group.active_pane,
+            );
 
-            if (over_budget or active.title_clock.read() - started_ns >= DRAIN_FRAME_BUDGET_NS) break;
-            const drained_inactive = self.drainNextInactiveChunk();
-            if (!drained_visible and !drained_inactive) break;
+            if (active.title_clock.read() - started_ns >= DRAIN_FRAME_BUDGET_NS) break;
+            if (completed_round != null and !completed_round.?) break;
         }
 
         for (group.panes) |p| {
@@ -1689,6 +1825,112 @@ test "next active index shifts when closing earlier tab" {
     try std.testing.expectEqual(@as(?usize, 1), nextActiveIndexAfterClose(2, 0, 2));
     try std.testing.expectEqual(@as(?usize, 1), nextActiveIndexAfterClose(1, 1, 2));
     try std.testing.expectEqual(@as(?usize, 1), nextActiveIndexAfterClose(1, 2, 2));
+}
+
+fn expectVisibleDrainPane(step: VisibleDrainStep, expected: pane_layout.PaneId) !void {
+    switch (step) {
+        .pane => |actual| try std.testing.expectEqual(expected, actual),
+        .hidden => try std.testing.expect(false),
+    }
+}
+
+fn takeVisibleDrainPane(
+    round: *VisibleDrainRound,
+    members: VisiblePaneMask,
+    active: pane_layout.PaneId,
+    expected: pane_layout.PaneId,
+    did_work: bool,
+) !void {
+    const step = round.next(members, active);
+    try expectVisibleDrainPane(step, expected);
+    try std.testing.expectEqual(@as(?bool, null), round.complete(step, did_work, members, active));
+}
+
+fn finishVisibleDrainRound(
+    round: *VisibleDrainRound,
+    members: VisiblePaneMask,
+    active: pane_layout.PaneId,
+    hidden_did_work: bool,
+) !bool {
+    const step = round.next(members, active);
+    switch (step) {
+        .pane => try std.testing.expect(false),
+        .hidden => {},
+    }
+    return round.complete(step, hidden_did_work, members, active).?;
+}
+
+test "#574 — 논리 드레인 라운드는 호출 경계를 넘어 이어진다" {
+    const members: VisiblePaneMask = 0b1111;
+    var round: VisibleDrainRound = .{};
+
+    // 각 줄 사이가 4 ms 호출 경계라고 해도 A를 다시 넣지 않고 A, B | C, D로 이어진다.
+    try takeVisibleDrainPane(&round, members, 0, 0, true);
+    try takeVisibleDrainPane(&round, members, 0, 1, true);
+
+    try takeVisibleDrainPane(&round, members, 0, 2, true);
+    try takeVisibleDrainPane(&round, members, 0, 3, true);
+
+    // 마지막 pane 직후 호출이 끝나도 hidden 차례가 사라지지 않는다.
+    try std.testing.expect(try finishVisibleDrainRound(&round, members, 0, false));
+    try takeVisibleDrainPane(&round, members, 0, 0, true);
+}
+
+test "#574 — 한 청크가 예산을 다 써도 두 pane이 번갈아 진행한다" {
+    const members: VisiblePaneMask = 0b11;
+    var round: VisibleDrainRound = .{};
+
+    // 호출마다 한 단계만 실행하는 최악 조건: A | B | hidden, 그다음 라운드의 A.
+    try takeVisibleDrainPane(&round, members, 0, 0, true);
+    try takeVisibleDrainPane(&round, members, 0, 1, true);
+    try std.testing.expect(try finishVisibleDrainRound(&round, members, 0, false));
+    try takeVisibleDrainPane(&round, members, 0, 0, true);
+}
+
+test "#574 — 빈 slot과 포커스 우선권이 남은 라운드를 폐기하지 않는다" {
+    const members = VisibleDrainRound.paneBit(0) |
+        VisibleDrainRound.paneBit(2) |
+        VisibleDrainRound.paneBit(5);
+    var round: VisibleDrainRound = .{};
+
+    try takeVisibleDrainPane(&round, members, 2, 2, true);
+    // 아직 pending인 pane 0은 다음으로 당긴다.
+    round.prioritize(members, 0);
+    try takeVisibleDrainPane(&round, members, 0, 0, true);
+    // 이미 처리한 pane 2는 한 번만 우선하고, pending pane 5는 그대로 남는다.
+    round.prioritize(members, 2);
+    try takeVisibleDrainPane(&round, members, 2, 2, true);
+    try takeVisibleDrainPane(&round, members, 2, 5, true);
+    try std.testing.expect(try finishVisibleDrainRound(&round, members, 2, false));
+}
+
+test "#574 — pane 구성 변경은 새 활성 pane에서 라운드를 다시 만든다" {
+    var round: VisibleDrainRound = .{};
+    try takeVisibleDrainPane(&round, 0b111, 0, 0, true);
+
+    // pane 0이 닫히고 pane 1이 활성이 된 상태. 옛 pending을 이어 pane 1을 건너뛰지 않는다.
+    try takeVisibleDrainPane(&round, 0b110, 1, 1, true);
+    try takeVisibleDrainPane(&round, 0b110, 1, 2, true);
+    try std.testing.expect(try finishVisibleDrainRound(&round, 0b110, 1, false));
+}
+
+test "#574 — 16 pane 라운드도 각 slot을 정확히 한 번 처리한다" {
+    const members = std.math.maxInt(VisiblePaneMask);
+    var round: VisibleDrainRound = .{};
+
+    try takeVisibleDrainPane(&round, members, 15, 15, true);
+    for (0..15) |i| {
+        try takeVisibleDrainPane(&round, members, 15, @intCast(i), true);
+    }
+    try std.testing.expect(try finishVisibleDrainRound(&round, members, 15, false));
+}
+
+test "#574 — 출력이 없는 완전한 라운드는 유휴로 끝난다" {
+    const members: VisiblePaneMask = 0b11;
+    var round: VisibleDrainRound = .{};
+    try takeVisibleDrainPane(&round, members, 0, 0, false);
+    try takeVisibleDrainPane(&round, members, 0, 1, false);
+    try std.testing.expect(!try finishVisibleDrainRound(&round, members, 0, false));
 }
 
 test "OSC 0 and 2 update automatic tab title and empty title restores default" {

--- a/src/stress.zig
+++ b/src/stress.zig
@@ -75,6 +75,10 @@ const env_timing_file = "TILDAZ_STRESS_TIMING_FILE";
 const env_hold_ms = "TILDAZ_STRESS_HOLD_MS";
 /// producer 가 이 그리드가 될 때까지 기다렸다가 출력을 시작한다 (`ProducerRequest.target_grid`).
 const env_grid = "TILDAZ_STRESS_GRID";
+/// `frame --panes N`의 producer를 모두 준비한 뒤 함께 시작하고, 마지막 VT marker가
+/// 파싱될 때까지 process를 살려 두는 파일 barrier의 공통 경로와 pane id.
+const env_start_barrier = "TILDAZ_STRESS_START_BARRIER";
+const env_pane_id = "TILDAZ_STRESS_PANE_ID";
 
 /// 자식이 죽은 뒤에도 read thread 가 아직 안 읽은 데이터가 남아 있을 수 있다 —
 /// `waitpid` 는 프로세스 종료만 알려주고 커널 버퍼가 비었는지는 말하지 않는다
@@ -84,6 +88,7 @@ const drain_quiet_ns: u64 = 50 * std.time.ns_per_ms;
 
 /// 무한 대기 방지. producer 가 죽지도 않고 데이터도 안 보내는 상황에서 빠져나온다.
 const total_timeout_ns: u64 = 120 * std.time.ns_per_s;
+const barrier_timeout_ns: u64 = 10 * std.time.ns_per_s;
 
 const chunk_size = 64 * 1024;
 
@@ -157,6 +162,9 @@ const ProducerRequest = struct {
     /// 다른 대상과 비교할 수 없다. 전후 그리드를 둘 다 남기는 것만으로는 **얼마나 오염됐는지**
     /// 를 알 수 없다 (전환 시점이 없다) — 그래서 아예 기다린다.
     target_grid: ?Grid = null,
+    /// 둘 다 있으면 내부 frame 하네스의 다중 producer barrier에 참여한다.
+    start_barrier: ?[]const u8 = null,
+    pane_id: ?pane_layout.PaneId = null,
 };
 
 /// `target_grid` 를 기다린 상한. 넘으면 그대로 진행하고 timing 에 대기 시간이 남는다 —
@@ -193,13 +201,91 @@ fn producerRequest(rt: Runtime, alloc: std.mem.Allocator) !?ProducerRequest {
         target_grid = parseGrid(text);
     }
 
+    var start_barrier: ?[]const u8 = null;
+    var pane_id: ?pane_layout.PaneId = null;
+    if (rt.envAlloc(alloc, env_start_barrier) catch null) |path| {
+        if (rt.envAlloc(alloc, env_pane_id) catch null) |text| {
+            defer alloc.free(text);
+            const parsed = std.fmt.parseInt(pane_layout.PaneId, text, 10) catch
+                @as(pane_layout.PaneId, @intCast(pane_layout.MAX_PANES_PER_TAB));
+            if (parsed < pane_layout.MAX_PANES_PER_TAB) {
+                start_barrier = path;
+                pane_id = parsed;
+            } else {
+                alloc.free(path);
+            }
+        } else {
+            alloc.free(path);
+        }
+    }
+
     return .{
         .kind = kind,
         .bytes = bytes,
         .timing_path = timing_path,
         .hold_ms = hold_ms,
         .target_grid = target_grid,
+        .start_barrier = start_barrier,
+        .pane_id = pane_id,
     };
+}
+
+fn paneBarrierPath(buf: []u8, base: []const u8, id: pane_layout.PaneId, suffix: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}.{d}.{s}", .{ base, id, suffix });
+}
+
+fn globalBarrierPath(buf: []u8, base: []const u8, suffix: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}.{s}", .{ base, suffix });
+}
+
+fn createBarrierFile(rt: Runtime, path: []const u8) !void {
+    const file = try std.Io.Dir.createFileAbsolute(rt.io, path, .{});
+    file.close(rt.io);
+}
+
+fn barrierFileExists(rt: Runtime, path: []const u8) bool {
+    const file = std.Io.Dir.openFileAbsolute(rt.io, path, .{}) catch return false;
+    file.close(rt.io);
+    return true;
+}
+
+fn waitForBarrierFile(rt: Runtime, path: []const u8) !void {
+    var timer: Timer = .start(rt);
+    while (!barrierFileExists(rt, path)) {
+        if (timer.read() >= barrier_timeout_ns) return error.StressBarrierTimeout;
+        rt.sleepNs(std.time.ns_per_ms);
+    }
+}
+
+/// producer가 준비됐음을 알리고 부모의 동시 시작 신호를 기다린다.
+fn waitForProducerStart(rt: Runtime, base: []const u8, id: pane_layout.PaneId) !void {
+    var ready_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const ready_path = try paneBarrierPath(&ready_buf, base, id, "ready");
+    try createBarrierFile(rt, ready_path);
+
+    var go_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const go_path = try globalBarrierPath(&go_buf, base, "go");
+    try waitForBarrierFile(rt, go_path);
+}
+
+fn doneTitle(buf: []u8, id: pane_layout.PaneId) ![]const u8 {
+    return std.fmt.bufPrint(buf, "tildaz-stress-done-{d}", .{id});
+}
+
+fn writeDoneMarker(rt: Runtime, out: std.Io.File, id: pane_layout.PaneId) !void {
+    var title_buf: [48]u8 = undefined;
+    const title = try doneTitle(&title_buf, id);
+    var marker_buf: [64]u8 = undefined;
+    const marker = try std.fmt.bufPrint(&marker_buf, "\x1b]0;{s}\x07", .{title});
+    try out.writeStreamingAll(rt.io, marker);
+}
+
+/// 마지막 marker가 부모 VT에 도달할 때까지 process 종료를 미뤄 close-time 강제 drain이
+/// 공정성 측정을 대신하지 못하게 한다.
+fn waitForProducerStop(rt: Runtime, base: []const u8) !void {
+    var stop_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const stop_path = try globalBarrierPath(&stop_buf, base, "stop");
+    try waitForBarrierFile(rt, stop_path);
 }
 
 fn parseGrid(text: []const u8) ?Grid {
@@ -255,6 +341,7 @@ fn produce(rt: Runtime, req: ProducerRequest) !void {
     // 목표 그리드를 받았으면 그 전에 **기다린다** (`target_grid` 주석). 기다린 뒤에 읽어야
     // `grid_start` 가 실제로 출력한 그리드와 같다.
     const grid_wait_ms = if (req.target_grid) |t| waitForGrid(rt, t) else 0;
+    if (req.start_barrier) |base| try waitForProducerStart(rt, base, req.pane_id.?);
     const grid_start = producerGrid();
 
     var timer: Timer = .start(rt);
@@ -267,6 +354,11 @@ fn produce(rt: Runtime, req: ProducerRequest) !void {
     }
     const elapsed_ns = timer.read();
     const grid_end = producerGrid();
+
+    if (req.start_barrier) |base| {
+        try writeDoneMarker(rt, out, req.pane_id.?);
+        try waitForProducerStop(rt, base);
+    }
 
     if (req.timing_path) |path| {
         writeTiming(rt, path, req, elapsed_ns, grid_start, grid_end, grid_wait_ms) catch {};
@@ -461,8 +553,7 @@ fn parseArgs(args: []const []const u8) !Options {
 }
 
 fn printUsage(rt: Runtime) !void {
-    try std.Io.File.stdout().writeStreamingAll(
-        rt.io,
+    try std.Io.File.stdout().writeStreamingAll(rt.io,
         \\usage: zig build stress -- <throughput | scrollback> [options]
         \\
         \\  throughput   how fast bulk output is consumed
@@ -522,11 +613,56 @@ const FrameSplit = struct {
     frames: u64,
     /// 프레임 예산 (`DRAIN_FRAME_BUDGET_NS`) 을 넘긴 프레임 수. 리포트가 값을 함께 찍는다.
     over_budget: u64,
-    /// #483 6단계 — pane 수 · pane 별 producer 종료 시각 (프레임 단위, timer 절대값) · 드레인 1 회 최장 점유.
+    /// #574 — pane별 마지막 OSC marker가 VT에 도달한 시각, process 종료 시각, 직접
+    /// drain 통계. process 종료 순번 대신 `PaneId` index로 보존한다.
     panes: u32 = 1,
-    finished: u32 = 0,
-    finish_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    parsed_done: u32 = 0,
+    parsed_done_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    exited: u32 = 0,
+    exit_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    drain_chunks: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    drain_bytes: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    max_service_gap_frames: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    max_chunk_skew: u64 = 0,
     max_drain_ns: u64 = 0,
+};
+
+const FramePaneProgress = struct {
+    last_chunks: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    last_service_frame: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    max_service_gap_frames: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB,
+    max_chunk_skew: u64 = 0,
+
+    fn observe(
+        progress: *FramePaneProgress,
+        group: *session_core.TabGroup,
+        panes: u32,
+        parsed_done_ns: *const [pane_layout.MAX_PANES_PER_TAB]u64,
+        frame: u64,
+    ) void {
+        var min_chunks: u64 = std.math.maxInt(u64);
+        var max_chunks: u64 = 0;
+        for (group.panes[0..panes], 0..) |pane, i| {
+            // 앞선 frame에서 marker까지 파싱한 pane은 더 이상 동시에 밀린 집합이 아니다.
+            if (parsed_done_ns[i] != 0) continue;
+            const tab = pane orelse continue;
+            const chunks = tab.stress_drain_chunks;
+            min_chunks = @min(min_chunks, chunks);
+            max_chunks = @max(max_chunks, chunks);
+            if (chunks == progress.last_chunks[i]) continue;
+            if (progress.last_service_frame[i] != 0) {
+                progress.max_service_gap_frames[i] = @max(
+                    progress.max_service_gap_frames[i],
+                    frame - progress.last_service_frame[i],
+                );
+            }
+            progress.last_service_frame[i] = frame;
+            progress.last_chunks[i] = chunks;
+        }
+        if (min_chunks != std.math.maxInt(u64)) {
+            progress.max_chunk_skew = @max(progress.max_chunk_skew, max_chunks - min_chunks);
+        }
+    }
 };
 
 const Counters = struct {
@@ -610,13 +746,40 @@ const ExitState = struct {
     exited: std.atomic.Value(bool) = .init(false),
     /// #483 6단계 — pane 마다 producer 가 하나라 마지막 pane 이 끝날 때 `exited`.
     exited_count: std.atomic.Value(u32) = .init(0),
+    exited_panes: std.atomic.Value(VisiblePaneMask) = .init(0),
+    tab_ptrs: [pane_layout.MAX_PANES_PER_TAB]usize = [_]usize{0} ** pane_layout.MAX_PANES_PER_TAB,
     total: u32 = 1,
+
+    const VisiblePaneMask = u16;
+
+    fn rememberPanes(state: *ExitState, group: *session_core.TabGroup) void {
+        for (group.panes, 0..) |pane, i| {
+            state.tab_ptrs[i] = if (pane) |tab| @intFromPtr(tab) else 0;
+        }
+    }
+
+    fn recordExit(state: *ExitState, tab_ptr: usize) void {
+        for (state.tab_ptrs, 0..) |known, i| {
+            if (known != tab_ptr) continue;
+            _ = state.exited_panes.fetchOr(@as(VisiblePaneMask, 1) << @intCast(i), .acq_rel);
+            break;
+        }
+        const n = state.exited_count.fetchAdd(1, .acq_rel) + 1;
+        if (n >= state.total) state.exited.store(true, .release);
+    }
 };
 
-fn onTabExit(_: usize, userdata: ?*anyopaque) void {
+fn onTabExit(tab_ptr: usize, userdata: ?*anyopaque) void {
     const state: *ExitState = @ptrCast(@alignCast(userdata.?));
-    const n = state.exited_count.fetchAdd(1, .acq_rel) + 1;
-    if (n >= state.total) state.exited.store(true, .release);
+    state.recordExit(tab_ptr);
+}
+
+fn stressCurrentPid() u32 {
+    return switch (builtin.os.tag) {
+        .windows => std.os.windows.GetCurrentProcessId(),
+        .linux => @intCast(std.os.linux.getpid()),
+        else => @intCast(std.c.getpid()),
+    };
 }
 
 /// producer 를 PTY 자식으로 띄운 세션. `pty` 와 `frame` 층이 같은 준비 과정을 쓴다.
@@ -624,17 +787,22 @@ fn onTabExit(_: usize, userdata: ?*anyopaque) void {
 /// 힙에 두는 이유는 `extra_env` 가 자기 안의 `bytes_text` 를 가리키기 때문이다 —
 /// 스택에 두면 이 struct 를 옮기는 순간 그 포인터가 어긋난다.
 const ProducerSession = struct {
+    rt: Runtime,
     alloc: std.mem.Allocator,
     shell_command: terminal.ShellCommand,
     bytes_text: [24]u8 = undefined,
-    extra_env: [2]terminal.ExtraEnv = undefined,
+    pane_id_text: [3]u8 = undefined,
+    barrier_path: [std.Io.Dir.max_path_bytes]u8 = undefined,
+    barrier_path_len: usize = 0,
+    extra_env: [4]terminal.ExtraEnv = undefined,
+    extra_env_len: usize = 2,
     state: ExitState = .{},
     core: session_core.SessionCore = undefined,
 
     fn start(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !*ProducerSession {
         const self = try alloc.create(ProducerSession);
         errdefer alloc.destroy(self);
-        self.* = .{ .alloc = alloc, .shell_command = undefined };
+        self.* = .{ .rt = rt, .alloc = alloc, .shell_command = undefined };
 
         var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
         // #451 — `fs.selfExePath` ➡️ `std.process.executablePath` (길이를 돌려준다).
@@ -646,7 +814,15 @@ const ProducerSession = struct {
         self.extra_env = .{
             .{ .name = env_workload, .value = @tagName(opts.workload_kind) },
             .{ .name = env_bytes, .value = bytes_text },
+            undefined,
+            undefined,
         };
+        if (opts.layer == .frame) {
+            try self.prepareBarrierPath();
+            self.extra_env_len = 4;
+            self.extra_env[2] = .{ .name = env_start_barrier, .value = self.barrierPath() };
+            self.setProducerPaneId(0);
+        }
 
         self.core = session_core.SessionCore.init(
             rt,
@@ -654,11 +830,12 @@ const ProducerSession = struct {
             self.shell_command,
             opts.scroll_lines,
             null,
-            &self.extra_env,
+            self.extra_env[0..self.extra_env_len],
             onTabExit,
             &self.state,
         );
         errdefer self.core.deinit();
+        errdefer self.releaseBarriers() catch {};
 
         // 여기서 자식이 뜨고 곧바로 쓰기 시작한다 — 호출자는 바로 비우기 시작해야 한다.
         self.state.total = opts.panes;
@@ -681,18 +858,97 @@ const ProducerSession = struct {
                 }
                 const pr = biggest orelse return error.NoTab;
                 _ = self.core.setActivePane(pr.pane);
+                if (opts.layer == .frame) self.setProducerPaneId(i);
                 try self.core.splitActive(if (pr.rect.w >= pr.rect.h) .right else .down, area, m);
                 // 분할마다 균등화 — 새 pane 만 계속 가르면 1/2 · 1/4 · 1/8 로 줄어 `TooSmall` 에 걸린다.
                 self.core.equalizeActive(area, m);
             }
         }
+        const group = self.core.activeGroup() orelse return error.NoTab;
+        self.state.rememberPanes(group);
+        if (opts.layer == .frame) try self.waitForReadyAndRelease(opts.panes);
         return self;
     }
 
     fn deinit(self: *ProducerSession) void {
+        self.releaseBarriers() catch {};
         self.core.deinit();
+        self.cleanupBarriers();
         freeShellCommand(self.alloc, self.shell_command);
         self.alloc.destroy(self);
+    }
+
+    fn prepareBarrierPath(self: *ProducerSession) !void {
+        const env_name = if (builtin.os.tag == .windows) "TEMP" else "TMPDIR";
+        const fallback = if (builtin.os.tag == .windows) "." else "/tmp";
+        const temp_dir = self.rt.envAlloc(self.alloc, env_name) catch try self.alloc.dupe(u8, fallback);
+        defer self.alloc.free(temp_dir);
+
+        var name_buf: [96]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "tildaz-stress-{d}-{d}", .{ stressCurrentPid(), perf.now() orelse 0 });
+        const path = try std.Io.Dir.path.join(self.alloc, &.{ temp_dir, name });
+        defer self.alloc.free(path);
+        if (path.len > self.barrier_path.len) return error.NameTooLong;
+        @memcpy(self.barrier_path[0..path.len], path);
+        self.barrier_path_len = path.len;
+    }
+
+    fn barrierPath(self: *const ProducerSession) []const u8 {
+        return self.barrier_path[0..self.barrier_path_len];
+    }
+
+    fn setProducerPaneId(self: *ProducerSession, id: anytype) void {
+        const text = std.fmt.bufPrint(&self.pane_id_text, "{d}", .{id}) catch unreachable;
+        self.extra_env[3] = .{ .name = env_pane_id, .value = text };
+    }
+
+    fn waitForReadyAndRelease(self: *ProducerSession, panes: u32) !void {
+        var timer: Timer = .start(self.rt);
+        while (true) {
+            var ready: u32 = 0;
+            for (0..panes) |i| {
+                var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+                const path = try paneBarrierPath(&path_buf, self.barrierPath(), @intCast(i), "ready");
+                if (barrierFileExists(self.rt, path)) ready += 1;
+            }
+            if (ready == panes) break;
+            if (timer.read() >= barrier_timeout_ns) return error.StressBarrierTimeout;
+            self.rt.sleepNs(std.time.ns_per_ms);
+        }
+
+        var go_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const go_path = try globalBarrierPath(&go_buf, self.barrierPath(), "go");
+        try createBarrierFile(self.rt, go_path);
+    }
+
+    fn stopProducers(self: *ProducerSession) !void {
+        if (self.barrier_path_len == 0) return;
+        var stop_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const stop_path = try globalBarrierPath(&stop_buf, self.barrierPath(), "stop");
+        try createBarrierFile(self.rt, stop_path);
+    }
+
+    /// 오류 정리에서는 producer가 go/stop 어느 쪽을 기다리는지 모르므로 둘 다 연다.
+    fn releaseBarriers(self: *ProducerSession) !void {
+        if (self.barrier_path_len == 0) return;
+        var go_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const go_path = try globalBarrierPath(&go_buf, self.barrierPath(), "go");
+        try createBarrierFile(self.rt, go_path);
+        try self.stopProducers();
+    }
+
+    fn cleanupBarriers(self: *ProducerSession) void {
+        if (self.barrier_path_len == 0) return;
+        for (0..pane_layout.MAX_PANES_PER_TAB) |i| {
+            var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+            const path = paneBarrierPath(&path_buf, self.barrierPath(), @intCast(i), "ready") catch continue;
+            std.Io.Dir.deleteFileAbsolute(self.rt.io, path) catch {};
+        }
+        for ([_][]const u8{ "go", "stop" }) |suffix| {
+            var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+            const path = globalBarrierPath(&path_buf, self.barrierPath(), suffix) catch continue;
+            std.Io.Dir.deleteFileAbsolute(self.rt.io, path) catch {};
+        }
     }
 
     fn tab(self: *ProducerSession) !*session_core.Tab {
@@ -747,6 +1003,13 @@ fn runPty(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
 
 // --- layer: frame ---
 
+fn paneParsedDone(tab: *session_core.Tab, id: pane_layout.PaneId) bool {
+    var expected_buf: [48]u8 = undefined;
+    const expected = doneTitle(&expected_buf, id) catch return false;
+    const actual = tab.terminal.getTitle() orelse return false;
+    return std.mem.eql(u8, actual, expected);
+}
+
 /// 프레임당 1 회 드레인을 모사한다 — `drainOutputForRender` 를 `--fps` 주기로 한 번씩 부르고,
 /// 그 안의 `drainFrame` 이 `session_core.SessionCore.DRAIN_FRAME_BUDGET_NS` 만 파싱한다.
 /// 그래서 처리량이 파서 상한이 아니라 `예산 / 프레임 간격` 으로 눌린다.
@@ -769,6 +1032,7 @@ fn runFrame(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
 
     const session = try ProducerSession.start(rt, alloc, opts);
     defer session.deinit();
+    const group = session.core.activeGroup() orelse return error.NoTab;
 
     const frame_ns = std.time.ns_per_s / @as(u64, opts.fps);
     var next_frame_ns: u64 = frame_ns;
@@ -778,8 +1042,12 @@ fn runFrame(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
     var first_data_ns: ?u64 = null;
     var last_data_ns: u64 = 0;
     var max_drain_ns: u64 = 0;
-    var finish_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB;
-    var finished: u32 = 0;
+    var parsed_done_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB;
+    var parsed_done: u32 = 0;
+    var exit_ns: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB;
+    var exited: u32 = 0;
+    var stop_sent = false;
+    var pane_progress: FramePaneProgress = .{};
 
     while (true) {
         const before_ns = timer.read();
@@ -789,14 +1057,35 @@ fn runFrame(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
         frames += 1;
         if (after_ns - before_ns > frame_budget_ns) over_budget += 1;
         max_drain_ns = @max(max_drain_ns, after_ns - before_ns);
-        // #483 6단계 — pane 별 producer 종료 시각 (이 프레임에서 처음 본 순간).
-        const exited_now = session.state.exited_count.load(.acquire);
-        while (finished < exited_now and finished < finish_ns.len) : (finished += 1) finish_ns[finished] = after_ns;
+        pane_progress.observe(group, opts.panes, &parsed_done_ns, frames);
+
+        // process 종료가 아니라 마지막 OSC marker를 VT가 실제로 적용한 시각을 pane별로 본다.
+        for (group.panes[0..opts.panes], 0..) |pane, i| {
+            if (parsed_done_ns[i] != 0) continue;
+            const tab = pane orelse continue;
+            if (!paneParsedDone(tab, @intCast(i))) continue;
+            parsed_done_ns[i] = after_ns;
+            parsed_done += 1;
+        }
+        if (!stop_sent and parsed_done == opts.panes) {
+            try session.stopProducers();
+            stop_sent = true;
+        }
+
+        // callback이 버리던 Tab pointer를 PaneId로 보존해 process 종료도 보조 지표로 남긴다.
+        const exited_mask = session.state.exited_panes.load(.acquire);
+        for (0..opts.panes) |i| {
+            const bit = @as(ExitState.VisiblePaneMask, 1) << @intCast(i);
+            if (exited_mask & bit == 0 or exit_ns[i] != 0) continue;
+            exit_ns[i] = after_ns;
+            exited += 1;
+        }
 
         if (had_output) {
             if (first_data_ns == null) first_data_ns = after_ns;
             last_data_ns = after_ns;
         } else if (session.exited() and after_ns - last_data_ns > drain_quiet_ns) {
+            if (parsed_done != opts.panes) return error.MissingStressDoneMarker;
             break;
         }
 
@@ -815,6 +1104,13 @@ fn runFrame(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
 
     const counters = takeCounters();
     const start_ns = first_data_ns orelse return error.NoOutput;
+    var drain_chunks: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB;
+    var drain_bytes: [pane_layout.MAX_PANES_PER_TAB]u64 = [_]u64{0} ** pane_layout.MAX_PANES_PER_TAB;
+    for (group.panes[0..opts.panes], 0..) |pane, i| {
+        const tab = pane orelse continue;
+        drain_chunks[i] = tab.stress_drain_chunks;
+        drain_bytes[i] = tab.stress_drain_bytes;
+    }
 
     try report(rt, opts, .{
         .consumed = counters.drain[2],
@@ -828,8 +1124,14 @@ fn runFrame(rt: Runtime, alloc: std.mem.Allocator, opts: Options) !void {
             .frames = frames,
             .over_budget = over_budget,
             .panes = opts.panes,
-            .finished = finished,
-            .finish_ns = finish_ns,
+            .parsed_done = parsed_done,
+            .parsed_done_ns = parsed_done_ns,
+            .exited = exited,
+            .exit_ns = exit_ns,
+            .drain_chunks = drain_chunks,
+            .drain_bytes = drain_bytes,
+            .max_service_gap_frames = pane_progress.max_service_gap_frames,
+            .max_chunk_skew = pane_progress.max_chunk_skew,
             .max_drain_ns = max_drain_ns,
         },
     });
@@ -1071,7 +1373,7 @@ fn reportScrollback(rt: Runtime, opts: Options, segments: []const Segment) !void
 // --- 리포트 ---
 
 fn report(rt: Runtime, opts: Options, result: Result) !void {
-    var buf: [4096]u8 = undefined;
+    var buf: [8192]u8 = undefined;
     var w = Report{ .buf = &buf };
 
     const mib = 1024.0 * 1024.0;
@@ -1183,13 +1485,42 @@ fn report(rt: Runtime, opts: Options, result: Result) !void {
         w.print("  drain max   {d:.2} ms (한 번 호출의 최장 점유)\n", .{
             @as(f64, @floatFromInt(split.max_drain_ns)) / std.time.ns_per_ms,
         });
-        // #483 6단계 — pane 마다 producer 하나. 종료 시각의 퍼짐이 pane 간 공정성이다.
+        // #574 — process 종료가 아니라 pane별 마지막 OSC marker의 VT parse 시각과 직접
+        // drain 통계를 공정성의 주 지표로 쓴다. 종료는 보조 지표다.
         if (split.panes > 1) {
-            w.print("  panes       {d} (pane 마다 producer 하나, 합쳐 {d} MiB)\n", .{ split.panes, opts.bytes / (1024 * 1024) * split.panes });
+            w.print("  panes       {d} (one producer per pane, {d} MiB total)\n", .{ split.panes, opts.bytes / (1024 * 1024) * split.panes });
             const base = result.spawn_ns orelse 0;
-            for (split.finish_ns[0..split.finished], 0..) |t, i| {
-                w.print("  pane exit   #{d} at {d:.1} ms\n", .{ i + 1, @as(f64, @floatFromInt(t -| base)) / std.time.ns_per_ms });
+            var first_done: u64 = std.math.maxInt(u64);
+            var last_done: u64 = 0;
+            for (0..split.panes) |i| {
+                const parsed_ns = split.parsed_done_ns[i];
+                if (parsed_ns != 0) {
+                    first_done = @min(first_done, parsed_ns);
+                    last_done = @max(last_done, parsed_ns);
+                }
+                w.print(
+                    "  pane #{d:<2}   parsed={d:.1} ms chunks={d} bytes={d} max-gap={d} frames\n",
+                    .{
+                        i,
+                        @as(f64, @floatFromInt(parsed_ns -| base)) / std.time.ns_per_ms,
+                        split.drain_chunks[i],
+                        split.drain_bytes[i],
+                        split.max_service_gap_frames[i],
+                    },
+                );
+                if (split.exit_ns[i] != 0) {
+                    w.print("              process exit={d:.1} ms\n", .{
+                        @as(f64, @floatFromInt(split.exit_ns[i] -| base)) / std.time.ns_per_ms,
+                    });
+                }
             }
+            if (first_done != std.math.maxInt(u64)) {
+                w.print("  parsed spread {d:.1} ms (final VT markers)\n", .{
+                    @as(f64, @floatFromInt(last_done - first_done)) / std.time.ns_per_ms,
+                });
+            }
+            w.print("  chunk skew   {d} max (while panes were pending)\n", .{split.max_chunk_skew});
+            w.print("  completed    parsed={d}/{d} process={d}/{d}\n", .{ split.parsed_done, split.panes, split.exited, split.panes });
         }
         // 기본값을 그대로 쓰면 고주사율 화면에서 크게 어긋난다. 실측 (당시 예산 8 ms):
         // 120 Hz 화면을 60 으로 모사했더니 ansi 가 103 MiB/s 로 나왔는데 (예산 초과 86 %),


### PR DESCRIPTION
## 변경

- 활성 `TabGroup`의 pane 드레인을 호출 경계를 넘는 논리 라운드로 바꿔, 4 ms 예산이 끝나도 다음 `PaneId`부터 이어갑니다.
- split·close·포커스·active tab 변경과 hidden round-robin 이월 규칙을 상태기계와 결정적 테스트로 고정합니다.
- stress frame 하네스에 동시 시작 barrier, pane별 최종 VT marker, 청크·바이트·service gap·skew 계측을 추가합니다.
- #574의 Linux 전후 실측과 quantum 2·4 실험 결과, 공통 사양을 `SPEC.md`와 stress 문서에 반영합니다.

## 검증

- `zig build check -j1`: Linux · macOS · Windows, x86_64 · aarch64 통과
- `zig build test -j1`: 413 pass, 5 skip, 기존 환경 의존 실패 1건
  - `process_cwd.test.process_cwd — 없는 pid 는 null`: 이 컨테이너에는 PID 1이 실제로 존재함
- `frame --panes 4 --mb 1 --fps 120`: 각 pane 17청크·1,061,708바이트, 최종 VT marker 퍼짐 0.0 ms, 최대 skew 1
- Linux 2·4·8·16 pane × pane당 64 MiB × 수정 전/후 각 5회 및 16 pane quantum 2·4 각 5회: [#574 결과](https://github.com/ensky0/tildaz/issues/574#issuecomment-5488591291)

관련: #574
