### PR TITLE
fix(render): macOS atlas 안전망 — 구간 경계에서 GPU 를 기다려 순서를 만든다 (#585)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1787,7 +1787,7 @@ cluster 경로가 거치는 shape 결과 캐시 (`font/cluster_cache.zig`, `CAPA
 
 **macOS 는 순서를 우리가 만든다.** `MTLTexture.replace(region:…)` 은 **즉시 CPU 복사이고 GPU 작업과 순서가 보장되지 않는다** (Apple 문서: *"immediately copies … does not synchronize against GPU accesses"*). blit encoder 로 옮겨도 staging 을 다음 구간이 덮어써 같은 문제가 났다 — 두 시도 모두 기준판과 **23~38 % 어긋났다.** 뿌리는 하나다: **앞 pass 가 텍스처를 다 읽기 전에 CPU 가 덮었다.** Windows 의 `UpdateSubresource` · Linux 의 `glTexSubImage2D` 는 드라이버가 command 순서에 업로드를 끼워 주지만 Metal 은 그렇지 않다.
 
-그래서 구간 경계에서 **앞 cmd_buf 를 present 없이 `commit` 하고 `waitUntilCompleted` 로 GPU 가 끝나기를 기다린 뒤** 텍스처를 갱신한다 — Apple 문서가 요구하는 그대로다 (*"ensure these operations complete before calling replaceRegion"*). drawable 에 그린 것은 Store 로 남고 present 는 프레임 끝의 마지막 cmd_buf 가 한다. **계약은 같고 순서를 만드는 주체만 다르다** — Windows · Linux 는 드라이버, macOS 는 우리. 비용은 구간마다 GPU 대기 한 번이고, 이 경로는 `grow` 가 `MAX_ATLAS_SIZE` 에 닿았을 때만 돈다.
+그래서 구간 경계에서 **앞 cmd_buf 를 present 없이 `commit` 하고 `waitUntilCompleted` 로 GPU 가 끝나기를 기다린 뒤** 텍스처를 갱신한다 — Apple 문서가 요구하는 그대로다 (*"ensure these operations complete before calling replaceRegion"*). drawable 에 그린 것은 Store 로 남고 present 는 프레임 끝의 마지막 cmd_buf 가 한다. **계약은 같고 순서를 만드는 주체만 다르다** — Windows · Linux 는 드라이버, macOS 는 우리. 비용은 구간마다 GPU 대기 한 번이고, 이 경로는 `grow` 가 `MAX_ATLAS_SIZE` 에 닿았을 때만 돈다. **비운 프레임에서는 그 뒤의 draw 앞에도 매번 올린다** (`atlas_reset_this_frame`) — 비우면 *"이번 프레임에 담은 것은 다음 프레임 시작에 올린다"* 는 2-frame 전제가 깨져서, 비운 뒤 담은 글리프가 그 프레임의 남은 draw 에 없고 정적 화면이면 다음 렌더가 없어 영영 안 보인다 (실측: 아랫부분 5.5 % 어긋남). 정상 프레임에는 이 비용이 없다.
 
 **macOS 실측** (MacBook Pro M5 Pro · macOS 26.6.2 · 내장 3024×1964 · Menlo 15pt · `cell 19x39`). `MAX_ATLAS_SIZE = INITIAL_ATLAS_SIZE` 로 두어 `grow` 를 막고 ① 만 돌게 했다. 화면은 mark 를 둘 쌓은 cluster **6,000 종** (150 칸 × 40 줄).
 
@@ -1875,6 +1875,11 @@ atlas grew to 4096x4096 (grows=N, glyphs=N, clusters=N)
 | macOS · Monaco | 2048² | 약 **5,880** |
 | Linux · DejaVu Sans Mono 15pt · `cell 14x31` (scale 1.6) · **gray** | 2048² | **8,971 ~ 9,156** (`filled_y` 2,042~2,047) |
 | Linux · Noto Color Emoji · 같은 기기 · **color** | 2048² | emoji **210 종** (`filled_y` 1,935) |
+| macOS · Menlo 15pt · `cell 19x39` (scale 2.0) · 내장 3024×1964 · 17 화면 누적 ([#585](https://github.com/ensky0/tildaz/issues/585)) | 2048² → 4096² 시점 | `clusters 5,134` |
+| 같은 회차 | 4096² → 8192² 시점 | `clusters 15,441` |
+| 같은 회차 | **8192² 가 찬 시점** | `glyphs 195` + `clusters 56,835` = **57,030** (`filled_y 8,165`) |
+
+**상한에 닿는 조건은 "한 화면" 이 아니라 "한 세션의 누적" 이다.** atlas 는 캐시라 과거에 그린 글리프도 남고, 비워지는 것은 배율 · 폰트 변경 때 (`applyScale`) 와 ① 안전망뿐이다. 5120×2880 화면에 들어가는 최대 셀이 269 × 73 = 19,637 이라 **한 화면으로는 8192² (약 57,000 종) 에 못 닿지만**, 한 세션에서 서로 다른 cluster 를 그만큼 넘게 보면 닿는다 — 다국어 텍스트를 오래 보는 사용자에게는 도달 가능한 조건이다. 위 macOS 행이 그 실측이다: 서로 다른 cluster 96,768 종을 17 화면으로 누적해 56,835 종에서 찼고, ① 이 한 번 돌아 (`atlas full` 1 회 = `pack fail` 1 회, 거짓 full 없음) 비운 뒤 정상 복귀했다.
 
 Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적이 376 px² 라 (cell 434 px² 보다 작다) 같은 넓이에 더 들어가기 때문이다. **회차마다 갈리는 것이 정상**이다 — 어느 셀에서 차는지가 프레임 경계에 따라 조금씩 달라진다.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1781,13 +1781,30 @@ cluster 경로가 거치는 shape 결과 캐시 (`font/cluster_cache.zig`, `CAPA
 |---|---|---|
 | **Windows** | `is_full` 을 세우고 **호출자가 처리한다** — `drawTextInstances` · `drawBgInstances` 로 먼저 flush, `reset()`, 재시도 ([`renderer/windows.zig`](src/renderer/windows.zig)) | **사양대로.** 실기 확인 |
 | **Linux** | `Atlas.full` 에 **찬 surface 를 표시**하고 호출자가 처리한다 — `glFlushText` 로 먼저 flush, `resetFull()`, 재시도 ([`host/linux/wayland_minimal.zig`](src/host/linux/wayland_minimal.zig) 의 `glAddGlyph`) | **사양대로.** 실기 확인 |
-| **macOS** | `is_full` 을 세우고 호출자가 처리하되, **먼저 ② 의 `grow` 를 시도한다.** 키우면 이 경로가 아예 안 돈다 | **상한 경로만.** 아래 ⚠️ |
+| **macOS** | `is_full` 을 세우고 호출자가 처리한다 — **앞 cmd_buf 를 commit 하고 GPU 가 끝나기를 기다린 뒤** 올리고 비우고 새 pass 로 재시도 (`restartPassAfterAtlasFull`). **먼저 ② 의 `grow` 를 시도**하므로 상한에서만 돈다 | **사양대로.** 실기 확인 |
 
 **Linux 는 축이 둘 더 있다.** 텍스처가 `gray` · `color` 둘이라 (위 머리말의 포맷 분리) **찬 쪽만** 비운다 — 다른 쪽은 커서가 그대로여서 이미 내준 좌표가 살아 있다. 그래서 캐시도 surface 별로 나눠 둔다. 그리고 flush 는 **그 시점의 clip 을 들고** 해야 한다 — chrome 은 항목마다 `glScissor` 로 탭 경계를 자르므로, 안전망 flush 가 clip 을 빼면 탭 제목이 탭 밖으로 샌다.
 
-⚠️ **macOS 는 ① 을 완전히 만족할 수 없다.** `MTLTexture.replace(region:…)` 은 **즉시 CPU 복사이고 GPU 작업과 순서가 보장되지 않는다** (Apple 문서: *"immediately copies … does not synchronize against GPU accesses"*). 그래서 render pass 를 끊어 그 사이에 올려도 **모든 pass 가 최종 텍스처를 읽는다** — Windows 의 `UpdateSubresource` · Linux 의 `glTexSubImage2D` 는 드라이버가 command 순서에 업로드를 끼워 주지만 Metal 은 그렇지 않다. 실측으로 확인했다: 안전망만으로는 기준판과 23~38 % 가 어긋났다.
->
-> **그래서 macOS 는 ② 의 `grow` 를 주 경로로 쓴다** (아래). 키우면 프레임 중간에 비우는 상황 자체가 없어서 이 문제가 성립하지 않는다. ① 은 `MAX_ATLAS_SIZE` 에 닿았을 때만 도는 마지막 방어이고, 그 경로에서는 그림이 어긋날 수 있다.
+**macOS 는 순서를 우리가 만든다.** `MTLTexture.replace(region:…)` 은 **즉시 CPU 복사이고 GPU 작업과 순서가 보장되지 않는다** (Apple 문서: *"immediately copies … does not synchronize against GPU accesses"*). blit encoder 로 옮겨도 staging 을 다음 구간이 덮어써 같은 문제가 났다 — 두 시도 모두 기준판과 **23~38 % 어긋났다.** 뿌리는 하나다: **앞 pass 가 텍스처를 다 읽기 전에 CPU 가 덮었다.** Windows 의 `UpdateSubresource` · Linux 의 `glTexSubImage2D` 는 드라이버가 command 순서에 업로드를 끼워 주지만 Metal 은 그렇지 않다.
+
+그래서 구간 경계에서 **앞 cmd_buf 를 present 없이 `commit` 하고 `waitUntilCompleted` 로 GPU 가 끝나기를 기다린 뒤** 텍스처를 갱신한다 — Apple 문서가 요구하는 그대로다 (*"ensure these operations complete before calling replaceRegion"*). drawable 에 그린 것은 Store 로 남고 present 는 프레임 끝의 마지막 cmd_buf 가 한다. **계약은 같고 순서를 만드는 주체만 다르다** — Windows · Linux 는 드라이버, macOS 는 우리. 비용은 구간마다 GPU 대기 한 번이고, 이 경로는 `grow` 가 `MAX_ATLAS_SIZE` 에 닿았을 때만 돈다.
+
+**macOS 실측** (MacBook Pro M5 Pro · macOS 26.6.2 · 내장 3024×1964 · Menlo 15pt · `cell 19x39`). `MAX_ATLAS_SIZE = INITIAL_ATLAS_SIZE` 로 두어 `grow` 를 막고 ① 만 돌게 했다. 화면은 mark 를 둘 쌓은 cluster **6,000 종** (150 칸 × 40 줄).
+
+| | 4096 (기준 · 안 넘침) | 1024 (① 만 돈다) |
+|---|---|---|
+| `atlas full` | 0 회 | 한 화면에 **1,672 회** |
+| 그림 | — | **기준판과 `0 / 4,584,100 px`** |
+
+**업로드 단위도 갈렸다가 이제 비슷하다.**
+
+| platform | 텍스처에 올리는 단위 |
+|---|---|
+| Windows | 글리프 하나 (`UpdateSubresource` + `D3D11_BOX`) |
+| Linux | 글리프 하나 (`glTexSubImage2D`) |
+| macOS | **dirty 구간** (`dirty_min_y`~`dirty_max_y`, blit encoder) — 프레임 시작과 안전망 구간 경계에서 |
+
+macOS 는 예전에 매 프레임 atlas **전체** (2048² × 4 = 16 MB · `grow` 후 64 MB) 를 `replaceRegion` 으로 올렸다. blit 은 영역 지정이 자연스러워 dirty 구간만 올린다. staging buffer 는 **atlas 마다 따로** 둔다 — blit 은 GPU 가 나중에 실행할 때 buffer 를 읽으므로, 하나를 두 atlas 가 나눠 쓰면 뒤에 복사한 내용이 앞의 blit 에 실린다 (실측으로 탭 아이콘이 깨졌다).
 
 **재시도는 한 번뿐이다** (세 platform 공통). 비운 직후에도 안 들어가면 그림 하나가 atlas 보다 크다는 뜻이라 그 셀을 건너뛴다 — 무한 루프가 없다. Linux 는 조건을 하나 더 둔다: **이미 빈 surface 인데 안 들어가면 `full` 을 아예 표시하지 않는다.** 표시하면 호출자가 글리프마다 헛되게 flush + reset 을 한다.
 
@@ -1865,7 +1882,7 @@ Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적
 
 #### ② 계속 — 차면 키운다 (macOS)
 
-**macOS 는 차면 두 배로 키운다** (`GlyphAtlas.grow`). ghostty 가 쓰는 방식이고 (`font.Atlas.grow` + `syncAtlasTexture`), macOS 가 ① 을 완전히 만족할 수 없기 때문에 여기서는 이것이 **주 경로**다.
+**macOS 는 차면 두 배로 키운다** (`GlyphAtlas.grow`). ghostty 가 쓰는 방식이고 (`font.Atlas.grow` + `syncAtlasTexture`), ① 도 완전하지만 구간마다 GPU 를 기다려야 하므로, **차기 전에 키우는 것이 주 경로**다 — ① 은 상한에서만 돈다.
 
 | | |
 |---|---|

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -256,6 +256,21 @@ pub const MetalRenderer = struct {
     bg_buffer: objc.id,
     text_buffer: objc.id,
     atlas_texture: objc.id,
+    /// #585 — atlas 업로드용 staging buffer. `replaceRegion` 이 **즉시 CPU 복사이고 GPU 작업과
+    /// 순서가 보장되지 않아서** (Apple 문서: *"does not synchronize against GPU accesses"*)
+    /// 그것을 쓰면 프레임 중간에 텍스처를 갈 수 없다. blit encoder 로 올리면 복사가 **command
+    /// buffer 안**에 들어가 순서가 지켜진다.
+    ///
+    /// Windows (`UpdateSubresource`) · Linux (`glTexSubImage2D`) 는 글리프 단위로 즉시 올리는데
+    /// macOS 만 프레임마다 atlas **전체** (2048² × 4 = 16 MB · `grow` 후 64 MB) 를 올리고
+    /// 있었다. blit 은 영역 지정이 자연스러워 `dirty_min_y`~`dirty_max_y` 만 올린다.
+    /// ⚠️ **atlas 마다 따로여야 한다.** blit 은 `replaceRegion` 과 달리 **GPU 가 나중에
+    /// 실행할 때** buffer 를 읽는다. 하나를 두 atlas 가 나눠 쓰면 뒤에 복사한 내용이 앞의
+    /// blit 에 실려 **본문 blit 이 탭 데이터를 읽는다** (실측으로 화면이 깨졌다).
+    staging_buffer: objc.id,
+    staging_bytes: u32 = 0,
+    tab_staging_buffer: objc.id,
+    tab_staging_bytes: u32 = 0,
     /// #584 ② — `atlas_texture` 를 만들 때의 한 변. `atlas.size` 가 이보다 커지면
     /// (`grow`) 텍스처를 새로 만들어야 한다 (`syncAtlasTexture`).
     atlas_texture_size: u32 = INITIAL_ATLAS_SIZE,
@@ -425,6 +440,9 @@ pub const MetalRenderer = struct {
 
         // constants buffer = float4 (screen_w, screen_h, atlas_w, atlas_h).
         const const_buf = createBuffer(device, 16);
+        // #585 — atlas 전체를 담을 수 있는 staging (grow 하면 재생성한다).
+        const staging = createBuffer(device, INITIAL_ATLAS_SIZE * INITIAL_ATLAS_SIZE * 4);
+        const tab_staging = createBuffer(device, INITIAL_ATLAS_SIZE * INITIAL_ATLAS_SIZE * 4);
         const tab_const_buf = createBuffer(device, 16);
 
         const atlas_tex = createAtlasTexture(device, INITIAL_ATLAS_SIZE);
@@ -469,6 +487,10 @@ pub const MetalRenderer = struct {
             .bg_buffer = bg_buf,
             .text_buffer = text_buf,
             .atlas_texture = atlas_tex,
+            .staging_buffer = staging,
+            .staging_bytes = INITIAL_ATLAS_SIZE * INITIAL_ATLAS_SIZE * 4,
+            .tab_staging_buffer = tab_staging,
+            .tab_staging_bytes = INITIAL_ATLAS_SIZE * INITIAL_ATLAS_SIZE * 4,
             .tab_atlas_texture = tab_atlas_tex,
             .constants_buffer = const_buf,
             .tab_constants_buffer = tab_const_buf,
@@ -614,6 +636,17 @@ pub const MetalRenderer = struct {
         const setClearColorFn: *const fn (objc.id, objc.SEL, ClearColor) callconv(.c) void = @ptrCast(objc.msgSend_raw);
         setClearColorFn(att0, objc.sel("setClearColor:"), clear);
 
+        // #585 — **blit 은 render encoder 밖에서 해야 한다** (Metal 은 command buffer 당 encoder
+        // 하나다). 그래서 atlas 업로드를 encoder 를 만들기 **전에** 한다. 예전 `replaceRegion`
+        // 은 encoder 와 무관했지만 GPU 와 순서가 안 맞았다 (SPEC §12.6 ①).
+        self.syncAtlasTexture(&self.atlas, &self.atlas_texture, &self.atlas_texture_size);
+        if (self.atlas.dirty) {
+            self.uploadAtlas(&self.atlas, self.atlas_texture, &self.staging_buffer, &self.staging_bytes);
+            self.atlas.dirty = false;
+        }
+        self.syncAtlasTexture(&self.tab_atlas, &self.tab_atlas_texture, &self.tab_atlas_texture_size);
+        self.uploadTabAtlasIfDirty();
+
         const encoder = objc.msgSend1(cmd_buf, objc.sel("renderCommandEncoderWithDescriptor:"), rpd);
         if (encoder == null) {
             self.current_drawable = null;
@@ -650,16 +683,8 @@ pub const MetalRenderer = struct {
         self.panes_drawn += 1;
         self.updateConstants();
 
-        self.syncAtlasTexture(&self.atlas, &self.atlas_texture, &self.atlas_texture_size);
-        if (self.atlas.dirty) {
-            self.uploadAtlas(&self.atlas, self.atlas_texture);
-            self.atlas.dirty = false;
-        }
-        // 탭 glyph/icon atlas도 main atlas와 같은 2-frame 정책: 이전 frame에서
-        // 만든 내용을 draw 전에 upload한다. 삽입 직후 같은 Metal encoder에서
-        // sample하면 정적인 단일 탭 최초 frame의 icon이 투명하게 남았다.
-        self.syncAtlasTexture(&self.tab_atlas, &self.tab_atlas_texture, &self.tab_atlas_texture_size);
-        self.uploadTabAtlasIfDirty();
+        // #585 — atlas 업로드는 **프레임 시작** (`renderTabBar` 의 encoder 생성 전) 으로 옮겼다.
+        // blit 이 render encoder 밖에서 일어나야 하기 때문이다.
 
         self.renderTerminalContent(encoder, pane);
     }
@@ -1852,13 +1877,34 @@ pub const MetalRenderer = struct {
         const old_encoder = self.current_encoder;
         if (old_encoder == null) return null;
         const drawable = self.current_drawable;
-        const cmd_buf = self.current_cmd_buf;
-        if (drawable == null or cmd_buf == null) return null;
+        const old_cmd_buf = self.current_cmd_buf;
+        if (drawable == null or old_cmd_buf == null) return null;
 
         objc.msgSendVoid(old_encoder, objc.sel("endEncoding"));
 
-        // 여기까지 담은 픽셀을 올린다 — 앞 pass 의 인스턴스가 이 자리를 가리킨다.
-        self.uploadAtlas(&self.atlas, self.atlas_texture);
+        // #585 — **GPU 가 앞 pass 를 끝낼 때까지 기다린다.** Metal 은 CPU 쓰기와 GPU 읽기의
+        // 순서를 대신 지켜 주지 않는다 — `replaceRegion` 은 즉시 복사라 최종 상태만 보였고,
+        // blit 도 staging 을 다음 구간이 덮어써서 마지막 내용을 올렸다. 두 번 실패한 뿌리가
+        // 같다: **앞 pass 가 텍스처를 다 읽기 전에 CPU 가 덮었다.** Apple 문서가 정확히 이것을
+        // 요구한다 — *"ensure these operations complete before calling replaceRegion"*.
+        //
+        // 그래서 앞 cmd_buf 를 present 없이 commit 하고 끝나기를 기다린다. drawable 에 그린 것은
+        // Store 로 남고, present 는 프레임 끝의 마지막 cmd_buf 가 한다. Windows · Linux 는
+        // 드라이버가 이 순서를 만들어 주지만 (`UpdateSubresource` · `glTexSubImage2D`) macOS 는
+        // 우리가 만든다 — 계약은 같고 주체만 다르다 (SPEC §12.6).
+        //
+        // 비용은 구간마다 GPU 대기 한 번이다. 이 경로는 `grow` 가 상한 (`MAX_ATLAS_SIZE`) 에
+        // 닿았을 때만 돌므로 정상 경로에는 영향이 없다.
+        objc.msgSendVoid(old_cmd_buf, objc.sel("commit"));
+        objc.msgSendVoid(old_cmd_buf, objc.sel("waitUntilCompleted"));
+
+        // 새 cmd_buf — 이후 blit 과 pass 가 여기 들어가고, `endFrame` 이 이것을 present 한다.
+        const cmd_buf = objc.msgSend(self.command_queue, objc.sel("commandBuffer"));
+        if (cmd_buf == null) return null;
+        self.current_cmd_buf = cmd_buf;
+
+        // 이제 안전하다 — 앞 pass 가 텍스처와 staging 을 다 읽었다.
+        self.uploadAtlas(&self.atlas, self.atlas_texture, &self.staging_buffer, &self.staging_bytes);
         self.atlas.dirty = false;
         self.atlas.resetFull();
 
@@ -1892,24 +1938,91 @@ pub const MetalRenderer = struct {
         atlas.dirty_max_y = atlas.size;
     }
 
-    fn uploadAtlas(_: *MetalRenderer, atlas: *GlyphAtlas, texture: objc.id) void {
-        const Region = extern struct { ox: usize, oy: usize, oz: usize, sx: usize, sy: usize, sz: usize };
-        const region = Region{ .ox = 0, .oy = 0, .oz = 0, .sx = atlas.size, .sy = atlas.size, .sz = 1 };
+    /// #585 — atlas 픽셀을 텍스처로 올린다. **blit encoder 를 쓴다.**
+    ///
+    /// 예전에는 `MTLTexture.replaceRegion` 이었는데 그것은 **즉시 CPU 복사이고 GPU 작업과
+    /// 순서가 보장되지 않는다** (Apple 문서: *"immediately copies … does not synchronize
+    /// against GPU accesses"*). 그래서 프레임 중간에 올려도 **모든 render pass 가 최종
+    /// 텍스처를 읽었다** — 안전망 (SPEC §12.6 ①) 이 macOS 에서 동작하지 못한 이유다.
+    ///
+    /// blit 은 복사를 **command buffer 안**에 넣으므로 앞뒤 pass 와 순서가 지켜진다. 그리고
+    /// 영역 지정이 자연스러워 **dirty 구간만** 올린다 — Windows (`UpdateSubresource`) ·
+    /// Linux (`glTexSubImage2D`) 가 글리프 단위로 올리는 것과 같은 방향이다.
+    ///
+    /// 실패하면 조용히 지나간다 (그 프레임은 옛 텍스처를 쓴다) — 다음 프레임이 다시 올린다.
+    fn uploadAtlas(
+        self: *MetalRenderer,
+        atlas: *GlyphAtlas,
+        texture: objc.id,
+        /// ⚠️ **atlas 마다 따로** — 위 필드 주석의 이유다.
+        staging: *objc.id,
+        staging_bytes: *u32,
+    ) void {
+        const cmd_buf = self.current_cmd_buf;
+        if (cmd_buf == null) return;
 
-        const f: *const fn (objc.id, objc.SEL, Region, objc.NSUInteger, [*]const u8, objc.NSUInteger) callconv(.c) void = @ptrCast(objc.msgSend_raw);
+        // dirty 구간만 — 줄 단위다 (`packRow` 가 줄로 채우므로 x 는 늘 전폭이 맞다).
+        const y0 = @min(atlas.dirty_min_y, atlas.size);
+        const y1 = @min(atlas.dirty_max_y, atlas.size);
+        if (y1 <= y0) return;
+        const row_bytes: usize = @as(usize, atlas.size) * 4;
+        const rows: usize = y1 - y0;
+        const bytes = rows * row_bytes;
+
+        // staging 이 작으면 키운다 (`grow` 뒤).
+        if (staging_bytes.* < atlas.size * atlas.size * 4) {
+            const new_buf = createBuffer(self.device, atlas.size * atlas.size * 4);
+            if (new_buf == null) return;
+            objc.msgSendVoid(staging.*, objc.sel("release"));
+            staging.* = new_buf;
+            staging_bytes.* = atlas.size * atlas.size * 4;
+        }
+
+        const dst = objc.msgSend(staging.*, objc.sel("contents")) orelse return;
+        const dst_ptr: [*]u8 = @ptrCast(dst);
+        @memcpy(dst_ptr[0..bytes], atlas.pixels[y0 * row_bytes ..][0..bytes]);
+
+        const blit = objc.msgSend(cmd_buf, objc.sel("blitCommandEncoder"));
+        if (blit == null) return;
+
+        const MTLSize = extern struct { w: usize, h: usize, d: usize };
+        const MTLOrigin = extern struct { x: usize, y: usize, z: usize };
+        const f: *const fn (
+            objc.id,
+            objc.SEL,
+            objc.id, // sourceBuffer
+            usize, // sourceOffset
+            usize, // sourceBytesPerRow
+            usize, // sourceBytesPerImage
+            MTLSize, // sourceSize
+            objc.id, // destinationTexture
+            usize, // destinationSlice
+            usize, // destinationLevel
+            MTLOrigin, // destinationOrigin
+        ) callconv(.c) void = @ptrCast(objc.msgSend_raw);
         f(
-            texture,
-            objc.sel("replaceRegion:mipmapLevel:withBytes:bytesPerRow:"),
-            region,
+            blit,
+            objc.sel("copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:"),
+            staging.*,
             0,
-            atlas.pixels.ptr,
-            atlas.size * 4, // BGRA8 = 4 bytes per pixel.
+            row_bytes,
+            bytes,
+            MTLSize{ .w = atlas.size, .h = rows, .d = 1 },
+            texture,
+            0,
+            0,
+            MTLOrigin{ .x = 0, .y = y0, .z = 0 },
         );
+        objc.msgSendVoid(blit, objc.sel("endEncoding"));
+
+        // 올린 구간은 깨끗해졌다.
+        atlas.dirty_min_y = atlas.size;
+        atlas.dirty_max_y = 0;
     }
 
     fn uploadTabAtlasIfDirty(self: *MetalRenderer) void {
         if (!self.tab_atlas.dirty) return;
-        self.uploadAtlas(&self.tab_atlas, self.tab_atlas_texture);
+        self.uploadAtlas(&self.tab_atlas, self.tab_atlas_texture, &self.tab_staging_buffer, &self.tab_staging_bytes);
         self.tab_atlas.dirty = false;
     }
 

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -321,6 +321,12 @@ pub const MetalRenderer = struct {
     current_drawable: objc.id = null,
     current_cmd_buf: objc.id = null,
     current_encoder: objc.id = null,
+    /// #585 — **이 프레임에** 안전망이 atlas 를 비웠는가. 비웠으면 "이번 프레임에 담은 것은
+    /// 다음 프레임 시작에 올린다" (2-frame) 는 전제가 깨진다 — 비운 뒤 담은 글리프는 이
+    /// 프레임의 남은 draw 시점에 텍스처에 없고, 정적 화면이면 다음 렌더가 없어 영영 안 보인다.
+    /// 그래서 그 뒤의 draw 앞에는 매번 올린다 (`uploadAndRestartPass`). 정상 프레임에는 비용이
+    /// 없다. 프레임 시작에 내린다.
+    atlas_reset_this_frame: bool = false,
     /// renderTabBar 가 받은 args 보관. endFrame 에서 z-order 상 terminal
     /// 위에 tabs 가 그려지도록 마지막에 encode (Windows 와 layout 자체가 분리
     /// 영역이라 z-order 무관하지만, 같은 frame state 의 일부로 처리).
@@ -616,6 +622,7 @@ pub const MetalRenderer = struct {
 
         const cmd_buf = objc.msgSend(self.command_queue, objc.sel("commandBuffer"));
         self.current_cmd_buf = cmd_buf;
+        self.atlas_reset_this_frame = false;
 
         const rpd_class = objc.getClass("MTLRenderPassDescriptor");
         const rpd = objc.msgSend(rpd_class, objc.sel("renderPassDescriptor"));
@@ -1095,10 +1102,9 @@ pub const MetalRenderer = struct {
                             const fg = resolveFg(st, &rr, &colors, sel, inv);
 
                             if (text_count >= MAX_CELLS) {
-                                // #584 ① — 이 flush 도 **올린 뒤에** 그려야 한다. atlas 가 찬
-                                // 적이 있는 프레임에서는 담긴 픽셀이 아직 텍스처에 없다.
-                                if (self.atlas.dirty and self.atlas.resets > 0) {
-                                    if (self.restartPassAfterAtlasFull()) |ne| encoder = ne;
+                                // #585 — 이 프레임에 안전망이 비웠으면 그 뒤 담은 글리프가 아직 텍스처에 없다.
+                                if (self.atlas_reset_this_frame and self.atlas.dirty) {
+                                    if (self.uploadAndRestartPass()) |ne| encoder = ne;
                                 }
                                 self.drawTextInstances(encoder, text_buf[0..text_count]);
                                 text_count = 0;
@@ -1151,9 +1157,9 @@ pub const MetalRenderer = struct {
 
                     // 개별 경로 — 런이 1 개거나 배칭이 실패했을 때. 렌더가 틀리느니 느린 게 낫다.
                     if (text_count >= MAX_CELLS) {
-                        // #584 ① — 위와 같은 규칙이다.
-                        if (self.atlas.dirty and self.atlas.resets > 0) {
-                            if (self.restartPassAfterAtlasFull()) |ne| encoder = ne;
+                        // #585 — 이 프레임에 안전망이 비웠으면 그 뒤 담은 글리프가 아직 텍스처에 없다.
+                        if (self.atlas_reset_this_frame and self.atlas.dirty) {
+                            if (self.uploadAndRestartPass()) |ne| encoder = ne;
                         }
                         self.drawTextInstances(encoder, text_buf[0..text_count]);
                         text_count = 0;
@@ -1233,9 +1239,9 @@ pub const MetalRenderer = struct {
                 }
 
                 if (text_count >= MAX_CELLS) {
-                    // #584 ① — 위와 같은 규칙이다.
-                    if (self.atlas.dirty and self.atlas.resets > 0) {
-                        if (self.restartPassAfterAtlasFull()) |ne| encoder = ne;
+                    // #585 — 이 프레임에 안전망이 비웠으면 그 뒤 담은 글리프가 아직 텍스처에 없다.
+                    if (self.atlas_reset_this_frame and self.atlas.dirty) {
+                        if (self.uploadAndRestartPass()) |ne| encoder = ne;
                     }
                     self.drawTextInstances(encoder, text_buf[0..text_count]);
                     text_count = 0;
@@ -1290,16 +1296,9 @@ pub const MetalRenderer = struct {
             }
         }
 
-        // #584 ① — **마지막 구간을 올린 뒤에 그린다.** 이 renderer 는 atlas 를 프레임 시작에
-        // 한 번만 올리므로 (2-frame 정책), 이 프레임에 담은 것은 그냥 두면 다음 프레임에나
-        // 텍스처에 나타난다. 그러면 마지막 구간의 글자가 이 프레임에서 빠지고, 어디가 마지막
-        // 구간인지가 프레임마다 달라 화면이 흔들린다.
-        //
-        // atlas 가 한 번도 안 찬 프레임에서는 이 재시작이 일어나지 않는다 — `dirty` 만 보고
-        // 끊으면 매 프레임 pass 가 갈리므로, **찬 적이 있을 때만** (`resets` 가 늘었을 때만)
-        // 마지막 구간을 올린다.
-        if (self.atlas.dirty and self.atlas.resets > 0) {
-            if (self.restartPassAfterAtlasFull()) |new_encoder| encoder = new_encoder;
+        // #585 — 이 프레임에 안전망이 비웠으면 마지막 구간도 올린 뒤에 그린다.
+        if (self.atlas_reset_this_frame and self.atlas.dirty) {
+            if (self.uploadAndRestartPass()) |ne| encoder = ne;
         }
         if (text_count > 0) self.drawTextInstances(encoder, text_buf[0..text_count]);
         // Block element pass flush — text pass 안에서 bg_buf 재사용해 누적된 것.
@@ -1873,7 +1872,10 @@ pub const MetalRenderer = struct {
     /// offset 이라 pass 를 넘어도 유효하다.
     ///
     /// 실패하면 `null` 을 돌려준다 — 호출자는 그 셀을 건너뛰고 프레임을 끝낸다.
-    fn restartPassAfterAtlasFull(self: *MetalRenderer) objc.id {
+    /// #585 — pass 를 끊고, GPU 가 끝나기를 기다린 뒤, dirty 구간을 올리고, 새 pass 를 연다.
+    /// **비우지는 않는다.** 두 곳이 쓴다 — 안전망 (`restartPassAfterAtlasFull`, 비우기 포함) 과,
+    /// 안전망이 돈 프레임의 이후 draw 들 (비운 뒤 담은 글리프를 그리기 전에 올려야 한다).
+    fn uploadAndRestartPass(self: *MetalRenderer) objc.id {
         const old_encoder = self.current_encoder;
         if (old_encoder == null) return null;
         const drawable = self.current_drawable;
@@ -1882,31 +1884,29 @@ pub const MetalRenderer = struct {
 
         objc.msgSendVoid(old_encoder, objc.sel("endEncoding"));
 
-        // #585 — **GPU 가 앞 pass 를 끝낼 때까지 기다린다.** Metal 은 CPU 쓰기와 GPU 읽기의
-        // 순서를 대신 지켜 주지 않는다 — `replaceRegion` 은 즉시 복사라 최종 상태만 보였고,
-        // blit 도 staging 을 다음 구간이 덮어써서 마지막 내용을 올렸다. 두 번 실패한 뿌리가
-        // 같다: **앞 pass 가 텍스처를 다 읽기 전에 CPU 가 덮었다.** Apple 문서가 정확히 이것을
-        // 요구한다 — *"ensure these operations complete before calling replaceRegion"*.
+        // **GPU 가 앞 pass 를 끝낼 때까지 기다린다.** Metal 은 CPU 쓰기와 GPU 읽기의 순서를
+        // 대신 지켜 주지 않는다 — `replaceRegion` 은 즉시 복사라 최종 상태만 보였고, blit 도
+        // staging 을 다음 구간이 덮어써서 마지막 내용을 올렸다. 뿌리가 같다: **앞 pass 가
+        // 텍스처를 다 읽기 전에 CPU 가 덮었다.** Apple 문서가 정확히 이것을 요구한다 —
+        // *"ensure these operations complete before calling replaceRegion"*.
         //
-        // 그래서 앞 cmd_buf 를 present 없이 commit 하고 끝나기를 기다린다. drawable 에 그린 것은
-        // Store 로 남고, present 는 프레임 끝의 마지막 cmd_buf 가 한다. Windows · Linux 는
-        // 드라이버가 이 순서를 만들어 주지만 (`UpdateSubresource` · `glTexSubImage2D`) macOS 는
-        // 우리가 만든다 — 계약은 같고 주체만 다르다 (SPEC §12.6).
-        //
-        // 비용은 구간마다 GPU 대기 한 번이다. 이 경로는 `grow` 가 상한 (`MAX_ATLAS_SIZE`) 에
-        // 닿았을 때만 돌므로 정상 경로에는 영향이 없다.
+        // 앞 cmd_buf 를 present 없이 commit 하고 끝나기를 기다린다. drawable 에 그린 것은 Store
+        // 로 남고, present 는 프레임 끝의 마지막 cmd_buf 가 한다. Windows · Linux 는 드라이버가
+        // 이 순서를 만들어 주지만 (`UpdateSubresource` · `glTexSubImage2D`) macOS 는 우리가 만든다
+        // — 계약은 같고 주체만 다르다 (SPEC §12.6). 비용은 GPU 대기 한 번이고, 안전망이 돈
+        // 프레임에서만 일어난다.
         objc.msgSendVoid(old_cmd_buf, objc.sel("commit"));
         objc.msgSendVoid(old_cmd_buf, objc.sel("waitUntilCompleted"));
 
-        // 새 cmd_buf — 이후 blit 과 pass 가 여기 들어가고, `endFrame` 이 이것을 present 한다.
         const cmd_buf = objc.msgSend(self.command_queue, objc.sel("commandBuffer"));
         if (cmd_buf == null) return null;
         self.current_cmd_buf = cmd_buf;
 
         // 이제 안전하다 — 앞 pass 가 텍스처와 staging 을 다 읽었다.
-        self.uploadAtlas(&self.atlas, self.atlas_texture, &self.staging_buffer, &self.staging_bytes);
-        self.atlas.dirty = false;
-        self.atlas.resetFull();
+        if (self.atlas.dirty) {
+            self.uploadAtlas(&self.atlas, self.atlas_texture, &self.staging_buffer, &self.staging_bytes);
+            self.atlas.dirty = false;
+        }
 
         const texture = objc.msgSend(drawable, objc.sel("texture"));
         const rpd_class = objc.getClass("MTLRenderPassDescriptor");
@@ -1920,6 +1920,16 @@ pub const MetalRenderer = struct {
 
         const enc = objc.msgSend1(cmd_buf, objc.sel("renderCommandEncoderWithDescriptor:"), rpd);
         self.current_encoder = enc;
+        return enc;
+    }
+
+    /// #584 ① — atlas 가 **프레임 중간에** 찼다 (`grow` 상한). 이미 그린 것을 지키고 비운 뒤
+    /// 이어 그린다. `uploadAndRestartPass` + 비우기다.
+    fn restartPassAfterAtlasFull(self: *MetalRenderer) objc.id {
+        const enc = self.uploadAndRestartPass();
+        if (enc == null) return null;
+        self.atlas.resetFull();
+        self.atlas_reset_this_frame = true;
         return enc;
     }
 


### PR DESCRIPTION
## 무엇을 고쳤나

[#585](https://github.com/ensky0/tildaz/issues/585) — macOS atlas 가 프레임 중간에 차면 이미 그린 것을 지키지 못하던 것 (SPEC §12.6 ① 의 macOS 칸이 **미구현 · 불완전**이었습니다). 이제 세 platform 이 **같은 계약을 실측으로** 만족합니다.

## 두 번 실패한 뒤 찾은 뿌리

| 시도 | CPU 쓰기 | GPU 읽기 | 어긋난 이유 |
|---|---|---|---|
| `replaceRegion` + pass 구간화 | 지금 (텍스처에 직접) | 나중 (commit 후) | 모든 pass 가 **최종 텍스처**만 본다 |
| blit encoder + staging | 지금 (staging 에) | 나중 (blit 실행 시) | staging 이 그새 **다음 구간에 덮어써짐** |

둘 다 23~38 % 어긋났고 **뿌리가 같습니다 — 앞 pass 가 텍스처를 다 읽기 전에 CPU 가 덮었습니다.** Windows(`UpdateSubresource`) · Linux(`glTexSubImage2D`) 는 드라이버가 command 순서에 업로드를 끼워 주지만 Metal 은 그렇지 않습니다.

## 해법 — 구간 경계에서 GPU 를 기다린다

```
차면:
  endEncoding                 ← 앞 pass 마감
  commit(cmd_buf)             ← GPU 로 보낸다 (present 없이)
  waitUntilCompleted          ← GPU 가 앞 pass 를 끝냄 = 텍스처를 다 읽었다
  blit 업로드 · reset
  새 cmd_buf + 새 render pass (loadAction = Load)
프레임 끝: 마지막 cmd_buf 를 present + commit
```

Apple 문서가 요구하는 그대로입니다 — *"ensure these operations complete before calling replaceRegion"*. **계약은 같고 순서를 만드는 주체만 다릅니다** — Windows · Linux 는 드라이버, macOS 는 우리. 비용은 구간마다 GPU 대기 한 번이고, 이 경로는 `grow` 가 상한(`MAX_ATLAS_SIZE`)에 닿았을 때만 돕니다.

## 함께 바뀐 것 — 업로드가 dirty 구간만

| | 전 | 후 |
|---|---|---|
| 업로드 방식 | `replaceRegion` | **blit encoder** |
| 프레임당 양 | atlas **전체** 16~64 MB | **dirty 구간만** (대개 수십 KB) |
| 시점 | `drawPane` (encoder 열린 뒤) | **encoder 생성 전** (blit 은 render encoder 밖에서만 됩니다) |

Windows · Linux 가 글리프 단위로 올리는 것과 같은 방향입니다. **staging buffer 는 atlas 마다 따로** 둡니다 — 하나를 두 atlas 가 나눠 쓰면 GPU 가 나중에 읽을 때 뒤에 복사한 내용이 앞 blit 에 실려 **탭 아이콘이 깨졌습니다** (실측으로 잡았습니다).

## 실측

MacBook Pro (M5 Pro) · macOS 26.6.2 · 내장 3024×1964 · Menlo 15pt · `cell 19x39`. `MAX_ATLAS_SIZE = INITIAL_ATLAS_SIZE` 로 두어 `grow` 를 막고 ① 만 돌게 했습니다. 화면은 mark 를 둘 쌓은 cluster **6,000 종** (150 칸 × 40 줄).

| | 4096 (기준 · 안 넘침) | 1024 (① 만 돈다) |
|---|---|---|
| `atlas full` | 0 회 | 한 화면에 **11 회** (= `pack fail` 11 · 거짓 full 없음) |
| 그림 | — | **기준판과 `0 / 4,584,100 px`** |

| platform | ① 검증 |
|---|---|
| Windows | 256 판 · 15 회 비움 → `0 px` |
| Linux | 256 판 · 292 회 비움 → `0 px` (4 조건) |
| **macOS** | **1024 판 · 11 회 비움 → `0 px`** |

**정상 경로 회귀**: blit 판 vs `replaceRegion` 판 `0 px` (cluster 2,816 종) · 이웃 프레임 `0/7` · `grow` 0 · `atlas full` 0.

## 두 번째 커밋 — 거짓 full 과 "비운 프레임" 규칙

첫 커밋의 상한 경로가 `0 px` 이었지만 로그가 이상했습니다 — overflow 화면(17 화면 누적 · 8192 도달)에서 `atlas full` **1,060 회** vs `pack fail` **3 회**. pass 구간화 시절 `MAX_CELLS` flush 3 곳과 최종 flush 1 곳에 남아 있던 `restartPassAfterAtlasFull` 호출이 **비우기까지 하면서** 첫 진짜 full 이후 4,096 인스턴스마다 atlas 를 비우고 있었습니다 (거짓 full).

그런데 **그 4 곳을 그냥 지우면 5.5 % 어긋납니다** (250,441 / 4,584,100 px · 화면 아랫부분). 안전망이 프레임 중간에 비우면 *"이번 프레임에 담은 것은 다음 프레임 시작에 올린다"* (2-frame) 는 전제가 깨져서, 비운 뒤 담은 글리프가 그 프레임의 남은 draw 시점에 텍스처에 없고, 정적 화면이면 다음 렌더가 없어 영영 안 보입니다.

그래서 upload 와 reset 을 갈랐습니다.

| 함수 | 하는 일 | 누가 부르나 |
|---|---|---|
| `uploadAndRestartPass` | 끊기 → GPU 대기 → dirty 구간 blit → 새 pass. **비우지 않는다** | 아래 둘 |
| `restartPassAfterAtlasFull` | 위 + `resetFull` + `atlas_reset_this_frame = true` | 안전망 (3 곳) |
| `atlas_reset_this_frame and dirty` 가드 | 위 함수만 (비우기 없음) | `MAX_CELLS` flush 3 곳 · 최종 flush |

플래그는 프레임 시작에 내리므로 **정상 프레임에는 비용이 없습니다.**

| | 전 | 후 |
|---|---|---|
| 상한 경로 (1024 vs 4096 기준판) | 0 px (거짓 full 1,635 회 포함) | **0 px · full 11 = pack fail 11** |
| overflow (8192 도달) | full 1,060 · pack fail 3 | **full 1 · pack fail 3 · grow 2** |
| 일반 화면 (2,816 종) | 0/7 | **0/7 · grow 0 · full 0** |

overflow 회차의 실측 — 4096 도달 시 5,134 종 · 8192 도달 시 15,441 종 · **8192 가 찬 시점 56,835 종** (glyph 195 · font 3 · `filled_y 8,165`).

## SPEC §12.6

- ① 표의 macOS 칸 → **사양대로 · 실기 확인**
- *"macOS 는 ① 을 완전히 만족할 수 없다"* 문단 → 해법과 실측으로 교체
- ② 절의 근거 → *"① 도 완전하지만 GPU 대기가 있어 차기 전에 키우는 것이 주 경로"*
- 세 platform 의 **업로드 단위 표** 신설
- ① 에 **"비운 프레임에서는 그 뒤의 draw 앞에도 매번 올린다"** 규칙과 이유 (2-frame 전제)
- ② 표에 **macOS 8192 행** (grow 시점 두 번 + 찬 시점) 과 **"상한은 한 화면이 아니라 한 세션의 누적으로 닿는다"** 도달 조건 — 이슈 본문이 남긴 항목

## 검증

`zig build check` (6 타겟) · `zig build test` · ReleaseFast 빌드 · `zig fmt --check` 통과.

**사용자 육안 확인 완료** (2026-09-02 시연). 2-frame 정책 자체의 제거는 [#591](https://github.com/ensky0/tildaz/issues/591) 로 잇습니다.

Closes #585

