### PR TITLE
docs(windows): dead key · launcher 실패 자동 검증 도구 — #494 · #577 의 Windows 몫 실기 확인 (#583 A2 · A3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -696,6 +696,42 @@ dist\windows\render-ab-shot.ps1 … -NewTab        # Ctrl+Shift+T 를 합성 입
   `stack2` 는 512 판도 2048 에서 멈춰 조건이 안 돼요. `overflow` + `-NewTab` 을 **main 판** (고정 2048 + 안전망) 과 견줘요.
   grow 판끼리는 같은 코드라 함정을 스스로 못 가르니까요 (2026-09-03 실측 `0 / 2,640,760 px`).
 
+# Windows — 합성 입력으로 dead key · launcher 실패를 자동 검증하는 법
+
+macOS 의 `deadkey-check.sh` 에 대응하는 도구 둘이에요 ([#583](https://github.com/ensky0/tildaz/issues/583) A2 · A3 의 Windows 몫).
+둘 다 `--instance 9` 또는 launcher 로 앱을 한 번 띄우고 끝나면 만든 것을 스스로 지워요. 실기라서 `# 실행 환경` 대로
+**시작 전에 알리고 동의를 받아요** — 합성 키가 나가고 세션 layout 목록 · `config_9.toml` 이 잠깐 바뀌어요.
+
+| 도구 | 무엇 |
+|---|---|
+| [`dist/windows/deadkey-check.ps1`](dist/windows/deadkey-check.ps1) | US-International (`00020409`) 을 올리고 `'`+`e` 등 네 케이스를 `SendInput` 으로 쳐 자식이 받은 UTF-8 바이트로 판정 (#494) |
+| [`dist/windows/launcher-fatal-check.ps1`](dist/windows/launcher-fatal-check.ps1) | TOML 이 깨진 `config_9.toml` 을 두고 인자 없는 `tildaz.exe` (launcher) 를 띄워 `TildaZ failed to start` 다이얼로그가 뜨고 닫으면 exit 0 인지 (#577 의 `showFatalRunError(rt, …)` 자리) |
+
+```powershell
+dist\windows\deadkey-check.ps1 -Bin zig-out\bin\tildaz.exe          # 창 1 회 · 합성 키 · layout 잠깐
+dist\windows\launcher-fatal-check.ps1 -Bin zig-out\bin\tildaz.exe   # 다이얼로그 1 회 · config_9 잠깐
+```
+
+- **layout 은 활성화하지 않고 (`LoadKeyboardLayoutW(klid, 0)`) 창 하나만 전환해요** — `WM_INPUTLANGCHANGEREQUEST` 를 tildaz 창에
+  `PostMessage` 하면 `DefWindowProc` 이 **그 스레드**의 layout 만 바꿔요. 우리 셸도 사용자의 다른 창도 그대로예요. 바뀌었는지
+  `GetKeyboardLayout(thread)` 로 확인하고 안 됐으면 키를 보내지 않아요. `LoadKeyboardLayoutW` 의 부작용 (세션 목록에 남아
+  `Win+Space` 에 나타남) 은 끝에 `UnloadKeyboardLayout` 으로 내리고 `GetKeyboardLayoutList` 를 전후로 찍어 확인해요 (위
+  `# Windows — 키보드 layout 조회 실측 방법` 의 같은 주의).
+- **자식은 `Read-Host` 로 줄을 받아요** — Windows 에는 `cat` 이 없어요. `-e` 가 명령줄을 통째로 `CreateProcessW` 에 넘기므로
+  `powershell -File <자식.ps1> <out> <N>` 처럼 인자도 그대로 가요 (#584 에서 확인). 자식이 N 줄을 받고 끝나면 앱도 끝나
+  정리가 자동이에요. 자식 PowerShell 이 `Read-Host` 에 닿기 전에 보낸 키는 콘솔 입력 버퍼에 남아 있다가 읽히지만, 2 초는 둬요.
+- **키마다 포커스 가드**예요 (`dist/stress/send-keys.ps1` 과 같은 규칙) — foreground 가 tildaz 창이 아니면 멈춰요. 합성 키는
+  포커스된 창으로 가니 회차 동안 사용자가 다른 창을 만지면 거기에 타이핑돼요.
+- **앱의 error 다이얼로그는 `MessageBox` (`#32770`) 가 아니에요** — `dialog/windows.zig` 의 자체 창
+  `TildaZScrollableDialogWindow` 이고 본문을 직접 그려 자식 컨트롤로는 제목 Static 과 OK Button 만 보여요. 본문 문구는
+  **캡처 (PrintWindow) 와 로그** (`tildaz_0.log` 의 `[fatal] run failed: <err>`) 로 확인해요. 첫 회차에 `#32770` 을 기대해
+  거짓 FAIL 이 났어요 (2026-09-03).
+- **launcher 단독 실패를 만드는 법은 "깨진 TOML 의 `config_9.toml` + 인자 없는 실행"** 이에요. `runLauncher` 가 spawn 전에
+  모든 index 의 config 를 `configAutoStart` 로 읽고 파서 오류를 그대로 전파하므로 worker 는 뜨지도 않아요 — worker 가 다이얼로그를
+  띄우는 경로 (macOS 2026-09-02 회차) 로는 이 자리를 못 가르니까요. 그 실패는 `autostart.enable/disable` **앞**이라 사용자의
+  자동 시작 설정도 떠 있는 instance 0 도 그대로예요. 다만 launcher 는 `tildaz_0.log` 에 `[fatal]` 한 줄을 남겨요. `config_9.toml`
+  이 이미 있으면 도구가 시작을 거부해요 — 사용자 설정을 덮지 않아요.
+
 # Windows — 키보드 layout 조회 실측 방법
 
 위 macOS 절과 같은 물음을 Windows 에서 재는 도구예요. [`dist/windows/layout-probe.zig`](dist/windows/layout-probe.zig) 가 scancode `0x01`..`0x58` 을 layout 별로 한 표에 덤프해요 — VK (`MapVirtualKeyExW`) · 라벨 base/shift/AltGr (`ToUnicodeEx`) · 역방향 (`VkKeyScanExW`).

--- a/SPEC.md
+++ b/SPEC.md
@@ -907,7 +907,7 @@ dead key (`^` `¨` `´` `` ` `` `~` — 프랑스어 · 독일어 · 스페인�
 | platform | 조합 주체 | 경로 |
 |---|---|---|
 | macOS | OS — 조합 중 `ˆ` 를 marked text 로 **보여 준다** (2026-08-27 실기: ABC + `Option+i`, `setMarkedText:` → preedit 렌더) | `interpretKeyEvents:` — AppKit 텍스트 입력 시스템이 dead key 상태를 든다 |
-| Windows | OS — 조합 중 표시 **없음** (`WM_DEADCHAR` 를 그리는 코드가 없다 — 코드 확정, 실기 미확인) | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
+| Windows | OS — 조합 중 표시 **없음** (`WM_DEADCHAR` 를 그리는 코드가 없다 — 코드 확정). 조합 자체는 2026-09-03 실기로 확인 (US-International · `'`+`e` → `é`, `Shift+6`+`o` → `ô`, `'`+space → `'`, `'`+`x` → `'x` — 조합 불가도 dead key 를 삼키지 않는다) | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
 | **Linux** | **tildaz** — #530 부터 조합 중 표시도 한다 | libxkbcommon **Compose** (`xkb_compose_state_feed`) — [`xkb.zig`](src/host/linux/xkb.zig) `Keyboard.composeFeed`. #494 전에는 `xkb_state_key_get_utf8` 만 있어 dead key 가 **빈 문자열** = 아무것도 보내지 않았다 |
 
 Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496 과 같은 뿌리). 규칙:
@@ -934,7 +934,7 @@ Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496
 - 대조군 foot 1.27.0 은 `^` 뒤 Enter 를 삼키고 (`65` 만 나옴) `^`+Ctrl+C 를 `ĉ` 로 조합해 **SIGINT 를 삼킨다** — "Ctrl/Alt 제외 · 조합 버림" 두 규칙의 근거가 실기로 재현됐다.
 - `ko_KR.UTF-8` 의 Compose 파일은 `en_US.UTF-8` 을 include 하는 한 줄이라 fallback 없이 바로 로드된다.
 
-macOS 의 조합 (과 조합 중 표시) 은 2026-08-27 실기로 확인했다 (위 표). **Windows 는 코드 판정이고 실기 미확인**이다 — OS 가 조합 주체라 코드 리뷰로는 드러나지 않으므로 따로 재야 한다.
+macOS 의 조합 (과 조합 중 표시) 은 2026-08-27 실기로 확인했다 (위 표). **Windows 의 조합도 2026-09-03 실기로 확인했다** — OS 가 조합 주체라 코드 리뷰로는 드러나지 않아 따로 잰 것이다. [`dist/windows/deadkey-check.ps1`](dist/windows/deadkey-check.ps1) 이 US-International layout 을 세션에 잠깐 올리고 `WM_INPUTLANGCHANGEREQUEST` 로 tildaz 창의 스레드만 전환한 뒤 `SendInput` 으로 네 케이스를 쳐 자식 (`Read-Host`) 이 받은 UTF-8 바이트로 판정한다 (노트북 Ryzen AI 7 350 · Windows 11 Pro 26200 — `c3 a9 78` · `27 78` · `c3 b4 78` · `27 78` 모두 기대와 일치, [#494 댓글](https://github.com/ensky0/tildaz/issues/494)). 조합 중 표시가 없는 것은 그대로다 (#583 B4).
 
 조합 중 표시 (#530) 의 검증 (2026-08-27): lima headless sway (software 렌더) 에서 `grim` 캡처의 preedit 배경색 픽셀 151 → 0 과 스크린샷 확인, **COSMIC 1.6.0 실기 (GL 렌더 · 실제 `fr` 자판 · fcitx5 공존 포함) 7 케이스 전부 일치** ([#530 댓글](https://github.com/ensky0/tildaz/issues/530#issuecomment-5432460964)) — `^` 표시 · `e` 로 확정 · Enter / Ctrl+C / 단축키 / 포커스 이탈에서 지움 · `^´` 두 글자 덧붙임 · IME preedit 과 같은 프레임에 겹치지 않음. **KDE Plasma 6.7.4 (KWin · scale 1.6 · GL 렌더) 실기에서도 7 케이스 전부 일치** ([#530 댓글](https://github.com/ensky0/tildaz/issues/530#issuecomment-5434640115)) — 384 px = 151 × 1.6² 로 셀 면적까지 맞는다. KDE 고유 관측 둘, 표시 동작에는 영향이 없었다: KWin 은 등록된 layout 전부를 **한 keymap** 에 담아 준다 (`layouts=[English (US), French]` — COSMIC 은 layout 마다 새 keymap); fcitx5 가 떠 있으면 **layout 제어권이 fcitx5 로 넘어가** 앱은 단일 layout keymap 을 받고 KWin 의 `getLayout` 은 `0` 을 계속 보고하므로 layout 근거로 쓸 수 없다.
 
@@ -1060,8 +1060,11 @@ macOS 의 조합 (과 조합 중 표시) 은 2026-08-27 실기로 확인했다 (
 - **launcher 의 기동 실패 안내도 세 platform 이 다이얼로그다** ([#577](https://github.com/ensky0/tildaz/issues/577)).
   launcher 는 `host.run` 을 거치지 않아 Linux 에서는 `Client` 가 아예 없고, 그래서 예전에는
   `log.userFacing` 으로 stderr + 로그에만 남겼다 — `.desktop` (메뉴 · autostart) 실행에서
-  stderr 는 어디에도 붙지 않으므로 **사용자는 아무것도 보지 못했다.** Windows
-  (`MessageBoxW`) · macOS (`NSAlert`) 는 OS 가 모달을 주므로 같은 자리에서 그냥 떴다.
+  stderr 는 어디에도 붙지 않으므로 **사용자는 아무것도 보지 못했다.** Windows (자체 다이얼로그
+  창 — window system 연결 없이도 `CreateWindow` 가 된다) · macOS (`NSAlert`) 는 같은 자리에서 그냥 떴다.
+  Windows 는 2026-09-03 실기로 확인했다 — 깨진 TOML 의 `config_9.toml` + 인자 없는 실행 (launcher 단독 실패) 에서
+  `TildaZ failed to start. / Error: CannotParseValue` 다이얼로그가 124 ms 에 뜨고 닫으면 exit 0
+  ([`dist/windows/launcher-fatal-check.ps1`](dist/windows/launcher-fatal-check.ps1) · [#577 댓글](https://github.com/ensky0/tildaz/issues/577)).
 
   Linux 는 창도 PTY 도 만들지 않고 **다이얼로그만** 세운다 (`showFatalStandalone`). dialog
   는 자기 layer-shell surface 이고 항상 `wl_shm` 이라 (GPU 불필요) Wayland 연결 + globals +
@@ -1528,7 +1531,7 @@ Configuration: missing required key "window" in (top-level).
 
 측정 인스턴스는 예외다 ([#382](https://github.com/ensky0/tildaz/issues/382)) — **일부러** 사용자 config 를 만들지 않으므로 안내도 없다.
 
-Windows는 짧은 본문을 기존 `MessageBoxW`로 표시하고 화면 또는 4096 UTF-16 변환 상한을 넘을 때만 read-only multiline EDIT window로 전환한다. macOS는 NSApplication을 config load 전에 준비해 짧은 본문은 기존 NSAlert, overflow 본문은 NSScrollView/NSTextView로 표시한다. Linux config parse는 Wayland 연결 전에 실행되므로 전체 동적 본문을 stderr + log fallback으로 출력한다. **현재 상태: 구현·자동 검증 완료, Linux · macOS · Windows 묶음 실기 대기 (#316).**
+Windows는 짧은 본문도 overflow 본문도 자체 다이얼로그 창 (`dialog/windows.zig` 의 `TildaZScrollableDialogWindow` — 아이콘 · 제목 · 구분선 · read-only EDIT 본문 · 버튼) 으로 표시하고, 본문이 화면을 넘을 때만 그 EDIT 에 세로 scroll 을 붙인다 (#540). 그 창을 만들 수 없을 때만 `MessageBoxW` 로 물러선다 (`showNative`). (#316 당시에는 짧은 본문이 `MessageBoxW` 였다 — 2026-09-03 #577 Windows 실기에서 launcher 실패 다이얼로그가 자체 창으로 뜨는 것을 보고 서술을 고쳤다.) macOS는 NSApplication을 config load 전에 준비해 짧은 본문은 기존 NSAlert, overflow 본문은 NSScrollView/NSTextView로 표시한다. Linux config parse는 Wayland 연결 전에 실행되므로 전체 동적 본문을 stderr + log fallback으로 출력한다. **현재 상태: 구현·자동 검증 완료, Linux · macOS · Windows 묶음 실기 대기 (#316).**
 
 ---
 

--- a/dist/windows/deadkey-check.ps1
+++ b/dist/windows/deadkey-check.ps1
@@ -1,0 +1,229 @@
+﻿# Windows 에서 dead key 조합이 PTY 까지 오는지 합성 입력으로 판정한다 (#494 의 Windows 몫 · #583 A3).
+# macOS 의 `dist/macos/deadkey-check.sh` 에 대응한다.
+#
+# ```powershell
+# dist\windows\deadkey-check.ps1                                   # zig-out\bin\tildaz.exe · US-International
+# dist\windows\deadkey-check.ps1 -Bin C:\path\tildaz.exe -Keep      # layout 을 세션에 남겨 둔다 (직접 쳐 볼 때)
+# ```
+#
+# 무엇을 하나 —
+# 1. `--instance 9 -e <자식.ps1>` 로 tildaz 를 띄운다. 자식은 `Read-Host` 로 줄을 N 개 받아 **UTF-8 바이트 hex** 로
+#    파일에 적고 끝난다 (자식이 끝나면 앱도 끝난다 — 정리가 자동이다). `-e` 는 stress run 이라 hotkey 도 config 도
+#    만들지 않는다. 로그는 `%APPDATA%\tildaz\tildaz_stress.log`.
+# 2. `LoadKeyboardLayoutW("00020409", 0)` 로 **US-International** 을 세션에 올린다 — `'` `` ` `` `^` `~` `"` 가 dead key 다.
+#    활성화는 하지 않고 (flags=0) `WM_INPUTLANGCHANGEREQUEST` 를 tildaz 창에 보내 **그 스레드만** 전환한다. 우리 셸도
+#    사용자의 다른 창도 layout 이 바뀌지 않는다. 전환됐는지 `GetKeyboardLayout(thread)` 로 확인하고 안 됐으면 키를 안 보낸다.
+# 3. 케이스마다 `SendInput` 으로 키를 치고 `Enter` 로 줄을 끝낸다. 키마다 **포커스 가드** — foreground 가 tildaz 창이
+#    아니면 그 자리에서 멈춘다 (`dist/stress/send-keys.ps1` 과 같은 규칙 — 합성 키는 포커스된 창으로 간다).
+# 4. 끝나면 올린 layout 을 `UnloadKeyboardLayout` 으로 내린다 (원래 세션에 있던 것이면 두고, `-Keep` 이면 남긴다).
+#    `GetKeyboardLayoutList` 를 전후로 찍어 기기 상태가 되돌아왔는지 보인다. `LoadKeyboardLayoutW` 의 부작용은
+#    프로세스보다 오래 살아 `Win+Space` 목록에 나타난다 (AGENTS.md `# Windows — 키보드 layout 조회 실측 방법`).
+#
+# 판정은 **자식이 받은 바이트**다 — macOS 판이 `cat` 으로 받은 것과 같은 자리. tildaz 가 PTY 에 쓴 것을 ConPTY 가 콘솔
+# 입력으로 바꿔 `Read-Host` 가 받으므로, dead key 가 OS (`TranslateMessage` → `WM_CHAR`) 에서 조합되어 앱을 거쳐
+# 자식까지 온전히 닿았는지가 여기서 갈린다.
+#
+# | # | 키 | 기대 | 뜻 |
+# |---|---|---|---|
+# | 1 | `'` `e` `x` | `c3 a9 78` (`éx`) | dead acute + e |
+# | 2 | `'` `Space` `x` | `27 78` (`'x`) | dead key + space = 문자 자체 |
+# | 3 | `Shift+6` (`^`) `o` `x` | `c3 b4 78` (`ôx`) | modifier 가 낀 dead key |
+# | 4 | `'` `x` | `27 78` (`'x`) | 조합 불가 — 둘 다 나와야 한다 (dead key 가 삼키면 `78` 만) |
+#
+# 실기라서 **시작 전에 알리고 동의를 받는다** (AGENTS.md `# 실행 환경`) — 창이 한 번 뜨고 합성 키가 나가며, 세션 layout
+# 목록이 잠깐 바뀐다. 회차 동안 키 · 마우스를 건드리면 포커스 가드가 멈추고, 이미 나간 키는 그 창에 들어간다.
+#
+# ⚠️ 이 파일은 UTF-8 **BOM** 으로 저장한다 (Windows PowerShell 5.1 이 BOM 없는 `.ps1` 을 cp949 로 읽는다).
+
+[CmdletBinding()]
+param(
+    [string]$Bin = "zig-out\bin\tildaz.exe",
+    # 올릴 layout 의 KLID. 기본 US-International.
+    [string]$Klid = "00020409",
+    [switch]$Keep
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class TzDead {
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x, y; }
+  public delegate bool EnumProc(IntPtr h, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref POINT p);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern int GetSystemMetrics(int i);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
+  [DllImport("user32.dll")] public static extern uint MapVirtualKeyW(uint c, uint t);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern IntPtr LoadKeyboardLayoutW(string klid, uint flags);
+  [DllImport("user32.dll")] public static extern bool UnloadKeyboardLayout(IntPtr hkl);
+  [DllImport("user32.dll")] public static extern int GetKeyboardLayoutList(int n, IntPtr[] list);
+  [DllImport("user32.dll")] public static extern IntPtr GetKeyboardLayout(uint thread);
+  [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint msg, IntPtr w, IntPtr l);
+  [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk, wScan; public uint dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx, dy; public uint mouseData, dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Explicit, Size = 40)] public struct INPUT { [FieldOffset(0)] public uint type; [FieldOffset(8)] public KEYBDINPUT ki; [FieldOffset(8)] public MOUSEINPUT mi; }
+  [DllImport("user32.dll", SetLastError = true)] public static extern uint SendInput(uint n, INPUT[] p, int cb);
+  public static IntPtr FindWindowOfPid(uint pid) {
+    IntPtr found = IntPtr.Zero;
+    EnumWindows((h, l) => {
+      uint p; GetWindowThreadProcessId(h, out p);
+      if (p != pid || !IsWindowVisible(h)) return true;
+      RECT r; if (!GetWindowRect(h, out r)) return true;
+      if (r.R - r.L < 64 || r.B - r.T < 64) return true;
+      found = h; return false;
+    }, IntPtr.Zero);
+    return found;
+  }
+  public static IntPtr[] Layouts() {
+    var a = new IntPtr[32]; int n = GetKeyboardLayoutList(32, a);
+    var r = new IntPtr[Math.Max(n, 0)]; Array.Copy(a, r, r.Length); return r;
+  }
+  public static IntPtr LayoutOfWindow(IntPtr h) { uint pid; uint tid = GetWindowThreadProcessId(h, out pid); return GetKeyboardLayout(tid); }
+  static INPUT Key(ushort vk, uint flags) { var i = new INPUT(); i.type = 1; i.ki.wVk = vk; i.ki.wScan = (ushort)MapVirtualKeyW(vk, 0); i.ki.dwFlags = flags; return i; }
+  static INPUT Mouse(int nx, int ny, uint flags) { var i = new INPUT(); i.type = 0; i.mi.dx = nx; i.mi.dy = ny; i.mi.dwFlags = flags; return i; }
+  static void Norm(int x, int y, out int nx, out int ny) {
+    int vx = GetSystemMetrics(76), vy = GetSystemMetrics(77), vw = GetSystemMetrics(78), vh = GetSystemMetrics(79);
+    nx = (int)(((long)(x - vx) * 65535) / (vw > 1 ? vw - 1 : 1)); ny = (int)(((long)(y - vy) * 65535) / (vh > 1 ? vh - 1 : 1));
+  }
+  // 앞에서부터 누르고 뒤에서부터 뗀다 — 한 글자 키는 길이 1, Shift+6 은 {Shift, 6}.
+  public static uint Chord(ushort[] vks) {
+    var a = new INPUT[vks.Length * 2]; int n = 0;
+    foreach (var v in vks) a[n++] = Key(v, 0);
+    for (int k = vks.Length - 1; k >= 0; k--) a[n++] = Key(vks[k], 2);
+    return SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+  }
+  public static bool Focus(IntPtr h) {
+    if (GetForegroundWindow() == h) return true;
+    SetForegroundWindow(h); System.Threading.Thread.Sleep(300);
+    if (GetForegroundWindow() == h) return true;
+    RECT r; GetClientRect(h, out r);
+    var p = new POINT(); p.x = (r.R - r.L) / 2; p.y = (r.B - r.T) / 2; ClientToScreen(h, ref p);
+    POINT before; bool hc = GetCursorPos(out before);
+    int nx, ny; Norm(p.x, p.y, out nx, out ny);
+    uint mv = 0x0001 | 0x8000 | 0x4000;
+    var a = new INPUT[] { Mouse(nx, ny, mv), Mouse(nx, ny, mv | 0x0002), Mouse(nx, ny, mv | 0x0004) };
+    SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+    System.Threading.Thread.Sleep(300);
+    if (hc) { int bx, by; Norm(before.x, before.y, out bx, out by); var m = new INPUT[] { Mouse(bx, by, mv) }; SendInput(1, m, Marshal.SizeOf(typeof(INPUT))); }
+    return GetForegroundWindow() == h;
+  }
+}
+"@
+
+$VK = @{ Apos = 0xDE; e = 0x45; o = 0x4F; x = 0x58; Space = 0x20; Enter = 0x0D; Shift = 0x10; D6 = 0x36 }
+# 케이스 — 이름 · 키 목록 (chord 는 배열) · 기대 hex
+$cases = @(
+    @{ name = "' e x";        keys = @(@($VK.Apos), @($VK.e), @($VK.x));                 expect = "c3 a9 78" },
+    @{ name = "' Space x";    keys = @(@($VK.Apos), @($VK.Space), @($VK.x));             expect = "27 78" },
+    @{ name = "Shift+6 o x";  keys = @(@($VK.Shift, $VK.D6), @($VK.o), @($VK.x));        expect = "c3 b4 78" },
+    @{ name = "' x";          keys = @(@($VK.Apos), @($VK.x));                           expect = "27 78" }
+)
+
+$Out = Join-Path $env:TEMP "tildaz-deadkey"
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+$result = Join-Path $Out "received.txt"
+Remove-Item $result -Force -ErrorAction SilentlyContinue
+$child = Join-Path $Out "child.ps1"
+# 자식 — 줄을 N 개 받아 UTF-8 hex 로 적는다. Read-Host 는 콘솔 입력을 UTF-16 으로 받으므로 인코딩 설정이 필요 없다.
+$childBody = @'
+param([string]$Out, [int]$N)
+$lines = @()
+for ($i = 0; $i -lt $N; $i++) {
+    $s = Read-Host
+    $lines += ((([Text.Encoding]::UTF8.GetBytes($s)) | ForEach-Object { $_.ToString("x2") }) -join " ")
+}
+[IO.File]::WriteAllLines($Out, $lines)
+'@
+[IO.File]::WriteAllText($child, $childBody, (New-Object System.Text.UTF8Encoding $true))
+
+if (-not (Test-Path $Bin)) { throw "바이너리 없음: $Bin" }
+$before = [TzDead]::Layouts()
+"세션 layout (전): " + (($before | ForEach-Object { '0x{0:x8}' -f [int64]$_ }) -join ' ')
+
+# 인스턴스 9 만 내린다.
+function Stop-Tz {
+    Get-CimInstance Win32_Process -Filter "Name like 'tildaz%'" |
+        Where-Object { $_.CommandLine -match '--instance 9' } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+}
+Stop-Tz
+$cmd = "powershell -NoProfile -ExecutionPolicy Bypass -File `"$child`" `"$result`" $($cases.Count)"
+$p = Start-Process -FilePath (Resolve-Path $Bin) -PassThru -ArgumentList '--instance', '9', '-e', "`"$cmd`""
+$h = [IntPtr]::Zero
+$sw = [Diagnostics.Stopwatch]::StartNew()
+while ($h -eq [IntPtr]::Zero -and $sw.ElapsedMilliseconds -lt 10000) {
+    Start-Sleep -Milliseconds 100
+    if ($p.HasExited) { break }
+    $h = [TzDead]::FindWindowOfPid([uint32]$p.Id)
+}
+if ($p.HasExited) { throw "앱이 먼저 끝남 exit=$($p.ExitCode)" }
+if ($h -eq [IntPtr]::Zero) { Stop-Tz; throw "창 못 찾음" }
+Start-Sleep -Seconds 2   # 자식 PowerShell 이 Read-Host 에 닿을 시간
+
+$hkl = [TzDead]::LoadKeyboardLayoutW($Klid, 0)
+if ($hkl -eq [IntPtr]::Zero) { Stop-Tz; throw "LoadKeyboardLayoutW($Klid) 실패" }
+$loadedByUs = -not ($before -contains $hkl)
+"layout $Klid → hkl 0x{0:x8} (이번에 올림: {1})" -f [int64]$hkl, $loadedByUs
+
+$ok = $true
+$sent = 0
+try {
+    if (-not [TzDead]::Focus($h)) { throw "tildaz 창을 활성으로 못 만들었다 — 키를 보내지 않는다" }
+    # 그 창의 스레드만 layout 전환. DefWindowProc 이 WM_INPUTLANGCHANGEREQUEST 를 받아 ActivateKeyboardLayout 한다.
+    [void][TzDead]::PostMessageW($h, 0x0050, [IntPtr]::Zero, $hkl)
+    Start-Sleep -Milliseconds 400
+    $now = [TzDead]::LayoutOfWindow($h)
+    "tildaz 창의 layout: 0x{0:x8}" -f [int64]$now
+    if ($now -ne $hkl) { throw "창의 layout 이 바뀌지 않았다 — 키를 보내지 않는다" }
+
+    foreach ($c in $cases) {
+        foreach ($chord in $c.keys) {
+            if ([TzDead]::GetForegroundWindow() -ne $h) { throw "포커스를 잃었다 (케이스 '$($c.name)') — 중단" }
+            [void][TzDead]::Chord([uint16[]]$chord)
+            Start-Sleep -Milliseconds 120
+        }
+        [void][TzDead]::Chord([uint16[]]@($VK.Enter))
+        $sent++
+        Start-Sleep -Milliseconds 300
+    }
+    # 자식이 N 줄을 받고 끝나면 앱도 끝난다.
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    while (-not $p.HasExited -and $sw.ElapsedMilliseconds -lt 8000) { Start-Sleep -Milliseconds 200 }
+    if (-not $p.HasExited) { "앱이 스스로 끝나지 않았다 — 자식이 줄을 다 못 받았을 수 있다"; $ok = $false }
+} catch {
+    "❌ $_"; $ok = $false
+} finally {
+    Stop-Tz
+    if (-not $Keep -and $loadedByUs) {
+        $u = [TzDead]::UnloadKeyboardLayout($hkl)
+        "layout 내림: $u"
+    }
+    $after = [TzDead]::Layouts()
+    "세션 layout (후): " + (($after | ForEach-Object { '0x{0:x8}' -f [int64]$_ }) -join ' ')
+}
+
+""
+if (Test-Path $result) {
+    $got = Get-Content $result
+    $i = 0
+    foreach ($c in $cases) {
+        $g = if ($i -lt $got.Count) { $got[$i] } else { "(없음)" }
+        $mark = if ($g -eq $c.expect) { "OK  " } else { "FAIL" }
+        "{0} {1,-14} 기대 [{2}]  받음 [{3}]" -f $mark, $c.name, $c.expect, $g
+        if ($g -ne $c.expect) { $ok = $false }
+        $i++
+    }
+} else {
+    "❌ 자식이 결과 파일을 남기지 않았다 ($result)"; $ok = $false
+}
+"보낸 줄 $sent / $($cases.Count) · 결과: $result · 로그: $env:APPDATA\tildaz\tildaz_stress.log"
+if ($ok) { "결과: 전부 OK" } else { "결과: 실패 있음" }

--- a/dist/windows/launcher-fatal-check.ps1
+++ b/dist/windows/launcher-fatal-check.ps1
@@ -1,0 +1,139 @@
+﻿# Windows 에서 **launcher 단독 실패** 가 다이얼로그로 알려지고 크래시가 없는지 본다 (#577 의 Windows 몫 · #583 A2).
+#
+# ```powershell
+# dist\windows\launcher-fatal-check.ps1                          # zig-out\bin\tildaz.exe
+# dist\windows\launcher-fatal-check.ps1 -Bin C:\path\tildaz.exe
+# ```
+#
+# 무엇을 재나 — `showFatalRunError(rt, …)` 가 **launcher 경로**에서 실행되는 자리다. #577 이 서명을 바꾸기 전에는
+# 그 함수가 `g_rt` 를 읽었는데 그 값은 `run()` 안에서만 심어지고 launcher 실패 경로는 `run()` 을 거치지 않아
+# **`undefined` 를 읽고 있었다.** macOS 회차 (2026-09-02) 는 worker 가 다이얼로그를 띄우는 경로여서 이 자리를 확정하지
+# 못했다 — worker 가 스스로 안내를 띄우면 launcher 는 조용히 물러나도록 설계돼 있기 때문이다.
+#
+# launcher 단독 실패를 만드는 법 — **TOML 문법이 깨진 `config_9.toml`** 을 두고 launcher (인자 없는 `tildaz.exe`) 를 띄운다.
+# `runLauncher` 는 spawn 전에 모든 index 의 config 를 `instances.configAutoStart` 로 읽고 (auto_start 집계), 그 파서
+# 오류는 **그대로 전파**된다 (#495 — `InvalidConfig` 로 뭉개면 원인이 안 보인다). 그래서 worker 는 뜨지도 않고 launcher 가
+# `main.zig` 의 `catch |err| host.showFatalRunError(rt, …, err)` 로 간다 — 기대 다이얼로그는 `TildaZ Error` /
+# `TildaZ failed to start.  Error: UnexpectedToken`. 그 실패는 `autostart.enable/disable` **앞**이라 사용자의 자동 시작 설정도,
+# 떠 있는 instance 0 도 건드리지 않는다 (launcher_lock · gate 는 defer 로 풀린다).
+#
+# 판정 — ① 그 프로세스의 `#32770` (MessageBox) 창이 뜬다 ② 제목 · 본문이 위 문구다 ③ 닫으면 (`WM_CLOSE`) 프로세스가
+# 끝난다 (다이얼로그 없이 사라졌으면 크래시 의심). 캡처는 PrintWindow 로 남긴다. 끝나면 `config_9.toml` 을 지운다 —
+# 있던 파일이면 시작 자체를 거부한다 (사용자 설정을 덮지 않는다).
+#
+# 곁가지 — 이 문구가 거친 것 (`UnexpectedToken` 만 · 줄 · 열 없음) 은 #583 B7 이고 이 검증의 범위 밖이다.
+#
+# 실기라서 시작 전에 알린다 — 다이얼로그가 한 번 뜨고 스크립트가 닫는다. launcher 가 `tildaz_0.log` (사용자 instance 의 로그)
+# 에 `[fatal]` 한 줄을 남긴다 — 진단 채널이라 그대로 둔다.
+#
+# ⚠️ 이 파일은 UTF-8 **BOM** 으로 저장한다 (Windows PowerShell 5.1 이 BOM 없는 `.ps1` 을 cp949 로 읽는다).
+
+[CmdletBinding()]
+param(
+    [string]$Bin = "zig-out\bin\tildaz.exe"
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+Add-Type -AssemblyName System.Drawing
+Add-Type -ReferencedAssemblies System.Drawing @"
+using System;
+using System.Text;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+public static class TzFatal {
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  public delegate bool EnumProc(IntPtr h, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool EnumChildWindows(IntPtr parent, EnumProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassNameW(IntPtr h, StringBuilder s, int n);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetWindowTextW(IntPtr h, StringBuilder s, int n);
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr hdc, uint flags);
+  [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint msg, IntPtr w, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr v);
+  public static void MakeDpiAware() { try { SetProcessDpiAwarenessContext(new IntPtr(-4)); } catch {} }
+  public static string ClassOf(IntPtr h) { var s = new StringBuilder(256); GetClassNameW(h, s, 256); return s.ToString(); }
+  public static string TextOf(IntPtr h) { var s = new StringBuilder(4096); GetWindowTextW(h, s, 4096); return s.ToString(); }
+  // pid 의 보이는 최상위 창 — 크기 조건 없음 (MessageBox 는 작다).
+  public static IntPtr FindWindowOfPid(uint pid) {
+    IntPtr found = IntPtr.Zero;
+    EnumWindows((h, l) => {
+      uint p; GetWindowThreadProcessId(h, out p);
+      if (p != pid || !IsWindowVisible(h)) return true;
+      RECT r; if (!GetWindowRect(h, out r)) return true;
+      if (r.R - r.L < 16 || r.B - r.T < 16) return true;
+      found = h; return false;
+    }, IntPtr.Zero);
+    return found;
+  }
+  // 자식 컨트롤의 텍스트를 모두 이어 붙인다 — MessageBox 본문은 Static 컨트롤이다.
+  public static string ChildTexts(IntPtr h) {
+    var sb = new StringBuilder();
+    EnumChildWindows(h, (c, l) => { var t = TextOf(c); if (t.Length > 0) { sb.Append('[').Append(ClassOf(c)).Append("] ").Append(t.Replace("\r\n", "⏎").Replace("\n", "⏎")).Append("  "); } return true; }, IntPtr.Zero);
+    return sb.ToString();
+  }
+  public static void Capture(IntPtr h, string png) {
+    RECT r; GetWindowRect(h, out r);
+    using (var bmp = new Bitmap(r.R - r.L, r.B - r.T, PixelFormat.Format32bppArgb)) {
+      using (var g = Graphics.FromImage(bmp)) { IntPtr hdc = g.GetHdc(); PrintWindow(h, hdc, 2); g.ReleaseHdc(hdc); }
+      bmp.Save(png, ImageFormat.Png);
+    }
+  }
+}
+"@
+[TzFatal]::MakeDpiAware()
+
+if (-not (Test-Path $Bin)) { throw "바이너리 없음: $Bin" }
+$c9 = Join-Path $env:APPDATA "tildaz\config_9.toml"
+if (Test-Path $c9) { throw "config_9.toml 이 이미 있다 — 사용자 설정일 수 있어 덮지 않는다: $c9" }
+$Out = Join-Path $env:TEMP "tildaz-launcher-fatal"
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+$log0 = Join-Path $env:APPDATA "tildaz\tildaz_0.log"
+$logLinesBefore = if (Test-Path $log0) { (Get-Content $log0 -Encoding UTF8).Count } else { 0 }
+
+# TOML 문법 오류 — `= =` 는 UnexpectedToken.
+[IO.File]::WriteAllText($c9, "hotkey = = `"F9`"`n", (New-Object System.Text.UTF8Encoding $false))
+$ok = $true
+try {
+    $p = Start-Process -FilePath (Resolve-Path $Bin) -PassThru      # 인자 없음 = launcher
+    $h = [IntPtr]::Zero
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    while ($h -eq [IntPtr]::Zero -and $sw.ElapsedMilliseconds -lt 15000) {
+        Start-Sleep -Milliseconds 100
+        if ($p.HasExited) { break }
+        $h = [TzFatal]::FindWindowOfPid([uint32]$p.Id)
+    }
+    if ($h -eq [IntPtr]::Zero) {
+        if ($p.HasExited) { "❌ 다이얼로그 없이 프로세스가 끝났다 (exit=$($p.ExitCode)) — 크래시 또는 조용한 실패" }
+        else { "❌ 15 초 안에 창이 뜨지 않았다"; Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        $ok = $false
+    } else {
+        $cls = [TzFatal]::ClassOf($h); $title = [TzFatal]::TextOf($h); $body = [TzFatal]::ChildTexts($h)
+        "다이얼로그 뜸 ({0:N0} ms) · class={1} · title=[{2}]" -f $sw.ElapsedMilliseconds, $cls, $title
+        "본문: $body"
+        $png = Join-Path $Out "dialog.png"; [TzFatal]::Capture($h, $png); "캡처: $png"
+        # 앱의 error 다이얼로그는 `dialog/windows.zig` 의 자체 창 (`TildaZScrollableDialogWindow` — 본문을 직접 그려 자식
+        # 컨트롤로는 제목 Static 과 OK Button 만 보인다) 이거나 짧은 경로의 MessageBox (`#32770`) 다. 본문 문구는 캡처와
+        # 로그 (`[fatal] run failed: <err>`) 로 확인한다.
+        if ($cls -ne "#32770" -and $cls -ne "TildaZScrollableDialogWindow") { "❌ 앱 다이얼로그 창이 아니다 (class=$cls)"; $ok = $false }
+        if ($title -ne "TildaZ Error") { "❌ 제목이 'TildaZ Error' 가 아니다"; $ok = $false }
+        [void][TzFatal]::PostMessageW($h, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero)   # WM_CLOSE
+        $sw2 = [Diagnostics.Stopwatch]::StartNew()
+        while (-not $p.HasExited -and $sw2.ElapsedMilliseconds -lt 5000) { Start-Sleep -Milliseconds 100 }
+        if ($p.HasExited) { "닫은 뒤 프로세스 종료 exit=$($p.ExitCode) ({0} ms)" -f $sw2.ElapsedMilliseconds }
+        else { "❌ 다이얼로그를 닫았는데 프로세스가 남아 있다"; Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue; $ok = $false }
+    }
+} finally {
+    Remove-Item $c9 -Force -ErrorAction SilentlyContinue
+    "config_9.toml 지움: $(-not (Test-Path $c9))"
+}
+if (Test-Path $log0) {
+    $new = Get-Content $log0 -Encoding UTF8 | Select-Object -Skip $logLinesBefore
+    "tildaz_0.log 에 새로 남은 줄 ($($new.Count)):"
+    $new | ForEach-Object { "  " + ($_ -replace '^\[[^\]]+\]\s*', '') }
+}
+if ($ok) { "결과: OK — launcher 단독 실패가 다이얼로그로 알려지고 크래시 없음" } else { "결과: 실패 있음" }


### PR DESCRIPTION
[#583](https://github.com/ensky0/tildaz/issues/583) **A2 · A3 의 Windows 몫.** #494 (dead key) · #577 (launcher 실패 다이얼로그) 이 *"Windows 는 코드 판정 · 실기 미확인"* 으로 남긴 두 자리를 합성 입력으로 재는 도구를 두고, 이 기기 (노트북 LENOVO 83JY · AMD Ryzen AI 7 350 · Windows 11 Pro 26200 · main `8ccc8bc`) 에서 확인한 결과를 SPEC 에 적습니다.

## 도구

| | |
|---|---|
| `dist/windows/deadkey-check.ps1` | US-International (`00020409`) 을 `LoadKeyboardLayoutW(…, 0)` 로 세션에 올리고 `WM_INPUTLANGCHANGEREQUEST` 로 **tildaz 창의 스레드만** 전환 → `SendInput` 으로 네 케이스 → 자식 (`Read-Host`) 이 받은 UTF-8 바이트로 판정 → `UnloadKeyboardLayout`. 세션 layout 목록 전후를 찍어 원복을 보입니다. macOS `deadkey-check.sh` 대응 |
| `dist/windows/launcher-fatal-check.ps1` | TOML 이 깨진 `config_9.toml` 을 두고 **인자 없는 `tildaz.exe` (launcher)** 를 띄웁니다 — `runLauncher` 가 spawn 전에 `configAutoStart` 로 모든 config 를 읽고 파서 오류를 그대로 전파하므로 worker 없이 `showFatalRunError(rt, …)` 로 가는 **launcher 단독 실패**입니다 (macOS 회차는 worker 가 띄우는 경로여서 이 자리를 확정하지 못했습니다). 다이얼로그 캡처 · `WM_CLOSE` 뒤 exit code · 로그를 봅니다. `config_9.toml` 이 이미 있으면 거부 |

## 결과

**dead key** (#494)

| # | 키 | 기대 | 받음 |
|---|---|---|---|
| 1 | `'` `e` `x` | `c3 a9 78` (`éx`) | ✅ 일치 |
| 2 | `'` `Space` `x` | `27 78` (`'x`) | ✅ |
| 3 | `Shift+6` (`^`) `o` `x` | `c3 b4 78` (`ôx`) | ✅ |
| 4 | `'` `x` (조합 불가) | `27 78` (`'x`) | ✅ — dead key 를 삼키지 않는다 |

**launcher 단독 실패** (#577) — 다이얼로그 `TildaZ Error` / `TildaZ failed to start.` / `Error: CannotParseValue` 가 **124 ms** 에 뜨고, 닫으면 **exit 0** (크래시 없음). `tildaz_0.log` 에 `[fatal] run failed: CannotParseValue` 한 줄. 예전 `undefined g_rt` 자리가 Windows 에서 닫힌 것을 확인했습니다.

## 문서

- SPEC §5.3 — Windows dead key 를 실기 확인으로. 조합 중 표시가 없는 것 (#583 B4) 은 그대로.
- SPEC #577 절 — Windows 실기 한 줄.
- SPEC #316 절 — *"Windows 는 짧은 본문을 `MessageBoxW` 로"* 가 현행과 어긋났습니다 (`dialog/windows.zig` 의 `show` 는 짧은 본문도 자체 창 `TildaZScrollableDialogWindow` 를 먼저 쓰고 실패 시에만 `showNative` → `MessageBoxW`). 이번 실기에서 launcher 다이얼로그가 자체 창으로 뜨는 것을 보고 고쳤습니다.
- AGENTS.md — 두 도구의 절과 함정 (앱 다이얼로그가 `#32770` 이 아니라 첫 회차가 거짓 FAIL · layout 은 창 하나만 전환 · Read-Host 자식 · `-e` 는 명령줄 통째).

코드 변경 없음 (문서 · 스크립트만). 실기는 각각 1 회, 사용자 동의 뒤 진행.

Refs #583 #494 #577