### PR TITLE
docs(macos): 합성 입력으로 마우스 보고 · dead key 를 자동 검증하는 도구 (#583 A3 · A4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,6 +592,26 @@ dist/macos/render-process-check.sh zig-out/TildaZ.app /tmp/many.sh 88x33 30 0.03
   (`pkill -x tildaz` 는 사용자의 instance 0 도 죽여요 — #583 A12). 실기라서 `# 실행 환경` 대로
   **시작 전에 창이 몇 번 뜨는지 알리고** 그동안 키 · 마우스를 건드리지 말라고 해요.
 
+# macOS — 합성 입력으로 마우스 보고 · dead key 를 자동 검증하는 법
+
+사람 손 없이 `cliclick` 으로 클릭 · 키를 보내 판정하는 도구 둘이에요 ([#583](https://github.com/ensky0/tildaz/issues/583) A3 · A4).
+
+| 도구 | 무엇 |
+|---|---|
+| [`dist/mouse/mouse-auto-check.sh`](dist/mouse/mouse-auto-check.sh) | `mouse-probe.sh --log` 를 띄우고 셀을 눌러 `?1005` · `?1015` · `?1016` 같은 형식의 바이트 형태를 판정 |
+| [`dist/macos/deadkey-check.sh`](dist/macos/deadkey-check.sh) | 입력 소스 ABC 에서 Option+e · e → `é` (c3 a9) 가 들어오는지 |
+
+- **창 위치는 `dist/macos/color-capture --list` 의 위치 열**에서 읽어요 — Accessory 앱은 AX 의
+  `position of window` 가 창을 못 찾고 (`유효하지 않은 인덱스`), JXA 의 `CGWindowListCopyWindowInfo`
+  는 CFArray 를 풀지 못했어요. 그래서 우리 도구에 열을 더했어요 (크기 뒤 · 제목 앞 — 앞 열로 읽는
+  스크립트가 그대로 맞아요).
+- **화면이 잠겨 있으면 클릭 · 키가 잠금 화면으로 가요.** 프로브는 떠 있고 캡처도 되는데 로그만 비어
+  있어서 원인을 못 짚어요 — 2026-09-02 에 한 회차를 통째로 버렸어요 (창 목록에 `com.apple.loginwindow`
+  30000×30000 이 클릭점을 덮고 있었어요). 두 스크립트가 시작 전에 `CGSSessionScreenIsLocked` 와
+  합성 입력 전달 (`cliclick m:` 뒤 `p` 로 위치 확인) 을 먼저 봐요. 회차 동안 `caffeinate -disu` 를 켜요.
+- 비활성 창의 **첫 클릭은 창을 깨우는 데 쓰일 수 있어** (`acceptsFirstMouse`) 두 번 눌러요 — 두 번째가
+  판정 대상이에요. 키는 창을 클릭해 key window 로 만든 뒤, 무해한 `arrow-right` 하나를 먼저 보내요.
+
 # macOS — 키보드 layout 조회 실측 방법
 
 단축키를 **라벨**로 매칭할지 **위치**로 매칭할지 ([#496](https://github.com/ensky0/tildaz/issues/496) 항목 2) 를 다룰 때, 활성 keyboard layout 이 **어느 키에 어느 글자를 두는지** 실기로 재는 도구예요. [`dist/macos/layout-probe.m`](dist/macos/layout-probe.m) 이 keycode `0..127` 을 네 방식으로 번역해 나란히 덤프해요.

--- a/dist/macos/color-capture.m
+++ b/dist/macos/color-capture.m
@@ -68,12 +68,18 @@ static SCShareableContent *shareableContentOrDie(void) {
 /// 사람이 눈으로 읽을 때는 `app` 이 여전히 편하므로 **두 열을 같이 둔다.**
 static void listWindows(void) {
     SCShareableContent *content = shareableContentOrDie();
-    printf("%-8s %-28s %-24s %-12s %s\n", "id", "bundle", "app", "크기(pt)", "제목");
+    printf("%-8s %-28s %-24s %-12s %-12s %s\n", "id", "bundle", "app", "크기(pt)", "위치(pt)", "제목");
     for (SCWindow *w in content.windows) {
         if (!w.onScreen) continue;
-        char size[32];
+        char size[32], pos[32];
         snprintf(size, sizeof(size), "%.0fx%.0f", w.frame.size.width,
                  w.frame.size.height);
+        // 위치 (pt · 화면 좌상단 원점) — 합성 클릭 (`cliclick c:x,y`) 의 좌표를 창에서
+        // 계산하려면 필요하다. Accessory 앱은 AX `position of window` 가 창을 못 찾고
+        // (#583 A4 실측), JXA 의 `CGWindowListCopyWindowInfo` 는 CFArray 를 풀지 못했다.
+        // **열은 크기 뒤 · 제목 앞**에 둔다 — 앞 열로 읽는 스크립트 (`$1` id · `$2` bundle ·
+        // `$4` 크기) 가 그대로 맞는다.
+        snprintf(pos, sizeof(pos), "%.0f,%.0f", w.frame.origin.x, w.frame.origin.y);
         // **빈 문자열도 `-` 로 채운다.** `?:` 는 nil 만 걸러서, bundle identifier 가 빈
         // 문자열인 앱은 그대로 통과해 **공백만 찍힌다.** 그러면 이 줄을 공백으로 쪼개 읽는
         // 쪽 (`compare-terminals.sh` 의 awk) 에서 **열이 하나 통째로 밀려** 엉뚱한 값을 본다.
@@ -82,8 +88,8 @@ static void listWindows(void) {
         if (!bundle || !*bundle) bundle = "-";
         const char *app = w.owningApplication.applicationName.UTF8String;
         if (!app || !*app) app = "(?)";
-        printf("%-8u %-28s %-24s %-12s %s\n", (unsigned)w.windowID, bundle, app,
-               size, w.title.UTF8String ?: "");
+        printf("%-8u %-28s %-24s %-12s %-12s %s\n", (unsigned)w.windowID, bundle, app,
+               size, pos, w.title.UTF8String ?: "");
     }
 }
 

--- a/dist/macos/deadkey-check.sh
+++ b/dist/macos/deadkey-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# dead key **자동** 검증 (macOS · #494 · #583 A3) — 입력 소스 ABC 에서 Option+e 뒤 e 가 `é` 로
+# 들어오는지. `-e` 로 `cat >> 로그` 를 띄우고 `cliclick` 으로 키를 보내 받은 바이트를 본다.
+#
+# ```sh
+# dist/macos/deadkey-check.sh zig-out/TildaZ.app          # 기대: c3 a9 ('é') 뒤 'x' 78
+# ```
+#
+# - 입력 소스가 ABC / U.S. 가 아니면 Option+e 가 dead key 가 아니다 — 스크립트가 확인하고 멈춘다
+#   (사용자 입력 소스를 바꾸지 않는다).
+# - 창을 먼저 클릭해 key window 로 만든다 (Accessory 앱은 frontmost 가 못 되어 `osascript keystroke`
+#   가 안 닿는다 — `cliclick` 키 이벤트는 key window 로 간다). 첫 키는 레이아웃 동기화에 먹힐 수
+#   있어 무해한 `arrow-right` 를 먼저 보낸다.
+# - `mouse-auto-check.sh` 와 같은 전제 — 손쉬운 사용 권한 · 화면 잠금 아님.
+set -u
+APP="${1:?앱 .app}"; # `open -a` 는 상대 경로를 앱 *이름*으로 해석해 못 찾는다 — 절대 경로로 바꾼다.
+APP="$(cd "$(dirname "$APP")" 2>/dev/null && pwd)/$(basename "$APP")"
+BIN="$APP/Contents/MacOS/tildaz"; [ -x "$BIN" ] || { echo "앱 없음: $BIN"; exit 1; }
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAP="${TMPDIR:-/tmp}/tildaz-frame-check/color-capture"
+if [ ! -x "$CAP" ] || [ "$HERE/color-capture.m" -nt "$CAP" ]; then
+  mkdir -p "$(dirname "$CAP")"
+  clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit -framework ImageIO \
+        -framework UniformTypeIdentifiers -o "$CAP" "$HERE/color-capture.m" || exit 1
+fi
+src=$(defaults read com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID 2>/dev/null)
+case "$src" in *ABC|*US|*U.S.) ;; *) echo "입력 소스가 $src — ABC/U.S. 에서만 Option+e 가 dead key 다"; exit 1;; esac
+if [ "$(ioreg -n Root -d1 -r 2>/dev/null | grep -c CGSSessionScreenIsLocked)" != "0" ]; then echo "화면이 잠겨 있다"; exit 1; fi
+LOG="${TMPDIR:-/tmp}/tildaz-deadkey.log"; rm -f "$LOG"
+# `stty -icanon` — 줄 단위가 아니라 **바이트가 오는 즉시** 파일에 쓴다. Enter 에 의존하면 합성 Enter 가
+# 안 닿았을 때 (2026-09-03 실측 — 화면에는 `abcéx` 가 찍혔는데 파일은 비었다) 판정을 못 한다.
+WRAP="${TMPDIR:-/tmp}/tildaz-deadkey-wrap.sh"; printf '#!/bin/sh\nstty -icanon\ncat >> %s\n' "$LOG" > "$WRAP"; chmod +x "$WRAP"
+pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.5
+open -n -a "$APP" --args --instance 9 -e "$WRAP" -size 60x12
+geom=""; for _ in $(seq 1 40); do sleep 0.2; geom=$("$CAP" --list 2>/dev/null | awk '$2 ~ /tildaz/ {print $4, $5; exit}'); [ -n "$geom" ] && break; done
+[ -z "$geom" ] && { echo "창 못 찾음"; pkill -f "tildaz --instance 9"; exit 1; }
+sleep 1.2; read -r sz pos <<<"$geom"; X=${pos%,*}; Y=${pos#*,}
+cliclick c:$((X + 150)),$((Y + 150)); sleep 0.5
+cliclick kp:arrow-right; sleep 0.5
+cliclick kd:alt t:e ku:alt; sleep 0.5      # dead key — 조합 중 표시 (preedit) 가 뜬다
+cliclick t:e; sleep 0.3                    # → é
+cliclick t:x; sleep 0.8
+hex=$(od -An -tx1 "$LOG" 2>/dev/null | tr -s ' \n' ' ')
+pkill -f "tildaz --instance 9" 2>/dev/null; rm -f "$HOME/.config/tildaz/config_9.toml"
+echo "창 $sz @ ($X,$Y) · 입력 소스 $src"
+echo "받은 바이트: ${hex:-(없음)}   텍스트: $(cat "$LOG" 2>/dev/null)"
+case "$hex" in *"c3 a9 78"*) echo "OK — Option+e, e → é (c3 a9), 그 뒤 x"; exit 0;; *) echo "**FAIL** — 기대 'c3 a9 78' (é x)"; exit 1;; esac

--- a/dist/mouse/README.md
+++ b/dist/mouse/README.md
@@ -84,6 +84,25 @@ open -n /Applications/TildaZ.app --args --instance 1 -e /tmp/wrap.sh -size 88x33
 탭을 닫으면 창이 원래 크기로 돌아와요. 예전에는 격자만 고정되고 창은 그대로여서 맨 아래
 행이 창 밖으로 밀렸는데, 지금은 그렇지 않아요.
 
+## 자동 회차 (macOS) — 사람 손 없이 형식만 바꿔 돌릴 때
+
+[`mouse-auto-check.sh`](mouse-auto-check.sh) 가 위 프로브를 `--log` 로 띄우고 `cliclick` 으로 셀 영역을
+두 번 눌러 (첫 클릭은 비활성 창을 깨우는 데 쓰일 수 있어요) 받은 바이트를 형식별 기대와 대조해요.
+`?1005` · `?1015` · `?1016` 처럼 사람 검증 A~E 절에 없는 형식을 돌리는 용도예요 ([#583](https://github.com/ensky0/tildaz/issues/583) A4).
+
+```sh
+dist/mouse/mouse-auto-check.sh zig-out/TildaZ.app 1000 1005 1015 1016
+```
+
+- 창 위치는 `dist/macos/color-capture --list` 의 **위치 열** (pt · 좌상단 원점) 에서 읽어요 — Accessory
+  앱은 AX `position of window` 가 창을 못 찾아요.
+- **전제 둘을 스크립트가 먼저 확인해요.** 이 셸을 띄운 앱에 손쉬운 사용 권한이 있어야 `cliclick` 이
+  닿고 (없으면 `CGEventPost` 가 성공을 돌려주며 아무 일도 안 해요), **화면이 잠겨 있으면 클릭이
+  잠금 화면으로 가요** — 프로브는 떠 있고 로그만 비어서 원인을 못 짚어요 (2026-09-02 에 회차 하나를
+  통째로 버렸어요). 사용자가 자리를 비운 사이 잠길 수 있으니 회차 동안 `caffeinate -disu` 를 켜요.
+- 판정은 좌표 값이 아니라 **형태**예요 — `1015` 는 `^[[32;C;RM` `^[[35;C;RM` (Cb+32 · 뗌도 M),
+  `1005` 는 `^[[M` + 3 글자 (press `' '` · release `'#'`), `1016` 은 `1006` 과 같은 꼴에 픽셀 좌표.
+
 ## A. 공통 시나리오 (세 platform)
 
 | # | 동작 | 기대 |

--- a/dist/mouse/mouse-auto-check.sh
+++ b/dist/mouse/mouse-auto-check.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# mouse reporting **자동** 검증 (macOS) — 프로브를 띄우고 합성 클릭을 보내 받은 바이트를 형식별
+# 기대와 대조한다 (#502 · #583 A4). 사람 손 없이 `?1005` · `?1015` · `?1016` 같은 안 쓰는 형식을
+# 돌릴 수 있다. 프로브는 `mouse-probe.sh --log` 그대로다 — 사람 검증과 같은 것을 본다.
+#
+# ```sh
+# dist/mouse/mouse-auto-check.sh zig-out/TildaZ.app 1000 1015      # tracking 1000 · format 1015
+# dist/mouse/mouse-auto-check.sh zig-out/TildaZ.app 1000 1005 1006 1015 1016   # 형식 여럿
+# ```
+#
+# 판정 (press 뒤 release 한 번 — 셀 (C,R) 은 창 위치 · cell 크기에 딸려 가므로 값이 아니라 **형태**만):
+#   1006  ^[[<0;C;RM  ^[[<0;C;Rm            (뗌은 소문자 m)
+#   1016  ^[[<0;X;YM  ^[[<0;X;Ym            (픽셀 좌표 — 1006 보다 큰 수)
+#   1015  ^[[32;C;RM  ^[[35;C;RM            (10진 · Cb+32 · 뗌도 M — 35 = 3+32)
+#   1005  ^[[M + 3 글자  (`32+Cb` · 좌표는 v+33 을 UTF-8 로) — press ' ' (0x20) · release '#' (0x23)
+#
+# 전제 — 이 셸을 띄운 앱 (터미널 · 에디터) 에 **손쉬운 사용 권한**이 있어야 `cliclick` 이 닿는다.
+# 없으면 `CGEventPost` 는 성공을 돌려주면서 아무 일도 하지 않는다 (README 의 같은 주의). 그리고
+# **화면이 잠겨 있으면 클릭이 잠금 화면으로 간다** — 프로브는 떠 있고 로그만 비어 있어 원인을 못
+# 짚는다 (2026-09-02 실측 — 회차 하나를 통째로 버렸다). 둘 다 시작 전에 확인한다.
+set -u
+APP="${1:?앱 .app}"; TRACKING="${2:?tracking 예 1000}"; shift 2
+[ $# -ge 1 ] || { echo "format 을 하나 이상"; exit 1; }
+# `open -a` 는 상대 경로를 앱 *이름*으로 해석해 못 찾는다 — 절대 경로로 바꾼다.
+APP="$(cd "$(dirname "$APP")" 2>/dev/null && pwd)/$(basename "$APP")"
+BIN="$APP/Contents/MacOS/tildaz"; [ -x "$BIN" ] || { echo "앱 없음: $BIN"; exit 1; }
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; REPO="$(cd "$HERE/../.." && pwd)"
+CAP="${TMPDIR:-/tmp}/tildaz-frame-check/color-capture"
+if [ ! -x "$CAP" ] || [ "$REPO/dist/macos/color-capture.m" -nt "$CAP" ]; then
+  mkdir -p "$(dirname "$CAP")"
+  clang -fobjc-arc -framework Cocoa -framework ScreenCaptureKit -framework ImageIO \
+        -framework UniformTypeIdentifiers -o "$CAP" "$REPO/dist/macos/color-capture.m" || exit 1
+fi
+command -v cliclick >/dev/null || { echo "cliclick 이 없다 (brew install cliclick)"; exit 1; }
+if [ "$(ioreg -n Root -d1 -r 2>/dev/null | grep -c CGSSessionScreenIsLocked)" != "0" ]; then echo "화면이 잠겨 있다"; exit 1; fi
+p0=$(cliclick p); cliclick m:600,400; sleep 0.2; [ "$(cliclick p)" = "600,400" ] || { echo "합성 입력이 전달되지 않는다 — 이 셸의 앱에 손쉬운 사용 권한이 없다"; exit 1; }
+cliclick m:"$p0"
+fail=0
+for FMT in "$@"; do
+  LOG="${TMPDIR:-/tmp}/tildaz-mouse-auto-$FMT.log"; rm -f "$LOG"
+  WRAP="${TMPDIR:-/tmp}/tildaz-mouse-auto-wrap-$FMT.sh"
+  printf '#!/usr/bin/env bash\nexec bash %s/dist/mouse/mouse-probe.sh %s %s --log %s\n' "$REPO" "$TRACKING" "$FMT" "$LOG" > "$WRAP"; chmod +x "$WRAP"
+  pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.5
+  open -n -a "$APP" --args --instance 9 -e "$WRAP" -size 88x33
+  geom=""; for _ in $(seq 1 40); do sleep 0.2; geom=$("$CAP" --list 2>/dev/null | awk '$2 ~ /tildaz/ {print $4, $5; exit}'); [ -n "$geom" ] && break; done
+  [ -z "$geom" ] && { echo "[?$FMT] 창 못 찾음"; fail=1; pkill -f "tildaz --instance 9"; continue; }
+  sleep 1.2
+  read -r sz pos <<<"$geom"; X=${pos%,*}; Y=${pos#*,}
+  # 첫 클릭은 비활성 창을 깨우는 데 쓰일 수 있어 (acceptsFirstMouse) 두 번 누른다 — 두 번째가 판정 대상.
+  CX=$((X + 120)); CY=$((Y + 220))
+  cliclick c:$CX,$CY; sleep 0.5; cliclick c:$((CX + 40)),$((CY + 60)); sleep 0.7
+  bytes=$(cat -v "$LOG" 2>/dev/null | tr -d '\n')
+  pkill -f "tildaz --instance 9" 2>/dev/null; sleep 0.3
+  case "$FMT" in
+    1006) re='\^\[\[<0;[0-9]+;[0-9]+M\^\[\[<0;[0-9]+;[0-9]+m$' ;;
+    1016) re='\^\[\[<0;[0-9]+;[0-9]+M\^\[\[<0;[0-9]+;[0-9]+m$' ;;
+    1015) re='\^\[\[32;[0-9]+;[0-9]+M\^\[\[35;[0-9]+;[0-9]+M$' ;;
+    1005) re='\^\[\[M .{2,8}\^\[\[M#' ;;
+    *)    re='.' ;;
+  esac
+  if [ -n "$bytes" ] && printf '%s' "$bytes" | grep -Eq "$re"; then verdict="OK"; else verdict="**FAIL**"; fail=1; fi
+  echo "[?$TRACKING;$FMT] $verdict  창 $sz @ ($X,$Y)  받은 바이트: ${bytes:-(없음)}"
+  [ "$FMT" = 1016 ] && echo "        (1016 은 좌표가 픽셀 — 같은 클릭의 1006 값보다 커야 한다)"
+done
+rm -f "$HOME/.config/tildaz/config_9.toml"
+exit $fail


### PR DESCRIPTION
[#583](https://github.com/ensky0/tildaz/issues/583) **A3 · A4** — #502 의 "안 한 것" 세 형식과 #494 의 macOS dead key 를 사람 손 없이 판정하는 도구 둘입니다. **둘 다 실제로 돌려 통과**했습니다 (MacBook Pro M5 Pro · macOS 26.6.2 · main `0d4cde6` 서명 빌드).

| 파일 | 무엇 | 실측 |
|---|---|---|
| `dist/mouse/mouse-auto-check.sh` | `mouse-probe.sh --log` 를 띄우고 `cliclick` 으로 셀을 두 번 눌러 바이트 형태 판정 | `?1005` · `?1015` · `?1016` **모두 OK** — 세 형식의 좌표가 서로 일치 (셀 13,11 ↔ 픽셀 228,428) ([#502 댓글](https://github.com/ensky0/tildaz/issues/502)) |
| `dist/macos/deadkey-check.sh` | 입력 소스 ABC 에서 Option+e → e → x, PTY 바이트 판정 | **`c3 a9 78`** (`éx`) OK ([#494 댓글](https://github.com/ensky0/tildaz/issues/494)) |
| `dist/macos/color-capture.m` | `--list` 에 **위치 열** (pt · 좌상단 원점) | Accessory 앱은 AX 가 창을 못 찾고 JXA 는 CFArray 를 못 풀어서. 크기 뒤 · 제목 앞이라 기존 스크립트 그대로 |
| `dist/mouse/README.md` · `AGENTS.md` | 자동 회차 절 · 새 절 | |

## 실측에서 배운 것 (스크립트에 반영)

| | |
|---|---|
| **화면 잠금** | 잠긴 채 돌리면 프로브는 떠 있고 캡처도 되는데 로그만 비어 원인을 못 짚는다 (`com.apple.loginwindow` 30000×30000 이 클릭점을 덮음). 시작 전 `CGSSessionScreenIsLocked` 확인 |
| **합성 입력 전달** | `cliclick m:` 뒤 `p` 로 커서가 움직였는지 확인 — 권한 없으면 `CGEventPost` 가 조용히 무시 |
| **`open -a` 상대 경로** | 앱 이름으로 해석해 못 찾는다 → 절대 경로 |
| **합성 `Return`** | `kp:return` 은 발행되는데 앱에서 개행이 안 된다 (화살표 · 글자는 됨) → dead key 판정은 `stty -icanon` 으로 Enter 에 의존하지 않게. 원인 미확인 — #583 **B20** |

Refs #583 · #502 · #494