### PR TITLE
fix: config·기동 실패를 화면에 보이게 한다 — Linux 무음 종료 (#577)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1037,6 +1037,46 @@ macOS 의 조합 (과 조합 중 표시) 은 2026-08-27 실기로 확인했다 (
   완료, Windows의 HWND·renderer·첫 tab·표시 정책 적용 후 message loop 진입 직전이다.
   최초 launcher는 기존처럼 worker lock/PID까지만 확인하고 반환하므로 endpoint 실패가
   terminal 자체 실행을 막지 않는 graceful-degradation 동작은 유지한다.
+- **최초 launcher 의 기동 대기도 worker 사망을 즉시 구분한다** ([#577](https://github.com/ensky0/tildaz/issues/577)).
+  예전에는 `waitUntilRunning` 이 lock 파일만 봐서 "아직 시작 중" 과 "이미 죽음" 이 똑같이
+  *빈 lock 파일* 로 보였고 (worker 는 PID 를 쓴 뒤 죽고 `clear_pid_on_close` 가 그것을
+  지운다), 그래서 기동 실패는 전부 타임아웃 10 초를 채운 뒤 generic `WorkerStartTimeout`
+  으로 끝났다. 사용자가 본 것은 "클릭했는데 10 초간 아무 일도 없음" 이었다.
+
+  판정 근거는 위 항목과 같은 **쓰기 순서**다 — lock 을 잡은 뒤 `.starting` 을 owner PID
+  보다 먼저 쓴다. 따라서 "endpoint 파일이 있는데 lock 이 비었다" 는 곧 "lock 을 잡는
+  데까지 갔다가 죽었다" 이고, `error.WorkerExitedDuringStartup` 으로 즉시 끝난다. PID 를
+  쓴 뒤 죽은 창 (PID 있음 + lock 없음) 도 같은 결론이다.
+
+  stale 파일로 오판하지 않는 근거는 `spawnWorker` 가 **spawn 직전에** 그 파일을 지운다는
+  것이다. 그래서 대기 중에 파일이 보이면 방금 띄운 worker 가 쓴 것이다. 응답 없는 worker
+  (hang) 에는 유한 타임아웃이 그대로 남는다 — 그 경우엔 타임아웃이 유일한 탈출구다.
+
+  문구도 갈라진다. `WorkerExitedDuringStartup` 은 *창이 한 번도 뜨지 못한 첫 기동* 이므로
+  "새 인스턴스를 만들라고 보내려던" 쪽 문구와 다르고, **로그를 가리킨다** — 여기까지 온
+  실행은 화면에 아무것도 남기지 않았으므로 남은 단서가 로그뿐이다. worker 가 스스로
+  안내를 띄운 경우 (§11.4 의 config 오류 등) 는 안내를 띄우는 동안 lock 을 들고 살아 있어
+  이 대기가 **성공**하므로 이 경로로 오지 않는다 — 다이얼로그가 두 번 뜨지 않는 근거다.
+- **launcher 의 기동 실패 안내도 세 platform 이 다이얼로그다** ([#577](https://github.com/ensky0/tildaz/issues/577)).
+  launcher 는 `host.run` 을 거치지 않아 Linux 에서는 `Client` 가 아예 없고, 그래서 예전에는
+  `log.userFacing` 으로 stderr + 로그에만 남겼다 — `.desktop` (메뉴 · autostart) 실행에서
+  stderr 는 어디에도 붙지 않으므로 **사용자는 아무것도 보지 못했다.** Windows
+  (`MessageBoxW`) · macOS (`NSAlert`) 는 OS 가 모달을 주므로 같은 자리에서 그냥 떴다.
+
+  Linux 는 창도 PTY 도 만들지 않고 **다이얼로그만** 세운다 (`showFatalStandalone`). dialog
+  는 자기 layer-shell surface 이고 항상 `wl_shm` 이라 (GPU 불필요) Wayland 연결 + globals +
+  keyboard 까지만 있으면 그릴 수 있다. config 는 기본값을 쓰고 다이얼로그 폰트도 시스템
+  폰트로 고정한다 — 이 경로가 알리는 것은 config 과 무관한 실패이고, 애초에 config 을
+  읽지 못한 실행일 수도 있다.
+
+  예외는 `WaylandSocketUnavailable` 이다 — Wayland 에 연결할 수 없다는 것이 그 오류의
+  내용이므로 Wayland 로 그리는 안내는 정의상 뜰 수 없다. 그 경로는 `Client.init` 이 이미
+  socket path 와 env 를 stderr + 로그에 남긴다.
+
+  `showFatalRunError` 가 `rt` 를 **인자로** 받는다. 예전에는 `g_rt` 를 읽었는데 그것은
+  `run()` 안에서만 심어지고 launcher 실패 경로는 `run()` 을 거치지 않으므로, Windows ·
+  macOS 에서 그 자리는 `undefined` Runtime 을 읽고 있었다. Linux 에 다이얼로그를 붙이려고
+  서명을 바꾸면서 함께 닫혔다.
 - `launcher.lock`은 config 열거, index별 생존 확인, 누락 worker spawn, 새-instance 요청
   결정과 worker 0의 hotkey dialog/config 생성 transaction을 직렬화한다. 누락 worker를
   spawn한 launcher 또는 새 config를 만든 worker 0은 각 worker가 자기 lock을 획득하고

--- a/SPEC.md
+++ b/SPEC.md
@@ -1423,7 +1423,25 @@ env var expansion (`~`, `%APPDATA%`) 안 쓰고 펼친 절대 경로. 사용자�
 
 ### 11.4 config error 시 dialog 경로 안내
 
-잘못된 config 값 발견 시 `dialog.showFatal` 본문에 *실제로 연 config 파일 절대경로*를 정확히 한 번 명시해 사용자가 어디를 고쳐야 할지 즉시 알게 한다 ([#316](https://github.com/ensky0/tildaz/issues/316)). `Config.load`가 연 path를 `Config.parse`에 직접 전달하고, TOML parse와 모든 semantic/schema 오류가 동적 message 조립을 사용한다. TOML parse 실패는 파서가 준 줄·열까지 함께 보인다. path 조회를 다시 수행하지 않으므로 instance 번호와 실제 파일이 갈리지 않는다.
+잘못된 config 값 발견 시 dialog 본문에 *실제로 연 config 파일 절대경로*를 정확히 한 번 명시해 사용자가 어디를 고쳐야 할지 즉시 알게 한다 ([#316](https://github.com/ensky0/tildaz/issues/316)). `Config.load`가 연 path를 `Config.parse`에 직접 전달하고, TOML parse와 모든 semantic/schema 오류가 동적 message 조립을 사용한다. TOML parse 실패는 파서가 준 줄·열까지 함께 보인다. path 조회를 다시 수행하지 않으므로 instance 번호와 실제 파일이 갈리지 않는다.
+
+**안내는 담아 두고 host 가 그릴 수 있게 된 뒤에 띄운다** ([#577](https://github.com/ensky0/tildaz/issues/577)). config 파싱은 세 platform 공통이고 Linux 에서는 dialog backend (layer-shell overlay) 가 등록되기 **전에** 돈다 — `Client` 가 config 을 인자로 받아 만들어지기 때문이다. 그 자리에서 `dialog.showFatal` 을 부르면 안내가 stderr + 로그로만 가고, `.desktop` (메뉴 · autostart) 로 띄운 사용자에게는 **창도 다이얼로그도 없이 조용히 죽는 것**만 보였다.
+
+그래서 `recordConfigFatalMsg` 가 문구를 process lifetime 고정 buffer 에 담고 `error.InvalidConfig` 를 반환한다. `Config.load` 는 그것을 받아 기본값으로 돌아오고, 표시는 각 host 가 **그 platform 에서 다이얼로그가 실제로 보이는 가장 이른 지점**에서 한다.
+
+| platform | 표시 지점 | 방법 |
+|---|---|---|
+| Linux | Wayland globals + keyboard 준비 후, 전역 hotkey 판정 · shell · 폰트 검증 **앞** | `runFatalDialog` (blocking pump) → `exit(1)` |
+| Windows | `Config.load` 직후, shell 검증 앞 | `showFatalNoticeIfAny` → `MessageBoxW` (OS modal) |
+| macOS | 같음 | `showFatalNoticeIfAny` → `NSAlert` (OS modal) |
+
+Linux 가 공통 함수를 쓰지 않는 이유는 그쪽 `dialog.showFatal` 이 overlay 요청만 걸고 바로 돌아오는 fire-and-forget 이라 뒤이은 `exit(1)` 이 paint 전에 프로세스를 죽이기 때문이다 (#282 F9). §11.5 의 `showLoadNotice` / `showLoadNoticeText` 가 갈리는 것과 같은 이유·같은 모양이다.
+
+**shell · 폰트 검증보다 앞이다.** config 를 못 읽은 실행은 기본값으로 도는 중이라, 그 검증이 보는 shell · 폰트가 사용자가 적은 값이 아니다. 순서가 뒤바뀌면 사용자는 자기가 고치지도 않은 shell 을 의심한다.
+
+**첫 오류만 담는다.** 사용자가 고칠 지점이 첫 오류이고, 그것을 고친 다음 실행에서 뒤 오류가 다시 걸린다. 예전 동작 (첫 오류에서 즉시 종료) 과 사용자가 보는 문구가 같아지는 것도 이 선택 덕이다.
+
+**stderr + 로그는 담을 때 즉시 남긴다.** overlay 를 못 그리는 환경 (headless, Wayland 연결 실패) 에서도 원인이 남아야 하고, 터미널에서 띄운 사용자는 예전과 같은 자리에서 문구를 본다.
 
 **경로는 첫 줄이고 형식이 하나다** ([#495](https://github.com/ensky0/tildaz/issues/495)).
 
@@ -1435,7 +1453,15 @@ Configuration: missing required key "window" in (top-level).
 
 예전에는 두 형식이 있었고 경로 위치가 오류 종류에 따라 달랐다 — 파싱 오류는 본문 셋째 줄 (`Path: {s}`), 의미 오류는 맨 끝 (`Config path:\n  {s}`). 의미 오류가 대부분인데 그쪽이 맨 끝이라, 읽는 순서상 *오류를 읽고 → 고쳐야겠다 판단하고 → 다이얼로그를 닫은 뒤* 경로가 필요해졌다. 위쪽 문구가 명확할수록 (`missing required key "window"`) 더 빨리 닫으므로 더 잘 놓쳤다. 사용자가 실제로 겪었다 (2026-08-22).
 
-조립 지점은 **`configErrorMessageAlloc` 한 곳**이다. 형식이 갈라진 원인이 파싱 오류만 그 함수를 지나지 않고 `dialog.showFatal` 을 직접 부른 것이었으므로, 그 경로도 `showConfigFatalMsg` 를 지나게 했다. 파싱 오류 본문은 경로를 담지 않는다 — 담으면 두 번 나온다.
+조립 지점은 **`configErrorMessageAlloc` 한 곳**이다. 형식이 갈라진 원인이 파싱 오류만 그 함수를 지나지 않고 `dialog.showFatal` 을 직접 부른 것이었으므로, 그 경로도 `recordConfigFatalMsg` 를 지나게 했다. 파싱 오류 본문은 경로를 담지 않는다 — 담으면 두 번 나온다.
+
+**세 갈래가 남아 있었고 [#577](https://github.com/ensky0/tildaz/issues/577) 에서 정리했다.** #495 가 위 문단을 적은 뒤에도 자기 형식으로 경로를 **맨 끝**에 붙이는 producer 가 셋 있었다 — 폰트 schema 오류 (`font_schema_error_path_format`, 경로를 `  ` 로 들여씀), 폰트 chain not-found (`font_chain_footer_format`, 들여쓰지 않음), shell 검증 세 문구 (`Config path:\n{s}`). 같은 다이얼로그 제목 (`TildaZ Config Error`) 아래에서 오류 종류에 따라 경로 위치와 들여쓰기가 달랐다.
+
+이제 넷 모두 `config_error_path_prefix_format` (`"Config: {s}\n\n"`) 한 정의를 지난다. 본문을 writer 로 조금씩 쌓는 폰트 chain 안내는 `{s}` 두 개를 한 번에 print 할 수 없어서 접두만 뺀 그 상수를 쓴다 — `config_error_with_path_format` 자체가 그 접두로 정의된다. 폰트 schema 오류는 producer 를 아예 없애고 `recordConfigFatalMsg` 에 문구 상수만 넘긴다: 경로를 `paths.configPath` 로 **다시 조회하지 않고** 파싱 중인 파일의 path 를 그대로 쓰므로 #316 이 막으려던 "instance 번호와 실제 파일이 갈림" 도 함께 닫힌다.
+
+부수 효과로 문구가 한 줄 짧아졌다 (맨 끝 3 줄 footer → 첫 줄 2 줄 접두). 640x480 최소 화면의 스크롤 행이 shell 오류 `2 → 1` (1.7x), 폰트 오류 `5/5/5 → 4/4/4` 로 줄었다.
+
+런타임 새 탭 실패 알림 (`shell_new_tab_not_found_format`, [#248](https://github.com/ensky0/tildaz/issues/248)) 은 **이 통일에서 제외한다.** startup config fatal 이 아니라 종료하지 않는 알림이고, 문구가 경로를 오류 헤더가 아니라 *다음 행동 안내* 로 제시한다 (`Check "shell" in this instance's config file:`).
 
 `allocPrint` 실패 시 fallback 도 **경로 자리를 비우지 않는다** (`Config: (unknown)`). 예전 파싱 쪽 fallback 은 경로를 아예 잃어서, 정작 가장 도움이 필요한 상황에서 가장 적은 정보를 줬다.
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -21,7 +21,6 @@ const instance_context = @import("instance_context.zig");
 // (`config.Hotkey`), 서로의 *값*에 의존하지 않아 순환 참조가 성립한다.
 const instances = @import("instances.zig");
 const paths = @import("paths.zig");
-const font_validate = @import("font/validate.zig");
 const font_constants = @import("font/constants.zig");
 const font_spec = @import("font/spec.zig");
 const physical_key = @import("physical_key.zig");
@@ -2729,22 +2728,23 @@ pub const Config = struct {
         // validateStructure 의 일반 missing-key / type-mismatch 메시지보다 schema
         // 의도 (primary single string + glyph fallback list) 를 명확히 안내.
         if (true) {
-            // #577 — 이 세 문구는 `font/validate.zig` 가 경로까지 조립해서 준다
-            // (경로가 본문 **끝**에 붙는 자기 형식 — `font_schema_error_path_format`).
-            // 그래서 #495 접두를 또 붙이지 않는 `...Prebuilt` 로 담는다.
-            var font_msg_buf: [1024]u8 = undefined;
+            // #577 — 예전에는 `font/validate.zig` 가 자기 형식으로 (경로를 본문 끝에)
+            // 조립해서 띄웠다. 이제 다른 config 오류와 **같은 한 형식**을 지난다
+            // (#495 — 경로가 첫 줄). 경로도 `paths.configPath` 로 다시 조회하지 않고
+            // 파싱 중인 파일의 `config_path` 를 그대로 쓴다 — 다시 조회하면 instance
+            // 번호와 실제 파일이 갈릴 수 있다 (#316).
             if (root.table.get("font")) |fv_pre| {
                 if (fv_pre == .table) {
                     if (fv_pre.table.get("family")) |fam_v| {
                         if (fam_v != .string)
-                            return recordConfigFatalPrebuilt(font_validate.familyMustBeStringMessage(rt, &font_msg_buf));
+                            return recordConfigFatalMsg(rt, config_path, messages.font_family_must_be_string_msg);
                     }
                     if (fv_pre.table.get("glyph_fallback")) |fb_v| {
                         if (fb_v != .array)
-                            return recordConfigFatalPrebuilt(font_validate.glyphFallbackMustBeListMessage(rt, &font_msg_buf));
+                            return recordConfigFatalMsg(rt, config_path, messages.font_glyph_fallback_must_be_list_msg);
                         for (fb_v.array.items) |item| {
                             if (item != .string)
-                                return recordConfigFatalPrebuilt(font_validate.glyphFallbackMustBeListMessage(rt, &font_msg_buf));
+                                return recordConfigFatalMsg(rt, config_path, messages.font_glyph_fallback_must_be_list_msg);
                         }
                     }
                 }
@@ -2906,7 +2906,7 @@ pub const Config = struct {
             config.line_height_ratio = f;
         }
         // font.family — primary, single string. type 은 사전 체크에서 이미
-        // 보장됨 (위 font_validate.showFamilyMustBeStringFatal). 여기서는 빈
+        // 보장됨 (위 `font_family_must_be_string_msg` 분기). 여기서는 빈
         // 문자열만 reject + chain[0] 에 저장.
         var chain_count: usize = 0;
         if (fv.table.get("family")) |v| {
@@ -3300,16 +3300,6 @@ fn recordConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const
     var buf: [1024]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch messages.config_error_fallback_msg;
     return recordConfigFatalMsg(rt, config_path, msg);
-}
-
-/// #577 — 경로까지 이미 조립된 문구를 **그대로** 담는다. 폰트 schema 오류
-/// (`font/validate.zig`) 는 경로를 본문 끝에 붙이는 자기 형식이 있어
-/// (`font_schema_error_path_format`), 여기서 #495 접두를 또 붙이면 경로가 두 번 나온다.
-fn recordConfigFatalPrebuilt(message: []const u8) LoadError {
-    if (fatal_notice_len != 0) return error.InvalidConfig;
-    const n = @min(message.len, fatal_notice_buf.len);
-    @memcpy(fatal_notice_buf[0..n], message[0..n]);
-    return publishFatalNotice(n);
 }
 
 /// 길이를 확정하고 stderr + 로그에 남긴다. **다이얼로그보다 먼저 남긴다** —

--- a/src/config.zig
+++ b/src/config.zig
@@ -3307,14 +3307,29 @@ fn recordConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const
 /// 환경에서도 원인이 남아야 한다.
 fn publishFatalNotice(len: usize) LoadError {
     fatal_notice_len = len;
-    log.userFacing("fatal", fatal_notice_buf[0..len]);
+    if (fatal_notice_quiet) {
+        // test — 로그만. `log.appendLine` 은 로그 파일이 없으면 no-op 이라 조용하다.
+        log.appendLine("fatal", "{s}", .{fatal_notice_buf[0..len]});
+    } else {
+        log.userFacing("fatal", fatal_notice_buf[0..len]);
+    }
     return error.InvalidConfig;
 }
 
+/// test 에서만 true. `log.userFacing` 은 stderr 로도 쓰는데, config 오류 본문은
+/// 여러 줄이라 `zig build test` 의 진행 표시와 뒤엉켜 **통과한 실행이 실패처럼**
+/// 보인다 (실측 — 413 passed · exit 0 인데 출력 끝이 `failed command` 였다).
+///
+/// stderr 경로 자체는 실기로 검증한다 — 터미널에서 띄우면 예전과 같은 자리에 같은
+/// 문구가 나온다. 여기서 끄는 것은 그 반향뿐이고, 담기는 문구와 로그는 그대로다.
+var fatal_notice_quiet: bool = false;
+
 /// 테스트 전용 — 담긴 문구를 비운다. `fatal_notice_*` 가 process 전역이라
-/// 테스트끼리 상태가 새는 것을 막는다.
+/// 테스트끼리 상태가 새는 것을 막는다. stderr 반향도 함께 끈다
+/// (`fatal_notice_quiet` 주석).
 fn resetFatalNoticeForTest() void {
     fatal_notice_len = 0;
+    fatal_notice_quiet = true;
 }
 
 /// user config 의 구조가 default config 와 일치하는지 재귀 검증:

--- a/src/config.zig
+++ b/src/config.zig
@@ -2595,9 +2595,31 @@ pub const Config = struct {
             };
             defer allocator.free(content);
 
-            // disk 정상 — parse 가 JSON 의 shell 을 dupe 하므로 인자는 미사용. 누수 방지 free.
+            // disk 정상 — parse 가 TOML 의 shell 을 dupe 하므로 인자는 미사용.
+            //
+            // #577 — free 를 parse **뒤로** 옮겼다. parse 가 이제 오류로 돌아올 수
+            // 있고, 그 경로는 `defaultOwned(allocator, shell_resolved)` 로 떨어지므로
+            // 먼저 free 하면 해제된 메모리를 넘기게 된다.
+            const parsed_config = parse(rt, allocator, content, path) catch {
+                // 문구는 `pendingFatalNotice` 에 담겼다. host 가 다이얼로그를 그릴 수
+                // 있게 된 뒤 읽어 안내하고 종료한다 — 여기서 죽지 않는 것이 요점이다.
+                //
+                // **버려지는 부분 config 를 정리하지 않는다.** `parse` 는 `shell` 과
+                // `font_families` 를 필드 순서대로 owned dupe 로 바꾸는데, 오류가 그
+                // 중간에서 나면 앞쪽만 owned 다. `Config{}` 의 기본값이 comptime
+                // 리터럴이라 (#501 test 주석) 일괄 `deinit` 은 static 메모리를 해제하게
+                // 되고, 어디까지 owned 인지 추적하려면 필드마다 소유권 flag 가 필요하다.
+                //
+                // 그렇게까지 하지 않는 근거는 이 경로의 **끝이 항상 `exit(1)`** 이라는
+                // 것이다 (host 세 곳 모두 안내 후 종료). `std.process.exit` 는 defer 를
+                // 돌리지 않아 `gpa.deinit()` 의 누수 검출도 지나가고, 반납은 OS 가 한다.
+                //
+                // 단 **테스트는 arena 를 쓴다** — testing allocator 로 늦은 단계 오류를
+                // 재현하면 이 미해제가 누수로 잡힌다.
+                break :blk defaultOwned(allocator, shell_resolved);
+            };
             allocator.free(shell_resolved);
-            break :blk parse(rt, allocator, content, path);
+            break :blk parsed_config;
         };
 
         // #431 — 핫키 중복 검사는 **여기 한 곳**이다. `parse` 안에 두면 위의 두 fallback
@@ -2608,7 +2630,12 @@ pub const Config = struct {
         // 기본값이 `F(N+1)` 이라 *기본값끼리는* 겹치지 않는다. 그래도 검사는 그대로 둔다 —
         // 사용자가 config 를 직접 겹치게 고치는 경우가 남고, 애초에 이 검사가 막는 것이
         // 그쪽이다.
-        fatalIfHotkeyTakenByLowerIndex(rt, allocator, loaded.hotkey, path);
+        //
+        // #577 — 이 검사도 오류를 **담아 두고** 돌아온다. 파싱이 성공한 config 를 그대로
+        // 들고 나가는 것이 중요하다 — host 는 이 config 로 창을 세운 뒤 담긴 문구를
+        // 안내하고 종료한다. 기본값으로 갈아치우면 안내를 그릴 창의 폰트 · 크기가
+        // 사용자 설정과 달라진다.
+        fatalIfHotkeyTakenByLowerIndex(rt, allocator, loaded.hotkey, path) catch {};
         return loaded;
     }
 
@@ -2619,7 +2646,7 @@ pub const Config = struct {
     /// 세 platform 이 여기서 함께 덮인다. 전에는 Windows 만 `RegisterHotKey` 실패로 뒤늦게
     /// 걸렸고 (원인이 자기 다른 인스턴스인지 알 수 없는 안내였다), macOS 는 `CGEventTap` 이
     /// 배타 등록이 아니라 **두 인스턴스가 같은 키에 함께 반응**했다.
-    fn fatalIfHotkeyTakenByLowerIndex(rt: Runtime, allocator: std.mem.Allocator, hotkey: Hotkey, config_path: []const u8) void {
+    fn fatalIfHotkeyTakenByLowerIndex(rt: Runtime, allocator: std.mem.Allocator, hotkey: Hotkey, config_path: []const u8) LoadError!void {
         // 측정 인스턴스는 전역 핫키를 등록하지 않는다 (#382). worker index 가 없으면
         // (단위 테스트 등) 비교할 자기 자신이 없다.
         if (instance_context.isStress()) return;
@@ -2634,7 +2661,7 @@ pub const Config = struct {
             messages.config_hotkey_duplicate_format,
             .{ hotkeyDisplay(&key_buf, hotkey), owner },
         ) catch messages.config_hotkey_duplicate_fallback_msg;
-        showConfigFatalMsg(rt, config_path, msg);
+        return recordConfigFatalMsg(rt, config_path, msg);
     }
 
     /// #218 — fail 경로 공통: shell 은 인수한 `shell_resolved`(owned) 보관, static
@@ -2658,7 +2685,7 @@ pub const Config = struct {
         return c;
     }
 
-    fn parse(rt: Runtime, allocator: std.mem.Allocator, content: []const u8, config_path: []const u8) Config {
+    fn parse(rt: Runtime, allocator: std.mem.Allocator, content: []const u8, config_path: []const u8) LoadError!Config {
         var config = Config{};
         // #493 — TOML. `toml.Table` 로 받아 **값 트리**를 직접 훑는다. 구조체 매핑을
         // 쓰지 않는 이유는 아래 필드별 오류 메시지다 — 매핑에 맡기면 "어느 필드가 왜
@@ -2690,7 +2717,7 @@ pub const Config = struct {
                 messages.config_parse_failed_format,
                 .{@errorName(err)},
             ) catch messages.config_parse_failed_fallback_msg;
-            showConfigFatalMsg(rt, config_path, msg);
+            return recordConfigFatalMsg(rt, config_path, msg);
         };
         defer parsed.deinit();
 
@@ -2702,15 +2729,22 @@ pub const Config = struct {
         // validateStructure 의 일반 missing-key / type-mismatch 메시지보다 schema
         // 의도 (primary single string + glyph fallback list) 를 명확히 안내.
         if (true) {
+            // #577 — 이 세 문구는 `font/validate.zig` 가 경로까지 조립해서 준다
+            // (경로가 본문 **끝**에 붙는 자기 형식 — `font_schema_error_path_format`).
+            // 그래서 #495 접두를 또 붙이지 않는 `...Prebuilt` 로 담는다.
+            var font_msg_buf: [1024]u8 = undefined;
             if (root.table.get("font")) |fv_pre| {
                 if (fv_pre == .table) {
                     if (fv_pre.table.get("family")) |fam_v| {
-                        if (fam_v != .string) font_validate.showFamilyMustBeStringFatal(rt);
+                        if (fam_v != .string)
+                            return recordConfigFatalPrebuilt(font_validate.familyMustBeStringMessage(rt, &font_msg_buf));
                     }
                     if (fv_pre.table.get("glyph_fallback")) |fb_v| {
-                        if (fb_v != .array) font_validate.showGlyphFallbackMustBeListFatal(rt);
+                        if (fb_v != .array)
+                            return recordConfigFatalPrebuilt(font_validate.glyphFallbackMustBeListMessage(rt, &font_msg_buf));
                         for (fb_v.array.items) |item| {
-                            if (item != .string) font_validate.showGlyphFallbackMustBeListFatal(rt);
+                            if (item != .string)
+                                return recordConfigFatalPrebuilt(font_validate.glyphFallbackMustBeListMessage(rt, &font_msg_buf));
                         }
                     }
                 }
@@ -2726,7 +2760,7 @@ pub const Config = struct {
         var default_parsed = default_parser.parseString(default_doc) catch unreachable;
         defer default_parsed.deinit();
         const default_root: toml.Value = .{ .table = &default_parsed.value };
-        validateStructure(rt, root, default_root, "(top-level)", config_path);
+        try validateStructure(rt, root, default_root, "(top-level)", config_path);
 
         // #533 — input section. macOS 만 값을 쓰지만 세 platform 이 같은 파일을
         // 읽을 수 있어야 해서 어디서든 파싱한다 (`MacOptionAsAlt` 주석 참고).
@@ -2741,7 +2775,7 @@ pub const Config = struct {
                         messages.config_macos_option_as_alt_invalid_format,
                         .{v.string},
                     ) catch messages.config_macos_option_as_alt_invalid_fallback_msg;
-                    showConfigFatalMsg(rt, config_path, msg);
+                    return recordConfigFatalMsg(rt, config_path, msg);
                 }
             }
         }
@@ -2758,27 +2792,27 @@ pub const Config = struct {
                         messages.config_dock_position_invalid_format,
                         .{v.string},
                     ) catch messages.config_dock_position_invalid_fallback_msg;
-                    showConfigFatalMsg(rt, config_path, msg);
+                    return recordConfigFatalMsg(rt, config_path, msg);
                 }
             }
             if (wv.table.get("width_percent")) |v| {
-                const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.width_percent"});
-                if (f < 1.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.width_percent", "1..100" });
+                const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.width_percent"});
+                if (f < 1.0 or f > 100.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.width_percent", "1..100" });
                 config.width_percent = f;
             }
             if (wv.table.get("height_percent")) |v| {
-                const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.height_percent"});
-                if (f < 1.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.height_percent", "1..100" });
+                const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.height_percent"});
+                if (f < 1.0 or f > 100.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.height_percent", "1..100" });
                 config.height_percent = f;
             }
             if (wv.table.get("offset_percent")) |v| {
-                const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.offset_percent"});
-                if (f < 0.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.offset_percent", "0..100" });
+                const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.offset_percent"});
+                if (f < 0.0 or f > 100.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.offset_percent", "0..100" });
                 config.offset_percent = f;
             }
             if (wv.table.get("opacity_percent")) |v| {
-                const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.opacity_percent"});
-                if (f < 0.0 or f > 100.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.opacity_percent", "0..100" });
+                const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"window.opacity_percent"});
+                if (f < 0.0 or f > 100.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "window.opacity_percent", "0..100" });
                 config.opacity_alpha = @round(f * 255.0 / 100.0);
             }
         }
@@ -2796,7 +2830,7 @@ pub const Config = struct {
                         if (i > 0) w.writeAll(", ") catch {};
                         w.writeAll(t.name) catch {};
                     }
-                    showConfigFatalMsg(rt, config_path, fbs.buffered());
+                    return recordConfigFatalMsg(rt, config_path, fbs.buffered());
                 }
             }
         }
@@ -2826,7 +2860,7 @@ pub const Config = struct {
                     .position_absent_on_macos => std.fmt.bufPrint(&buf, messages.config_hotkey_position_absent_format, .{v.string}) catch
                         messages.config_hotkey_position_absent_fallback_msg,
                 };
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             }
         }
 
@@ -2846,7 +2880,7 @@ pub const Config = struct {
         // max_scroll_lines
         if (root.table.get("max_scroll_lines")) |v| {
             if (v.integer < 100 or v.integer > 10_000_000) {
-                showConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "max_scroll_lines", "100..10_000_000" });
+                return recordConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "max_scroll_lines", "100..10_000_000" });
             }
             config.max_scroll_lines = @intCast(v.integer);
         }
@@ -2857,18 +2891,18 @@ pub const Config = struct {
         const fv = root.table.get("font").?;
         if (fv.table.get("size_point")) |v| {
             if (v.integer < 8 or v.integer > 72) {
-                showConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "font.size_point", "8..72" });
+                return recordConfigFatal(rt, config_path, messages.config_field_integer_range_required_format, .{ "font.size_point", "8..72" });
             }
             config.font_size_point = @intCast(v.integer);
         }
         if (fv.table.get("cell_width_ratio")) |v| {
-            const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.cell_width_ratio"});
-            if (f < 0.5 or f > 2.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.cell_width_ratio", "0.5..2.0" });
+            const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.cell_width_ratio"});
+            if (f < 0.5 or f > 2.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.cell_width_ratio", "0.5..2.0" });
             config.cell_width_ratio = f;
         }
         if (fv.table.get("line_height_ratio")) |v| {
-            const f = parseFloat(v) orelse showConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.line_height_ratio"});
-            if (f < 0.5 or f > 2.0) showConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.line_height_ratio", "0.5..2.0" });
+            const f = parseFloat(v) orelse return recordConfigFatal(rt, config_path, messages.config_field_number_required_format, .{"font.line_height_ratio"});
+            if (f < 0.5 or f > 2.0) return recordConfigFatal(rt, config_path, messages.config_field_range_required_format, .{ "font.line_height_ratio", "0.5..2.0" });
             config.line_height_ratio = f;
         }
         // font.family — primary, single string. type 은 사전 체크에서 이미
@@ -2876,7 +2910,7 @@ pub const Config = struct {
         // 문자열만 reject + chain[0] 에 저장.
         var chain_count: usize = 0;
         if (fv.table.get("family")) |v| {
-            if (v.string.len == 0) showConfigFatalMsg(rt, config_path, messages.config_font_family_empty_msg);
+            if (v.string.len == 0) return recordConfigFatalMsg(rt, config_path, messages.config_font_family_empty_msg);
             config.font_families[0] = allocator.dupe(u8, v.string) catch v.string;
             chain_count = 1;
         }
@@ -2895,7 +2929,7 @@ pub const Config = struct {
                         messages.config_font_chain_too_long_format,
                         .{MAX_FONT_FAMILIES},
                     ) catch messages.config_font_chain_too_long_fallback_msg;
-                    showConfigFatalMsg(rt, config_path, msg);
+                    return recordConfigFatalMsg(rt, config_path, msg);
                 }
                 config.font_families[chain_count] = allocator.dupe(u8, item.string) catch item.string;
                 chain_count += 1;
@@ -2906,7 +2940,7 @@ pub const Config = struct {
         while (i < MAX_FONT_FAMILIES) : (i += 1) config.font_families[i] = "";
         config.font_family_count = @intCast(chain_count);
 
-        parseKeys(rt, root, config_path, &config);
+        try parseKeys(rt, root, config_path, &config);
 
         return config;
     }
@@ -2921,7 +2955,7 @@ pub const Config = struct {
     /// `[keys]` 자체가 없거나 특정 액션이 빠져 있으면 **기본값으로 채운다** (결정 2).
     /// 정상 상태에서는 생성기가 모든 액션을 적으므로 이 경로는 버전 업그레이드 뒤의
     /// 안전망이다.
-    fn parseKeys(rt: Runtime, root: toml.Value, config_path: []const u8, config: *Config) void {
+    fn parseKeys(rt: Runtime, root: toml.Value, config_path: []const u8, config: *Config) LoadError!void {
         const keys_table: ?*toml.Table = if (root.table.get("keys")) |kv|
             (if (kv == .table) kv.table else null)
         else
@@ -2939,7 +2973,7 @@ pub const Config = struct {
                         var buf: [512]u8 = undefined;
                         const msg = std.fmt.bufPrint(&buf, messages.config_key_not_list_format, .{ name, name }) catch
                             messages.config_key_not_list_fallback_msg;
-                        showConfigFatalMsg(rt, config_path, msg);
+                        return recordConfigFatalMsg(rt, config_path, msg);
                     }
                     from_file = v.array;
                 }
@@ -2951,13 +2985,13 @@ pub const Config = struct {
                         var buf: [512]u8 = undefined;
                         const msg = std.fmt.bufPrint(&buf, messages.config_key_not_list_format, .{ name, name }) catch
                             messages.config_key_not_list_fallback_msg;
-                        showConfigFatalMsg(rt, config_path, msg);
+                        return recordConfigFatalMsg(rt, config_path, msg);
                     }
-                    count = addBinding(rt, config, count, action, item.string, config_path);
+                    count = try addBinding(rt, config, count, action, item.string, config_path);
                 }
             } else {
                 for (defaultBindings(action)) |text| {
-                    count = addBinding(rt, config, count, action, text, config_path);
+                    count = try addBinding(rt, config, count, action, text, config_path);
                 }
             }
         }
@@ -2973,33 +3007,33 @@ pub const Config = struct {
         action: KeyAction,
         text: []const u8,
         config_path: []const u8,
-    ) usize {
+    ) LoadError!usize {
         const parsed = switch (parseHotkeyString(text, .app_binding)) {
             .ok => |v| v,
             .unknown_key => {
                 var buf: [512]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.config_key_invalid_format, .{ action.configName(), text }) catch
                     messages.config_key_invalid_fallback_msg;
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             },
             .modifier_required => {
                 var buf: [512]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.config_key_needs_modifier_format, .{ action.configName(), text }) catch
                     messages.config_key_needs_modifier_fallback_msg;
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             },
             // #496 — macOS 에서만 나온다. 겹침 / 부재를 갈라 다른 안내를 준다.
             .position_aliased_on_macos => {
                 var buf: [640]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.config_key_position_aliased_format, .{ action.configName(), text }) catch
                     messages.config_key_position_aliased_fallback_msg;
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             },
             .position_absent_on_macos => {
                 var buf: [640]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, messages.config_key_position_absent_format, .{ action.configName(), text }) catch
                     messages.config_key_position_absent_fallback_msg;
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             },
         };
         const hotkey = Hotkey.fromParsed(parsed);
@@ -3012,7 +3046,7 @@ pub const Config = struct {
                     existing.action.configName(),
                     action.configName(),
                 }) catch messages.config_key_conflict_fallback_msg;
-                showConfigFatalMsg(rt, config_path, msg);
+                return recordConfigFatalMsg(rt, config_path, msg);
             }
         }
 
@@ -3020,7 +3054,7 @@ pub const Config = struct {
             var buf: [256]u8 = undefined;
             const msg = std.fmt.bufPrint(&buf, messages.config_key_too_many_format, .{MAX_KEY_BINDINGS}) catch
                 messages.config_key_too_many_fallback_msg;
-            showConfigFatalMsg(rt, config_path, msg);
+            return recordConfigFatalMsg(rt, config_path, msg);
         }
         config.key_bindings[count] = .{ .hotkey = hotkey, .action = action };
         return count + 1;
@@ -3184,16 +3218,113 @@ pub fn showLoadNoticeText(rt: Runtime, notice: []const u8) void {
     dialog.showError(rt, messages.config_not_loaded_title, notice);
 }
 
-fn showConfigFatalMsg(rt: Runtime, config_path: []const u8, message: []const u8) noreturn {
-    const full_message = configErrorMessageAlloc(std.heap.page_allocator, message, config_path) catch
-        messages.config_error_with_path_fallback_msg;
-    dialog.showFatal(rt, messages.config_error_title, full_message);
+/// #577 — 담긴 config fatal 문구를 보여주고 **종료한다.** 담긴 것이 없으면 아무 일도
+/// 하지 않으므로 host 는 조건 없이 부르면 된다.
+///
+/// **Windows · macOS 전용이다.** 두 platform 은 OS 가 modal 을 주므로
+/// (`MessageBoxW` / `NSAlert`) `dialog.showFatal` 이 사용자가 창을 닫을 때까지
+/// 돌아오지 않고, 그래서 `Config.load` 직후 — 창을 세우기 전 — 에 그대로 부를 수 있다.
+///
+/// **Linux 는 이 함수를 쓰지 않는다.** 그쪽 `dialog.showFatal` 은 overlay 요청만 걸고
+/// 바로 돌아오는 fire-and-forget 이라 뒤이은 `exit(1)` 이 paint 전에 프로세스를 죽인다
+/// (#282 F9). Linux host 는 `pendingFatalNotice` 를 직접 읽어 blocking overlay
+/// (`runFatalDialog`) 로 띄운 뒤 종료한다 — `showLoadNotice` 와 `showLoadNoticeText`
+/// 가 갈리는 것과 **같은 이유, 같은 모양**이다 (#501).
+pub fn showFatalNoticeIfAny(rt: Runtime) void {
+    const notice = pendingFatalNotice() orelse return;
+    // 문구는 담을 때 이미 stderr + 로그에 남았다 (`publishFatalNotice`).
+    dialog.showFatal(rt, messages.config_error_title, notice);
 }
 
-fn showConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const u8, args: anytype) noreturn {
+/// #577 — config 오류로 시작을 거부할 때 그 사실을 나르는 error. 문구 자체는
+/// `pendingFatalNotice` 가 들고 있다 — Zig error 는 payload 를 못 실어서다.
+pub const LoadError = error{InvalidConfig};
+
+/// 담아 두는 문구의 상한. Linux overlay 가 받는 상한
+/// (`dialog/linux.zig` 의 `message_capacity`) 과 **같은 값**이다 — 여기서 더 담아도
+/// 그쪽에서 잘리므로 두 상한이 갈리면 로그와 화면의 문구가 달라진다 (#310 과 같은 이유).
+const fatal_notice_capacity: usize = 4096;
+
+/// process lifetime 고정 buffer. allocator 를 쓰지 않는 이유가 두 가지다 —
+/// (1) 이 문구를 읽는 host 는 `load` 가 끝나고 **한참 뒤**라 스택 buffer 로는
+/// 살아남지 못하고, (2) 오류를 만드는 자리 중 `validateStructure` 는 allocator 를
+/// 안 들고 있어 넘기려면 재귀 전체에 인자를 하나 더 끼워야 한다.
+var fatal_notice_buf: [fatal_notice_capacity]u8 = undefined;
+var fatal_notice_len: usize = 0;
+
+/// #577 — host 가 다이얼로그를 그릴 수 있게 된 뒤 읽는다. 담긴 것이 없으면 `null`.
+///
+/// **첫 오류만 담는다.** 사용자가 고칠 지점이 첫 오류이고, 그 뒤 오류는 첫 것을 고친
+/// 다음 실행에서 다시 걸린다. 예전 동작 (첫 오류에서 즉시 종료) 과 사용자가 보는
+/// 문구가 같아지는 것도 이 선택 덕이다.
+pub fn pendingFatalNotice() ?[]const u8 {
+    if (fatal_notice_len == 0) return null;
+    return fatal_notice_buf[0..fatal_notice_len];
+}
+
+/// #577 — 문구를 **담아 두기만 한다.** 예전에는 이 자리가 곧바로
+/// `dialog.showFatal` + `exit(1)` 이었는데, config 파싱은 Linux 에서 dialog backend
+/// 등록 **전에** 돌아서 (`dialog/linux.zig` 의 `showFatal` 주석) 메뉴 · autostart 로
+/// 띄운 사용자에게 그 안내가 **한 번도 보이지 않았다** — 창도 다이얼로그도 없이
+/// 조용히 죽었다.
+///
+/// #501 이 로드 실패 안내에 쓴 방식과 같다 — 담아 두고 host 가 그릴 수 있게 된 뒤에
+/// 보여준다. 다른 점은 이것이 **fatal** 이라는 것뿐이다: host 는 blocking overlay 로
+/// 띄운 뒤 종료한다 (#282 C2 의 shell · 폰트 검증과 같은 자리, 같은 이유).
+///
+/// **stderr + 로그는 여기서 즉시 남긴다.** overlay 를 못 그리는 환경 (headless,
+/// Wayland 연결 실패) 에서도 원인이 남아야 하고, 터미널에서 띄운 사용자는 예전과
+/// 똑같이 그 자리에서 문구를 본다. shell 검증 (`wayland_minimal.zig`) 이 쓰는
+/// `log.userFacing` + blocking overlay 조합과 같은 모양이다.
+fn recordConfigFatalMsg(rt: Runtime, config_path: []const u8, message: []const u8) LoadError {
+    // 문구 조립에 rt 가 필요 없다 — 표시는 host 가 나중에 한다.
+    _ = rt;
+    if (fatal_notice_len != 0) return error.InvalidConfig;
+
+    const written = std.fmt.bufPrint(
+        &fatal_notice_buf,
+        messages.config_error_with_path_format,
+        .{ config_path, message },
+    ) catch blk: {
+        // 경로가 너무 길어 상한을 넘긴 경우. 조립을 포기하더라도 **무음으로는
+        // 돌아가지 않는다** — 이 이슈가 고치려는 것이 바로 그 무음이다.
+        const fallback = messages.config_error_with_path_fallback_msg;
+        const n = @min(fallback.len, fatal_notice_buf.len);
+        @memcpy(fatal_notice_buf[0..n], fallback[0..n]);
+        break :blk fatal_notice_buf[0..n];
+    };
+    return publishFatalNotice(written.len);
+}
+
+fn recordConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const u8, args: anytype) LoadError {
     var buf: [1024]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch messages.config_error_fallback_msg;
-    showConfigFatalMsg(rt, config_path, msg);
+    return recordConfigFatalMsg(rt, config_path, msg);
+}
+
+/// #577 — 경로까지 이미 조립된 문구를 **그대로** 담는다. 폰트 schema 오류
+/// (`font/validate.zig`) 는 경로를 본문 끝에 붙이는 자기 형식이 있어
+/// (`font_schema_error_path_format`), 여기서 #495 접두를 또 붙이면 경로가 두 번 나온다.
+fn recordConfigFatalPrebuilt(message: []const u8) LoadError {
+    if (fatal_notice_len != 0) return error.InvalidConfig;
+    const n = @min(message.len, fatal_notice_buf.len);
+    @memcpy(fatal_notice_buf[0..n], message[0..n]);
+    return publishFatalNotice(n);
+}
+
+/// 길이를 확정하고 stderr + 로그에 남긴다. **다이얼로그보다 먼저 남긴다** —
+/// `dialog.showFatal` 이 그렇게 하는 이유와 같다 (#510): overlay 를 못 그리는
+/// 환경에서도 원인이 남아야 한다.
+fn publishFatalNotice(len: usize) LoadError {
+    fatal_notice_len = len;
+    log.userFacing("fatal", fatal_notice_buf[0..len]);
+    return error.InvalidConfig;
+}
+
+/// 테스트 전용 — 담긴 문구를 비운다. `fatal_notice_*` 가 process 전역이라
+/// 테스트끼리 상태가 새는 것을 막는다.
+fn resetFatalNoticeForTest() void {
+    fatal_notice_len = 0;
 }
 
 /// user config 의 구조가 default config 와 일치하는지 재귀 검증:
@@ -3205,7 +3336,7 @@ fn showConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const u
 /// #493 — `std.json.Value` 트리 비교에서 `toml.Value` 트리 비교로 옮겼다. 구조는
 /// 그대로다: 사용자 문서와 `defaultConfigToml` 을 파싱한 기준 문서를 같은 자리에서
 /// 비교해 key set · 중첩 · 타입을 검사한다.
-fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []const u8, config_path: []const u8) void {
+fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []const u8, config_path: []const u8) LoadError!void {
     const user_tag = std.meta.activeTag(user);
     const def_tag = std.meta.activeTag(def);
     if (user_tag != def_tag) {
@@ -3218,7 +3349,7 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
                 messages.config_type_mismatch_format,
                 .{ ctx, @tagName(def_tag), @tagName(user_tag) },
             ) catch messages.config_type_mismatch_fallback_msg;
-            showConfigFatalMsg(rt, config_path, msg);
+            return recordConfigFatalMsg(rt, config_path, msg);
         }
     }
 
@@ -3234,7 +3365,7 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
                 messages.config_missing_key_format,
                 .{ key, ctx },
             ) catch messages.config_missing_key_fallback_msg;
-            showConfigFatalMsg(rt, config_path, msg);
+            return recordConfigFatalMsg(rt, config_path, msg);
         }
     }
 
@@ -3252,7 +3383,7 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
                 messages.config_unknown_key_format,
                 .{ key, ctx },
             ) catch messages.config_unknown_key_fallback_msg;
-            showConfigFatalMsg(rt, config_path, msg);
+            return recordConfigFatalMsg(rt, config_path, msg);
         }
     }
 
@@ -3265,7 +3396,7 @@ fn validateStructure(rt: Runtime, user: toml.Value, def: toml.Value, ctx: []cons
             std.fmt.bufPrint(&path_buf, "{s}", .{key}) catch key
         else
             std.fmt.bufPrint(&path_buf, "{s}.{s}", .{ ctx, key }) catch key;
-        validateStructure(rt, u_val, entry.value_ptr.*, path, config_path);
+        try validateStructure(rt, u_val, entry.value_ptr.*, path, config_path);
     }
 }
 
@@ -3368,6 +3499,108 @@ test "#316 · #495 어떤 오류 종류든 경로가 같은 자리에 온다" {
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, long_message, &long_path));
 }
 
