### PR TITLE
docs(macos): 렌더 결과 · 과정 검증 도구와 절차를 레포에 둔다 (#583 A12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,11 @@ git rebase origin/main
 **에이전트 memory 기능은 쓰지 않아요.** 사용자는 여러 머신을 오가며 작업하는데 (아래 `# 실행 환경`
 의 머신 목록), memory 는 **기록한 그 머신에만** 남아서 *한쪽에서만 보이는 사실*을 만들어요 — 다른
 머신으로 옮기거나 같은 노트북을 다른 OS 로 부팅하면 없는 것과 같아요. 남길 가치가 있는 내용은
-**관련 GitHub 이슈 댓글**에 적어요. 어느 머신에서든 같이 보이고, 바로 위의 "작업 기록은 GitHub
-이슈에" 와 같은 방향이에요. (2026-08-05 사용자 지적 — 세션마다 반복돼서 문서에 적어요.)
+**레포에서 관리되는 곳**에 적어요 — 작업 기록은 **관련 GitHub 이슈 댓글**, 검증 절차 · 함정 · 도구
+사용법은 **이 문서 (AGENTS.md)** 나 스크립트 머리 주석, 동작 사양은 **SPEC.md**, 재사용할 스크립트는
+`dist/<platform>/` 에 커밋. 어느 머신에서든 같이 보이고, 바로 위의 "작업 기록은 GitHub 이슈에" 와
+같은 방향이에요. (2026-08-05 사용자 지적 — 세션마다 반복돼서 문서에 적어요. 2026-09-02 에 또
+반복됐어요 — 세션이 이 절을 읽기 전에 memory 를 썼어요. **이 문서를 끝까지 읽는 것이 먼저예요.**)
 
 **용어 — Wayland `advertise` 를 "광고 / 미광고" 로 옮기지 않아요.** compositor 가 `wl_registry.global` 로 client 에게 지원 protocol 을 알리는 행위 (*advertise*) 를 "광고" 로 직역하면 한국어로 의미가 안 통해요 (사용자 두 번 지적). 대신 "client 에게 노출 (*advertise*)", "지원 통보가 온다 / 안 온다", "`wl_registry.global` 로 알린다", 또는 영어 *advertised* / *not advertised* 를 그대로 써요. "이 capability 는 compositor 에 없음" 처럼 풀어 써도 좋아요. 이슈 / 답변 / 공유 문서 / 코드 주석 / 커밋 메시지 모두 적용.
 
@@ -539,6 +542,55 @@ dist/macos/repeat-render-check.sh 24 6 /path/show.sh    # 다른 화면으로
 - **한 회차를 먼저 돌려 조건을 확인하고 시작해요.** 앱이 뜨는지 · 캡처 크기 · 주사율
   (`[startup] display timing`) 을 보고 나서 전체를 돌려요. 이걸 건너뛰어 10 회를 통째로
   버린 적이 있어요 (앱이 매 회차 죽고 있었는데 모르고 끝까지 돌렸어요).
+
+# macOS — 렌더 결과와 그리는 과정을 픽셀로 검증하는 법
+
+렌더 경로 (atlas · 업로드 · pass 구조) 를 바꿨을 때 쓰는 절차예요. #584 · #585 · #591 에서 다듬었어요.
+**최종 그림 한 장만 보지 않아요 — 그리는 과정도 봐요** (2026-09-02 사용자 지시). 도구는 셋이에요.
+
+| 도구 | 무엇 |
+|---|---|
+| [`dist/macos/render-ab-shot.sh`](dist/macos/render-ab-shot.sh) | 두 앱 판을 같은 화면으로 찍어 **최종 그림**을 픽셀 수로 견줘요 |
+| [`dist/macos/render-process-check.sh`](dist/macos/render-process-check.sh) | 기동 직후부터 촘촘히 찍어 **이웃 프레임 차이 · 최종 대비 차이**를 내요 — 과정이 단계적으로 채워지면 여기서 보여요 |
+| [`dist/screens/clusters.py`](dist/screens/clusters.py) | 검증 화면 생성기 — `many` (일반 · grow 0) · `stack2` (좁은 atlas 를 채움) · `overflow` (17 화면 누적 · 8192² 상한) · `mini` (프레임 수 계측) |
+
+```sh
+python3 dist/screens/clusters.py many > /tmp/many.sh && chmod +x /tmp/many.sh
+git worktree add /tmp/wt-main main && (cd /tmp/wt-main && zig build -Doptimize=ReleaseFast -Dsimd=true)   # 기준판
+zig build -Dmacos-sign-identity=TildazLocal -Doptimize=ReleaseFast -Dsimd=true                             # 수정판
+dist/macos/render-ab-shot.sh /tmp/many.sh 88x33 5 /tmp/wt-main/zig-out/TildaZ.app zig-out/TildaZ.app      # 정적 → 0 px
+dist/macos/render-process-check.sh zig-out/TildaZ.app /tmp/many.sh 88x33 30 0.03                          # 과정 → 전부 0
+```
+
+- **기준판은 별도 worktree 에서 빌드해요.** `.zig-cache` 를 나누지 않으면 두 판의 바이너리가 같아져
+  "0 차이" 가짜 통과가 나요. 스크립트가 md5 를 찍어 주니 다른지 봐요.
+- **픽셀 수는 `-compose difference` + `-threshold 0` 로 세요.** `magick compare -metric AE` 는 소수 ·
+  지수 표기를 내서 (Linux 회차가 실측으로 걸렸어요) 행별 합이 안 맞아요.
+- **픽셀 대조에는 로그의 계수도 같이 봐요** — `atlas full` 회수가 `pack fail` 같은 원인 로그 회수와
+  맞는지. #585 에서 pass 구간화 시절 잔재 코드가 4,096 인스턴스마다 atlas 를 비우며 우연히 그림을 지켜
+  `0 px` 가 났고 (`atlas full` 1,060 회 vs 원인 3 회 — 거짓 full), 잔재를 지우자 5.5 % 어긋났어요.
+  임시 · 잔재 코드를 지운 뒤에는 **반드시 다시 견줘요.**
+- **atlas 안전망 경로를 강제로 돌리려면** `MAX_ATLAS_SIZE = INITIAL_ATLAS_SIZE` (예 1024) 로 빌드한
+  판을 `INITIAL = 4096` (그 화면으로 안 넘침) 판과 견줘요 — 안전망이 정확하면 `0 px` 예요. 상수는 끝나면
+  되돌리고 `git diff` 로 확인해요.
+- **과정 캡처의 첫 장이 최종과 크게 다르면 "present 전 투명 창" 인지 먼저 가르세요** — 배경색
+  `srgba(0,0,0,0)` · 배경 아닌 픽셀 0 이면 아직 아무것도 안 그린 거예요 (안전망이 GPU 를 여러 번 기다리는
+  판은 첫 present 가 늦어요). 스크립트가 그 판정을 함께 찍어요.
+- **"한 프레임 늦음" 은 캡처로 못 가르세요** — 캡처 간격 20~50 ms 가 60 Hz 한 프레임 (16 ms) 보다
+  길어요 (main 의 2-frame 지연도 30 장 전부 0 이었어요). 대신 perf 종료 덤프의 `render calls` (프레임당
+  1) 를 봐요 — `clusters.py mini` 가 스스로 끝나는 화면이라 `atexit` 덤프가 남아요 (`pkill` 로 내리면
+  덤프가 없어요). 출력이 크면 여러 프레임에 걸쳐 도착해 ±2 노이즈가 나니 작은 화면으로 **3 회 반복**하고,
+  구조로 확실한 것과 수치로 보인 것을 갈라 적어요 (#591 2 단계는 기대한 −1 프레임이 수치로 안 보였어요).
+- **사용자에게 보여 줄 창은 서명 빌드를 `open` 으로 띄워요** — `zig build -Dmacos-sign-identity=TildazLocal …`
+  뒤 `open -n -a zig-out/TildaZ.app --args --instance 9`. 바이너리를 직접 실행하면 TCC 권한이 안 맞아
+  안내 다이얼로그가 뜨고 키 입력이 막혀요 (아래 `# 실행 환경` 의 같은 규칙 — 2026-09-02 에 또 걸렸어요).
+  캡처만 하는 무입력 회차는 직접 실행도 동작해요.
+- **화면이 잠겨 있으면 캡처가 전부 실패해요** (`Display 1 Shield`). 사용자가 자리를 비우면 30 분
+  넘게 이어지니 `ioreg -n Root -d1 -r | grep -c CGSSessionScreenIsLocked` 가 0 이 될 때까지 백그라운드로
+  기다리고, 그동안 캡처가 필요 없는 일 (빌드 · 문서) 을 먼저 해요. `caffeinate -disu` 는 검증 동안만 켜요.
+- 도구는 `--instance 9` 로만 띄우고 내릴 때도 `pkill -f "tildaz --instance 9"` 로 **그 인스턴스만** 잡아요
+  (`pkill -x tildaz` 는 사용자의 instance 0 도 죽여요 — #583 A12). 실기라서 `# 실행 환경` 대로
+  **시작 전에 창이 몇 번 뜨는지 알리고** 그동안 키 · 마우스를 건드리지 말라고 해요.
 
 # macOS — 키보드 layout 조회 실측 방법
 

--- a/dist/macos/render-ab-shot.sh
+++ b/dist/macos/render-ab-shot.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# 두 앱 판을 **같은 화면**으로 찍어 최종 그림을 픽셀로 견준다 (macOS) — 기준판 vs 수정판.
+#
+# ```sh
+# dist/macos/render-ab-shot.sh <화면.sh> <격자> <대기초> <A.app> <B.app>
+# dist/macos/render-ab-shot.sh /tmp/many.sh 88x33 5 /tmp/main.app zig-out/TildaZ.app
+# ```
+#
+# - 기준판은 main 을 **별도 worktree** 에서 빌드한다 (`.zig-cache` 가 갈려야 한다 — 캐시를 나누지
+#   않으면 두 판의 바이너리가 같아져 "0 차이" 가짜 통과가 난다). 판정 전에 md5 가 다른지 본다.
+# - 픽셀 수는 `-compose difference` 로 센다. `magick compare -metric AE` 는 소수 · 지수 표기를 낸다.
+# - atlas 안전망 경로를 강제로 돌리려면 `MAX_ATLAS_SIZE = INITIAL_ATLAS_SIZE` (예 1024) 로 빌드한 판을
+#   `INITIAL = 4096` 판 (안 넘침) 과 견준다 — 안전망이 정확하면 `0 px` 다. **픽셀 대조에는 로그의
+#   `atlas full` 회수도 같이 본다** — 잔재 코드가 우연히 그림을 지키고 있어도 `0 px` 가 나온다 (#585).
+set -u
+TARGET="${1:?화면}"; SIZE="${2:?격자}"; WAIT="${3:-6}"; A="${4:?A.app}"; B="${5:?B.app}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAP="${TMPDIR:-/tmp}/tildaz-frame-check/color-capture"
+if [ ! -x "$CAP" ] || [ "$HERE/color-capture.m" -nt "$CAP" ]; then
+  mkdir -p "$(dirname "$CAP")"
+  clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit -framework ImageIO \
+        -framework UniformTypeIdentifiers -o "$CAP" "$HERE/color-capture.m" || exit 1
+fi
+OUT="${TMPDIR:-/tmp}/tildaz-ab-shot"; mkdir -p "$OUT"
+echo "md5  A $(md5 -q "$A/Contents/MacOS/tildaz")  B $(md5 -q "$B/Contents/MacOS/tildaz")"
+i=0
+for app in "$A" "$B"; do
+  i=$((i+1)); bin="$app/Contents/MacOS/tildaz"; [ -x "$bin" ] || { echo "앱 없음: $bin"; exit 1; }
+  pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.5
+  "$bin" --instance 9 -e "$TARGET" -size "$SIZE" >/dev/null 2>&1 & disown
+  wid=""; for _ in $(seq 1 40); do sleep 0.2; wid=$("$CAP" --list 2>/dev/null | awk '$2 ~ /tildaz/ {print $1; exit}'); [ -n "$wid" ] && break; done
+  [ -z "$wid" ] && { echo "창 못 찾음 ($app)"; pkill -f "tildaz --instance 9"; exit 1; }
+  sleep "$WAIT"; "$CAP" --window "$wid" "$OUT/shot_$i.png" >/dev/null 2>&1
+  pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.3
+done
+n=$(magick "$OUT/shot_1.png" "$OUT/shot_2.png" -compose difference -composite -colorspace Gray -threshold 0 -format '%[fx:mean*w*h]' info: | python3 -c "print(int(round(float(input()))))")
+tot=$(magick identify -format '%[fx:w*h]' "$OUT/shot_1.png" | python3 -c "print(int(float(input())))")
+echo "A vs B: $n / $tot px  ($OUT/shot_1.png · shot_2.png)"

--- a/dist/macos/render-process-check.sh
+++ b/dist/macos/render-process-check.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# 그리는 **과정**을 본다 (macOS) — 기동 직후부터 촘촘히 찍어 (1) 이웃 프레임 차이, (2) 최종 프레임
+# 대비 차이를 **픽셀 수**로 낸다. (2) 가 첫 장부터 0 이면 첫 프레임에 이미 최종 그림이다.
+#
+# 최종 그림 한 장만 견주면 "그리는 도중 단계적으로 채워지는" 이상을 못 잡는다 — #585 에서 사용자가
+# 눈으로 본 "아랫부분이 지지직" 을 정적 대조 `0 px` 가 놓쳤다. 렌더 경로를 바꾸면 이걸로 과정도 본다.
+#
+# ```sh
+# dist/macos/render-process-check.sh <앱.app> <화면.sh> <격자> [장수=30] [간격초=0.03] [태그]
+# dist/macos/render-process-check.sh zig-out/TildaZ.app /tmp/many.sh 88x33
+# ```
+#
+# - 첫 장이 최종과 크게 다르면 **"present 전 투명 창"** 인지 먼저 가른다 — 배경색이 `srgba(0,0,0,0)`
+#   이고 배경 아닌 픽셀이 0 이면 아직 아무것도 안 그린 것이다 (안전망이 GPU 를 여러 번 기다리는
+#   판은 첫 present 가 늦어 그렇게 잡힌다). 이상이 아니다.
+# - 캡처 간격은 20~50 ms 라 60 Hz 한 프레임 (16 ms) 을 직접 가르지는 못한다 — "한 프레임 늦음" 은
+#   perf 종료 덤프의 `render calls` 로 본다 (`dist/screens/clusters.py mini`).
+# - 화면이 잠겨 있으면 캡처가 전부 실패한다 — 시작 전에 확인하고, 사용자에게 알린다.
+set -u
+APP="${1:?앱 .app 경로}"; TARGET="${2:?화면 스크립트}"; SIZE="${3:?격자 예 88x33}"
+N="${4:-30}"; GAP="${5:-0.03}"; TAG="${6:-$(basename "$APP" .app)}"
+BIN="$APP/Contents/MacOS/tildaz"; [ -x "$BIN" ] || { echo "앱 없음: $BIN"; exit 1; }
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAP="${TMPDIR:-/tmp}/tildaz-frame-check/color-capture"
+if [ ! -x "$CAP" ] || [ "$HERE/color-capture.m" -nt "$CAP" ]; then
+  mkdir -p "$(dirname "$CAP")"
+  clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit -framework ImageIO \
+        -framework UniformTypeIdentifiers -o "$CAP" "$HERE/color-capture.m" || exit 1
+fi
+if [ "$(ioreg -n Root -d1 -r 2>/dev/null | grep -c CGSSessionScreenIsLocked)" != "0" ]; then
+  echo "화면이 잠겨 있다 — 캡처가 안 된다"; exit 1
+fi
+OUT="${TMPDIR:-/tmp}/tildaz-process-check/$TAG"; rm -rf "$OUT"; mkdir -p "$OUT"
+pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.5
+"$BIN" --instance 9 -e "$TARGET" -size "$SIZE" >/dev/null 2>&1 & disown
+wid=""
+for _ in $(seq 1 100); do wid=$("$CAP" --list 2>/dev/null | awk '$2 ~ /tildaz/ {print $1; exit}'); [ -n "$wid" ] && break; sleep 0.02; done
+[ -z "$wid" ] && { echo "창 못 찾음"; pkill -f "tildaz --instance 9"; exit 1; }
+for i in $(seq 1 "$N"); do "$CAP" --window "$wid" "$OUT/f_$(printf '%02d' "$i").png" >/dev/null 2>&1; sleep "$GAP"; done
+sleep 1.5; "$CAP" --window "$wid" "$OUT/final.png" >/dev/null 2>&1
+pkill -f "tildaz --instance 9" 2>/dev/null
+px() { magick "$1" "$2" -compose difference -composite -colorspace Gray -threshold 0 -format '%[fx:mean*w*h]' info: 2>/dev/null | python3 -c "print(int(round(float(input() or 0))))"; }
+tot=$(magick identify -format '%[fx:w*h]' "$OUT/final.png" | python3 -c "print(int(float(input())))")
+echo "[$TAG] $(magick identify -format '%wx%h' "$OUT/final.png")  총 $tot px  ($OUT)"
+prev=""; line_n=""; line_f=""; first=""
+for f in "$OUT"/f_*.png; do
+  d=$(px "$f" "$OUT/final.png"); [ -z "$first" ] && first=$d; line_f="$line_f $d"
+  [ -n "$prev" ] && line_n="$line_n $(px "$prev" "$f")"; prev="$f"
+done
+echo "  최종 대비:$line_f"; echo "  이웃 차이:$line_n"; echo "  첫 장 vs 최종: $first px"
+if [ "$first" != "0" ]; then
+  bg=$(magick "$OUT/f_01.png" -format '%[pixel:p{10,300}]' info:)
+  echo "  첫 장 배경색 $bg — srgba(0,0,0,0) 이면 present 전 투명 창 (이상 아님)"
+fi

--- a/dist/macos/repeat-render-check.sh
+++ b/dist/macos/repeat-render-check.sh
@@ -66,10 +66,11 @@ echo "   결과 : $OUT"
 echo "   ⚠️ 도는 동안 기기를 만지지 않는다. 창이 회차마다 떴다 사라진다."
 echo
 
-# 사용자의 일상 인스턴스를 건드리지 않도록 `--instance 9` 로만 띄운다.
+# 사용자의 일상 인스턴스를 건드리지 않도록 `--instance 9` 로만 띄우고, 내릴 때도 그 인스턴스만 잡는다
+# (`pkill -x tildaz` 는 instance 0 도 죽였다 — #583 A12).
 for i in $(seq 1 "$N"); do
   printf "  회차 %2d/%d ... " "$i" "$N"
-  pkill -x tildaz 2>/dev/null
+  pkill -f "tildaz --instance 9" 2>/dev/null
   sleep 0.5
 
   # `disown` 은 아래 `pkill` 로 내릴 때 셸이 "Terminated: 15" 를 찍는 것을 막는다.
@@ -87,7 +88,7 @@ for i in $(seq 1 "$N"); do
     echo "캡처 실패 (화면이 잠겼는지 확인한다)"
   fi
 
-  pkill -x tildaz 2>/dev/null
+  pkill -f "tildaz --instance 9" 2>/dev/null
   sleep 0.5
 done
 
@@ -135,7 +136,7 @@ fi
 
 echo
 echo "== 정리 =="
-pkill -x tildaz 2>/dev/null
+pkill -f "tildaz --instance 9" 2>/dev/null
 rm -f "$HOME/.config/tildaz/config_9.toml"   # 안 지우면 로그온 때 그 인스턴스가 같이 뜬다
 echo "  tildaz 프로세스 $(pgrep -x tildaz | wc -l | tr -d ' ') 개 · config_9.toml 제거"
 echo "  캡처는 $OUT 에 남겼다 (판정이 끝나면 지운다)."

--- a/dist/screens/clusters.py
+++ b/dist/screens/clusters.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""atlas · cluster 렌더 검증용 화면을 만든다 — 세 platform 공용.
+
+`tildaz -e` 는 실행 파일 하나만 받으므로, 이 생성기는 **stdout 에 실행 가능한 sh 스크립트**를 낸다.
+받아서 파일로 저장하고 `chmod +x` 한 뒤 `-e` 에 넘긴다. 각 화면은 서로 다른 cluster 를 겹치지 않게
+만들어 atlas 에 담기는 **종 수**가 예측 가능하다 (아래 표는 기본 인자 기준 · 실측은 #584 · #585 · #591).
+
+    python3 dist/screens/clusters.py many     > /tmp/many.sh      # 2,938 종 · 88x33 · 일반 화면 (grow 0 이어야 한다)
+    python3 dist/screens/clusters.py stack2   > /tmp/stack2.sh    # 6,000 종 · 150x40 · mark 둘 — 1024² 가 찬다 (안전망 검증)
+    python3 dist/screens/clusters.py overflow > /tmp/overflow.sh  # 17 화면 · 96,768 종 누적 · 150x40 — 8192² 상한에 닿는다
+    python3 dist/screens/clusters.py mini     > /tmp/mini.sh      # 1.5 s 뒤 한 줄 · 4 s 뒤 종료 — 렌더 프레임 수 계측용
+    chmod +x /tmp/*.sh
+    tildaz --instance 9 -e /tmp/many.sh -size 88x33
+
+| 화면 | 무엇 | 왜 |
+|---|---|---|
+| `many` | 소문자 26 × 결합 기호 (U+0300~U+036F) 한 겹 | 일반 화면 회귀 — atlas 가 커지지 않아야 한다 |
+| `stack2` | base 8 종 × 위 mark × 아래 mark 두 겹 | 비트맵이 cell 보다 커서 좁은 atlas 를 빨리 채운다 — `MAX = INITIAL` 판으로 안전망만 돌린다 |
+| `overflow` | 대문자 base × mark 세 겹, 화면마다 다른 조합 — 17 화면을 차례로 | 캐시가 누적되어 8192² 상한에 닿는다 (SPEC §12.6 ② "한 세션의 누적") |
+| `mini` | 잠시 뒤 한 줄만 · 스스로 끝난다 | perf 종료 덤프의 `render calls` 를 읽어 프레임 수를 센다 (`pkill` 은 `atexit` 덤프를 못 남긴다) |
+
+`sleep` 은 화면이 남아 있게 하는 것이다 — `-e` 로 띄운 프로세스가 끝나면 앱도 끝난다.
+"""
+import sys
+
+ABOVE = [chr(c) for c in range(0x0300, 0x0315)] + [chr(c) for c in range(0x033D, 0x0345)]   # 위 mark 29
+BELOW = [chr(c) for c in range(0x0316, 0x0334)]                                              # 아래 mark 30
+ALL = [chr(c) for c in range(0x0300, 0x0370)]                                                # 112
+
+
+def emit(lines, tail="sleep 3600", head=""):
+    out = ["#!/bin/sh", head] if head else ["#!/bin/sh"]
+    out += ["cat <<'S'"] + lines + ["S", tail]
+    sys.stdout.write("\n".join(out) + "\n")
+
+
+def rows(items, per_line):
+    return ["".join(items[i:i + per_line]) for i in range(0, len(items), per_line)]
+
+
+def many(cols=88):
+    items = [b + m for b in "abcdefghijklmnopqrstuvwxyz" for m in ALL]   # 26 × 112 = 2,912
+    emit(rows(items, cols))
+
+
+def stack2(cols=150):
+    bases = ["a", "á", "â", "ã", "ā", "ă", "ȧ", "ä"]  # 8
+    items = [b + a + w for b in bases for a in ABOVE for w in BELOW]                    # 8 × 29 × 30 = 6,960
+    emit(rows(items[:6000], cols))
+
+
+def overflow(cols=150, screens=17):
+    # 화면마다 base 를 바꿔 조합이 겹치지 않게 한다. 각 화면 5,692 종 (= 4 base × 29 × 30 × ... 를 cols 줄로).
+    bases_all = [chr(c) for c in range(0x0100, 0x0100 + 4 * screens)]   # Ā Ă Ą Ć … 화면마다 4 개
+    lines = []
+    for s in range(screens):
+        bases = bases_all[s * 4:(s + 1) * 4]
+        items = [b + a + w + x for b in bases for a in ABOVE for w in BELOW for x in ("̀", "́")][:5692]
+        lines += rows(items, cols)
+        lines.append("")  # 화면 사이 빈 줄 — 스크롤로 넘어간다
+    emit(lines)
+
+
+def mini():
+    sys.stdout.write('#!/bin/sh\nsleep 1.5\nprintf "\\303\\240\\303\\241\\303\\242\\303\\243 a\\314\\205a\\314\\206a\\314\\207 \\303\\244\\341\\272\\243\\n"\nsleep 4\n')
+
+
+if __name__ == "__main__":
+    which = sys.argv[1] if len(sys.argv) > 1 else "many"
+    cols = int(sys.argv[2]) if len(sys.argv) > 2 else None
+    if which == "many":
+        many(cols or 88)
+    elif which == "stack2":
+        stack2(cols or 150)
+    elif which == "overflow":
+        overflow(cols or 150)
+    elif which == "mini":
+        mini()
+    else:
+        sys.exit("사용법: clusters.py many|stack2|overflow|mini [cols]")


### PR DESCRIPTION
memory 에 남기던 검증 방법을 레포로 옮깁니다 — AGENTS.md 에 *"memory 기능은 쓰지 않아요"* 규칙이 있는데도 2026-09-02 세션이 그 절을 읽기 전에 memory 를 썼습니다. 그 절을 보강하고 (검증 절차 · 도구는 AGENTS.md · 스크립트 주석 · SPEC · `dist/` 로), **이 문서를 끝까지 읽는 것이 먼저**라고 적었습니다.

## 새 절 — `# macOS — 렌더 결과와 그리는 과정을 픽셀로 검증하는 법`

#584 · #585 · #591 에서 다듬은 절차입니다. **최종 그림 한 장만 보지 않고 과정도 봅니다** (사용자 지시).

| 함정 | |
|---|---|
| 기준판은 별도 worktree | `.zig-cache` 공유 시 두 판이 같은 바이너리 → 가짜 `0 px` |
| `-compose difference` | `compare -metric AE` 는 소수 · 지수 표기 |
| 계수 로그 동반 | #585 의 거짓 full — 잔재 코드가 우연히 그림을 지켜 `0 px` |
| `MAX = INITIAL` 판 | 안전망 경로 강제 |
| present 전 투명 창 | 과정 첫 장이 다를 때 먼저 가른다 |
| 프레임 수는 perf 덤프 | 16 ms 는 캡처로 못 가른다 · `pkill` 은 덤프 없음 |
| 서명 빌드 + `open` | 바이너리 직접 실행은 TCC 권한 문제 |
| 화면 잠금 · instance 9 만 | |

## 도구

| 파일 | |
|---|---|
| `dist/macos/render-ab-shot.sh` | 두 앱 판 → 최종 그림 픽셀 수 |
| `dist/macos/render-process-check.sh` | 기동 직후 촘촘히 → 이웃 · 최종 대비 차이 + 투명 창 판정 |
| `dist/screens/clusters.py` | 화면 생성기 — `many` 2,938 종 · `stack2` 6,000 · `overflow` 96,764 누적 · `mini` |
| `dist/macos/repeat-render-check.sh` | **#583 A12** — `pkill -x tildaz` → `pkill -f "tildaz --instance 9"` (instance 0 을 죽이던 것) |

## 검증

세 스크립트를 실제로 돌렸습니다 — A/B `0 / 2,251,390 px` (1 단계 판 vs 2 단계 판) · 과정 20 장 전부 0 · 반복 검사 2 회 정상 종료. A12 는 패턴상 확실하고, 실측은 이번에 instance 0 이 떠 있지 않아 못 했습니다.

Refs #583 · #591