### PR TITLE
feat(render): Windows atlas 도 차면 두 배로 키운다 — macOS 와 같은 grow 정책 (#586 1/2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -647,6 +647,55 @@ clang -fobjc-arc -framework AppKit -framework Carbon -framework CoreGraphics \
 
 **입력 소스 전환은 사용자가 직접 해야 해요.** 한국어 UI 는 설정 앱의 항목 이름이 영어 문서와 달라 보이니, `--list-sources` 로 **그 기기에 실제로 표시되는 이름**을 뽑아서 안내해요 (예: `Russian – Phonetic` 이 이 기기에서는 `Russian – QWERTY` 로 보였어요). 그리고 이 측정도 위 `# 실행 환경` 의 규칙대로 **시작 전에 알리고 확인을 받아요.**
 
+# Windows — 렌더 결과를 픽셀로 검증하는 법
+
+macOS (`dist/macos/render-ab-shot.sh`) · Linux (`dist/linux/render-ab-shot.sh`) 와 같은 일을 PowerShell 로 해요 —
+[`dist/windows/render-ab-shot.ps1`](dist/windows/render-ab-shot.ps1). 여러 판을 **같은 화면**으로 띄워 창을 찍고 최종
+그림을 픽셀 수로 견줘요. [#586](https://github.com/ensky0/tildaz/issues/586) Windows atlas `grow` 실기에서 만들었고,
+[#584](https://github.com/ensky0/tildaz/issues/584) Windows 계측이 밟은 함정을 피해 둔 상태예요.
+
+```powershell
+python dist\screens\clusters.py stack2 --cmd $env:TEMP\stack2.txt > $env:TEMP\stack2.cmd   # 화면 (.cmd 래퍼 + UTF-8 본문)
+# 판마다 INITIAL_ATLAS_SIZE 만 바꿔 빌드하고 exe 를 한 폴더에 모아요 — **_internal 폴더도 그 옆에 복사**해요 (아래)
+dist\windows\render-ab-shot.ps1 -Screen $env:TEMP\stack2.cmd -Size 150x40 -Wait 8 -Tag stack2 `
+    -Bins $env:TEMP\bins\tildaz-4096.exe,$env:TEMP\bins\tildaz-2048.exe,$env:TEMP\bins\tildaz-512.exe
+dist\windows\render-ab-shot.ps1 … -NewTab        # Ctrl+Shift+T 를 합성 입력으로 보내 탭 2 개 화면 (탭바 · 아이콘) 을 찍어요
+```
+
+- **판 exe 를 다른 폴더로 옮기면 `_internal` (conpty.dll · OpenConsole.exe) 도 함께** 옮겨요. 없으면 앱이 `TildaZ — Cannot
+  Start` fatal 다이얼로그를 띄우고, 하네스는 **그 다이얼로그를 창으로 잡아 찍어요** (870x968 짜리 캡처가 나오면 이거예요).
+  하네스가 로그의 `[fatal]` 줄을 함께 찍어 주니 판 줄 아래를 봐요. 2026-09-03 첫 회차에서 걸렸어요.
+- **`clusters.py` 는 `--cmd <본문.txt>` 로** 불러요 — Windows 에는 `sh` 가 없어요. 본문을 UTF-8 (BOM 없음) 로 쓰고
+  stdout 에 `.cmd` 래퍼 (`chcp 65001` → `type` → `timeout` 대기) 를 내요. 그 전에는 stdout 이 cp949 라 결합 기호에서
+  `UnicodeEncodeError` 로 죽었는데, 스크립트가 stdout 을 UTF-8 로 고정해 `PYTHONUTF8` 없이도 돌아요.
+- **`-e` 회차는 config 를 만들지도 hotkey 를 등록하지도 않아요** (`global hotkey not registered (stress run)`) — 사용자의
+  `F1` 과 충돌하지 않고 `config_9.toml` 도 남지 않아요. 로그는 `%APPDATA%\tildaz\tildaz_stress.log` 예요. 단축키가
+  필요한 회차 (`-NewTab`) 만 `config_0.toml` 을 복사해 `config_9.toml` 을 잠깐 만들고 (`auto_start = false`) 끝나면 지워요.
+- **창은 `EnumWindows` + pid + 보이는 · 크기 있는 조건으로** 찾아요. `Process.MainWindowHandle` 은 `TildaZOwner` (0x0)
+  가 owner 로 달린 진짜 창을 건너뛰어 0 이고, `FindWindow(class)` 는 그 0x0 창을 집어요 (#584).
+- **PowerShell 은 DPI 비인식**이라 `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` 를 먼저 불러요. 안 하면
+  `GetWindowRect` 가 논리 좌표를 줘서 150 % 화면의 1272x989 창이 848x659 로 잡혀요.
+- **캡처는 `PrintWindow(PW_RENDERFULLCONTENT)`** 예요 — 가려져 있어도 되고 창 그림자가 안 들어가요. 단색이면 (아직 안
+  그렸거나 창이 닫혔거나) `CopyFromScreen` 으로 한 번 물러서고, 어느 쪽이었는지 판 줄에 적어요.
+- **픽셀 수는 `LockBits` 로 직접 세요.** ImageMagick 이 없어도 되고, 다른 픽셀의 **경계 상자**를 같이 찍어 주니 커서
+  자리 (`14x29`) 처럼 좁은 차이인지 한눈에 갈려요. 픽셀 대조에는 로그의 `atlas grew` · `atlas full` 회수도 같이 봐요.
+- 인스턴스 9 만 내려요 — `Win32_Process` 의 `CommandLine` 에 `--instance 9` 가 있는 `tildaz*` 만. 판 바이너리 이름이
+  `tildaz-4096.exe` 처럼 달라도 잡혀요.
+- 실기라서 `# 실행 환경` 대로 **시작 전에 창이 몇 번 뜨는지 알리고 동의를 받아요.** `-NewTab` 은 합성 키라 특히요.
+  그리고 **한 회차를 먼저 돌려** 창 크기 (1272x989 @ 88x33 · 150 %) · `render_path=hardware` · 캡처가 실제 그림인지
+  (PNG 을 열어 봐요) 를 확인하고 전체를 돌려요.
+- **`grow` 회수 기대표를 판정에 쓰지 말아요 — 최종 그림 `0 px` 과 `atlas full` 0 으로 판정해요.** 두 가지 이유예요.
+  ① 150 % 의 `cell 14x29` 에서는 `stack2` 6,000 종이 2048² 에 들어가 기본 판이 `grow` 0 이에요 (Linux `14x31` 과 같고
+  macOS `19x39` 와 달라요) — 기본 판의 `grow` 는 `overflow` (17 화면 누적 · `-Wait 15` 이상) 로 봐요. ② `overflow` 의
+  누적 종 수는 **회차마다 달라요** (8192 로 커진 시점의 `clusters` 가 22,043 · 23,916 · 25,319) — Windows 는 화면이 바뀔
+  때만 그려서 빠른 스크롤의 중간 화면을 건너뛰어요. 4096 판이 같은 화면에서 `grow` 0 인 회차가 실제로 있었어요.
+- **`-e` 회차의 새 탭도 같은 `-e` 명령을 다시 실행해요.** `-NewTab` 으로 `Ctrl+Shift+T` 를 보내면 Tab 2 가 화면을 처음부터
+  다시 뿌리고 (그동안 Tab 1 도 계속 출력), 캡처는 Tab 2 의 최종 화면 + 탭바예요. 대조에는 지장이 없지만 대기를 화면 출력
+  시간만큼 넉넉히 둬요 (`overflow` 는 18 초로 돌렸어요).
+- 탭 atlas 의 UV 정규화 (#586 W-a) 를 가르려면 **본문 atlas 가 탭 atlas (2048) 보다 커진 뒤 탭바를 그린 화면**이어야 해요 —
+  `stack2` 는 512 판도 2048 에서 멈춰 조건이 안 돼요. `overflow` + `-NewTab` 을 **main 판** (고정 2048 + 안전망) 과 견줘요.
+  grow 판끼리는 같은 코드라 함정을 스스로 못 가르니까요 (2026-09-03 실측 `0 / 2,640,760 px`).
+
 # Windows — 키보드 layout 조회 실측 방법
 
 위 macOS 절과 같은 물음을 Windows 에서 재는 도구예요. [`dist/windows/layout-probe.zig`](dist/windows/layout-probe.zig) 가 scancode `0x01`..`0x58` 을 layout 별로 한 표에 덤프해요 — VK (`MapVirtualKeyExW`) · 라벨 base/shift/AltGr (`ToUnicodeEx`) · 역방향 (`VkKeyScanExW`).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1719,7 +1719,7 @@ Windows 는 `MapCharacters` 의 base family 힌트도 이 정식 이름을 쓴�
 |---|---|
 | ⓿ **폰트 식별** | cluster 캐시 키는 폰트를 **주소가 아니라 안정된 id** 로 식별한다 |
 | ① **찼을 때** | **이미 그린 것을 먼저 flush 하고, 비우고, 재시도한다.** 그 프레임의 화면은 온전하다 |
-| ② **용량** | `ATLAS_SIZE` 는 **2048**. 산술이 아니라 ③ 의 실측으로 정한다 |
+| ② **용량** | macOS · Windows 는 `INITIAL_ATLAS_SIZE` **2048** 에서 시작해 차면 두 배로 키우고 (`MAX_ATLAS_SIZE` **8192**), Linux 는 아직 `ATLAS_SIZE` **2048** 고정. 산술이 아니라 ③ 의 실측으로 정한다 |
 | ③ **로그** | [`log.logAtlasFull`](src/log.zig) 한 문구를 세 platform 이 그대로 쓴다 |
 
 #### ⓿ 폰트 식별 — 주소를 키에 싣지 않는다
@@ -1779,7 +1779,7 @@ cluster 경로가 거치는 shape 결과 캐시 (`font/cluster_cache.zig`, `CAPA
 
 | platform | 구현 | 상태 |
 |---|---|---|
-| **Windows** | `is_full` 을 세우고 **호출자가 처리한다** — `drawTextInstances` · `drawBgInstances` 로 먼저 flush, `reset()`, 재시도 ([`renderer/windows.zig`](src/renderer/windows.zig)) | **사양대로.** 실기 확인 |
+| **Windows** | `is_full` 을 세우고 **호출자가 처리한다** — **먼저 `grow`** ([#586](https://github.com/ensky0/tildaz/issues/586) · `emitClusterInstance` 와 `insertOrGrow`), 상한이면 `drawTextInstances` · `drawBgInstances` 로 flush, `reset()`, 재시도 ([`renderer/windows.zig`](src/renderer/windows.zig)). 빈 atlas 면 `is_full` 을 세우지 않는 가드 (`packOrMarkFull`) 도 #586 에서 붙였다 — 전에는 Windows 만 없었다 | **사양대로.** ① 실기 확인 · `grow` 는 **실기 대기** |
 | **Linux** | `Atlas.full` 에 **찬 surface 를 표시**하고 호출자가 처리한다 — `glFlushText` 로 먼저 flush, `resetFull()`, 재시도 ([`host/linux/wayland_minimal.zig`](src/host/linux/wayland_minimal.zig) 의 `glAddGlyph`) | **사양대로.** 실기 확인 |
 | **macOS** | `is_full` 을 세우고 호출자가 처리한다 (`insertGlyphOrRecover` · `insertClusterOrRecover` → `recoverFromAtlasFull`) — **먼저 ② 의 `grow`**, 상한이면 **지금까지 담은 구간을 pass 로 제출하고 GPU 가 끝나기를 기다린 뒤** (`submitPassEarly`) 비우고 재시도. cluster · 단일 · ligature **모든 삽입 경로가 같은 함수를 지난다** ([#591](https://github.com/ensky0/tildaz/issues/591) — 전에는 ligature 경로만 복구가 없어 조용히 버렸다) | **사양대로.** 실기 확인 |
 
@@ -1870,7 +1870,7 @@ atlas full — cleared and refilling (<kind>, resets=N, glyphs=N, clusters=N, fo
 
 Linux 는 cluster 를 별도 맵에 두지 않아 `clusters` · `fonts` 자리가 `0` 이고, `glyphs` 는 **찬 surface 의 캐시 항목 수**다 (`kind` 와 같은 축이라 두 값이 짝이 맞는다).
 
-**키울 때는 다른 줄을 남긴다** (macOS 만 — ② 의 `grow`).
+**키울 때는 다른 줄을 남긴다** (macOS · Windows — ② 의 `grow`).
 
 ```
 atlas grew to 4096x4096 (grows=N, glyphs=N, clusters=N)
@@ -1898,18 +1898,18 @@ Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적
 
 **컬러 쪽은 자리수가 다르다** — 회색이 9 천인데 컬러는 210 이다. 컬러 비트맵은 **cell 이 아니라 폰트 strike 크기**로 담기기 때문이다 (Noto Color Emoji 는 한 변이 100 px 대다). cell 로 줄이는 것은 그릴 때 하고 (`colorGlyphFit`), atlas 에는 구운 크기가 그대로 들어간다. 그래서 **emoji 를 수백 종 쓰는 화면은 컬러 텍스처를 먼저 채운다** — 회색이 한참 남아 있어도 그렇다. Linux 는 텍스처가 둘이라 그때 컬러만 비운다 (위 ①).
 
-#### ② 계속 — 차면 키운다 (macOS)
+#### ② 계속 — 차면 키운다 (macOS · Windows)
 
-**macOS 는 차면 두 배로 키운다** (`GlyphAtlas.grow`). ghostty 가 쓰는 방식이고 (`font.Atlas.grow` + `syncAtlasTexture`), ① 도 완전하지만 구간마다 GPU 를 기다려야 하므로, **차기 전에 키우는 것이 주 경로**다 — ① 은 상한에서만 돈다.
+**macOS · Windows 는 차면 두 배로 키운다** (`GlyphAtlas.grow`). ghostty 가 쓰는 방식이고 (`font.Atlas.grow` + `syncAtlasTexture`), ① 도 완전하지만 구간마다 GPU 를 기다려야 하므로, **차기 전에 키우는 것이 주 경로**다 — ① 은 상한에서만 돈다.
 
 | | |
 |---|---|
 | 시작 크기 | `INITIAL_ATLAS_SIZE` = **2048** |
 | 상한 | `MAX_ATLAS_SIZE` = **8192** — 8192² 는 이미 256 MB (BGRA8) 다. 여기 닿으면 더 키우지 않고 ① 로 물러선다 |
 | 옛 내용 | **같은 (x, y) 로 옮긴다.** row-based packing 이라 좌표가 그대로 유효하고 커서도 이어 쓴다 |
-| UV | 셰이더가 `atlas_w`/`atlas_h` uniform 으로 정규화하므로, 크기가 바뀌면 renderer 가 그 uniform 과 Metal 텍스처를 함께 갱신한다 (`syncAtlasTexture`) |
+| UV | 셰이더가 `atlas_w`/`atlas_h` uniform 으로 정규화하므로 크기가 바뀌면 그 uniform 과 텍스처를 함께 갱신한다 — macOS 는 `syncAtlasTexture` 가 Metal 텍스처를 다시 만들고, Windows 는 `grow` 가 텍스처 · SRV · D2D render target 체인 일곱 객체를 다시 만들고 옛 내용을 `CopySubresourceRegion` 으로 같은 자리에 복사한다 (CPU 사본이 없다) |
 
-**uniform 은 atlas 마다 따로다.** 본문 atlas 는 커지고 탭 atlas 는 안 커지므로, 크기가 갈리면 하나로는 둘 다 맞출 수 없다 — 실측에서 본문이 4096 이 된 판의 컨트롤 스트립 아이콘이 절반 자리를 가리켜 잘렸다. `grow` 를 넣기 전에는 둘이 늘 같은 크기라 드러나지 않던 문제다.
+**uniform 은 atlas 마다 따로다.** 본문 atlas 는 커지고 탭 atlas 는 안 커지므로, 크기가 갈리면 하나로는 둘 다 맞출 수 없다 — 실측에서 본문이 4096 이 된 판의 컨트롤 스트립 아이콘이 절반 자리를 가리켜 잘렸다. `grow` 를 넣기 전에는 둘이 늘 같은 크기라 드러나지 않던 문제다. **Windows 는 상수 버퍼를 나누지 않고 text draw 마다 그 atlas 크기로 다시 쓴다** (`writeConstants` — DYNAMIC + `WRITE_DISCARD` 는 rename 이라 앞서 기록된 draw 는 옛 값을 그대로 본다). Windows 는 삽입 즉시 업로드 · 즉시 draw 라 macOS 의 GPU 대기 (`submitPassEarly`) 도 필요 없다 — 이미 기록된 draw 는 옛 SRV 를 참조한다 (D3D11 계약 · 실기로는 아직 확인 전).
 
 **검증** (MacBook Pro M5 Pro · macOS 26.6.2 · 5120x2880 60 Hz · Menlo 15pt · `cell 19x39`). mark 를 둘 쌓은 cluster **10,000 종** 화면 (200 칸 × 50 줄) 이라 2048² 을 넘긴다. **`INITIAL_ATLAS_SIZE` 만 바꾼 세 판**을 맞댔다 — `grow` 가 정확하면 **시작 크기와 무관하게 최종 그림이 같아야** 한다.
 
@@ -1922,9 +1922,9 @@ Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적
 
 **`atlas full` 이 0 회인 것이 핵심이다** — 차기 전에 커지므로 ① 이 발동하지 않는다.
 
-**Windows · Linux 는 아직 고정 크기 + ① 이다.** 그쪽은 ① 로 계약을 이미 만족하고 실측으로 `0 px` 을 확인했으므로, `grow` 로 갈아타면 그 검증이 무효가 된다. **세 platform 을 `grow` 로 통일하는 것은 후속 항목이다** ([#584](https://github.com/ensky0/tildaz/issues/584)) — 그때는 이미 검증된 ① 이 안전망으로 남아 있어 위험이 낮다.
+**Linux 는 아직 고정 크기 + ① 이다.** ① 로 계약을 만족하고 실측으로 `0 px` 을 확인했으므로 `grow` 로 갈아타면 그 검증이 무효가 된다 — 그리고 Linux 는 UV 를 정점에 미리 나눠 넣어 (`gl_text.zig` 의 `inv_atlas`) `grow` 앞에 uniform 화가 먼저 필요하다. **Windows 는 [#586](https://github.com/ensky0/tildaz/issues/586) 으로 `grow` 를 얹었고 실기 검증 대기다** — 검증은 macOS 와 같은 방법 (`INITIAL` 만 바꾼 판을 기준판과 대조 · `dist/screens/clusters.py`) 이고 Windows 는 예전에 `ATLAS_SIZE` 2048 vs 256 을 `0 px` 로 확인한 선례가 있다. Linux 통일은 같은 이슈의 다음 단계다.
 
-**용량으로 막는 것을 포기하는 것은 고정 크기 platform 에 해당한다.** Windows · Linux 는 4K@2x 최악 (11,110 종) 을 4096² (약 11,000) 으로도 못 담으므로 ① 이 받는다. macOS 는 8192 까지 키워 그 지점을 넘긴다.
+**용량으로 막는 것을 포기하는 것은 고정 크기 platform 에 해당한다.** Linux 는 4K@2x 최악 (11,110 종) 을 4096² (약 11,000) 으로도 못 담으므로 ① 이 받는다. macOS · Windows 는 8192 까지 키워 그 지점을 넘긴다.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1779,7 +1779,7 @@ cluster 경로가 거치는 shape 결과 캐시 (`font/cluster_cache.zig`, `CAPA
 
 | platform | 구현 | 상태 |
 |---|---|---|
-| **Windows** | `is_full` 을 세우고 **호출자가 처리한다** — **먼저 `grow`** ([#586](https://github.com/ensky0/tildaz/issues/586) · `emitClusterInstance` 와 `insertOrGrow`), 상한이면 `drawTextInstances` · `drawBgInstances` 로 flush, `reset()`, 재시도 ([`renderer/windows.zig`](src/renderer/windows.zig)). 빈 atlas 면 `is_full` 을 세우지 않는 가드 (`packOrMarkFull`) 도 #586 에서 붙였다 — 전에는 Windows 만 없었다 | **사양대로.** ① 실기 확인 · `grow` 는 **실기 대기** |
+| **Windows** | `is_full` 을 세우고 **호출자가 처리한다** — **먼저 `grow`** ([#586](https://github.com/ensky0/tildaz/issues/586) · `emitClusterInstance` 와 `insertOrGrow`), 상한이면 `drawTextInstances` · `drawBgInstances` 로 flush, `reset()`, 재시도 ([`renderer/windows.zig`](src/renderer/windows.zig)). 빈 atlas 면 `is_full` 을 세우지 않는 가드 (`packOrMarkFull`) 도 #586 에서 붙였다 — 전에는 Windows 만 없었다 | **사양대로.** ① · `grow` 모두 실기 확인 (② 의 Windows 실측표) |
 | **Linux** | `Atlas.full` 에 **찬 surface 를 표시**하고 호출자가 처리한다 — `glFlushText` 로 먼저 flush, `resetFull()`, 재시도 ([`host/linux/wayland_minimal.zig`](src/host/linux/wayland_minimal.zig) 의 `glAddGlyph`) | **사양대로.** 실기 확인 |
 | **macOS** | `is_full` 을 세우고 호출자가 처리한다 (`insertGlyphOrRecover` · `insertClusterOrRecover` → `recoverFromAtlasFull`) — **먼저 ② 의 `grow`**, 상한이면 **지금까지 담은 구간을 pass 로 제출하고 GPU 가 끝나기를 기다린 뒤** (`submitPassEarly`) 비우고 재시도. cluster · 단일 · ligature **모든 삽입 경로가 같은 함수를 지난다** ([#591](https://github.com/ensky0/tildaz/issues/591) — 전에는 ligature 경로만 복구가 없어 조용히 버렸다) | **사양대로.** 실기 확인 |
 
@@ -1909,7 +1909,7 @@ Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적
 | 옛 내용 | **같은 (x, y) 로 옮긴다.** row-based packing 이라 좌표가 그대로 유효하고 커서도 이어 쓴다 |
 | UV | 셰이더가 `atlas_w`/`atlas_h` uniform 으로 정규화하므로 크기가 바뀌면 그 uniform 과 텍스처를 함께 갱신한다 — macOS 는 `syncAtlasTexture` 가 Metal 텍스처를 다시 만들고, Windows 는 `grow` 가 텍스처 · SRV · D2D render target 체인 일곱 객체를 다시 만들고 옛 내용을 `CopySubresourceRegion` 으로 같은 자리에 복사한다 (CPU 사본이 없다) |
 
-**uniform 은 atlas 마다 따로다.** 본문 atlas 는 커지고 탭 atlas 는 안 커지므로, 크기가 갈리면 하나로는 둘 다 맞출 수 없다 — 실측에서 본문이 4096 이 된 판의 컨트롤 스트립 아이콘이 절반 자리를 가리켜 잘렸다. `grow` 를 넣기 전에는 둘이 늘 같은 크기라 드러나지 않던 문제다. **Windows 는 상수 버퍼를 나누지 않고 text draw 마다 그 atlas 크기로 다시 쓴다** (`writeConstants` — DYNAMIC + `WRITE_DISCARD` 는 rename 이라 앞서 기록된 draw 는 옛 값을 그대로 본다). Windows 는 삽입 즉시 업로드 · 즉시 draw 라 macOS 의 GPU 대기 (`submitPassEarly`) 도 필요 없다 — 이미 기록된 draw 는 옛 SRV 를 참조한다 (D3D11 계약 · 실기로는 아직 확인 전).
+**uniform 은 atlas 마다 따로다.** 본문 atlas 는 커지고 탭 atlas 는 안 커지므로, 크기가 갈리면 하나로는 둘 다 맞출 수 없다 — 실측에서 본문이 4096 이 된 판의 컨트롤 스트립 아이콘이 절반 자리를 가리켜 잘렸다. `grow` 를 넣기 전에는 둘이 늘 같은 크기라 드러나지 않던 문제다. **Windows 는 상수 버퍼를 나누지 않고 text draw 마다 그 atlas 크기로 다시 쓴다** (`writeConstants` — DYNAMIC + `WRITE_DISCARD` 는 rename 이라 앞서 기록된 draw 는 옛 값을 그대로 본다). Windows 는 삽입 즉시 업로드 · 즉시 draw 라 macOS 의 GPU 대기 (`submitPassEarly`) 도 필요 없다 — 이미 기록된 draw 는 옛 SRV 를 참조한다 (D3D11 계약 — 아래 Windows 실측의 `0 px` 이 그 근거다. 특히 마지막 줄은 본문 atlas 가 8192 · 탭 atlas 가 2048 인 채 탭바를 그린 화면이다).
 
 **검증** (MacBook Pro M5 Pro · macOS 26.6.2 · 5120x2880 60 Hz · Menlo 15pt · `cell 19x39`). mark 를 둘 쌓은 cluster **10,000 종** 화면 (200 칸 × 50 줄) 이라 2048² 을 넘긴다. **`INITIAL_ATLAS_SIZE` 만 바꾼 세 판**을 맞댔다 — `grow` 가 정확하면 **시작 크기와 무관하게 최종 그림이 같아야** 한다.
 
@@ -1922,7 +1922,24 @@ Linux 의 gray 값이 큰 것은 결합 기호 합성 비트맵의 평균 면적
 
 **`atlas full` 이 0 회인 것이 핵심이다** — 차기 전에 커지므로 ① 이 발동하지 않는다.
 
-**Linux 는 아직 고정 크기 + ① 이다.** ① 로 계약을 만족하고 실측으로 `0 px` 을 확인했으므로 `grow` 로 갈아타면 그 검증이 무효가 된다 — 그리고 Linux 는 UV 를 정점에 미리 나눠 넣어 (`gl_text.zig` 의 `inv_atlas`) `grow` 앞에 uniform 화가 먼저 필요하다. **Windows 는 [#586](https://github.com/ensky0/tildaz/issues/586) 으로 `grow` 를 얹었고 실기 검증 대기다** — 검증은 macOS 와 같은 방법 (`INITIAL` 만 바꾼 판을 기준판과 대조 · `dist/screens/clusters.py`) 이고 Windows 는 예전에 `ATLAS_SIZE` 2048 vs 256 을 `0 px` 로 확인한 선례가 있다. Linux 통일은 같은 이슈의 다음 단계다.
+**Windows 실측** (노트북 LENOVO 83JY · AMD Ryzen AI 7 350 · Radeon 860M · Windows 11 Pro build 26200 · 내장 2880x1800 **120 Hz** · 배율 150 % · Cascadia Code 15pt · `cell 14x29` · 2026-09-03 · [#586](https://github.com/ensky0/tildaz/issues/586)). 같은 방법이다 — `INITIAL_ATLAS_SIZE` 만 바꾼 판을 [`dist/screens/clusters.py`](dist/screens/clusters.py) 의 세 화면으로 띄워 창 캡처를 [`dist/windows/render-ab-shot.ps1`](dist/windows/render-ab-shot.ps1) 로 견줬다. cell 이 macOS (`19x39`) 보다 작아 **`stack2` 6,000 종이 2048² 에 들어가므로** 기본 판의 `grow` 는 `overflow` (17 화면 누적) 에서 보인다.
+
+| 화면 · 판 | `grow` | `atlas full` | 4096 판과 다른 픽셀 |
+|---|---|---|---|
+| `many` 88x33 (2,912 종) · **2048** | 0 회 | 0 회 | **0** / 1,258,008 px |
+| `many` · **512** | 2 회 → 2048 | 0 회 | **0 px** |
+| `stack2` 150x40 (6,000 종) · **2048** | 0 회 | 0 회 | **0** / 2,550,880 px |
+| `stack2` · **512** | 2 회 → 2048 | 0 회 | **0 px** |
+| `stack2` · **8192** (시작부터 상한 — 8192² RGBA + `BIND_RENDER_TARGET` 을 이 내장 GPU 가 받는지) | 0 회 | 0 회 | **0 px** |
+| `overflow` 150x40 (17 화면 누적) · **2048** | 2 회 → 4096 → **8192** | **0 회** | **0** / 2,550,880 px |
+| `overflow` · **512** | 4 회 → 1024 → 2048 → 4096 → 8192 | 0 회 | **0 px** |
+| `overflow` + **탭 2 개** (`Ctrl+Shift+T`) · **2048** vs **main** (`8ccc8bc` — 고정 2048 + ① 만, `atlas full` **6 회**) | 2 회 → 8192 | 0 회 | **0** / 2,640,760 px |
+
+- **마지막 줄이 `writeConstants` 의 근거다.** 본문 atlas 8192 · 탭 atlas 2048 인 채 탭바 · 컨트롤 스트립을 그린 화면이 `grow` 가 없는 main 과 같다 — macOS 가 실측으로 겪은 아이콘 잘림이 Windows 에는 없다. 그리고 그 줄은 **① 만 쓰는 판과 `grow` 판이 같은 그림을 낸다**는 확인이기도 하다.
+- **8192² 텍스처는 이 내장 GPU 에서 만들어졌다** — `INITIAL = 8192` 판이 정상 기동했고 `overflow` 의 두 판이 8192 까지 자랐다. `CreateTexture2D` 실패 → ① 경로는 이 기기에서는 타지 않았다.
+- **누적 종 수는 회차마다 다르다** (`overflow` 에서 8192 로 커진 시점의 `clusters` 가 22,043 · 23,916 · 25,319). Windows 는 화면이 바뀔 때만 그리므로 (§13.4) 빠른 스크롤의 중간 화면을 건너뛰기 때문이다 — 4096 판은 같은 화면에서 `grow` 0 이었다 (누적이 4096² 안에 머문 회차). 그래서 **판정은 `grow` 회수가 아니라 최종 그림 `0 px` 과 `atlas full` 0** 이다. macOS 표의 `grow` 회수는 정적 화면 (`stack2`) 이라 판마다 고정이었다.
+
+**Linux 는 아직 고정 크기 + ① 이다.** ① 로 계약을 만족하고 실측으로 `0 px` 을 확인했으므로 `grow` 로 갈아타면 그 검증이 무효가 된다 — 그리고 Linux 는 UV 를 정점에 미리 나눠 넣어 (`gl_text.zig` 의 `inv_atlas`) `grow` 앞에 uniform 화가 먼저 필요하다. **Windows 는 [#586](https://github.com/ensky0/tildaz/issues/586) 으로 `grow` 를 얹고 실기로 확인했다** (위 Windows 실측표 — 다섯 판 `0 px` · `atlas full` 0 회). Linux 통일은 같은 이슈의 다음 단계다.
 
 **용량으로 막는 것을 포기하는 것은 고정 크기 platform 에 해당한다.** Linux 는 4K@2x 최악 (11,110 종) 을 4096² (약 11,000) 으로도 못 담으므로 ① 이 받는다. macOS · Windows 는 8192 까지 키워 그 지점을 넘긴다.
 

--- a/dist/screens/clusters.py
+++ b/dist/screens/clusters.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""atlas · cluster 렌더 검증용 화면을 만든다 — 세 platform 공용.
+r"""atlas · cluster 렌더 검증용 화면을 만든다 — 세 platform 공용.
 
 `tildaz -e` 는 실행 파일 하나만 받으므로, 이 생성기는 **stdout 에 실행 가능한 sh 스크립트**를 낸다.
 받아서 파일로 저장하고 `chmod +x` 한 뒤 `-e` 에 넘긴다. 각 화면은 서로 다른 cluster 를 겹치지 않게
@@ -12,6 +12,13 @@
     chmod +x /tmp/*.sh
     tildaz --instance 9 -e /tmp/many.sh -size 88x33
 
+**Windows 는 `--cmd <본문.txt>` 를 준다** (#586). `sh` 가 없으므로 본문을 그 경로에 UTF-8 (BOM 없음) 로 쓰고
+stdout 에는 그것을 `type` 하는 **`.cmd` 래퍼** (CRLF · `chcp 65001` · `timeout` 대기) 를 낸다. `-e` 가 `.cmd` 를
+받는 것은 #584 Windows 계측에서 확인했다.
+
+    python dist\screens\clusters.py stack2 --cmd $env:TEMP\stack2.txt > $env:TEMP\stack2.cmd
+    tildaz --instance 9 -e $env:TEMP\stack2.cmd -size 150x40
+
 | 화면 | 무엇 | 왜 |
 |---|---|---|
 | `many` | 소문자 26 × 결합 기호 (U+0300~U+036F) 한 겹 | 일반 화면 회귀 — atlas 가 커지지 않아야 한다 |
@@ -23,12 +30,24 @@
 """
 import sys
 
+# Windows 콘솔은 stdout 인코딩이 ANSI 코드페이지 (한국어는 cp949) 라 결합 기호에서 `UnicodeEncodeError` 로
+# 죽는다 (2026-09-03 Windows 실기 — #586). 세 platform 이 같은 바이트를 내도록 UTF-8 로 고정한다.
+sys.stdout.reconfigure(encoding="utf-8", newline="\n")
+
 ABOVE = [chr(c) for c in range(0x0300, 0x0315)] + [chr(c) for c in range(0x033D, 0x0345)]   # 위 mark 29
 BELOW = [chr(c) for c in range(0x0316, 0x0334)]                                              # 아래 mark 30
 ALL = [chr(c) for c in range(0x0300, 0x0370)]                                                # 112
 
 
+CMD_TXT = None  # `--cmd <경로>` — Windows 용 .cmd 래퍼를 낼 때 본문을 쓸 텍스트 파일
+
+
 def emit(lines, tail="sleep 3600", head=""):
+    if CMD_TXT:
+        with open(CMD_TXT, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(lines) + "\n")
+        sys.stdout.write("@echo off\r\nchcp 65001>nul\r\ntype \"%s\"\r\ntimeout /t 3600 /nobreak >nul\r\n" % CMD_TXT)
+        return
     out = ["#!/bin/sh", head] if head else ["#!/bin/sh"]
     out += ["cat <<'S'"] + lines + ["S", tail]
     sys.stdout.write("\n".join(out) + "\n")
@@ -66,8 +85,17 @@ def mini():
 
 
 if __name__ == "__main__":
-    which = sys.argv[1] if len(sys.argv) > 1 else "many"
-    cols = int(sys.argv[2]) if len(sys.argv) > 2 else None
+    args = sys.argv[1:]
+    if "--cmd" in args:
+        k = args.index("--cmd")
+        if k + 1 >= len(args):
+            sys.exit("--cmd 뒤에 본문을 쓸 .txt 경로가 필요하다")
+        CMD_TXT = args[k + 1]
+        del args[k:k + 2]
+    which = args[0] if args else "many"
+    cols = int(args[1]) if len(args) > 1 else None
+    if which == "mini" and CMD_TXT:
+        sys.exit("mini 는 sh 전용이다 (perf 종료 덤프 계측) — --cmd 와 함께 쓸 수 없다")
     if which == "many":
         many(cols or 88)
     elif which == "stack2":
@@ -77,4 +105,4 @@ if __name__ == "__main__":
     elif which == "mini":
         mini()
     else:
-        sys.exit("사용법: clusters.py many|stack2|overflow|mini [cols]")
+        sys.exit("사용법: clusters.py many|stack2|overflow|mini [cols] [--cmd <본문.txt>]")

--- a/dist/windows/render-ab-shot.ps1
+++ b/dist/windows/render-ab-shot.ps1
@@ -1,0 +1,256 @@
+﻿# 여러 tildaz 판을 **같은 화면**으로 띄워 창을 찍고 최종 그림을 픽셀 수로 견준다 (Windows · PowerShell 5.1).
+# macOS 의 `dist/macos/render-ab-shot.sh` · Linux 의 `dist/linux/render-ab-shot.sh` 에 대응한다 — #586 Windows atlas `grow`
+# 실기에서 만들었다. #584 의 Windows 계측 (같은 기기) 이 밟은 함정을 그대로 피한다.
+#
+# ```powershell
+# dist\windows\render-ab-shot.ps1 -Screen <화면.cmd> -Size <격자> -Wait <대기초> -Tag <태그> -Bins <exeA>,<exeB>[,<exeC> …]
+# dist\windows\render-ab-shot.ps1 -Screen $env:TEMP\stack2.cmd -Size 150x40 -Wait 8 -Tag stack2 -Bins $env:TEMP\tildaz-4096.exe,zig-out\bin\tildaz.exe
+# ```
+#
+# - 화면은 **`.cmd` 래퍼**다 — `-e` 가 `CreateProcessW` 에 명령줄을 통째로 넘기므로 인자도 되지만, `chcp 65001` 과
+#   대기 (`timeout /t 3600 /nobreak >nul`) 가 필요해 배치 파일로 감싼다. `dist/screens/clusters.py` 의 출력에서
+#   heredoc 본문만 UTF-8 (BOM 없음) 텍스트로 저장하고 `type` 으로 뿌린다. 끝의 대기가 없으면 자식이 끝나며 앱도 끝난다.
+# - 판마다 `--instance 9 -e <화면> -size <격자>` 로 띄운다. `-e` 는 stress run 이라 **hotkey 를 등록하지 않고**
+#   (`global hotkey not registered (stress run)`) config 도 만들지 않으며 로그는 `%APPDATA%\tildaz\tildaz_stress.log` 다
+#   (`run_options.zig` 의 `isStressRun` · `paths.zig` 의 `logFileName`). 사용자의 instance 0 은 건드리지 않는다.
+# - **창 찾기** — `Process.MainWindowHandle` 은 `TildaZOwner` (0x0 · `WS_EX_TOOLWINDOW`) 가 owner 로 달린 진짜 창을
+#   건너뛰어 0 을 준다 (#584 실측). `EnumWindows` 로 그 pid 의 **보이는 · 크기 있는** 창을 고른다.
+# - **DPI** — PowerShell 은 DPI 비인식이라 `GetWindowRect` 가 논리 좌표를 준다 (150 % 에서 1272x989 창이 848x659 로).
+#   `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` 를 먼저 부른다.
+# - **캡처는 `PrintWindow(PW_RENDERFULLCONTENT)`** — 가려져 있어도 DWM 이 합성한 최신 내용을 준다 (#413 에서 다섯
+#   터미널 전부 성공). 결과가 단색이면 (창이 이미 닫혔거나 아직 안 그렸다) `CopyFromScreen` 으로 한 번 물러선다.
+# - **픽셀 대조는 `LockBits`** 로 직접 센다 — 이 기기에 ImageMagick 이 없고, 있어도 `compare -metric AE` 는 소수 · 지수
+#   표기를 내서 (AGENTS.md) 쓰지 않는다. 크기가 다르면 그것부터 알린다.
+# - 판정에는 로그의 `atlas grew` · `atlas full` 회수를 같이 본다 — `grow` 가 정확하면 **시작 크기가 달라도 최종 그림이
+#   같고**, `atlas full` 은 0 이어야 한다 (SPEC §12.6 ②).
+# - 실기라서 **시작 전에 창이 몇 번 뜨는지 알리고 동의를 받는다** (AGENTS.md `# 실행 환경`). 회차 동안 키 · 마우스를
+#   건드리면 그 회차가 오염된다.
+#
+# ⚠️ 이 파일은 **UTF-8 BOM** 으로 저장한다 — Windows PowerShell 5.1 은 BOM 없는 `.ps1` 을 ANSI (cp949) 로 읽어 한글
+# 주석이 토큰까지 깨뜨릴 수 있다 (`compare-terminals.sh` 의 같은 주석).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Screen,
+    [Parameter(Mandatory)][string]$Size,
+    [int]$Wait = 8,
+    [Parameter(Mandatory)][string]$Tag,
+    [Parameter(Mandatory)][string[]]$Bins,
+    # 판마다 몇 번 띄울지. 회차 간 비결정을 보려면 2 이상.
+    [int]$Repeat = 1,
+    # 창이 뜬 뒤 `Ctrl+Shift+T` 를 합성 입력으로 보내 **탭을 하나 더 만든다** — 탭바 · 컨트롤 스트립 아이콘이
+    # 그려진 화면을 견줄 때 (#586 W-a: 본문 atlas 만 커진 뒤 탭 atlas 의 UV 정규화가 맞는지). 단축키는
+    # `config_9.toml` 이 있어야 산다 (AGENTS.md `# config_N.toml 이 없는 실행에는 …`) — `config_0.toml` 을
+    # 복사해 `auto_start = false` 로 두고, 끝나면 지운다. 합성 입력이라 시작 전 사용자 동의가 필요하다.
+    [switch]$NewTab
+)
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Drawing
+Add-Type -ReferencedAssemblies System.Drawing @"
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+public static class TzShot {
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  public delegate bool EnumProc(IntPtr h, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr hdc, uint flags);
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr v);
+  [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+  public static void MakeDpiAware() {
+    try { if (SetProcessDpiAwarenessContext(new IntPtr(-4))) return; } catch {}
+    try { SetProcessDPIAware(); } catch {}
+  }
+  // pid 의 보이는 · 크기 있는 최상위 창. owner 창 (0x0) 은 크기 조건에서 떨어진다.
+  public static IntPtr FindWindowOfPid(uint pid) {
+    IntPtr found = IntPtr.Zero;
+    EnumWindows((h, l) => {
+      uint p; GetWindowThreadProcessId(h, out p);
+      if (p != pid || !IsWindowVisible(h)) return true;
+      RECT r; if (!GetWindowRect(h, out r)) return true;
+      if (r.R - r.L < 64 || r.B - r.T < 64) return true;
+      found = h; return false;
+    }, IntPtr.Zero);
+    return found;
+  }
+  public static Bitmap Capture(IntPtr h, out string how) {
+    RECT r; GetWindowRect(h, out r);
+    int w = r.R - r.L, hh = r.B - r.T;
+    var bmp = new Bitmap(w, hh, PixelFormat.Format32bppArgb);
+    using (var g = Graphics.FromImage(bmp)) {
+      IntPtr hdc = g.GetHdc();
+      bool ok = PrintWindow(h, hdc, 2);
+      g.ReleaseHdc(hdc);
+      how = ok ? "PrintWindow" : "PrintWindow(failed)";
+    }
+    if (IsUniform(bmp)) {
+      using (var g = Graphics.FromImage(bmp)) g.CopyFromScreen(r.L, r.T, 0, 0, new Size(w, hh));
+      how += "->CopyFromScreen";
+    }
+    return bmp;
+  }
+  static bool IsUniform(Bitmap b) {
+    var d = b.LockBits(new Rectangle(0, 0, b.Width, b.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+    try {
+      var px = new int[b.Width * b.Height];
+      Marshal.Copy(d.Scan0, px, 0, px.Length);
+      for (int i = 1; i < px.Length; i++) if (px[i] != px[0]) return false;
+      return true;
+    } finally { b.UnlockBits(d); }
+  }
+  // 두 PNG 의 다른 픽셀 수. 크기가 다르면 -1. `bbox` 는 다른 픽셀의 경계 상자 (x,y,w,h) — 커서 자리처럼
+  // 좁은 차이인지 한눈에 가른다.
+  public static long Diff(string a, string b, out long total, out string bbox) {
+    bbox = "";
+    using (var A = new Bitmap(a)) using (var B = new Bitmap(b)) {
+      total = (long)A.Width * A.Height;
+      if (A.Width != B.Width || A.Height != B.Height) return -1;
+      var da = A.LockBits(new Rectangle(0, 0, A.Width, A.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+      var db = B.LockBits(new Rectangle(0, 0, B.Width, B.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+      try {
+        var pa = new int[A.Width * A.Height]; var pb = new int[pa.Length];
+        Marshal.Copy(da.Scan0, pa, 0, pa.Length); Marshal.Copy(db.Scan0, pb, 0, pb.Length);
+        long n = 0; int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1;
+        for (int i = 0; i < pa.Length; i++) if (pa[i] != pb[i]) {
+          n++; int x = i % A.Width, y = i / A.Width;
+          if (x < x0) x0 = x; if (y < y0) y0 = y; if (x > x1) x1 = x; if (y > y1) y1 = y;
+        }
+        if (n > 0) bbox = string.Format("{0},{1} {2}x{3}", x0, y0, x1 - x0 + 1, y1 - y0 + 1);
+        return n;
+      } finally { A.UnlockBits(da); B.UnlockBits(db); }
+    }
+  }
+  // ---- 합성 입력 (`-NewTab`) — `dist/stress/send-keys.ps1` 과 같은 규칙: SendInput · scan code 채움 ·
+  //      포커스 가드 (foreground 가 아니면 SetForegroundWindow → 그래도 아니면 client 한가운데 클릭 → 확인).
+  [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk, wScan; public uint dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx, dy; public uint mouseData, dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Explicit, Size = 40)] public struct INPUT { [FieldOffset(0)] public uint type; [FieldOffset(8)] public KEYBDINPUT ki; [FieldOffset(8)] public MOUSEINPUT mi; }
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x, y; }
+  [DllImport("user32.dll", SetLastError = true)] public static extern uint SendInput(uint n, INPUT[] p, int cb);
+  [DllImport("user32.dll")] public static extern uint MapVirtualKeyW(uint c, uint t);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref POINT p);
+  [DllImport("user32.dll")] public static extern int GetSystemMetrics(int i);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
+  static INPUT Key(ushort vk, uint flags) {
+    var i = new INPUT(); i.type = 1; i.ki.wVk = vk; i.ki.wScan = (ushort)MapVirtualKeyW(vk, 0); i.ki.dwFlags = flags; return i;
+  }
+  static INPUT Mouse(int nx, int ny, uint flags) { var i = new INPUT(); i.type = 0; i.mi.dx = nx; i.mi.dy = ny; i.mi.dwFlags = flags; return i; }
+  static void Norm(int x, int y, out int nx, out int ny) {
+    int vx = GetSystemMetrics(76), vy = GetSystemMetrics(77), vw = GetSystemMetrics(78), vh = GetSystemMetrics(79);
+    nx = (int)(((long)(x - vx) * 65535) / (vw > 1 ? vw - 1 : 1)); ny = (int)(((long)(y - vy) * 65535) / (vh > 1 ? vh - 1 : 1));
+  }
+  // 겹쳐 누르는 chord — 앞에서부터 누르고 뒤에서부터 뗀다.
+  public static uint Chord(ushort[] vks) {
+    var a = new INPUT[vks.Length * 2]; int n = 0;
+    foreach (var v in vks) a[n++] = Key(v, 0);
+    for (int k = vks.Length - 1; k >= 0; k--) a[n++] = Key(vks[k], 2);
+    return SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+  }
+  public static bool Focus(IntPtr h) {
+    if (GetForegroundWindow() == h) return true;
+    SetForegroundWindow(h); System.Threading.Thread.Sleep(300);
+    if (GetForegroundWindow() == h) return true;
+    RECT r; GetClientRect(h, out r);
+    var p = new POINT(); p.x = (r.R - r.L) / 2; p.y = (r.B - r.T) / 2; ClientToScreen(h, ref p);
+    POINT before; bool hc = GetCursorPos(out before);
+    int nx, ny; Norm(p.x, p.y, out nx, out ny);
+    uint mv = 0x0001 | 0x8000 | 0x4000;
+    var a = new INPUT[] { Mouse(nx, ny, mv), Mouse(nx, ny, mv | 0x0002), Mouse(nx, ny, mv | 0x0004) };
+    SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+    System.Threading.Thread.Sleep(300);
+    if (hc) { int bx, by; Norm(before.x, before.y, out bx, out by); var m = new INPUT[] { Mouse(bx, by, mv) }; SendInput(1, m, Marshal.SizeOf(typeof(INPUT))); }
+    return GetForegroundWindow() == h;
+  }
+}
+"@
+[TzShot]::MakeDpiAware()
+
+$Out = Join-Path $env:TEMP "tildaz-ab-shot\$Tag"
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+$Log = Join-Path $env:APPDATA "tildaz\tildaz_stress.log"
+if (-not (Test-Path $Screen)) { throw "화면 없음: $Screen" }
+
+# 인스턴스 9 만 내린다 — 명령줄에 `--instance 9` 가 있는 tildaz 만.
+function Stop-Tz {
+    Get-CimInstance Win32_Process -Filter "Name like 'tildaz%'" |
+        Where-Object { $_.CommandLine -match '--instance 9' } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+}
+
+"md5:"
+foreach ($b in $Bins) {
+    if (-not (Test-Path $b)) { throw "바이너리 없음: $b" }
+    "  {0}  {1}" -f (Get-FileHash -Algorithm MD5 $b).Hash.ToLower(), $b
+}
+# 앞선 로그는 치운다 (측정 전용 파일 — 사용자 설정과 무관).
+if (Test-Path $Log) { Move-Item $Log (Join-Path $Out "log_prev.txt") -Force }
+
+$shots = @()
+$i = 0
+foreach ($bin in $Bins) {
+    for ($rep = 1; $rep -le $Repeat; $rep++) {
+        $i++
+        Stop-Tz; Start-Sleep -Milliseconds 500
+        if (Test-Path $Log) { Remove-Item $Log -Force }
+        $p = Start-Process -FilePath (Resolve-Path $bin) -PassThru -ArgumentList '--instance', '9', '-e', "`"$Screen`"", '-size', $Size
+        $h = [IntPtr]::Zero
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        while ($h -eq [IntPtr]::Zero -and $sw.ElapsedMilliseconds -lt 10000) {
+            Start-Sleep -Milliseconds 100
+            if ($p.HasExited) { break }
+            $h = [TzShot]::FindWindowOfPid([uint32]$p.Id)
+        }
+        if ($p.HasExited) { "판 $i 가 먼저 끝남 exit=$($p.ExitCode) — $bin"; continue }
+        if ($h -eq [IntPtr]::Zero) { "판 $i 창 못 찾음 — $bin"; Stop-Tz; continue }
+        if ($NewTab) {
+            Start-Sleep -Seconds 2
+            if ([TzShot]::Focus($h)) {
+                [void][TzShot]::Chord([uint16[]]@(0x11, 0x10, 0x54))   # Ctrl+Shift+T
+            } else {
+                "판 $i 포커스를 못 잡아 새 탭 키를 보내지 않았다"
+            }
+        }
+        Start-Sleep -Seconds $Wait
+        $how = ""
+        $bmp = [TzShot]::Capture($h, [ref]$how)
+        $png = Join-Path $Out "shot_$i.png"
+        $bmp.Save($png, [Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
+        Start-Sleep -Milliseconds 300
+        $logCopy = Join-Path $Out "log_$i.txt"
+        if (Test-Path $Log) { Copy-Item $Log $logCopy -Force } else { "(로그 없음)" | Set-Content $logCopy }
+        Stop-Tz; Start-Sleep -Milliseconds 500
+        $lines = Get-Content $logCopy -Encoding UTF8
+        $grew = @($lines | Where-Object { $_ -match 'atlas grew' })
+        $full = @($lines | Where-Object { $_ -match 'atlas full' })
+        $path = [string]($lines | Where-Object { $_ -match 'render_path=' } | Select-Object -First 1) -replace '.*(render_path=\S+).*', '$1'
+        $cell = [string]($lines | Where-Object { $_ -match 'window initialized' } | Select-Object -First 1) -replace '.*(dpi=\S+ cell=\S+).*', '$1'
+        $fatal = @($lines | Where-Object { $_ -match '\[fatal\]' })
+        if ($fatal.Count -gt 0) {
+            $m = $fatal[0] -replace '^\[[^\]]+\]\s*', ''
+            if ($m.Length -gt 160) { $m = $m.Substring(0, 160) + "…" }
+            "판 $i fatal: $m"
+        }
+        "판 {0}: {1} · {2} · grew={3} full={4} · {5} · {6} · {7}" -f $i, (Split-Path $bin -Leaf), $how, $grew.Count, $full.Count, $path, $cell, $png
+        foreach ($g in $grew) { "    " + ($g -replace '^\[[^\]]+\]\s*', '') }
+        $shots += $png
+    }
+}
+if ($shots.Count -ge 2) {
+    for ($j = 1; $j -lt $shots.Count; $j++) {
+        $tot = [long]0; $bbox = ""
+        $n = [TzShot]::Diff($shots[0], $shots[$j], [ref]$tot, [ref]$bbox)
+        if ($n -lt 0) { "판 1 vs 판 $($j+1): 크기 다름" }
+        elseif ($n -eq 0) { "판 1 vs 판 $($j+1): 0 / $tot px" }
+        else { "판 1 vs 판 $($j+1): $n / $tot px  (다른 영역 $bbox)" }
+    }
+}
+"캡처 · 로그: $Out"

--- a/src/log.zig
+++ b/src/log.zig
@@ -280,7 +280,7 @@ pub fn logPrimaryFont(family: []const u8, cell_w: anytype, cell_h: anytype, asce
 /// 라스터 경로가 갈리는 자리가 달라서 값도 다르다: Linux 는 텍스처 종류 (`gray` · `color`),
 /// macOS 는 채우던 경로 (`glyph` · `cluster` · `icon`), Windows 는 (`icon` · `mono` · `color`).
 ///
-/// **이 줄이 자주 보이면 `ATLAS_SIZE` 를 키울 근거다.** 한 화면이 요구하는 글리프가 용량을
+/// **이 줄이 자주 보이면 atlas 를 더 키울 근거다 (`MAX_ATLAS_SIZE`).** 한 화면이 요구하는 글리프가 용량을
 /// 넘으면 매 프레임 다시 차서 이 줄이 계속 늘어난다.
 ///
 /// `glyphs` · `clusters` 는 비우기 직전에 담고 있던 항목 수 (단일 글리프 / 합성 cluster 로
@@ -288,7 +288,7 @@ pub fn logPrimaryFont(family: []const u8, cell_w: anytype, cell_h: anytype, asce
 /// 채운 높이 (px) 다. `fonts` 는 cluster 키에 실린 **서로 다른 폰트 객체 수**다 — 화면이
 /// 한 폰트로 그려지는데 이 값이 1 을 넘으면 같은 그림이 폰트 주소별로 여러 번 담긴다는
 /// 뜻이다 —
-/// **이 둘이 실제 용량이다.** `ATLAS_SIZE` 를 얼마로 할지는 산술이 아니라 이 값으로 정한다
+/// **이 둘이 실제 용량이다.** `INITIAL_ATLAS_SIZE` · `MAX_ATLAS_SIZE` 를 얼마로 할지는 산술이 아니라 이 값으로 정한다
 /// (cluster 비트맵은 cell 보다 크고 `packRow` 가 줄마다 낭비를 낸다).
 /// glyph atlas 를 **두 배로 키웠다** ([#584](https://github.com/ensky0/tildaz/issues/584) ②).
 ///

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -15,7 +15,6 @@ const scrollbar = @import("../scrollbar.zig");
 const GlyphAtlas = @import("windows/glyph_atlas.zig").GlyphAtlas;
 const AtlasEntry = @import("windows/glyph_atlas.zig").AtlasEntry;
 
-const ATLAS_SIZE = @import("windows/glyph_atlas.zig").ATLAS_SIZE;
 const perf = @import("../perf.zig");
 const log = @import("../log.zig");
 const display_width = @import("../font/display_width.zig");
@@ -1824,7 +1823,7 @@ pub const D3d11Renderer = struct {
             while (utf8_iter.nextCodepoint()) |cp| {
                 if (pre_bg_n >= pre_bg_buf.len) break;
                 const result = self.font.resolveGlyph(@intCast(cp), .regular) orelse continue;
-                const entry = self.atlas.getOrInsert(result.face, result.font_id, result.index) orelse {
+                const entry = self.insertOrGrow(result.face, result.font_id, result.index) orelse {
                     if (result.owned) _ = result.face.vtable.Release(result.face);
                     continue;
                 };
@@ -2145,20 +2144,8 @@ pub const D3d11Renderer = struct {
         const rtvs = [1]?*d3d.ID3D11RenderTargetView{rtv};
         self.ctx.OMSetRenderTargets(1, &rtvs, null);
 
-        // Update constant buffer
-        var mapped: d3d.D3D11_MAPPED_SUBRESOURCE = .{};
-        if (self.ctx.Map(@ptrCast(self.cb), 0, d3d.D3D11_MAP_WRITE_DISCARD, 0, &mapped) >= 0) {
-            const cb_data: *Constants = @ptrCast(@alignCast(mapped.pData));
-            cb_data.* = .{
-                .screen_w = @floatFromInt(self.vp_width),
-                .screen_h = @floatFromInt(self.vp_height),
-                .atlas_w = @floatFromInt(ATLAS_SIZE),
-                .atlas_h = @floatFromInt(ATLAS_SIZE),
-                .enhanced_contrast = self.sys_enhanced_contrast,
-                .gamma_ratios = self.gamma_ratios,
-            };
-            self.ctx.Unmap(@ptrCast(self.cb), 0);
-        }
+        // Update constant buffer — 본문 atlas 크기로. text draw 는 자기 atlas 크기로 다시 쓴다 (`writeConstants`).
+        self.writeConstants(self.atlas.size);
 
         // Bind constant buffer to both VS and PS
         const cbs = [1]?*d3d.ID3D11Buffer{self.cb};
@@ -2171,6 +2158,26 @@ pub const D3d11Renderer = struct {
             .Height = @floatFromInt(self.vp_height),
         }};
         self.ctx.RSSetViewports(1, &vp);
+    }
+
+    /// #586 — 상수 버퍼를 다시 쓴다. `atlas_w/h` 는 **draw 가 쓰는 atlas 의 크기**여야 한다 — 본문 atlas 는
+    /// `grow` 로 커지고 탭 atlas 는 안 커지므로 값 하나로 둘을 못 맞춘다 (macOS 는 이 함정을 실측으로
+    /// 겪고 `tab_constants_buffer` 를 분리했다). 버퍼가 DYNAMIC + `WRITE_DISCARD` 라 매 Map 이 rename 되어
+    /// **앞서 기록된 draw 는 옛 값을 그대로 본다** (D3D11 계약) — 그래서 버퍼 둘 대신 draw 직전에 한 번 쓴다.
+    fn writeConstants(self: *D3d11Renderer, atlas_size: u32) void {
+        var mapped: d3d.D3D11_MAPPED_SUBRESOURCE = .{};
+        if (self.ctx.Map(@ptrCast(self.cb), 0, d3d.D3D11_MAP_WRITE_DISCARD, 0, &mapped) >= 0) {
+            const cb_data: *Constants = @ptrCast(@alignCast(mapped.pData));
+            cb_data.* = .{
+                .screen_w = @floatFromInt(self.vp_width),
+                .screen_h = @floatFromInt(self.vp_height),
+                .atlas_w = @floatFromInt(atlas_size),
+                .atlas_h = @floatFromInt(atlas_size),
+                .enhanced_contrast = self.sys_enhanced_contrast,
+                .gamma_ratios = self.gamma_ratios,
+            };
+            self.ctx.Unmap(@ptrCast(self.cb), 0);
+        }
     }
 
     fn drawBgInstances(self: *D3d11Renderer, instances: []const BgInstance) void {
@@ -2201,8 +2208,21 @@ pub const D3d11Renderer = struct {
         self.drawTextInstancesWithAtlas(instances, &self.atlas);
     }
 
+    /// #586 — 본문 atlas 에 단일 글리프를 넣는다 — 차면 **키우고** 다시 넣는다. ① 비우기는 대기 중인
+    /// 인스턴스를 flush 할 수 있는 셀 루프 (`emitClusterInstance`) 만 한다 — preedit · split cluster 의
+    /// mark 처럼 그 버퍼가 없는 자리에서는 상한이면 그 글리프를 건너뛴다 (전과 같다).
+    fn insertOrGrow(self: *D3d11Renderer, face: *dw.IDWriteFontFace, font_id: u64, index: u16) ?AtlasEntry {
+        var entry = self.atlas.getOrInsert(face, font_id, index);
+        while (entry == null and self.atlas.is_full and self.atlas.grow()) {
+            entry = self.atlas.getOrInsert(face, font_id, index);
+        }
+        return entry;
+    }
+
     fn drawTextInstancesWithAtlas(self: *D3d11Renderer, instances: []const TextInstance, atlas: *const GlyphAtlas) void {
         if (instances.len == 0) return;
+        // #586 — 이 atlas 의 크기로 UV 를 정규화한다 (`grow` 뒤 본문과 탭 atlas 크기가 갈린다).
+        self.writeConstants(atlas.size);
 
         // Upload instance data
         var mapped: d3d.D3D11_MAPPED_SUBRESOURCE = .{};
@@ -2285,6 +2305,11 @@ pub const D3d11Renderer = struct {
             text_count.* = 0;
         }
         var entry_opt = self.atlas.getOrInsertCluster(result.face, result.font_id, result.indices[0..result.count], result.advances[0..result.count], result.offsets[0..result.count], result.overlay_marks);
+        // #586 — **먼저 키운다** (macOS #584 ② 와 같다). 키우면 프레임 중간에 비우는 상황이 없어 이미
+        // emit 한 UV 가 무효화되지 않는다. 상한이면 아래 ① 안전망으로.
+        while (entry_opt == null and self.atlas.is_full and self.atlas.grow()) {
+            entry_opt = self.atlas.getOrInsertCluster(result.face, result.font_id, result.indices[0..result.count], result.advances[0..result.count], result.offsets[0..result.count], result.overlay_marks);
+        }
         if (entry_opt == null and self.atlas.is_full) {
             if (text_count.* > 0) {
                 self.drawTextInstances(text_buf[0..text_count.*]);
@@ -2367,7 +2392,7 @@ pub const D3d11Renderer = struct {
         const base_ink_center = @as(f32, @floatFromInt(base.entry.bearing_x)) + @as(f32, @floatFromInt(base.entry.w)) / 2.0;
 
         for (split.marks[0..split.mark_count]) |m| {
-            const me = self.atlas.getOrInsert(m.face, m.font_id, m.index) orelse {
+            const me = self.insertOrGrow(m.face, m.font_id, m.index) orelse {
                 if (m.owned) _ = m.face.vtable.Release(m.face);
                 continue;
             };

--- a/src/renderer/windows/glyph_atlas.zig
+++ b/src/renderer/windows/glyph_atlas.zig
@@ -24,7 +24,12 @@ const d2d = @import("direct2d.zig");
 const tab_icons = @import("../../tab_icons.zig");
 const atlas_common = @import("../glyph_atlas_common.zig");
 
-pub const ATLAS_SIZE: u32 = 2048;
+/// #586 — 시작 크기와 상한. macOS (`macos/glyph_atlas.zig`) 와 같은 값 · 같은 정책이다 — **차면 두 배로
+/// 키운다** (`grow`) 그리고 상한에서만 ① 안전망 (비우기) 으로 물러선다. 지금 크기는 `size` 필드다.
+/// 8192² 는 BGRA8 로 256 MB 다 (`BIND_RENDER_TARGET` 까지 붙는다) — 실제 상한은 `CreateTexture2D` 가
+/// 실패하는 지점이고, 그러면 `grow` 가 `false` 를 돌려 ① 로 간다 (feature level 은 조회하지 않는다).
+pub const INITIAL_ATLAS_SIZE: u32 = 2048;
+pub const MAX_ATLAS_SIZE: u32 = 8192;
 
 /// cluster 하나가 가질 수 있는 글리프 수 — shaping 쪽 상한과 같은 값을 쓴다.
 const MAX_CLUSTER_GLYPHS = dwrite_font.MAX_CLUSTER_GLYPHS;
@@ -55,6 +60,10 @@ pub const GlyphAtlas = struct {
     cursor_x: u32 = 0,
     cursor_y: u32 = 0,
     row_height: u32 = 0,
+    /// #586 — 지금 한 변. `grow` 가 두 배로 키운다.
+    size: u32 = INITIAL_ATLAS_SIZE,
+    /// #586 — 키운 횟수 (진단).
+    grows: u32 = 0,
 
     // DWrite resources for rasterization
     dw_factory: *dw.IDWriteFactory,
@@ -139,13 +148,96 @@ pub const GlyphAtlas = struct {
         ) < 0) return error.RenderingParamsFailed;
         errdefer _ = rp.?.vtable.Release(rp.?);
 
+        // Allocate temp buffers for max glyph size (256x256)
+        const temp_buf = try alloc.alloc(u8, 256 * 256 * 4); // RGBA
+        errdefer alloc.free(temp_buf);
+        const ct_buf = try alloc.alloc(u8, 256 * 256 * 3); // ClearType 3x1 RGB
+
+        // D2D factory 는 atlas 수명 동안 하나다. 실패해도 init 성공 — `d2d_factory==null` 이면 color emoji
+        // path disable, mono fallback. 텍스처 · SRV · D2D RT 체인은 `createGpu` 가 만든다 — `grow` 가 같은
+        // 함수로 더 큰 것을 다시 만든다 (#586).
+        var d2d_factory: ?*d2d.ID2D1Factory = null;
+        _ = d2d.D2D1CreateFactory(d2d.D2D1_FACTORY_TYPE_SINGLE_THREADED, &d2d.IID_ID2D1Factory, null, &d2d_factory);
+        errdefer if (d2d_factory) |fac| d2d.factoryRelease(fac);
+
+        const gpu = try createGpu(device, INITIAL_ATLAS_SIZE, d2d_factory, rp.?, pixels_per_dip);
+        errdefer gpu.release();
+
+        // IDWriteFactory4 QI (#137-4) — Factory2.TranslateColorGlyphRun 은
+        // desiredGlyphImageFormats 인자 없어 PNG layer 안 받음. Factory4 신규
+        // overload 로 모든 형식 (TRUETYPE | CFF | COLR | SVG | PNG | JPEG | TIFF |
+        // PREMULTIPLIED) 명시 요청.
+        var dw_factory4: ?*dw.IDWriteFactory4 = null;
+        var f4_ptr: ?*anyopaque = null;
+        if (dw_factory.QueryInterface(&dw.IID_IDWriteFactory4, &f4_ptr) >= 0 and f4_ptr != null) {
+            dw_factory4 = @ptrCast(@alignCast(f4_ptr));
+        }
+        errdefer if (dw_factory4) |f| dw.factory4Release(f);
+
+        return .{
+            .alloc = alloc,
+            .cache = std.AutoHashMap(GlyphKey, AtlasEntry).init(alloc),
+            .cluster_cache = std.AutoHashMap(ClusterKey, AtlasEntry).init(alloc),
+            .dw_factory = dw_factory,
+            .rendering_params = rp.?,
+            .rendering_mode = sys_rendering_mode,
+            .font_em_size = font_em_size,
+            .pixels_per_dip = pixels_per_dip,
+            .texture = gpu.texture,
+            .srv = gpu.srv,
+            .d3d_device = device,
+            .d3d_ctx = ctx,
+            .temp_buf = temp_buf,
+            .ct_buf = ct_buf,
+            .d2d_factory = d2d_factory,
+            .atlas_dxgi_surface = gpu.dxgi_surface,
+            .atlas_d2d_rt = gpu.d2d_rt,
+            .atlas_brush = gpu.brush,
+            .atlas_dc = gpu.dc,
+            .atlas_dc4 = gpu.dc4,
+            .dw_factory4 = dw_factory4,
+        };
+    }
+
+    /// #586 — atlas 의 GPU 자원 한 묶음. 텍스처 하나에 D2D render target 체인이 딸려 있어 (컬러 emoji 를
+    /// packed 자리에 직접 그린다) 크기를 바꾸면 **일곱 객체를 함께** 다시 만들어야 한다. `init` 과
+    /// `grow` 가 같은 `createGpu` 를 쓴다.
+    const Gpu = struct {
+        texture: *d3d.ID3D11Texture2D,
+        srv: *d3d.ID3D11ShaderResourceView,
+        dxgi_surface: ?*d3d.IDXGISurface,
+        d2d_rt: ?*d2d.ID2D1RenderTarget,
+        dc: ?*d2d.ID2D1DeviceContext,
+        dc4: ?*d2d.ID2D1DeviceContext4,
+        brush: ?*d2d.ID2D1SolidColorBrush,
+
+        fn release(self: Gpu) void {
+            if (self.brush) |b_| d2d.brushRelease(b_);
+            if (self.dc4) |c_| d2d.deviceContext4Release(c_);
+            if (self.dc) |c_| d2d.deviceContextRelease(c_);
+            if (self.d2d_rt) |r_| d2d.renderTargetRelease(r_);
+            if (self.dxgi_surface) |s_| _ = s_.Release();
+            _ = self.srv.Release();
+            _ = self.texture.Release();
+        }
+    };
+
+    fn createGpu(
+        device: *d3d.ID3D11Device,
+        size: u32,
+        d2d_factory: ?*d2d.ID2D1Factory,
+        rp: *dw.IDWriteRenderingParams,
+        pixels_per_dip: f32,
+    ) !Gpu {
         // Create atlas texture — BIND_SHADER_RESOURCE (shader sample) +
         // BIND_RENDER_TARGET (D2D 가 atlas 의 packed 위치에 직접 그림).
         // USAGE_DEFAULT 라 mono path 의 UpdateSubresource 도 그대로 동작.
+        // 내용은 초기화하지 않는다 — 샘플러가 POINT 필터라 (`D3D11_FILTER_MIN_MAG_MIP_POINT`) 담긴
+        // 사각형 밖 텍셀은 읽히지 않고, 컬러 경로는 자기 clip 영역을 먼저 Clear 한다.
         var tex: ?*d3d.ID3D11Texture2D = null;
         if (device.CreateTexture2D(&.{
-            .Width = ATLAS_SIZE,
-            .Height = ATLAS_SIZE,
+            .Width = size,
+            .Height = size,
             .Format = d3d.DXGI_FORMAT_R8G8B8A8_UNORM,
             .BindFlags = d3d.D3D11_BIND_SHADER_RESOURCE | d3d.D3D11_BIND_RENDER_TARGET,
         }, null, &tex) < 0) return error.AtlasTextureFailed;
@@ -157,27 +249,15 @@ pub const GlyphAtlas = struct {
             return error.AtlasSrvFailed;
         errdefer _ = srv.?.Release();
 
-        // Allocate temp buffers for max glyph size (256x256)
-        const temp_buf = try alloc.alloc(u8, 256 * 256 * 4); // RGBA
-        errdefer alloc.free(temp_buf);
-        const ct_buf = try alloc.alloc(u8, 256 * 256 * 3); // ClearType 3x1 RGB
-
-        // D2D factory + atlas D2D RT 한 번 생성. per-glyph staging 폐기 — atlas
-        // 자체에 D2D RT 만들고 layer 마다 PushAxisAlignedClip + DrawGlyphRun 으로
-        // packed 위치에 직접 그림. atlas RGBA + D2D RT RGBA 같은 format 이라
-        // byte swap 자동 해결. 실패해도 init 성공 — d2d_factory==null 이면
-        // color emoji path disable, mono fallback.
-        var d2d_factory: ?*d2d.ID2D1Factory = null;
-        _ = d2d.D2D1CreateFactory(d2d.D2D1_FACTORY_TYPE_SINGLE_THREADED, &d2d.IID_ID2D1Factory, null, &d2d_factory);
-        errdefer if (d2d_factory) |f| d2d.factoryRelease(f);
-
+        // atlas D2D RT — per-glyph staging 폐기, atlas 자체에 RT 를 만들고 layer 마다
+        // PushAxisAlignedClip + DrawGlyphRun 으로 packed 위치에 직접 그림. atlas RGBA + D2D RT RGBA
+        // 같은 format 이라 byte swap 자동 해결.
         var atlas_dxgi: ?*d3d.IDXGISurface = null;
         var atlas_d2d_rt: ?*d2d.ID2D1RenderTarget = null;
         if (d2d_factory) |fac| {
             var dxgi_ptr: ?*anyopaque = null;
             if (tex.?.QueryInterface(&d3d.IID_IDXGISurface, &dxgi_ptr) >= 0 and dxgi_ptr != null) {
                 atlas_dxgi = @ptrCast(@alignCast(dxgi_ptr));
-                // atlas D2D RT — RGBA format (atlas 와 동일) + PREMULTIPLIED.
                 // dpi=96 으로 두면 1 DIP = 1 device pixel — bounds (device px)
                 // 좌표를 그대로 baseline DIP 로 줘도 일치 (high DPI 정밀도는
                 // 별도 작업 — SetUnitMode(PIXELS) 도입 시).
@@ -189,15 +269,13 @@ pub const GlyphAtlas = struct {
                     .usage = d2d.D2D1_RENDER_TARGET_USAGE_NONE,
                     .minLevel = d2d.D2D1_FEATURE_LEVEL_DEFAULT,
                 };
-                // RGBA atlas 에 BGRA RT 연결 — pixelFormat.format 은 R8G8B8A8 이어야
-                // atlas 와 일치. 위 props 의 format 도 R8G8B8A8 으로 변경 필요.
+                // RGBA atlas 에 BGRA RT 연결 — pixelFormat.format 은 R8G8B8A8 이어야 atlas 와 일치.
                 var props_rgba = rt_props;
                 props_rgba.pixelFormat.format = d3d.DXGI_FORMAT_R8G8B8A8_UNORM;
                 if (d2d.factoryCreateDxgiSurfaceRenderTarget(fac, @ptrCast(atlas_dxgi.?), &props_rgba, &atlas_d2d_rt) >= 0 and atlas_d2d_rt != null) {
-                    // 한 번만 antialias mode + rendering params 설정 (BeginDraw
-                    // 와 무관한 RT state).
+                    // 한 번만 antialias mode + rendering params 설정 (BeginDraw 와 무관한 RT state).
                     d2d.renderTargetSetTextAntialiasMode(atlas_d2d_rt.?, d2d.D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-                    d2d.renderTargetSetTextRenderingParams(atlas_d2d_rt.?, @ptrCast(rp.?));
+                    d2d.renderTargetSetTextRenderingParams(atlas_d2d_rt.?, @ptrCast(rp));
                     // sys_dpi 적용 — RT 가 device pixel 좌표를 정확히 해석.
                     const sys_dpi: f32 = 96.0 * pixels_per_dip;
                     d2d.renderTargetSetDpi(atlas_d2d_rt.?, sys_dpi, sys_dpi);
@@ -205,8 +283,8 @@ pub const GlyphAtlas = struct {
             }
         }
         errdefer if (atlas_d2d_rt) |r| d2d.renderTargetRelease(r);
-        errdefer if (atlas_dxgi) |s| {
-            _ = s.Release();
+        errdefer if (atlas_dxgi) |sf| {
+            _ = sf.Release();
         };
 
         // ID2D1DeviceContext QI (#137-3) — SetUnitMode(PIXELS) + GetGlyphRunWorldBounds.
@@ -221,7 +299,7 @@ pub const GlyphAtlas = struct {
                 d2d.deviceContextSetUnitMode(atlas_dc.?, d2d.D2D1_UNIT_MODE_PIXELS);
             }
         }
-        errdefer if (atlas_dc) |c| d2d.deviceContextRelease(c);
+        errdefer if (atlas_dc) |c_| d2d.deviceContextRelease(c_);
 
         // ID2D1DeviceContext4 QI (#137-4) — Win 10 1607+ 에서 bitmap emoji 글리프
         // (PNG/SVG) 처리 위한 DrawColorBitmapGlyphRun. null 이면 outline path 만.
@@ -233,68 +311,81 @@ pub const GlyphAtlas = struct {
                 atlas_dc4 = @ptrCast(@alignCast(dc4_ptr));
             }
         }
-        errdefer if (atlas_dc4) |c| d2d.deviceContext4Release(c);
+        errdefer if (atlas_dc4) |c_| d2d.deviceContext4Release(c_);
 
-        // IDWriteFactory4 QI (#137-4) — Factory2.TranslateColorGlyphRun 은
-        // desiredGlyphImageFormats 인자 없어 PNG layer 안 받음. Factory4 신규
-        // overload 로 모든 형식 (TRUETYPE | CFF | COLR | SVG | PNG | JPEG | TIFF |
-        // PREMULTIPLIED) 명시 요청.
-        var dw_factory4: ?*dw.IDWriteFactory4 = null;
-        var f4_ptr: ?*anyopaque = null;
-        if (dw_factory.QueryInterface(&dw.IID_IDWriteFactory4, &f4_ptr) >= 0 and f4_ptr != null) {
-            dw_factory4 = @ptrCast(@alignCast(f4_ptr));
-        }
-        errdefer if (dw_factory4) |f| dw.factory4Release(f);
-
-        // Reusable solid brush (#137-6) — atlas init 시 흰색으로 한 번 생성,
-        // layer 마다 SetColor 만 호출해서 재사용. brush 매번 생성/release 비용
-        // 제거. Win Terminal `_emojiBrush` (BackendD3D.cpp:892) 동등.
+        // Reusable solid brush (#137-6) — 흰색으로 한 번 생성, layer 마다 SetColor 만 호출해서 재사용.
+        // Win Terminal `_emojiBrush` (BackendD3D.cpp:892) 동등.
         var atlas_brush: ?*d2d.ID2D1SolidColorBrush = null;
         if (atlas_d2d_rt) |rt| {
             const white = d2d.D2D1_COLOR_F{ .r = 1, .g = 1, .b = 1, .a = 1 };
             _ = d2d.renderTargetCreateSolidColorBrush(rt, &white, &atlas_brush);
         }
-        errdefer if (atlas_brush) |b| d2d.brushRelease(b);
 
         return .{
-            .alloc = alloc,
-            .cache = std.AutoHashMap(GlyphKey, AtlasEntry).init(alloc),
-            .cluster_cache = std.AutoHashMap(ClusterKey, AtlasEntry).init(alloc),
-            .dw_factory = dw_factory,
-            .rendering_params = rp.?,
-            .rendering_mode = sys_rendering_mode,
-            .font_em_size = font_em_size,
-            .pixels_per_dip = pixels_per_dip,
             .texture = tex.?,
             .srv = srv.?,
-            .d3d_device = device,
-            .d3d_ctx = ctx,
-            .temp_buf = temp_buf,
-            .ct_buf = ct_buf,
-            .d2d_factory = d2d_factory,
-            .atlas_dxgi_surface = atlas_dxgi,
-            .atlas_d2d_rt = atlas_d2d_rt,
-            .atlas_brush = atlas_brush,
-            .atlas_dc = atlas_dc,
-            .atlas_dc4 = atlas_dc4,
-            .dw_factory4 = dw_factory4,
+            .dxgi_surface = atlas_dxgi,
+            .d2d_rt = atlas_d2d_rt,
+            .dc = atlas_dc,
+            .dc4 = atlas_dc4,
+            .brush = atlas_brush,
         };
     }
 
+    fn currentGpu(self: *const GlyphAtlas) Gpu {
+        return .{
+            .texture = self.texture,
+            .srv = self.srv,
+            .dxgi_surface = self.atlas_dxgi_surface,
+            .d2d_rt = self.atlas_d2d_rt,
+            .dc = self.atlas_dc,
+            .dc4 = self.atlas_dc4,
+            .brush = self.atlas_brush,
+        };
+    }
+
+    /// #586 — 차면 **두 배로 키운다** (macOS `grow` 와 같은 정책 · ghostty 방식). 새 텍스처를 만들고 옛 내용을
+    /// **같은 (x, y) 로** 복사한다 — row-based packing 이라 좌표가 그대로 유효하고 커서도 이어 쓴다. 이미
+    /// emit 된 인스턴스의 UV 는 픽셀 좌표고 셰이더가 `atlas_w/h` 로 정규화하므로 그대로 맞는다
+    /// (`drawTextInstancesWithAtlas` 가 draw 마다 그 atlas 크기를 상수 버퍼에 쓴다).
+    ///
+    /// Windows 는 삽입 즉시 업로드 · 즉시 draw 라 macOS 가 필요했던 GPU 대기 (`submitPassEarly`) 가 없다 —
+    /// 이미 기록된 draw 는 옛 SRV 를 참조하고, `CopySubresourceRegion` 은 command stream 안에서 앞의
+    /// 업로드 · D2D 그리기 뒤에 놓인다 (D3D11 계약 — 이 레포에서 실측하지는 않았다, 실기 검증 항목).
+    ///
+    /// 상한 (`MAX_ATLAS_SIZE`) 이거나 텍스처 생성이 실패하면 `false` — 호출자가 ① 안전망으로 물러선다.
+    pub fn grow(self: *GlyphAtlas) bool {
+        if (self.size >= MAX_ATLAS_SIZE) return false;
+        const new_size = self.size * 2;
+        const gpu = createGpu(self.d3d_device, new_size, self.d2d_factory, self.rendering_params, self.pixels_per_dip) catch return false;
+
+        const box = d3d.D3D11_BOX{ .left = 0, .top = 0, .right = self.size, .bottom = self.size };
+        self.d3d_ctx.CopySubresourceRegion(@ptrCast(gpu.texture), 0, 0, 0, 0, @ptrCast(self.texture), 0, &box);
+
+        // 옛 객체는 command list 가 참조를 들고 있어 지연 파괴는 드라이버가 처리한다.
+        self.currentGpu().release();
+        self.texture = gpu.texture;
+        self.srv = gpu.srv;
+        self.atlas_dxgi_surface = gpu.dxgi_surface;
+        self.atlas_d2d_rt = gpu.d2d_rt;
+        self.atlas_dc = gpu.dc;
+        self.atlas_dc4 = gpu.dc4;
+        self.atlas_brush = gpu.brush;
+        self.size = new_size;
+        self.grows += 1;
+        self.is_full = false;
+        log.logAtlasGrew(new_size, self.grows, self.cache.count(), self.cluster_cache.count());
+        return true;
+    }
+
     pub fn deinit(self: *GlyphAtlas) void {
-        if (self.atlas_brush) |b| d2d.brushRelease(b);
-        if (self.atlas_dc4) |c| d2d.deviceContext4Release(c);
-        if (self.atlas_dc) |c| d2d.deviceContextRelease(c);
-        if (self.atlas_d2d_rt) |r| d2d.renderTargetRelease(r);
-        if (self.atlas_dxgi_surface) |s| _ = s.Release();
+        self.currentGpu().release();
         if (self.dw_factory4) |f| dw.factory4Release(f);
         if (self.d2d_factory) |f| d2d.factoryRelease(f);
         self.alloc.free(self.ct_buf);
         self.alloc.free(self.temp_buf);
         self.cache.deinit();
         self.cluster_cache.deinit();
-        _ = self.srv.Release();
-        _ = self.texture.Release();
         _ = self.rendering_params.Release();
     }
 
@@ -529,11 +620,7 @@ pub const GlyphAtlas = struct {
             }
         }
 
-        const pos = self.packGlyph(size, size) orelse {
-            self.is_full = true;
-            self.full_kind = "icon";
-            return null;
-        };
+        const pos = self.packOrMarkFull(size, size, "icon") orelse return null;
         const box = d3d.D3D11_BOX{
             .left = pos[0],
             .top = pos[1],
@@ -724,11 +811,7 @@ pub const GlyphAtlas = struct {
         }
 
         // Pack into atlas; if full, signal caller to flush+reset+retry before we overwrite anything
-        const pos = self.packGlyph(w, h) orelse {
-            self.is_full = true;
-            self.full_kind = "mono";
-            return null;
-        };
+        const pos = self.packOrMarkFull(w, h, "mono") orelse return null;
 
         // Upload to GPU texture via UpdateSubresource
         const box = d3d.D3D11_BOX{
@@ -893,11 +976,7 @@ pub const GlyphAtlas = struct {
         const h: u32 = @intCast(gh);
         if (w > 256 or h > 256) return null;
 
-        const pos = self.packGlyph(w, h) orelse {
-            self.is_full = true;
-            self.full_kind = "color";
-            return null;
-        };
+        const pos = self.packOrMarkFull(w, h, "color") orelse return null;
 
         // atlas D2D RT 의 packed 영역에 직접 그림. dpi=96 (init 시 설정) 라 1 DIP =
         // 1 device pixel — pos / bounds (device pixel) 좌표를 baseline 에 그대로
@@ -1006,6 +1085,22 @@ pub const GlyphAtlas = struct {
 
     /// #282 G5 — 공통 row-based packing 에 위임.
     fn packGlyph(self: *GlyphAtlas, w: u32, h: u32) ?[2]u32 {
-        return atlas_common.packRow(&self.cursor_x, &self.cursor_y, &self.row_height, ATLAS_SIZE, w, h);
+        return atlas_common.packRow(&self.cursor_x, &self.cursor_y, &self.row_height, self.size, w, h);
+    }
+
+    /// 자리를 잡고, 못 잡으면 **비울 가치가 있을 때만** `is_full` 을 세운다 (#586 — macOS `packOrMarkFull` ·
+    /// Linux `glAddGlyph` 와 같은 규칙, 전에는 Windows 만 이 가드가 없었다).
+    ///
+    /// 1. **판정은 호출 *전* 값으로 한다.** `packRow` 는 실패할 때도 커서를 움직인다.
+    /// 2. **이미 빈 atlas 인데 안 들어가면 세우지 않는다.** 그림 하나가 atlas 보다 크다는 뜻이라 비워도
+    ///    (키워도) 소용없고, 세우면 호출자가 글리프마다 헛되게 flush + reset 을 돈다.
+    fn packOrMarkFull(self: *GlyphAtlas, w: u32, h: u32, kind: []const u8) ?[2]u32 {
+        const was_empty = self.cursor_x == 0 and self.cursor_y == 0 and self.row_height == 0;
+        if (self.packGlyph(w, h)) |pos| return pos;
+        if (!was_empty) {
+            self.is_full = true;
+            self.full_kind = kind;
+        }
+        return null;
     }
 };


### PR DESCRIPTION
[#586](https://github.com/ensky0/tildaz/issues/586) **1/2 — Windows.** `ATLAS_SIZE` 2048 고정 + ① 안전망이던 Windows atlas 에 macOS (#584 ②) 와 같은 `grow` 정책을 얹습니다 — `INITIAL_ATLAS_SIZE` 2048 → 차면 두 배 → `MAX_ATLAS_SIZE` 8192, 상한에서만 ①.

## 무엇이 바뀌었나

| | |
|---|---|
| `size` · `grows` 필드 · `packGlyph` 가 `self.size` | 런타임 크기 |
| `createGpu(device, size, …)` | 텍스처 · SRV · `IDXGISurface` · D2D RT · DC · DC4 · brush **일곱 객체**를 한 묶음으로 — atlas 가 D2D render target 의 기반이라 크기를 바꾸면 전부 다시 만들어야 한다. `init` · `grow` 공유 |
| `grow` | 새 텍스처 → `CopySubresourceRegion` 으로 옛 내용을 **같은 (x, y)** 에 (CPU 사본이 없다) → 일곱 객체 교체. 텍스처 생성 실패 = 실제 상한 → `false` → ① |
| `packOrMarkFull` | 빈 atlas 면 `is_full` 을 세우지 않는 가드 — **Windows 만 없던 것** |
| `writeConstants` | 상수 버퍼를 **text draw 마다 그 atlas 크기로** 다시 쓴다 (본문은 커지고 탭은 안 커진다 — macOS 가 실측으로 겪은 함정). `WRITE_DISCARD` rename 이라 앞 draw 는 옛 값 유지 |
| `emitClusterInstance` | **먼저 `grow`** (while) → 상한이면 기존 ① |
| `insertOrGrow` | preedit · split mark — 키우고 다시 넣되, flush 버퍼가 없는 자리라 상한이면 건너뜀 (전과 같다) |
| 탭 atlas | 키우지 않는다 (Q1) |
| `dist/windows/render-ab-shot.ps1` (신규) | Windows A/B 캡처 하네스 — Linux · macOS 판에 대응. `EnumWindows` + pid 로 진짜 창 · DPI aware · `PrintWindow` · `LockBits` 대조 · `-NewTab` (합성 `Ctrl+Shift+T`) |
| `dist/screens/clusters.py` | stdout UTF-8 고정 (Windows 콘솔 cp949 에서 죽던 것) · `--cmd <본문.txt>` 로 Windows 용 `.cmd` 래퍼 출력 |
| `SPEC.md` §12.6 ② · `AGENTS.md` | Windows 실측표 · Windows 렌더 검증 절 (함정 포함) |

## Windows 가 macOS 보다 쉬운 이유 — 실기로 확인

삽입 즉시 업로드 · 즉시 draw 라 이미 기록된 draw 는 옛 SRV 를 참조하고, `CopySubresourceRegion` 은 command stream 안에서 앞 업로드 뒤에 놓입니다 → macOS 의 GPU 대기가 필요 없습니다. D3D11 계약이고, 아래 실측의 `0 px` 이 그 근거입니다.

## 검증

`zig build check` (6 타겟) · `zig build test` (363 passed) · `zig fmt --check` 통과 — `origin/main` (`8ccc8bc`) 위로 rebase 한 뒤 다시 돌렸습니다.

**실기** (노트북 LENOVO 83JY · AMD Ryzen AI 7 350 · Radeon 860M · Windows 11 Pro 26200 · 2880x1800 120 Hz · 150 % · Cascadia Code 15pt · `cell 14x29` · 2026-09-03). `INITIAL_ATLAS_SIZE` 만 바꾼 판을 `clusters.py` 세 화면으로 띄워 창 캡처를 `render-ab-shot.ps1` 로 견줬습니다 — **`grow` 가 정확하면 시작 크기와 무관하게 최종 그림이 같아야** 합니다.

| 화면 · 판 | `grow` | `atlas full` | 4096 판과 다른 픽셀 |
|---|---|---|---|
| `many` 88x33 · 2048 / 512 | 0 / 2 회 → 2048 | 0 | **0** / 1,258,008 px (둘 다) |
| `stack2` 150x40 · 2048 / 512 / **8192** (시작부터 상한) | 0 / 2 회 → 2048 / 0 | 0 | **0** / 2,550,880 px (셋 다) |
| `overflow` 150x40 (17 화면 누적) · 2048 / 512 | 2 회 → **8192** / 4 회 → 8192 | **0** | **0** / 2,550,880 px (둘 다) |
| `overflow` + **탭 2 개** · 2048 vs **main** (고정 2048 + ① — `atlas full` 6 회) | 2 회 → 8192 | 0 | **0** / 2,640,760 px |

- 마지막 줄이 `writeConstants` 의 근거 — 본문 8192 · 탭 2048 인 채 탭바 · 컨트롤 스트립을 그린 화면이 `grow` 없는 main 과 같습니다. ① 만 쓰는 판과 `grow` 판이 같은 그림을 낸다는 확인이기도 합니다.
- 8192² RGBA + `BIND_RENDER_TARGET` 텍스처가 이 내장 GPU 에서 만들어졌습니다 (`INITIAL = 8192` 판 정상 기동 · `overflow` 두 판이 8192 까지).
- 이 기기는 cell 이 작아 `stack2` 6,000 종이 2048² 에 들어갑니다 (기본 판 `grow` 0). 누적 종 수는 회차마다 달라 (Windows 는 화면이 바뀔 때만 그림) 판정은 `grow` 회수가 아니라 **최종 그림 `0 px` + `atlas full` 0** 으로 했습니다 — SPEC · AGENTS.md 에 적었습니다.

Refs #586