+/// #577 — 늦은 단계 config 오류는 `parse` 가 버리는 부분 할당을 남긴다 (`load` 의
+/// catch 주석). arena 로 감싸 어느 단계에서 걸려도 test 가 누수로 실패하지 않게 한다.
+fn expectParseInvalid(content: []const u8, config_path: []const u8) !void {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const rt: Runtime = .{ .io = std.testing.io, .environ = .empty };
+    // **죽지 않고 오류로 돌아온다.** 예전에는 이 자리가 `dialog.showFatal` +
+    // `exit(1)` 이라 이런 test 자체를 쓸 수 없었다 — 그것이 #577 의 원인이다.
+    try std.testing.expectError(
+        error.InvalidConfig,
+        Config.parse(rt, arena.allocator(), content, config_path),
+    );
+}
+
+/// 기본 template 에서 한 section 을 통째로 지운다 — "예전 버전이 쓴 config" 를
+/// 만드는 가장 정확한 방법이다. 문구를 손으로 적으면 schema 가 넓어질 때 test 가
+/// 조용히 현실과 갈린다.
+fn tomlWithoutSection(allocator: std.mem.Allocator, doc: []const u8, header: []const u8, next_header: []const u8) ![]u8 {
+    const from = std.mem.indexOf(u8, doc, header) orelse return error.TestUnexpectedResult;
+    const to = std.mem.indexOf(u8, doc, next_header) orelse return error.TestUnexpectedResult;
+    return std.mem.concat(allocator, u8, &.{ doc[0..from], doc[to..] });
+}
+
+test "#577 스키마가 넓어진 뒤의 옛 config 는 프로세스를 죽이지 않고 문구를 담아 돌아온다" {
+    const allocator = std.testing.allocator;
+    resetFatalNoticeForTest();
+    defer resetFatalNoticeForTest();
+
+    // v0.9.2 가 더한 `[input]` 이 없는 config — #577 의 실제 재현 조건이다.
+    const full = try defaultConfigToml(allocator, Defaults.shell, Defaults.hotkeyFor(0));
+    defer allocator.free(full);
+    const old = try tomlWithoutSection(allocator, full, "\n[input]\n", "\n[keys]\n");
+    defer allocator.free(old);
+
+    const path = "/home/user/.config/tildaz/config_0.toml";
+    try expectParseInvalid(old, path);
+
+    // 문구가 담겨 있어야 한다. 담기지 않으면 host 가 보여줄 것이 없어 증상이 그대로다.
+    const notice = pendingFatalNotice() orelse return error.TestUnexpectedResult;
+    // #495 형식 — 경로가 첫 줄, 정확히 한 번.
+    try std.testing.expect(std.mem.startsWith(u8, notice, "Config: " ++ path));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, notice, path));
+    // 사용자가 무엇을 고쳐야 하는지 — 빠진 key 이름이 들어 있어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, notice, "\"input\"") != null);
+}
+
+test "#577 pane 액션이 빠진 v0.9.2 config 도 같은 경로로 안내된다" {
+    const allocator = std.testing.allocator;
+    resetFatalNoticeForTest();
+    defer resetFatalNoticeForTest();
+
+    // v0.9.3 이 더한 15 개 pane 액션이 없는 config. `[keys]` 를 통째로 지우면 첫
+    // 액션에서 걸리므로, 여기서는 **pane 그룹만** 지운 상태를 만든다.
+    const full = try defaultConfigToml(allocator, Defaults.shell, Defaults.hotkeyFor(0));
+    defer allocator.free(full);
+    const old = try tomlWithoutSection(allocator, full, "\n# Panes\n", "\n# Clipboard\n");
+    defer allocator.free(old);
+
+    try expectParseInvalid(old, "/home/user/.config/tildaz/config_0.toml");
+    const notice = pendingFatalNotice() orelse return error.TestUnexpectedResult;
+    // 빠진 액션 이름이 나와야 한다 — 15 개 중 어느 것이든 첫 번째가 지목된다.
+    try std.testing.expect(std.mem.indexOf(u8, notice, "in keys") != null);
+}
+
+test "#577 첫 오류만 담는다 — 뒤 오류가 앞 문구를 덮지 않는다" {
+    const allocator = std.testing.allocator;
+    resetFatalNoticeForTest();
+    defer resetFatalNoticeForTest();
+
+    const full = try defaultConfigToml(allocator, Defaults.shell, Defaults.hotkeyFor(0));
+    defer allocator.free(full);
+    const no_input = try tomlWithoutSection(allocator, full, "\n[input]\n", "\n[keys]\n");
+    defer allocator.free(no_input);
+
+    try expectParseInvalid(no_input, "/first/config_0.toml");
+    const first = pendingFatalNotice() orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.startsWith(u8, first, "Config: /first/config_0.toml"));
+
+    // 두 번째 오류는 담기지 않는다. 사용자가 고칠 지점은 첫 오류이고, 예전 동작
+    // (첫 오류에서 즉시 종료) 과 보이는 문구가 같아야 한다.
+    try expectParseInvalid(no_input, "/second/config_0.toml");
+    const still_first = pendingFatalNotice() orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.startsWith(u8, still_first, "Config: /first/config_0.toml"));
+    try std.testing.expectEqual(@as(usize, 0), std.mem.count(u8, still_first, "/second/"));
+}
+
+test "#577 정상 config 는 문구를 담지 않는다" {
+    const allocator = std.testing.allocator;
+    resetFatalNoticeForTest();
+    defer resetFatalNoticeForTest();
+
+    var arena: std.heap.ArenaAllocator = .init(allocator);
+    defer arena.deinit();
+    const full = try defaultConfigToml(arena.allocator(), Defaults.shell, Defaults.hotkeyFor(0));
+
+    const rt: Runtime = .{ .io = std.testing.io, .environ = .empty };
+    _ = try Config.parse(rt, arena.allocator(), full, "/home/user/.config/tildaz/config_0.toml");
+
+    // 담긴 것이 없어야 한다 — 있으면 host 가 정상 부팅을 오류로 끊는다.
+    try std.testing.expectEqual(@as(?[]const u8, null), pendingFatalNotice());
+}
+
 test "DockPosition.fromString" {
     try std.testing.expectEqual(DockPosition.top, DockPosition.fromString("top").?);
     try std.testing.expectEqual(DockPosition.bottom, DockPosition.fromString("bottom").?);
@@ -3428,7 +3661,7 @@ test "explicit line height ratio is preserved when parsing" {
     // #451 — 정상 문서라 `parse` 가 fatal 경로 (config 경로 조회) 로 가지 않는다.
     // 그래서 `Environ.empty` 로 두어 테스트가 기계의 환경에 안 묶이게 한다.
     const rt: Runtime = .{ .io = std.testing.io, .environ = .empty };
-    const config = Config.parse(rt, allocator, json_text, "/tmp/config_0.toml");
+    const config = try Config.parse(rt, allocator, json_text, "/tmp/config_0.toml");
     defer config.deinit(allocator);
     try std.testing.expectEqual(@as(f32, 0.9), config.line_height_ratio);
 }

--- a/src/font/validate.zig
+++ b/src/font/validate.zig
@@ -19,39 +19,19 @@ const dialog = @import("../dialog.zig");
 const messages = @import("../messages.zig");
 const paths = @import("../paths.zig");
 
-/// `font.family` 가 string 이 아닐 때 (예: 구 schema 의 array). 메시지 +
-/// runtime 에서 결정한 config path 한 줄.
-///
-/// #577 — **문구만 만들고 띄우지 않는다.** 이 검증은 config 파싱 안에서 도는데
-/// 그 시점의 Linux 는 dialog backend 가 없어 (`dialog/linux.zig` 의 `showFatal`
-/// 주석) 여기서 `dialog.showFatal` 을 부르면 안내가 stderr 로만 가고 메뉴로 띄운
-/// 사용자에게는 보이지 않는다. 표시는 `config.zig` 의 지연 표시 경로가 맡는다.
-pub fn familyMustBeStringMessage(rt: Runtime, msg_buf: []u8) []const u8 {
-    return schemaErrorMessageFor(rt, msg_buf, messages.font_family_must_be_string_msg);
-}
-
-/// `font.glyph_fallback` 이 string 의 list 가 아닐 때 (다른 type, 또는 array
-/// element 가 string 아닌 경우). 위와 같은 이유로 문구만 만든다 (#577).
-pub fn glyphFallbackMustBeListMessage(rt: Runtime, msg_buf: []u8) []const u8 {
-    return schemaErrorMessageFor(rt, msg_buf, messages.font_glyph_fallback_must_be_list_msg);
-}
-
-/// 단순 schema 위반 메시지 + Config path 라인. 위 두 fn 의 공유 helper.
-fn schemaErrorMessageFor(rt: Runtime, msg_buf: []u8, line: []const u8) []const u8 {
-    var alloc_buf: [4096]u8 = undefined;
-    var fba = std.heap.FixedBufferAllocator.init(&alloc_buf);
-    const cfg_path: []const u8 = paths.configPath(rt, fba.allocator()) catch messages.unknown_path_msg;
-
-    return schemaErrorMessage(msg_buf, line, cfg_path);
-}
-
-fn schemaErrorMessage(msg_buf: []u8, line: []const u8, cfg_path: []const u8) []const u8 {
-    var fbs: std.Io.Writer = .fixed(msg_buf);
-    const w = &fbs;
-    w.writeAll(line) catch {};
-    w.print(messages.font_schema_error_path_format, .{cfg_path}) catch {};
-    return fbs.buffered();
-}
+// #577 — `font.family` / `font.glyph_fallback` 의 **schema** 위반 (string 이
+// 아님 · list 가 아님) 은 이 파일을 더 이상 지나지 않는다. 두 가지가 바뀌었다.
+//
+// (1) 그 검증은 config 파싱 안에서 도는데, 그 시점의 Linux 에는 dialog backend 가
+//     없어 여기서 `dialog.showFatal` 을 부르면 안내가 stderr 로만 갔다. 이제
+//     `config.zig` 가 문구를 담아 두고 host 가 그릴 수 있게 된 뒤 띄운다.
+// (2) 문구 조립도 `config.zig` 의 `recordConfigFatalMsg` 한 곳으로 모았다. 여기서
+//     만들면 경로를 `paths.configPath` 로 **다시 조회**해야 했는데, 파싱 중인 파일의
+//     경로는 이미 인자로 들어와 있다. 다시 조회하면 instance 번호와 실제 파일이
+//     갈릴 수 있다 (#316 의 교훈).
+//
+// 문구 상수 자체 (`messages.font_family_must_be_string_msg` 등) 는 그대로다 —
+// `config.zig` 가 그것을 `recordConfigFatalMsg` 에 넘긴다.
 
 /// `missing` 은 시스템에서 lookup 실패한 chain entry 이름. `chain` 은 사용자
 /// config 의 font.family 전체 (UTF-8 raw). 본 함수는 dialog.showFatal 로
@@ -95,6 +75,10 @@ pub fn notFoundMessageSub(rt: Runtime, msg_buf: []u8, missing: []const u8, chain
 pub fn notFoundMessageForPath(msg_buf: []u8, missing: []const u8, chain: []const []const u8, cfg_path: []const u8, substitute: ?[]const u8) []const u8 {
     var fbs: std.Io.Writer = .fixed(msg_buf);
     const w = &fbs;
+    // #577 — 경로가 **첫 줄**이다 (#495). 예전에는 맨 끝 footer 였다. 본문을 writer 로
+    // 쌓는 구조라 `config_error_with_path_format` 을 한 번에 print 할 수 없어서, 접두만
+    // 뺀 `config_error_path_prefix_format` 을 쓴다 — 다른 config 오류와 같은 첫 줄이다.
+    w.print(messages.config_error_path_prefix_format, .{cfg_path}) catch {};
     w.print(messages.font_not_found_format, .{missing}) catch {};
     w.writeAll(messages.font_chain_header_msg) catch {};
     for (chain) |fam| {
@@ -109,31 +93,43 @@ pub fn notFoundMessageForPath(msg_buf: []u8, missing: []const u8, chain: []const
             w.print(messages.font_substituted_format, .{ sub, missing }) catch {};
         }
     }
-    w.print(messages.font_chain_footer_format, .{cfg_path}) catch {};
+    w.writeAll(messages.font_chain_footer_msg) catch {};
     return fbs.buffered();
 }
 
 test "font validation messages preserve runtime values and final newline" {
-    var schema_buf: [256]u8 = undefined;
-    try std.testing.expectEqualStrings(
-        "Invalid config: font.family must be a string (font name).\n\nConfig path:\n  /tmp/config_3.json",
-        schemaErrorMessage(
-            &schema_buf,
-            messages.font_family_must_be_string_msg,
-            "/tmp/config_3.json",
-        ),
-    );
-
     var missing_buf: [1024]u8 = undefined;
     const chain = [_][]const u8{ "DejaVu Sans Mono", "Missing Font", "Noto Color Emoji" };
+    // #577 — 경로가 **첫 줄**이다 (#495). 예전에는 맨 끝 `Config path:` 였고,
+    // 폰트 schema 오류는 또 다른 자기 형식 (`  ` 들여쓰기) 이라 세 갈래였다.
     try std.testing.expectEqualStrings(
-        "Font not found: \"Missing Font\"\n\n" ++
+        "Config: /tmp/config_3.json\n\n" ++
+            "Font not found: \"Missing Font\"\n\n" ++
             "config \"font.family\" chain (in order):\n" ++
             "  - \"DejaVu Sans Mono\"\n" ++
             "  - \"Missing Font\" ← not installed\n" ++
             "  - \"Noto Color Emoji\"\n" ++
-            "\nAll families listed in font.family must be installed on the system.\n\n" ++
-            "Config path:\n/tmp/config_3.json\n",
+            "\nAll families listed in font.family must be installed on the system.\n",
         notFoundMessageForPath(&missing_buf, "Missing Font", &chain, "/tmp/config_3.json", null),
+    );
+    // 경로는 정확히 한 번만 나온다 — 접두로 옮기면서 footer 에서 뺐다.
+    const message = notFoundMessageForPath(&missing_buf, "Missing Font", &chain, "/tmp/config_3.json", null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, message, "/tmp/config_3.json"));
+}
+
+test "#577 폰트 schema 오류도 다른 config 오류와 같은 첫 줄을 쓴다" {
+    // 이 문구는 이제 `config.zig` 의 `recordConfigFatalMsg` 가 조립한다. 여기서는
+    // 그 조립이 지나는 공통 형식만 고정한다 — 세 갈래였던 형식이 하나로 모였다는
+    // 사실이 test 로 남아야 한다 (#495 가 노렸고 #577 이 마무리한 지점).
+    var buf: [512]u8 = undefined;
+    const message = try std.fmt.bufPrint(
+        &buf,
+        messages.config_error_with_path_format,
+        .{ "/tmp/config_3.toml", messages.font_family_must_be_string_msg },
+    );
+    try std.testing.expectEqualStrings(
+        "Config: /tmp/config_3.toml\n\n" ++
+            "Invalid config: font.family must be a string (font name).",
+        message,
     );
 }

--- a/src/font/validate.zig
+++ b/src/font/validate.zig
@@ -21,24 +21,28 @@ const paths = @import("../paths.zig");
 
 /// `font.family` 가 string 이 아닐 때 (예: 구 schema 의 array). 메시지 +
 /// runtime 에서 결정한 config path 한 줄.
-pub fn showFamilyMustBeStringFatal(rt: Runtime) noreturn {
-    showSchemaErrorFatal(rt, messages.font_family_must_be_string_msg);
+///
+/// #577 — **문구만 만들고 띄우지 않는다.** 이 검증은 config 파싱 안에서 도는데
+/// 그 시점의 Linux 는 dialog backend 가 없어 (`dialog/linux.zig` 의 `showFatal`
+/// 주석) 여기서 `dialog.showFatal` 을 부르면 안내가 stderr 로만 가고 메뉴로 띄운
+/// 사용자에게는 보이지 않는다. 표시는 `config.zig` 의 지연 표시 경로가 맡는다.
+pub fn familyMustBeStringMessage(rt: Runtime, msg_buf: []u8) []const u8 {
+    return schemaErrorMessageFor(rt, msg_buf, messages.font_family_must_be_string_msg);
 }
 
 /// `font.glyph_fallback` 이 string 의 list 가 아닐 때 (다른 type, 또는 array
-/// element 가 string 아닌 경우).
-pub fn showGlyphFallbackMustBeListFatal(rt: Runtime) noreturn {
-    showSchemaErrorFatal(rt, messages.font_glyph_fallback_must_be_list_msg);
+/// element 가 string 아닌 경우). 위와 같은 이유로 문구만 만든다 (#577).
+pub fn glyphFallbackMustBeListMessage(rt: Runtime, msg_buf: []u8) []const u8 {
+    return schemaErrorMessageFor(rt, msg_buf, messages.font_glyph_fallback_must_be_list_msg);
 }
 
-/// 단순 schema 위반 메시지 + Config path 라인 → fatal. 위 두 fn 의 공유 helper.
-fn showSchemaErrorFatal(rt: Runtime, line: []const u8) noreturn {
+/// 단순 schema 위반 메시지 + Config path 라인. 위 두 fn 의 공유 helper.
+fn schemaErrorMessageFor(rt: Runtime, msg_buf: []u8, line: []const u8) []const u8 {
     var alloc_buf: [4096]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&alloc_buf);
     const cfg_path: []const u8 = paths.configPath(rt, fba.allocator()) catch messages.unknown_path_msg;
 
-    var msg_buf: [1024]u8 = undefined;
-    dialog.showFatal(rt, messages.config_error_title, schemaErrorMessage(&msg_buf, line, cfg_path));
+    return schemaErrorMessage(msg_buf, line, cfg_path);
 }
 
 fn schemaErrorMessage(msg_buf: []u8, line: []const u8, cfg_path: []const u8) []const u8 {

--- a/src/host/linux/dialog_layout.zig
+++ b/src/host/linux/dialog_layout.zig
@@ -496,13 +496,19 @@ test "current Linux dialog messages fit the 640x480 logical minimum" {
         .{ .title = messages.config_error_title, .message = parse_msg, .kind = .info },
         .{ .title = messages.config_error_title, .message = hotkey_invalid_msg, .kind = .info },
         .{ .title = messages.config_error_title, .message = theme_msg, .kind = .info },
-        // 여백을 폰트 비례로 넓히면서 (#407) 1.7x 에서만 2 행이 넘친다 — 고정 chrome
+        // 여백을 폰트 비례로 넓히면서 (#407) 1.7x 에서만 행이 넘친다 — 고정 chrome
         // 반올림이 그 배율에서 한 행을 더 먹는다 (font 오류 주석과 같은 이유).
-        .{ .title = messages.config_error_title, .message = shell_msg, .kind = .info, .standard_scroll_by_scale = .{ 0, 2, 0 } },
+        //
+        // #577 — 2 → 1. 경로를 맨 끝 `Config path:` 에서 첫 줄 `Config: ` 로 옮기면서
+        // 문구가 한 줄 짧아졌다 (예전 footer 는 빈 줄 + 라벨 줄 + 경로 줄 셋이었다).
+        .{ .title = messages.config_error_title, .message = shell_msg, .kind = .info, .standard_scroll_by_scale = .{ 0, 1, 0 } },
         .{ .title = messages.shell_new_tab_error_title, .message = new_tab_msg, .kind = .info },
         // 64pt branded icon을 고정하면 최대 8-entry font 오류는 640x480에서
         // 본문만 overflow한다. 여백을 폰트 비례로 넓히며 (#407) 3/4/3 → 5/5/5 가 됐다.
-        .{ .title = messages.config_error_title, .message = font_msg, .kind = .info, .standard_scroll_by_scale = .{ 5, 5, 5 } },
+        //
+        // #577 — 5/5/5 → 4/4/4. 위 shell 과 같은 이유다 — 경로가 맨 끝 3 줄 footer 에서
+        // 첫 줄 2 줄 접두로 옮겨져 문구가 한 줄 짧아졌다. 세 배율이 함께 줄었다.
+        .{ .title = messages.config_error_title, .message = font_msg, .kind = .info, .standard_scroll_by_scale = .{ 4, 4, 4 } },
         .{ .title = messages.hotkey_takeover_title, .message = takeover_msg, .kind = .confirm },
         .{ .title = messages.new_instance_title, .message = prompt_msg, .kind = .prompt },
         .{ .title = messages.new_instance_title, .message = create_error_msg, .kind = .info },

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1759,6 +1759,38 @@ const Client = struct {
         try self.createKeyboardIfAvailable();
         if (self.keyboard_id != 0) try self.roundtrip();
         self.logBootElapsed("keyboard ready");
+
+        // #577 — **config 오류를 여기서 안내하고 멈춘다.** `Config.load` 는 문구를
+        // 담아 두고 기본값으로 돌아온다 (`config.zig` 의 `recordConfigFatalMsg` 주석) —
+        // 파싱 시점의 Linux 에는 dialog backend 가 없어서 그 자리에서 띄우면 안내가
+        // stderr 로만 가고, 메뉴 · autostart 로 띄운 사용자는 **창도 다이얼로그도 없이**
+        // 죽는 것만 본다. 그것이 이 이슈다.
+        //
+        // 자리가 여기인 이유는 아래 shell · 폰트 검증과 같다 (#282 C2) — Wayland
+        // globals + keyboard 가 준비돼 overlay 를 그릴 수 있고, 첫 탭 PTY 는 아직
+        // 안 띄웠다. 다만 그 둘보다 **앞이다**:
+        //
+        //   - config 를 못 읽은 실행은 기본값으로 도는 중이라, shell · 폰트 검증이
+        //     보는 값이 사용자가 적은 값이 아니다. 그 상태의 안내를 먼저 내면 사용자는
+        //     자기가 고치지도 않은 shell 을 의심한다.
+        //   - 위치 표기 hotkey 의 KDE 등록 (`registerKdePositionHotkey`) 과 hotkey
+        //     claim 판정 (`fatalIfHotkeyClaimFailed`) 보다 앞이다. 그 판정이 보는
+        //     hotkey 도 기본값이라 "F1 을 못 잡았다" 가 사용자 설정과 무관해진다.
+        //
+        // **라벨 표기 hotkey 의 KGlobalAccel 등록은 이미 위에서 지나갔다** — 그쪽은
+        // keymap 이 필요 없어 `createKeyboardIfAvailable` 앞에 있고, overlay 는 keyboard
+        // 준비 뒤에만 그릴 수 있어 여기보다 앞으로 옮길 수 없다. 그래서 이 경로는 KDE
+        // 단축키 등록을 남긴 채 종료한다 — `exit(1)` 이 `deinit` 의 `setInactive` 를
+        // 건너뛰기 때문이다. 아래 shell · 폰트 검증도 같은 성질이라 새로 생긴 것은 아니다.
+        //
+        // 문구는 담을 때 이미 stderr + 로그에 남았다 (`publishFatalNotice`). 여기서
+        // 다시 남기지 않는다 — 로그에 같은 문장이 두 번 찍히면 어느 것이 실제 표시
+        // 시점인지 알 수 없다.
+        if (config_mod.pendingFatalNotice()) |notice| {
+            self.runFatalDialog(messages.config_error_title, notice);
+            std.process.exit(1);
+        }
+
         // #496 1-c — 위치 표기 hotkey 의 KDE 등록. keymap 이 방금 도착했다.
         if (!self.run_opts.isStressRun()) {
             self.registerKdePositionHotkey();

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1693,6 +1693,42 @@ const Client = struct {
         closeFd(self.wayland_fd);
     }
 
+    /// #577 — registry → globals 까지. `run` 과 `showFatalStandalone` 이 **같은 코드**를
+    /// 쓴다. 사이에 끼어드는 것이 없는 구간이라 그대로 뺄 수 있었고, 그래서 `run` 의
+    /// 나머지 순서 (GPU → KGlobalAccel → keyboard) 는 손대지 않았다 — 그 순서에는
+    /// #277 · #496 1-c 의 근거가 붙어 있다.
+    fn connectAndBindGlobals(self: *Client) !void {
+        try self.getRegistry();
+        try self.roundtrip();
+        self.logBootElapsed("registry+roundtrip");
+
+        if (self.caps.compositor.name == 0) return error.WaylandCompositorMissing;
+        if (self.caps.shm.name == 0) return error.WaylandShmMissing;
+        if (self.caps.xdg_wm_base.name == 0) return error.WaylandXdgWmBaseMissing;
+
+        try self.bindGlobals();
+        try self.roundtrip();
+    }
+
+    /// #577 — dialog overlay 를 그릴 수 있는 최소 상태까지만 세운다
+    /// (`showFatalStandalone` 전용). GPU 와 전역 hotkey 등록은 건너뛴다 — dialog surface
+    /// 는 항상 `wl_shm` 이고, 곧 종료할 프로세스가 KDE 단축키 레지스트리를 건드릴 이유가
+    /// 없다.
+    ///
+    /// `argb8888` 과 keyboard 는 `run` 과 겹치는 세 줄이다. 그쪽 순서를 바꾸지 않으려고
+    /// (사이에 GPU · KGlobalAccel 이 있다) 여기 다시 적었다 — **bring-up 순서를 고칠
+    /// 때는 `run` 과 이 함수를 함께 본다.**
+    fn bringUpForDialog(self: *Client) !void {
+        try self.connectAndBindGlobals();
+        self.logCapabilities();
+        // L13-γ — dialog surface 도 alpha 채널이 필요하다 (`run` 의 같은 검사).
+        if (!self.saw_argb8888) return error.WaylandShmArgb8888Missing;
+        // dialog 를 Enter · Esc 로 닫을 수 있어야 한다.
+        try self.createKeyboardIfAvailable();
+        if (self.keyboard_id != 0) try self.roundtrip();
+        self.logBootElapsed("dialog-only bring-up");
+    }
+
     fn run(self: *Client) !void {
         // #205 — boot phase elapsed timer start. 사용자 *체감* 1-2 sec startup
         // latency 진단용. monotonic, ns_per_ms 단위로 log.
@@ -1722,16 +1758,7 @@ const Client = struct {
         });
         defer dialog_linux.unregisterCallbacks();
 
-        try self.getRegistry();
-        try self.roundtrip();
-        self.logBootElapsed("registry+roundtrip");
-
-        if (self.caps.compositor.name == 0) return error.WaylandCompositorMissing;
-        if (self.caps.shm.name == 0) return error.WaylandShmMissing;
-        if (self.caps.xdg_wm_base.name == 0) return error.WaylandXdgWmBaseMissing;
-
-        try self.bindGlobals();
-        try self.roundtrip();
+        try self.connectAndBindGlobals();
         // #277 — roundtrip 이후여야 dmabuf 의 modifier event 가 다 도착해 있다.
         self.initGpuIfAvailable();
         self.logCapabilities();
@@ -10156,6 +10183,53 @@ pub fn runBaselineWindow(
     // 으로 자동 등록. 그 외 DE 면 no-op.
     if (!opts.isStressRun()) gsettings_hotkey.registerToggleHotkey(rt, allocator, cfg);
     try client.run();
+}
+
+/// #577 — **창도 PTY 도 없이 fatal 다이얼로그 하나만 띄운다.**
+///
+/// launcher (`main.zig` 의 `runLauncher`) 는 `host.run` 을 거치지 않아 `Client` 가 아예
+/// 없다. 그래서 Linux 에서는 기동 실패 안내가 `log.userFacing` 으로 stderr + 로그에만
+/// 갔고, `.desktop` (메뉴 · autostart) 실행에서 stderr 는 어디에도 붙지 않으므로
+/// **사용자는 아무것도 보지 못했다.** Windows (`MessageBoxW`) · macOS (`NSAlert`) 는 OS 가
+/// 모달을 주므로 같은 자리에서 그냥 떴다 — SPEC §0 #1 (세 platform 동등) 이 깨진 자리다.
+///
+/// 그릴 수 있는 근거: dialog 는 **자기 layer-shell surface** 이고 항상 `wl_shm` 이라
+/// (GPU 불필요) Wayland 연결 + globals + keyboard 까지만 있으면 된다. 그리고
+/// `runFatalDialog` 는 이미 "터미널 세션이 없는 상태에서 blocking 안내" 를 하는 경로다
+/// (#282 C2 — 그 함수 주석의 *"그 시점엔 세션이 아직 없어서 `deinit` 을 건너뛰어도 거둘
+/// PTY 자식이 없다"*). 여기서는 그 상태를 **처음부터** 만든다.
+///
+/// config 는 **기본값**을 쓴다 (`Config{}`). 이 경로가 알리는 것은 config 과 무관한
+/// 실패 (spawn 실패 · lock 실패 · worker 무응답) 이고, 애초에 config 을 읽지 못한
+/// 실행일 수도 있다. 다이얼로그 폰트도 시스템 폰트로 고정한다 — 사용자 폰트 설정이
+/// 잘못됐을 가능성을 이 화면이 다시 밟지 않게 한다 (폰트 오류 안내가 쓰는 것과 같은
+/// 이유, #406).
+///
+/// **`deinit` 을 부르지 않는다.** 호출처가 곧 `exit(1)` 하고, 이 시점에는 거둘 PTY
+/// 자식도 KDE 등록도 없다 (`runFatalDialog` 의 세 기존 호출처와 같은 성질).
+///
+/// 실패하면 **조용히 돌아간다.** 호출처가 이미 stderr + 로그에 같은 문구를 남겼으므로,
+/// 여기서 또 오류를 내면 "안내를 못 띄웠다" 가 원래 오류를 덮는다.
+pub fn showFatalStandalone(rt: Runtime, allocator: std.mem.Allocator, title: []const u8, message: []const u8) void {
+    const cfg = config_mod.Config{};
+    var client = Client.init(rt, allocator, &cfg, .{}) catch |err| {
+        // Wayland 연결 자체가 안 되는 환경 (headless · X11 세션). `Client.init` 이
+        // socket path 와 env 를 이미 stderr + 로그에 남겼다 (`reportWaylandSocketFailure`).
+        log.appendLine("dialog", "standalone fatal dialog unavailable: {s} — stderr/log only", .{@errorName(err)});
+        return;
+    };
+    // 사용자 폰트 설정과 무관하게 읽히게 한다.
+    client.renderer.dialog_use_system_font = true;
+
+    // `Client.run` 의 앞부분과 **같은 순서**다 — registry → globals → keyboard. GPU
+    // (`initGpuIfAvailable`) 와 전역 hotkey 등록은 건너뛴다: dialog 는 `wl_shm` 으로
+    // 그리고, 곧 종료할 프로세스가 KDE 단축키 레지스트리를 건드릴 이유가 없다.
+    client.bringUpForDialog() catch |err| {
+        log.appendLine("dialog", "standalone fatal dialog bring-up failed: {s} — stderr/log only", .{@errorName(err)});
+        return;
+    };
+
+    client.runFatalDialog(title, message);
 }
 
 const Msg = struct {

--- a/src/host/linux_wayland.zig
+++ b/src/host/linux_wayland.zig
@@ -39,7 +39,7 @@ pub fn showPanic(msg: []const u8, addr: usize, _: ?*std.builtin.StackTrace) nore
     std.debug.defaultPanic(msg, addr);
 }
 
-pub fn showFatalRunError(err: anyerror) void {
+pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerror) void {
     // #197 — 사용자 메시지를 stderr + 로그에 동일하게 (log.userFacing). 로그와
     // 화면 내용이 갈리지 않는다.
     switch (err) {
@@ -49,6 +49,9 @@ pub fn showFatalRunError(err: anyerror) void {
         // Wayland socket 실패는 `Client.init` 안에서 path / env 까지 포함한
         // 정확한 메시지를 이미 stderr + log 양쪽에 남겼다. 여기선 errorName 만
         // compact 하게 한 줄 — generic 본문을 다시 내면 그 진단을 가린다.
+        //
+        // #577 — 다이얼로그도 띄우지 않는다. Wayland 에 연결할 수 없다는 것이 이 오류의
+        // 내용이므로, Wayland 로 그리는 안내는 정의상 뜰 수 없다.
         error.WaylandSocketUnavailable => {
             log.logRunFailed(err);
         },
@@ -60,7 +63,19 @@ pub fn showFatalRunError(err: anyerror) void {
         else => {
             var buf: [256]u8 = undefined;
             const text = messages.runFailureMessage(&buf, err);
+            // stderr + 로그를 **먼저** 남긴다 — 아래 다이얼로그는 사용자가 닫을 때까지
+            // 돌아오지 않으므로, 뒤에 두면 창을 안 닫고 프로세스를 죽인 회차에 아무것도
+            // 안 남는다 (`dialog.showFatal` 이 같은 순서를 쓰는 이유, #510).
             log.userFacing("fatal", text);
+            // #577 — **여기가 이 이슈의 원인 ② 다.** 예전에는 위 한 줄로 끝이라, launcher
+            // 가 기동 실패를 알려도 `.desktop` 실행에서는 stderr 가 어디에도 붙지 않아
+            // 사용자가 아무것도 보지 못했다. Windows (`MessageBoxW`) · macOS (`NSAlert`) 는
+            // 같은 자리에서 OS 모달을 띄웠다 — SPEC §0 #1 이 깨진 자리였다.
+            //
+            // launcher 는 `host.run` 을 거치지 않아 `Client` 가 없으므로 `dialog.showError`
+            // 로는 안 된다 (등록된 backend 가 없어 stderr fallback 으로 되돌아간다). 그래서
+            // 창도 PTY 도 없이 다이얼로그만 세우는 경로를 쓴다.
+            wayland.showFatalStandalone(rt, allocator, messages.error_title, text);
         },
     }
     std.process.exit(1);

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -57,11 +57,14 @@ pub fn showPanic(msg: []const u8, addr: usize, _: ?*std.builtin.StackTrace) nore
     std.process.exit(1);
 }
 
-pub fn showFatalRunError(err: anyerror) void {
+pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerror) void {
+    // #577 — `rt` 를 인자로 받는다. `g_rt` 는 `run()` 안에서만 심어지는데 launcher 실패
+    // 경로는 `run()` 을 거치지 않아 `undefined` 를 읽었다 (Windows host 주석 참고).
+    _ = allocator;
     log.logRunFailed(err);
     var buf: [256]u8 = undefined;
     const text = messages.runFailureMessage(&buf, err);
-    dialog.showError(g_rt, messages.error_title, text);
+    dialog.showError(rt, messages.error_title, text);
 }
 
 // AppKit / Metal 상수.

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -3776,6 +3776,15 @@ pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {
     g_config = config.Config.load(rt, g_gpa.allocator(), shell_resolved);
     log.logConfigLoaded(g_config);
 
+    // #577 — config 오류가 담겨 있으면 여기서 안내하고 종료한다. `Config.load` 는
+    // 더 이상 그 자리에서 죽지 않고 문구를 담아 기본값으로 돌아온다 (Linux 에서
+    // 파싱 시점에는 다이얼로그를 그릴 수 없기 때문이다 — `config.zig` 의
+    // `recordConfigFatalMsg` 주석). macOS 는 `NSAlert` 가 modal 이라 창을 세우기
+    // 전 이 자리에서 그대로 띄울 수 있다.
+    //
+    // **shell 검증보다 앞이다** — 세 platform 같은 순서다 (Windows host 주석 참고).
+    config.showFatalNoticeIfAny(g_rt);
+
     // shell executable 이 실제 존재하고 실행 가능한지 검증. PTY 단계까지 가서
     // execve 실패하면 generic 에러로 끝나 사용자에게 어디 고쳐야 할지 안내 안
     // 됨 — config 로드 직후 fatal 로 종료. Windows host 와 같은 정책.

--- a/src/host/unsupported.zig
+++ b/src/host/unsupported.zig
@@ -7,7 +7,10 @@ pub fn showPanic(msg: []const u8, addr: usize, _: ?*std.builtin.StackTrace) nore
     std.process.exit(1);
 }
 
-pub fn showFatalRunError(err: anyerror) void {
+pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerror) void {
+    // #577 — 세 host 와 같은 서명. 이 platform 은 다이얼로그가 없어 둘 다 안 쓴다.
+    _ = rt;
+    _ = allocator;
     std.debug.print("TildaZ failed to start.\n\nError: {s}\n", .{@errorName(err)});
 }
 

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -40,12 +40,17 @@ pub fn showPanic(msg: []const u8, addr: usize, _: ?*std.builtin.StackTrace) nore
     std.process.exit(1);
 }
 
-pub fn showFatalRunError(err: anyerror) void {
+pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerror) void {
+    // #577 — `rt` 를 인자로 받는다. 예전에는 `g_rt` 를 읽었는데 그것은 `run()` 안에서만
+    // 심어지고, **launcher 실패 경로는 `run()` 을 거치지 않는다** (`main.zig` 의
+    // `runLauncher` catch). 즉 그 경로에서 `g_rt` 는 `undefined` 였다. Linux 가 이 자리에
+    // 다이얼로그를 붙이려고 서명을 바꾸면서 함께 닫았다.
+    _ = allocator;
     log.logRunFailed(err);
 
     var buf: [256]u8 = undefined;
     const text = messages.runFailureMessage(&buf, err);
-    dialog.showError(g_rt, messages.error_title, text);
+    dialog.showError(rt, messages.error_title, text);
 }
 
 pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -81,6 +81,17 @@ pub fn run(rt: Runtime, opts: run_options.RunOptions) !void {
     defer config.deinit(alloc);
     log.logConfigLoaded(config);
 
+    // #577 — config 오류가 담겨 있으면 여기서 안내하고 종료한다. `Config.load` 는
+    // 더 이상 그 자리에서 죽지 않고 문구를 담아 기본값으로 돌아온다 (Linux 에서
+    // 파싱 시점에는 다이얼로그를 그릴 수 없기 때문이다 — `config.zig` 의
+    // `recordConfigFatalMsg` 주석). Windows 는 `MessageBoxW` 가 modal 이라 창을
+    // 세우기 전 이 자리에서 그대로 띄울 수 있다.
+    //
+    // **shell 검증보다 앞이다** — config 를 못 읽은 실행은 기본값으로 도는 중이라
+    // 아래 검증이 보는 shell 이 사용자가 적은 값이 아니다. 순서가 뒤바뀌면 사용자는
+    // 자기가 고치지도 않은 shell 을 의심한다 (Linux host 도 같은 순서다).
+    config_mod.showFatalNoticeIfAny(rt);
+
     // shell executable 이 PATH 또는 절대경로로 실제 존재하는지 *지금* 검증.
     // CreateProcessW 단계까지 가면 윈도우 / 렌더러 / PTY 초기화 비용 다 쓴
     // 뒤 generic 에러로 끝남 — 사용자에게 어디 고쳐야 할지 안내 안 됨.

--- a/src/instances.zig
+++ b/src/instances.zig
@@ -241,17 +241,89 @@ fn workerLockOwned(rt: Runtime, path: []const u8) !bool {
 }
 
 pub fn waitUntilRunning(rt: Runtime, allocator: std.mem.Allocator, index: u32, timeout_ns: u64) !void {
-    const path = try paths.instanceLockPath(rt, allocator, index);
-    defer allocator.free(path);
-    var timer: runtime.Timer = .start(rt);
-    while (timer.read() < timeout_ns) {
-        // PID는 worker가 lock을 획득한 뒤 기록한다. 파일이 비어 있는 동안 lock을
-        // probe하면 launcher가 worker보다 먼저 lock을 잡는 race가 생기므로 metadata만
-        // 확인한다. PID가 쓰인 뒤 실제 생존 판정은 다시 advisory lock으로 검증한다.
-        if (ownerPidWritten(rt, path) and try isRunning(rt, allocator, index)) return;
-        rt.sleepNs(10 * std.time.ns_per_ms);
+    const lock_path = try paths.instanceLockPath(rt, allocator, index);
+    defer allocator.free(lock_path);
+    const endpoint_path = try paths.instanceEndpointStatePath(rt, allocator, index);
+    defer allocator.free(endpoint_path);
+
+    var probe = FileStartupProbe{
+        .rt = rt,
+        .lock_path = lock_path,
+        .endpoint_path = endpoint_path,
+        .timer = .start(rt),
+    };
+    try waitUntilRunningWithProbe(&probe, timeout_ns);
+}
+
+/// #577 — launcher 가 방금 띄운 worker 의 기동 결과. 예전에는 `waitUntilRunning` 이
+/// lock 파일만 봐서 "아직 시작 중" 과 "이미 죽음" 을 구별하지 못했고, 그래서 기동에
+/// 실패한 실행은 전부 타임아웃 10 초를 통째로 기다린 뒤 generic `WorkerStartTimeout`
+/// 을 냈다. 사용자가 본 것은 "클릭했는데 10 초간 아무 일도 없음" 이었다.
+const StartupProbeResult = enum {
+    not_yet,
+    running,
+    worker_exited,
+};
+
+const startup_poll_interval_ns = 10 * std.time.ns_per_ms;
+
+const FileStartupProbe = struct {
+    rt: Runtime,
+    lock_path: []const u8,
+    endpoint_path: []const u8,
+    timer: runtime.Timer,
+
+    fn poll(self: *@This()) !StartupProbeResult {
+        return probeStartupFiles(self.rt, self.lock_path, self.endpoint_path);
+    }
+
+    fn elapsedNs(self: *@This()) u64 {
+        return self.timer.read();
+    }
+
+    fn sleep(self: *@This(), duration_ns: u64) void {
+        self.rt.sleepNs(duration_ns);
+    }
+};
+
+fn waitUntilRunningWithProbe(probe: anytype, timeout_ns: u64) !void {
+    while (probe.elapsedNs() < timeout_ns) {
+        switch (try probe.poll()) {
+            .running => return,
+            .worker_exited => return error.WorkerExitedDuringStartup,
+            .not_yet => {},
+        }
+
+        const elapsed = probe.elapsedNs();
+        if (elapsed >= timeout_ns) break;
+        probe.sleep(@min(startup_poll_interval_ns, timeout_ns - elapsed));
     }
     return error.WorkerStartTimeout;
+}
+
+/// 두 파일로 기동 여부를 읽는다. 판정 근거는 `acquireWorkerLock` 의 **쓰기 순서**다 —
+/// lock 을 잡은 뒤 endpoint 상태 `.starting` 을 먼저 쓰고, 그 다음 owner PID 를 쓴다.
+///
+/// 이 읽기가 **이전 실행이 남긴 endpoint 파일을 보고 오판하지 않는** 근거는
+/// `spawnWorker` 가 spawn 직전에 그 파일을 지운다는 것이다 (`clearEndpointState`).
+/// 그래서 여기서 파일이 보이면 방금 띄운 worker 가 쓴 것이다.
+fn probeStartupFiles(rt: Runtime, lock_path: []const u8, endpoint_path: []const u8) !StartupProbeResult {
+    // PID는 worker가 lock을 획득한 뒤 기록한다. 파일이 비어 있는 동안 lock을
+    // probe하면 launcher가 worker보다 먼저 lock을 잡는 race가 생기므로 metadata만
+    // 확인한다. PID가 쓰인 뒤 실제 생존 판정은 다시 advisory lock으로 검증한다.
+    if (ownerPidWritten(rt, lock_path)) {
+        if (try workerLockOwned(rt, lock_path)) return .running;
+        // PID 는 쓰였는데 lock 이 비었다 — 쓴 뒤에 죽었다. 정상 종료는
+        // `clear_pid_on_close` 가 PID 를 비우므로 아래 분기로 간다.
+        return .worker_exited;
+    }
+
+    // PID 가 아직 없다. endpoint 상태 파일이 있으면 worker 가 lock 을 잡는 데까지는
+    // 갔다는 뜻이고, 그런데 lock 이 비어 있다면 그 사이에 죽은 것이다.
+    if (try readEndpointSnapshot(rt, endpoint_path) != null and !try workerLockOwned(rt, lock_path))
+        return .worker_exited;
+
+    return .not_yet;
 }
 
 pub fn recordEndpointState(rt: Runtime, allocator: std.mem.Allocator, index: u32, state: EndpointState) !void {
@@ -489,10 +561,27 @@ pub fn spawnWorker(rt: Runtime, allocator: std.mem.Allocator, index: u32) !void 
     const exe = exe_buf[0..exe_len];
     const index_text = try std.fmt.allocPrint(allocator, "{d}", .{index});
     defer allocator.free(index_text);
+    // #577 — spawn **직전에** 이전 실행이 남긴 endpoint 상태 파일을 지운다.
+    // `waitUntilRunning` 이 "그 파일이 있다 = 방금 띄운 worker 가 lock 을 잡았다" 로
+    // 읽어 조기 사망을 판정하므로, stale 파일이 남아 있으면 시작하자마자 죽은 것으로
+    // 오판한다. 여기가 자리인 이유는 spawn 하는 쪽이 한 곳이라 호출처가 잊을 수 없다는
+    // 것이다. 이 시점에 그 index 의 worker 는 살아 있지 않다 (`main.zig` 가
+    // `!isRunning(index)` 일 때만 부른다).
+    try clearEndpointState(rt, allocator, index);
     // 자식을 기다리지 않는다 — worker 는 독립 프로세스이고, launcher 는 lock 파일로
     // 기동을 확인한 뒤 (`waitUntilRunning`) 곧 끝난다. 예전 `Child.init` + `spawn` 도
     // 같았다 (`wait` 를 부르지 않았다).
     _ = try std.process.spawn(rt.io, .{ .argv = &.{ exe, "--instance", index_text } });
+}
+
+/// #577 — endpoint 상태 파일을 없앤다. 없으면 아무 일도 하지 않는다.
+fn clearEndpointState(rt: Runtime, allocator: std.mem.Allocator, index: u32) !void {
+    const path = try paths.instanceEndpointStatePath(rt, allocator, index);
+    defer allocator.free(path);
+    std.Io.Dir.deleteFileAbsolute(rt.io, path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
 }
 
 pub fn defaultShell(rt: Runtime, allocator: std.mem.Allocator) ![]u8 {
@@ -855,4 +944,101 @@ test "endpoint ready wait has a finite timeout" {
         waitUntilEndpointReadyWithProbe(&probe, timeout_ns),
     );
     try std.testing.expectEqual(timeout_ns, probe.elapsed_ns);
+}
+
+const FakeStartupProbe = struct {
+    results: []const StartupProbeResult,
+    next_result: usize = 0,
+    elapsed_ns: u64 = 0,
+
+    fn poll(self: *@This()) !StartupProbeResult {
+        const index = @min(self.next_result, self.results.len - 1);
+        self.next_result += 1;
+        return self.results[index];
+    }
+
+    fn elapsedNs(self: *@This()) u64 {
+        return self.elapsed_ns;
+    }
+
+    fn sleep(self: *@This(), duration_ns: u64) void {
+        self.elapsed_ns += duration_ns;
+    }
+};
+
+test "#577 기동 대기는 worker 사망을 타임아웃 없이 알린다" {
+    const results = [_]StartupProbeResult{ .not_yet, .worker_exited };
+    var probe = FakeStartupProbe{ .results = &results };
+    try std.testing.expectError(
+        error.WorkerExitedDuringStartup,
+        waitUntilRunningWithProbe(&probe, 10 * std.time.ns_per_s),
+    );
+    // **10 초를 기다리지 않는다.** 예전에는 사망도 타임아웃으로만 드러나서 사용자가
+    // 클릭 후 10 초를 아무 반응 없이 기다렸다 — 이 값이 그 회귀를 막는다.
+    try std.testing.expectEqual(startup_poll_interval_ns, probe.elapsed_ns);
+}
+
+test "#577 기동 대기는 성공 시 즉시 돌아온다" {
+    const results = [_]StartupProbeResult{.running};
+    var probe = FakeStartupProbe{ .results = &results };
+    try waitUntilRunningWithProbe(&probe, 10 * std.time.ns_per_s);
+    try std.testing.expectEqual(@as(u64, 0), probe.elapsed_ns);
+}
+
+test "#577 기동 대기는 응답 없는 worker 에 유한 타임아웃을 유지한다" {
+    // 죽지도 뜨지도 않는 worker (hang) — 여기서는 타임아웃이 유일한 탈출구다.
+    const results = [_]StartupProbeResult{.not_yet};
+    var probe = FakeStartupProbe{ .results = &results };
+    const timeout_ns = 25 * std.time.ns_per_ms;
+    try std.testing.expectError(
+        error.WorkerStartTimeout,
+        waitUntilRunningWithProbe(&probe, timeout_ns),
+    );
+    try std.testing.expectEqual(timeout_ns, probe.elapsed_ns);
+}
+
+test "#577 기동 probe 는 lock 과 endpoint 파일로 사망을 가려낸다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const allocator = std.testing.allocator;
+    const rt = testRuntime();
+    const root = try tmp.dir.realPathFileAlloc(rt.io, ".", allocator);
+    defer allocator.free(root);
+    const lock_path = try std.Io.Dir.path.join(allocator, &.{ root, "instance0.lock" });
+    defer allocator.free(lock_path);
+    const endpoint_path = try std.Io.Dir.path.join(allocator, &.{ root, "instance0.endpoint" });
+    defer allocator.free(endpoint_path);
+
+    // 아무것도 없다 — 방금 spawn 했고 worker 가 아직 lock 을 못 잡았다.
+    // `spawnWorker` 가 endpoint 파일을 지우고 spawn 하므로 이것이 실제 초기 상태다.
+    try std.testing.expectEqual(
+        StartupProbeResult.not_yet,
+        try probeStartupFiles(rt, lock_path, endpoint_path),
+    );
+
+    const pid = currentProcessId();
+    {
+        var worker_lock = (try tryAcquireProcessLock(rt, lock_path)).?;
+        defer worker_lock.deinit(rt);
+
+        // lock 을 잡고 `.starting` 만 쓴 상태 (PID 는 아직) — 계속 기다려야 한다.
+        try writeEndpointSnapshot(rt, allocator, endpoint_path, pid, .starting);
+        try std.testing.expectEqual(
+            StartupProbeResult.not_yet,
+            try probeStartupFiles(rt, lock_path, endpoint_path),
+        );
+
+        // PID 까지 썼다 — 기동 성공.
+        try writeOwnerPid(rt, worker_lock.file);
+        try std.testing.expectEqual(
+            StartupProbeResult.running,
+            try probeStartupFiles(rt, lock_path, endpoint_path),
+        );
+    }
+
+    // lock 이 풀렸고 endpoint 파일은 남아 있다 = 쓰고 나서 죽었다.
+    try std.testing.expectEqual(
+        StartupProbeResult.worker_exited,
+        try probeStartupFiles(rt, lock_path, endpoint_path),
+    );
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -214,7 +214,7 @@ pub fn main(init: std.process.Init) void {
                 // 않는다.
                 log.appendLine("toggle-ipc", "--toggle found no running instance {d} — starting it", .{index});
                 initLogging(rt, arena);
-                runLauncher(rt, init.gpa, autostart_launch) catch |launch_err| host.showFatalRunError(launch_err);
+                runLauncher(rt, init.gpa, autostart_launch) catch |launch_err| host.showFatalRunError(rt, init.gpa, launch_err);
                 return;
             };
             log.appendLine("toggle-ipc", "--toggle sent to running instance", .{});
@@ -243,7 +243,7 @@ pub fn main(init: std.process.Init) void {
         instance_context.setRole(.stress);
         instance_context.setWorkerIndex(worker_index orelse 0);
         initLogging(rt, arena);
-        host.run(rt, run_opts) catch |err| host.showFatalRunError(err);
+        host.run(rt, run_opts) catch |err| host.showFatalRunError(rt, init.gpa, err);
         return;
     }
 
@@ -251,16 +251,16 @@ pub fn main(init: std.process.Init) void {
         instance_context.setWorkerIndex(index);
         initLogging(rt, arena);
         var worker_lock = (instances.acquireWorkerLock(rt, init.gpa, index) catch |err| {
-            host.showFatalRunError(err);
+            host.showFatalRunError(rt, init.gpa, err);
             return;
         }) orelse return;
         defer worker_lock.deinit(rt);
-        host.run(rt, run_opts) catch |err| host.showFatalRunError(err);
+        host.run(rt, run_opts) catch |err| host.showFatalRunError(rt, init.gpa, err);
         return;
     }
 
     initLogging(rt, arena);
-    runLauncher(rt, init.gpa, autostart_launch) catch |err| host.showFatalRunError(err);
+    runLauncher(rt, init.gpa, autostart_launch) catch |err| host.showFatalRunError(rt, init.gpa, err);
 }
 
 fn runLauncher(rt: Runtime, allocator: std.mem.Allocator, autostart_launch: bool) !void {

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -134,6 +134,21 @@ pub const request_endpoint_unavailable_msg =
     "TildaZ is running, but it cannot receive a request to create another instance. Restart TildaZ and try again. If this continues, check the TildaZ log.";
 pub const worker_exited_before_endpoint_ready_msg =
     "TildaZ exited before it was ready to receive a request to create another instance. Start TildaZ again and check the log if this continues.";
+/// #577 — launcher 가 띄운 worker 가 **기동 중에** 끝난 경우. 위 문구와 상황이 다르다:
+/// 그쪽은 이미 떠 있는 인스턴스에 "새 인스턴스를 만들라" 고 보내려던 참이고, 이쪽은
+/// 창이 한 번도 뜨지 못한 첫 기동이다.
+///
+/// 예전에는 이 경우가 generic `WorkerStartTimeout` ("Error: WorkerStartTimeout") 이었고,
+/// 그것도 10 초를 기다린 뒤였다. 사용자가 무엇을 해야 하는지 말해 주지 않았다.
+///
+/// **로그를 가리키는 것이 핵심이다.** worker 가 스스로 안내를 띄웠다면 (config 오류 등)
+/// launcher 는 여기까지 오지 않는다 — 그쪽은 안내를 띄우는 동안 lock 을 들고 살아 있어
+/// `waitUntilRunning` 이 성공한다. 그래서 이 문구에 도달한 실행은 **아무 화면도 없이**
+/// 끝난 경우이고, 남은 단서가 로그뿐이다.
+pub const worker_exited_during_startup_msg =
+    "TildaZ stopped while starting up, before any window appeared.\n\n" ++
+    "The reason is in the TildaZ log -- open it and read the last lines. " ++
+    "Start TildaZ again and check the log if this continues.";
 pub const request_endpoint_ready_timeout_msg =
     "TildaZ did not become ready to create another instance in time. Restart TildaZ and try again. If this continues, check the TildaZ log.";
 pub const toggle_unsupported_msg =
@@ -230,6 +245,8 @@ pub fn runFailureMessage(buf: []u8, err: anyerror) []const u8 {
         error.RequestEndpointUnavailable => request_endpoint_unavailable_msg,
         error.WorkerExitedBeforeEndpointReady => worker_exited_before_endpoint_ready_msg,
         error.RequestEndpointReadyTimeout => request_endpoint_ready_timeout_msg,
+        // #577 — 첫 기동이 화면 없이 끝난 경우. generic `WorkerStartTimeout` 대신.
+        error.WorkerExitedDuringStartup => worker_exited_during_startup_msg,
         else => std.fmt.bufPrint(buf, run_failed_format, .{@errorName(err)}) catch run_failed_fallback_msg,
     };
 }
@@ -248,6 +265,15 @@ test "request endpoint run errors have specific user messages" {
         request_endpoint_ready_timeout_msg,
         runFailureMessage(&buf, error.RequestEndpointReadyTimeout),
     );
+    // #577 — 첫 기동이 화면 없이 끝난 경우. 예전에는 generic
+    // `"Error: WorkerStartTimeout"` 이었고 그것도 10 초 뒤였다.
+    try std.testing.expectEqualStrings(
+        worker_exited_during_startup_msg,
+        runFailureMessage(&buf, error.WorkerExitedDuringStartup),
+    );
+    // 이 문구는 사용자에게 **무엇을 볼지** 말해야 한다 — 여기까지 온 실행은 화면에
+    // 아무것도 남기지 않았으므로 단서가 로그뿐이다.
+    try std.testing.expect(std.mem.indexOf(u8, worker_exited_during_startup_msg, "log") != null);
     try std.testing.expectEqualStrings(
         "TildaZ failed to start.\n\nError: ExampleFailure",
         runFailureMessage(&buf, error.ExampleFailure),

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -287,7 +287,11 @@ pub const linux_wayland_socket_unavailable_format =
 ;
 pub const already_running_msg = "TildaZ is already running.";
 pub const unknown_path_msg = "(unknown)";
-pub const font_schema_error_path_format = "\n\nConfig path:\n  {s}";
+// #577 — `font_schema_error_path_format` 을 없앴다. 폰트 schema 오류
+// (`font.family` 가 string 이 아님 등) 는 config 파싱 안에서 나므로 다른 config
+// 오류와 같은 `config_error_with_path_format` 을 지난다. 경로를 본문 끝에 다시
+// 붙이는 자기 형식이 있어서 #495 가 정한 "경로는 첫 줄" 과 어긋나 있었고,
+// 들여쓰기 (`  {s}`) 까지 아래 chain footer 와 달랐다.
 pub const font_not_found_format = "Font not found: \"{s}\"\n\n";
 pub const font_chain_header_msg = "config \"font.family\" chain (in order):\n";
 pub const font_chain_entry_format = "  - \"{s}\"{s}\n";
@@ -310,8 +314,11 @@ pub const font_substituted_format =
     "\nThis name resolves to \"{s}\" instead of \"{s}\".\n" ++
     "Use the exact family name as installed on this system.\n" ++
     "See CONFIG.md \"Font names\" for how to list them.\n";
-pub const font_chain_footer_format =
-    "\nAll families listed in font.family must be installed on the system.\n\nConfig path:\n{s}\n";
+/// #577 — 경로가 빠졌다. 이제 `notFoundMessageForPath` 가 본문 **앞에**
+/// `config_error_path_prefix_format` 으로 붙인다 (#495 의 "경로는 첫 줄").
+/// 형식 인자가 없어져 `_format` 이 아니라 `_msg` 다.
+pub const font_chain_footer_msg =
+    "\nAll families listed in font.family must be installed on the system.\n";
 
 /// glyph fallback chain 의 모든 명시 폰트 lookup 실패 — chain 비어있는 케이스
 /// (사용자가 모두 잘못된 이름 명시) 등 edge. strict 검증 path 는 한 개 이름을
@@ -403,7 +410,13 @@ pub const config_error_fallback_msg = "Configuration is invalid.";
 ///
 /// 그리고 **모든 config 오류가 이 한 형식을 지난다** — 파싱 오류든 의미 오류든.
 /// 형식이 두 갈래였던 것이 위치 불일치의 원인이었다.
-pub const config_error_with_path_format = "Config: {s}\n\n{s}";
+///
+/// #577 — 경로 접두만 따로 뺀다. 본문을 writer 로 조금씩 쌓는 쪽 (폰트 chain 안내)
+/// 은 `{s}` 두 개를 한 번에 print 할 수 없어서 예전에는 자기 형식으로 경로를 **끝에**
+/// 붙였다. 접두를 상수로 두면 그쪽도 같은 첫 줄을 쓴다 — #495 가 노린 "한 형식" 이
+/// 그 세 갈래 (config / 폰트 / shell) 까지 실제로 덮인다.
+pub const config_error_path_prefix_format = "Config: {s}\n\n";
+pub const config_error_with_path_format = config_error_path_prefix_format ++ "{s}";
 /// `allocPrint` 실패 시. **경로 자리를 비우지 않는다** — 예전 파싱 쪽 fallback 은
 /// 경로를 아예 잃어서 (`"Failed to parse config JSON."`) 정작 가장 도움이 필요한
 /// 상황에서 가장 적은 정보를 줬다.
@@ -495,14 +508,23 @@ pub const config_missing_key_fallback_msg = "Configuration: missing key";
 pub const config_unknown_key_format = "Configuration: unknown key \"{s}\" in {s}.";
 pub const config_unknown_key_fallback_msg = "Configuration: unknown key";
 
+// #577 — 세 문구 모두 경로가 **첫 줄**로 왔다 (#495). 예전에는 맨 끝의
+// `Config path:` 였는데, 그러면 같은 다이얼로그 안에서도 오류 종류에 따라 경로
+// 위치가 달라졌다 — #495 가 없애려던 바로 그 불일치다.
+//
+// 경로가 첫 인자가 된 것에 주의한다 (`shell_validate.zig` 의 인자 순서도 함께
+// 바뀐다). 형식 문자열이 인자 순서를 정하므로 접두를 앞에 두면 경로가 앞이다.
 pub const shell_empty_format =
-    "Configuration: \"shell\" is empty.\n\n{s}\n\nConfig path:\n{s}";
+    config_error_path_prefix_format ++
+    "Configuration: \"shell\" is empty.\n\n{s}";
 pub const shell_empty_fallback_msg = "Configuration: shell is empty.";
 pub const shell_first_token_empty_format =
-    "Configuration: \"shell\" first token is empty.\n\nValue: \"{s}\"\n\n{s}\n\nConfig path:\n{s}";
+    config_error_path_prefix_format ++
+    "Configuration: \"shell\" first token is empty.\n\nValue: \"{s}\"\n\n{s}";
 pub const shell_first_token_empty_fallback_msg = "Configuration: shell first token empty.";
 pub const shell_executable_not_found_format =
-    "Configuration: shell executable not found.\n\n\"shell\" value: \"{s}\"\nLookup token: \"{s}\"\n\n{s}\n\nConfig path:\n{s}";
+    config_error_path_prefix_format ++
+    "Configuration: shell executable not found.\n\n\"shell\" value: \"{s}\"\nLookup token: \"{s}\"\n\n{s}";
 pub const shell_executable_not_found_fallback_msg = "Configuration: shell executable not found.";
 
 // #248 — 런타임 새 탭 생성 시 shell 바이너리가 사라진 경우 (brew/패키지 업데이트로

--- a/src/shell_validate.zig
+++ b/src/shell_validate.zig
@@ -55,23 +55,25 @@ fn formatValidationFailure(
     token: []const u8,
     config_path: []const u8,
 ) ValidationMessage {
+    // #577 — `config_path` 가 **첫 인자**다. 세 형식이 경로를 첫 줄에 두는
+    // `config_error_path_prefix_format` 으로 시작하도록 바뀌었다 (#495).
     return switch (failure) {
         .empty => allocMessageOrFallback(
             allocator,
             messages.shell_empty_format,
-            .{ examples(), config_path },
+            .{ config_path, examples() },
             messages.shell_empty_fallback_msg,
         ),
         .first_token_empty => allocMessageOrFallback(
             allocator,
             messages.shell_first_token_empty_format,
-            .{ shell, examples(), config_path },
+            .{ config_path, shell, examples() },
             messages.shell_first_token_empty_fallback_msg,
         ),
         .executable_not_found => allocMessageOrFallback(
             allocator,
             messages.shell_executable_not_found_format,
-            .{ shell, token, examples(), config_path },
+            .{ config_path, shell, token, examples() },
             messages.shell_executable_not_found_fallback_msg,
         ),
     };
@@ -226,7 +228,10 @@ test "shell validation preserves long and multibyte failure details beyond 1024 
     try std.testing.expect(message.text.len > 1024);
     try std.testing.expect(std.unicode.utf8ValidateSlice(message.text));
     try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, message.text, shell));
-    try std.testing.expect(std.mem.endsWith(u8, message.text, config_path));
+    // #577 — 경로가 **첫 줄**이다 (#495). 예전에는 맨 끝의 `Config path:` 라
+    // 여기도 `endsWith` 였다. 긴 경로에서도 잘리지 않는 것은 그대로 본다.
+    try std.testing.expect(std.mem.startsWith(u8, message.text, "Config: " ++ config_path));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, message.text, config_path));
 }
 
 test "shell validation uses the specific static fallback only when allocation fails" {


### PR DESCRIPTION
Fixes #577.

Linux 에서 config 오류로 기동에 실패하면 **화면에 아무것도 나오지 않았다.** 메뉴 (`.desktop`) 로 띄운 사용자는 10 초 무반응 뒤 조용한 `exit(1)` 만 봤고, 원인은 로그 파일에만 남았다. 안내 문구는 "파일을 `.bak` 으로 옮기고 다시 시작하라" 까지 정확히 적어 두었는데 그 문장을 읽을 방법이 없었다.

원인이 셋이었고 넷으로 나눠 고쳤다.

## 1. config 오류를 창이 뜬 뒤 blocking overlay 로 안내한다 (원인 ①)

`showConfigFatalMsg` 가 config 파싱 도중 `dialog.showFatal` + 종료를 직접 했다. 그 시점의 Linux 에는 dialog backend 가 없다 — `Client` 가 config 을 인자로 받아 만들어지기 때문이다. 그래서 안내가 stderr 로만 갔고, `.desktop` 실행에서 stderr 는 어디에도 붙지 않는다.

#501 이 로드 실패 안내에 쓴 방식을 fatal 에도 적용한다 — 문구를 담아 두고 host 가 그릴 수 있게 된 뒤 보여준다. 다른 점은 fatal 이라는 것뿐이다: blocking overlay 로 띄운 뒤 종료한다 (#282 C2 의 shell · 폰트 검증과 같은 자리, 같은 이유).

- `showConfigFatal*` → `recordConfigFatal*`. `error.InvalidConfig` 를 반환하고 문구는 process lifetime 고정 buffer 에 담는다. 첫 오류만 담아 사용자가 보는 문구가 예전과 같다.
- 호출부 35 곳 + `parse` · `validateStructure` · `parseKeys` · `addBinding` 을 error union 으로 옮겼다.
- 표시 지점 — Linux 는 keyboard 준비 직후 `runFatalDialog`, Windows · macOS 는 `Config.load` 직후 `showFatalNoticeIfAny`. Linux 가 공통 함수를 안 쓰는 이유는 그쪽 `dialog.showFatal` 이 fire-and-forget 이라 뒤이은 `exit(1)` 이 paint 전에 죽이기 때문이다 (#282 F9).
- 세 platform 모두 **shell 검증보다 앞**이다. config 를 못 읽은 실행은 기본값으로 도는 중이라, 순서가 뒤바뀌면 사용자가 고치지도 않은 shell 을 의심한다.

## 2. config 오류 경로를 세 갈래 producer 에서도 첫 줄로 모은다 (#495 마무리)

#495 가 "경로는 첫 줄이고 형식이 하나다" 를 정하고 SPEC 에도 그렇게 적었지만, 자기 형식으로 경로를 **맨 끝**에 붙이는 producer 가 셋 남아 있었다 — 폰트 schema 오류 (들여쓰기 `  `), 폰트 chain not-found (들여쓰기 없음), shell 검증 세 문구. 같은 `TildaZ Config Error` 다이얼로그 안에서 오류 종류에 따라 경로 위치가 달랐다.

넷 모두 `config_error_path_prefix_format` 한 정의를 지난다. 폰트 schema 오류는 producer 를 없애고 `config.zig` 가 문구 상수를 넘긴다 — 경로를 `paths.configPath` 로 다시 조회하지 않고 파싱 중인 파일의 path 를 쓰므로 #316 이 막으려던 "instance 번호와 실제 파일이 갈림" 도 함께 닫힌다.

부수 효과로 문구가 한 줄 짧아져 640x480 최소 화면의 스크롤 행이 줄었다 (shell `2 → 1`, 폰트 `5/5/5 → 4/4/4`).

## 3. 기동 실패를 10 초 기다리지 않고 사인을 말한다 (원인 ③)

`waitUntilRunning` 이 lock 파일만 봐서 "아직 시작 중" 과 "이미 죽음" 이 똑같이 *빈 lock 파일* 로 보였다 (worker 는 PID 를 쓴 뒤 죽고 `clear_pid_on_close` 가 그것을 지운다). 그래서 기동 실패는 전부 타임아웃 10 초를 채운 뒤 generic `WorkerStartTimeout` 으로 끝났다.

#304 가 만든 endpoint 상태 파일이 그 둘을 가른다 — `acquireWorkerLock` 은 lock 을 잡은 뒤 `.starting` 을 **PID 보다 먼저** 쓴다. "endpoint 파일이 있는데 lock 이 비었다" 는 곧 "lock 을 잡는 데까지 갔다가 죽었다" 다. `spawnWorker` 가 spawn 직전에 그 파일을 지워 stale 오판을 막는다.

응답 없는 worker (hang) 에는 유한 타임아웃이 그대로 남는다.

## 4. launcher 의 기동 실패도 다이얼로그로 알린다 (원인 ②)

launcher 는 `host.run` 을 거치지 않아 Linux 에서 `Client` 가 아예 없다. `dialog.showError` 로 바꿔도 같은 `g_callbacks == null` 에 걸려 stderr 로 되돌아간다 — 그래서 창도 PTY 도 만들지 않고 **다이얼로그만** 세우는 경로를 넣었다 (`showFatalStandalone`). dialog surface 는 자기 layer-shell surface 이고 항상 `wl_shm` 이라 (GPU 불필요) Wayland 연결 + globals + keyboard 까지만 있으면 그릴 수 있다.

`Client.run` 의 registry → globals 구간만 공유하고 (`connectAndBindGlobals`), 그 뒤 GPU → KGlobalAccel → keyboard 순서는 손대지 않았다 — 그 순서에는 #277 · #496 1-c 의 근거가 붙어 있다.

**곁들여 Windows · macOS 의 잠재 버그를 닫았다.** `showFatalRunError` 가 읽던 `g_rt` 는 `run()` 안에서만 심어지는데 launcher 실패 경로는 `run()` 을 거치지 않는다 — 두 platform 은 그 자리에서 `var g_rt: Runtime = undefined` 를 읽고 있었다. 서명을 `showFatalRunError(rt, allocator, err)` 로 바꾸며 함께 닫혔다.

## 실기 측정

KDE Plasma Wayland, 격리 XDG 경로 (사용자 config 은 사본만, 원본 md5 불변 확인).

| 시나리오 | 릴리스 0.9.4 | 이 PR |
|---|---|---|
| v0.9.0 스키마 config (재현 조건) | 화면 무음, 10 초 뒤 `exit(1)` | `[dialog] open info severity=err` → `rows=10/10 fits=true`, **`(stderr fallback)` 0 줄** |
| worker 가 화면 없이 조기 사망 | `Error: WorkerStartTimeout`, **10,059 ms** | **29 ms** |
| launcher 단독 실패 (TOML 문법 오류) | 3 ms 에 stderr 로 사라짐, **dialog 로그 0 줄** | overlay 다이얼로그, 닫을 때까지 대기 |
| 늦은 단계 config 오류 (`keys.new_tab` 미인식 키) | — | 같은 overlay 경로, `rows=12/12` |
| 폰트 없음 · shell 없음 | 경로가 본문 끝 | 경로가 첫 줄, 중복 없음 |

회귀 — 정상 config 은 `[fatal]` · `[dialog]` 없이 `Wayland terminal window mapped`. Wayland 연결 불가는 다이얼로그를 시도하지 않고 65 ms 에 끝난다 (그 오류의 내용이 "Wayland 에 연결할 수 없다" 이므로 Wayland 로 그리는 안내는 정의상 뜰 수 없다).

`zig build test` 417 passed / 0 failed (신규 14), `zig build check` 6 타깃 통과. **rebase 뒤 다시 돌렸다.**

## 일부러 남긴 것

- **런타임 새 탭 실패 알림** (`shell_new_tab_not_found_format`, #248) 은 문구 통일에서 뺐다. startup fatal 이 아니라 종료하지 않는 알림이고, 경로를 오류 헤더가 아니라 *다음 행동 안내* 로 제시한다.
- **`parse` 가 오류로 빠질 때 부분 할당을 정리하지 않는다.** `Config{}` 의 기본값이 comptime 리터럴이라 일괄 `deinit` 이 static 메모리를 해제하게 되고, 어디까지 owned 인지 추적하려면 필드마다 소유권 flag 가 필요하다. 근거는 이 경로의 끝이 항상 `exit(1)` 이라는 것 — `std.process.exit` 는 defer 를 돌리지 않아 누수 검출도 지나가고 반납은 OS 가 한다. 주석에 적었고 테스트는 arena 를 쓴다.
- **launcher 가 내는 TOML 파싱 오류 문구가 여전히 거칠다** (`Error: UnexpectedToken`). 이제 다이얼로그로 뜨므로 예전보다 낫지만 문구 자체는 별건이다.

## 남은 검증

- **Windows · macOS 실기.** 서명 변경은 `zig build check` 의 크로스컴파일이 잡지만, `undefined g_rt` 를 읽던 자리가 실제로 고쳐졌는지는 그 platform 에서 launcher 를 실패시켜 봐야 한다.
- **layer-shell 없는 GNOME mutter / Cinnamon muffin** 에서 standalone 다이얼로그가 #231 의 `xdg_toplevel` fallback 으로 뜨는지.

