### PR TITLE
fix(windows): dead key 조합 중 표시 · kitty report_all 글자 키를 인코더로 (#530 · #602 — #583 B4 · B5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,6 +706,7 @@ macOS 의 `deadkey-check.sh` 에 대응하는 도구 둘이에요 ([#583](https:
 |---|---|
 | [`dist/windows/deadkey-check.ps1`](dist/windows/deadkey-check.ps1) | US-International (`00020409`) 을 올리고 `'`+`e` 등 네 케이스를 `SendInput` 으로 쳐 자식이 받은 UTF-8 바이트로 판정 (#494) |
 | [`dist/windows/launcher-fatal-check.ps1`](dist/windows/launcher-fatal-check.ps1) | TOML 이 깨진 `config_9.toml` 을 두고 인자 없는 `tildaz.exe` (launcher) 를 띄워 `TildaZ failed to start` 다이얼로그가 뜨고 닫으면 exit 0 인지 (#577 의 `showFatalRunError(rt, …)` 자리) |
+| [`dist/windows/kitty-text-check.ps1`](dist/windows/kitty-text-check.ps1) | kitty keyboard protocol 을 flags 11 · 1 로 켠 채 `a` · `Shift+a` · `Space` · `Enter` · dead key 를 쳐 **앱이 PTY 에 쓴 바이트**를 판정 (#602). 자식 (Python) 이 `ENABLE_VIRTUAL_TERMINAL_INPUT` 으로 raw 바이트를 받는다 — `Read-Host` 로는 `CSI u` 를 볼 수 없다 |
 
 ```powershell
 dist\windows\deadkey-check.ps1 -Bin zig-out\bin\tildaz.exe          # 창 1 회 · 합성 키 · layout 잠깐
@@ -731,6 +732,19 @@ dist\windows\launcher-fatal-check.ps1 -Bin zig-out\bin\tildaz.exe   # 다이얼�
   띄우는 경로 (macOS 2026-09-02 회차) 로는 이 자리를 못 가르니까요. 그 실패는 `autostart.enable/disable` **앞**이라 사용자의
   자동 시작 설정도 떠 있는 instance 0 도 그대로예요. 다만 launcher 는 `tildaz_0.log` 에 `[fatal]` 한 줄을 남겨요. `config_9.toml`
   이 이미 있으면 도구가 시작을 거부해요 — 사용자 설정을 덮지 않아요.
+- **`deadkey-check.ps1 -Capture`** 는 dead key 직후와 조합 직후 창을 찍어 preedit 색 (`64,64,128` · ±2) 픽셀을 세요 — #530 의
+  Windows 표시 판정이에요 (기대 `>0` → `0`). 2026-09-03 실측 374 → 0.
+- **PowerShell 은 원소가 하나인 배열을 평탄화해요** — `@(@($Shift, $A))` 는 `@(16, 65)` 가 되어 chord 가 **키 두 개를 따로**
+  누르는 것으로 바뀌어요 (2026-09-03: `Shift+a` 가 `a` 로 나와 앱 결함으로 보일 뻔했어요). chord 는 `,@(…)` (단항 콤마) 로
+  감싸요. 원소가 둘 이상인 배열은 그대로 남아서 `deadkey-check` 의 `Shift+6` 은 우연히 살아남았어요.
+- **다른 창이 tildaz 창을 덮고 있으면 `SetForegroundWindow` 도 창 중앙 클릭도 안 닿아요** — 사용자가 브라우저를 앞에 두고
+  머지하던 회차에서 포커스 가드가 막았어요. 도구들은 잠깐 `HWND_TOPMOST` 로 올려 활성화하고 끝나면 내려요.
+- **`ToUnicodeEx` 는 상태 불변 플래그 (bit 2) 로 부르면 dead key 에도 글자 (`'`) 를 돌려줘요** — 반환값으로 dead key 를
+  가를 수 없어요. 그래서 `report_all` 에서 dead key 누름도 인코더로 가 `CSI 39 u` 가 나가요 (kitty 도 dead key 누름을 보고하니
+  무해) — 다만 그때 세운 "짝꿍 `WM_CHAR` 삼킴" 은 `WM_DEADCHAR` 가 소비해야 다음 글자가 안 삼켜져요 (#602 2 회차에서 `é` 가
+  사라졌던 원인).
+- **화면 보호기가 켜져 있으면 foreground 창이 없고 합성 키는 화면 보호기로 가요.** 실기 전에 `SystemParametersInfo
+  (SPI_GETSCREENSAVERRUNNING)` 과 `GetForegroundWindow` 를 봐요 — 사용자 부재 중에는 돌리지 않아요.
 
 # Windows — 키보드 layout 조회 실측 방법
 
@@ -1245,6 +1259,13 @@ magick /tmp/site.png -crop 1280x1000+0+3350 +repage /tmp/crop.png    # 볼 절�
 는 `tail` 이 성공하면 "OK" 를 찍어요 — 빌드가 실패해도요. 통과를 보고하기 전에 **실제 성공 표식**을 봐요:
 `set -o pipefail`, 또는 `zig build check; echo "CHECK=$?"` 처럼 exit code 를 따로 찍기, 또는 `${PIPESTATUS[0]}`.
 `| tail && echo OK` 로 가짜 통과를 보고한 적이 있어요.
+
+**Bash 도구의 작업 디렉터리는 앞 호출의 `cd` 가 그대로 남아요 — 검증 명령은 저장소 경로를 명시해요.**
+2026-09-03 에 문서용 worktree 로 `cd` 한 호출 뒤에 `zig build check` · `zig build test` 를 돌렸는데, 그것이
+**검증하려던 브랜치가 아니라 그 worktree (다른 브랜치) 에서 돌았어요.** 출력만 보면 통과라 알아채지 못했고,
+그 worktree 에 `zig-out/test` 가 생긴 것으로 뒤늦게 드러났어요 (이슈 댓글 두 곳을 정정했어요). 검증 · 커밋 · push 처럼
+어디서 도는지가 결과를 바꾸는 명령은 `cd /c/Users/<user>/tildaz && …` 로 시작하거나 `git -C` 를 써요. 백그라운드
+호출은 cwd 를 바꾸지 않지만 (도구가 알려 줘요) 동기 호출의 `cd` 는 다음 호출까지 살아요.
 
 # 실행 환경
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -177,8 +177,11 @@ too. If no Compose file is installed at all (the `libx11-data` package on Debian
 and Ubuntu), dead keys stay silent and the log says so: `compose table
 unavailable`.
 
-macOS and Windows are not affected — the OS combines dead keys before TildaZ
-sees the text.
+On macOS and Windows the OS combines dead keys before TildaZ sees the text, and
+both show the pending accent highlighted at the cursor the same way. One
+difference: on Windows the pending accent stays through a tab or pane switch,
+because Windows itself holds the dead-key state and will still combine it with
+the next letter.
 
 ### macOS
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -621,6 +621,8 @@ Windows 실측).
 손대지 않는다** — 그 규격은 주 키 코드가 배열의 코드포인트이고 US 기준 키는 `report_alternates`
 를 요청한 앱에만 alternate 로 준다 (실측: `^[[12618;5u`, 플래그 5 면 `^[[12618::99;5u`).
 
+**Windows 의 글자 키는 kitty `report_all` 에서만 인코더를 지난다** ([#602](https://github.com/ensky0/tildaz/issues/602), 2026-09-03). Windows 는 글자를 `WM_CHAR` 로 따로 받아 그 경로가 legacy 텍스트를 내는데, `report_all` 이 꺼진 kitty 에서는 인코더도 수식키 없는 인쇄 글자를 텍스트 그대로 내므로 (ghostty `kitty()` 의 `plain_text` 분기) 결과가 같다 — #533 이 검증한 `disambiguate` 모드는 그대로다. `report_all` 이면 `WM_KEYDOWN` 에서 글자 (와 Enter · Tab · Backspace · Escape) 를 인코더로 보내고 짝꿍 `WM_CHAR` 를 삼킨다. 실측 (노트북 Ryzen AI 7 350 · flags 11): `a` → `CSI 97 u` · `Shift+a` → `CSI 97;2 u` · `Space` → `CSI 32 u` · `Enter` → `CSI 13 u` — 뗌은 `CSI <cp>;<mods>:3 u`. dead key 는 누름이 `CSI 39 u` 로 보고되고 조합 결과 `é` 는 텍스트 (`c3 a9`) 로 온다 (`ToUnicodeEx` 는 상태 불변 플래그로 dead key 에도 글자를 돌려주므로 누름을 가를 수 없다 — kitty 자체도 dead key 누름을 보고한다; 그때 세운 `WM_CHAR` 삼킴은 `WM_DEADCHAR` 가 소비한다). 제외 — IME 조합 중 · dead key 대기 중 (#530 의 표시 상태) · `Ctrl` (위 블록). **modifier 단독 누름 (`Shift` 만) 은 Windows 가 보고하지 않는다** — Linux 는 모든 키가 인코더를 지나 `CSI 57441 u` 를 낸다. 넣을지는 결정 대기. 검증 도구 [`dist/windows/kitty-text-check.ps1`](dist/windows/kitty-text-check.ps1).
+
 ### 2.7 Key repeat (길게 누름 반복)
 
 | 항목 | Windows | macOS | Linux | Win | Mac | Linux |
@@ -907,7 +909,7 @@ dead key (`^` `¨` `´` `` ` `` `~` — 프랑스어 · 독일어 · 스페인�
 | platform | 조합 주체 | 경로 |
 |---|---|---|
 | macOS | OS — 조합 중 `ˆ` 를 marked text 로 **보여 준다** (2026-08-27 실기: ABC + `Option+i`, `setMarkedText:` → preedit 렌더) | `interpretKeyEvents:` — AppKit 텍스트 입력 시스템이 dead key 상태를 든다 |
-| Windows | OS — 조합 중 표시 **없음** (`WM_DEADCHAR` 를 그리는 코드가 없다 — 코드 확정). 조합 자체는 2026-09-03 실기로 확인 (US-International · `'`+`e` → `é`, `Shift+6`+`o` → `ô`, `'`+space → `'`, `'`+`x` → `'x` — 조합 불가도 dead key 를 삼키지 않는다) | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
+| Windows | OS — 조합 중 `´` 를 **보여 준다** ([#530](https://github.com/ensky0/tildaz/issues/530) 2026-09-03: `WM_DEADCHAR` 의 `wParam` 을 IME preedit 과 같은 자리 · 같은 모양으로. 실기 — 표시 중 preedit 색 픽셀 374 → 조합 뒤 0). 조합 자체는 2026-09-03 실기로 확인 (US-International · `'`+`e` → `é`, `Shift+6`+`o` → `ô`, `'`+space → `'`, `'`+`x` → `'x` — 조합 불가도 dead key 를 삼키지 않는다) | `TranslateMessage` → `WM_CHAR`. `ToUnicode` 가 상태를 든다 |
 | **Linux** | **tildaz** — #530 부터 조합 중 표시도 한다 | libxkbcommon **Compose** (`xkb_compose_state_feed`) — [`xkb.zig`](src/host/linux/xkb.zig) `Keyboard.composeFeed`. #494 전에는 `xkb_state_key_get_utf8` 만 있어 dead key 가 **빈 문자열** = 아무것도 보내지 않았다 |
 
 Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496 과 같은 뿌리). 규칙:
@@ -920,7 +922,10 @@ Linux 만 앱이 keysym → 글자 변환을 스스로 하기 때문이다 (#496
     - **키보드도 같은 결과다.** `processKeyEvent` 의 `defer` 가 compose 를 거치지 않은 키마다 이미 버리므로 (위 · 아래 규칙), 마우스와 갈리지 않는다. 그래서 *바뀌지 않는* 경우까지 대칭이다 — 이미 활성인 탭을 클릭해도 (`Alt+1` 을 그 탭에서 누른 것과 같이) 버리고, 새 탭이 32 개 한도에 걸려 dialog 로 되돌아가도 (`Ctrl+Shift+T` 와 같이) 버린다.
     - **활성 pane 안을 클릭하는 것은 해당 없다** — 셸이 그대로다 (`focusPaneUnderPointer` 가 같은 pane 이면 `false` 로 빠진다). 커서를 놓으려는 평범한 터미널 클릭이 조합을 깨지 않는다.
     - **자식 셸이 스스로 끝나서 활성 pane 이 바뀌는 경우 (`drainExitedTabs`) 는 이 규칙 밖이다 — 확인 필요.** 사용자 동작이 아니라 PTY 종료가 원인이고, 그 자리에서는 IME preedit 을 *확정* 하는 것이 옳은지부터 갈린다 (확정 대상 셸이 이미 죽었다). 조합 중에 활성 pane 의 셸이 스스로 끝나면 조합이 형제 pane 으로 따라갈 수 있다 — 미검증.
-    - **macOS · Windows 는 해당 없음** — 조합 주체가 OS 라 앱이 들고 있는 상태가 없다 (`grep -c compose` = 0).
+    - **macOS 는 해당 없음** — 조합 주체가 OS 라 앱이 들고 있는 상태가 없다. **Windows 는 표시만 들고 있다** (#530 — `compose_preview`)
+      **— 상태는 OS (스레드 키보드 상태) 가 들므로 탭 · pane 전환 · 포커스 이탈에 표시를 지우지 않는다.** 지우면 상태와 어긋난다
+      (전환 뒤 다음 글자가 그대로 조합된다). 표시는 다음 `WM_CHAR` (조합 결과든 조합 불가의 두 글자든) 가 지우고, 새 dead key 가
+      바꾼다. OS 상태까지 버릴지 (`ToUnicodeEx` 를 상태 변경으로 한 번 불러 소비) 는 결정 대기.
 - **compose 를 거치지 않은 키가 끼면 조합을 버린다** (`composeReset`). `^` → Enter → `e` 는 `\r` `e` 다. modifier 키 자체 (Shift 를 누르는 것) 는 libxkbcommon 이 IGNORED 로 받아 상태를 지킨다 — `^` → Shift+`e` → `Ê`.
 - 상태별 동작: `NOTHING` → 기존 utf8 경로 · `COMPOSING` → 아무것도 안 보냄 · `COMPOSED` → 결과 바이트 · `CANCELLED` (`^` 다음 `x`) → **둘 다 버림**. X11 · xterm 관례다 — GTK 만 `^x` 를 내는데 Compose 표 밖의 별도 규칙이라 채택하지 않았다.
 - key repeat 은 press 와 같은 경로라 `^` 를 누르고 있으면 `<dead_circumflex><dead_circumflex>` → `^` 가 두 번마다 하나 — X 앱과 같다.

--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -20,3 +20,6 @@ Internal changes belong in neither.
 ## Upgrade notes
 
 ## Body candidates
+
+- Windows now shows the pending dead key (for example `´`) highlighted at the cursor until the next key, as macOS and Linux already did ([#530](https://github.com/ensky0/tildaz/issues/530)).
+- Windows: programs that enable the kitty keyboard protocol with "report all keys" now receive letters, Enter, Tab, Backspace and Escape as `CSI u` sequences, matching macOS and Linux ([#602](https://github.com/ensky0/tildaz/issues/602)).

--- a/dist/windows/deadkey-check.ps1
+++ b/dist/windows/deadkey-check.ps1
@@ -40,15 +40,38 @@ param(
     [string]$Bin = "zig-out\bin\tildaz.exe",
     # 올릴 layout 의 KLID. 기본 US-International.
     [string]$Klid = "00020409",
-    [switch]$Keep
+    [switch]$Keep,
+    # #530 — 첫 케이스의 dead key 직후와 조합 직후 창을 찍어 preedit 색 (64,64,128) 픽셀을 센다.
+    [switch]$Capture
 )
 
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
-Add-Type @"
+Add-Type -AssemblyName System.Drawing
+Add-Type -ReferencedAssemblies System.Drawing @"
 using System;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 public static class TzDead {
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr hdc, uint flags);
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr v);
+  public static void MakeDpiAware() { try { SetProcessDpiAwarenessContext(new IntPtr(-4)); } catch {} }
+  // 창을 찍어 저장하고 (r,g,b) ±tol 인 픽셀 수를 돌려준다 — preedit 배경 (0.25,0.25,0.5 → 64,64,128) 계수용.
+  public static long CaptureCount(IntPtr h, string png, int r, int g, int b, int tol) {
+    RECT rc; GetWindowRect(h, out rc);
+    using (var bmp = new Bitmap(rc.R - rc.L, rc.B - rc.T, PixelFormat.Format32bppArgb)) {
+      using (var gr = Graphics.FromImage(bmp)) { IntPtr hdc = gr.GetHdc(); PrintWindow(h, hdc, 2); gr.ReleaseHdc(hdc); }
+      bmp.Save(png, ImageFormat.Png);
+      var d = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+      try {
+        var px = new int[bmp.Width * bmp.Height]; Marshal.Copy(d.Scan0, px, 0, px.Length); long n = 0;
+        foreach (var v in px) { int pb = v & 0xff, pg = (v >> 8) & 0xff, pr = (v >> 16) & 0xff;
+          if (Math.Abs(pr - r) <= tol && Math.Abs(pg - g) <= tol && Math.Abs(pb - b) <= tol) n++; }
+        return n;
+      } finally { bmp.UnlockBits(d); }
+    }
+  }
   [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
   [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x, y; }
   public delegate bool EnumProc(IntPtr h, IntPtr l);
@@ -60,6 +83,7 @@ public static class TzDead {
   [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref POINT p);
   [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
   [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int cx, int cy, uint flags);
   [DllImport("user32.dll")] public static extern int GetSystemMetrics(int i);
   [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
   [DllImport("user32.dll")] public static extern uint MapVirtualKeyW(uint c, uint t);
@@ -101,10 +125,18 @@ public static class TzDead {
     for (int k = vks.Length - 1; k >= 0; k--) a[n++] = Key(vks[k], 2);
     return SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
   }
+  // 다른 창이 덮고 있으면 SetForegroundWindow 도 클릭도 안 닿는다 (2026-09-03 실기 — 브라우저가 앞에 있던 회차).
+  // 잠깐 최상위로 올려 활성화하고, 끝나면 내린다 (compare-terminals 의 찍기 직전 TOPMOST 와 같은 수).
   public static bool Focus(IntPtr h) {
     if (GetForegroundWindow() == h) return true;
+    SetWindowPos(h, new IntPtr(-1), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0040);   // TOPMOST · NOSIZE|NOMOVE|SHOWWINDOW
     SetForegroundWindow(h); System.Threading.Thread.Sleep(300);
-    if (GetForegroundWindow() == h) return true;
+    bool ok = GetForegroundWindow() == h;
+    if (!ok) ok = ClickCenter(h);
+    SetWindowPos(h, new IntPtr(-2), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0010);  // NOTOPMOST · NOACTIVATE
+    return ok;
+  }
+  static bool ClickCenter(IntPtr h) {
     RECT r; GetClientRect(h, out r);
     var p = new POINT(); p.x = (r.R - r.L) / 2; p.y = (r.B - r.T) / 2; ClientToScreen(h, ref p);
     POINT before; bool hc = GetCursorPos(out before);
@@ -118,6 +150,7 @@ public static class TzDead {
   }
 }
 "@
+[TzDead]::MakeDpiAware()
 
 $VK = @{ Apos = 0xDE; e = 0x45; o = 0x4F; x = 0x58; Space = 0x20; Enter = 0x0D; Shift = 0x10; D6 = 0x36 }
 # 케이스 — 이름 · 키 목록 (chord 는 배열) · 기대 hex
@@ -176,6 +209,7 @@ $loadedByUs = -not ($before -contains $hkl)
 
 $ok = $true
 $sent = 0
+$capCounts = @()
 try {
     if (-not [TzDead]::Focus($h)) { throw "tildaz 창을 활성으로 못 만들었다 — 키를 보내지 않는다" }
     # 그 창의 스레드만 layout 전환. DefWindowProc 이 WM_INPUTLANGCHANGEREQUEST 를 받아 ActivateKeyboardLayout 한다.
@@ -186,10 +220,20 @@ try {
     if ($now -ne $hkl) { throw "창의 layout 이 바뀌지 않았다 — 키를 보내지 않는다" }
 
     foreach ($c in $cases) {
+        $ci = 0
         foreach ($chord in $c.keys) {
             if ([TzDead]::GetForegroundWindow() -ne $h) { throw "포커스를 잃었다 (케이스 '$($c.name)') — 중단" }
             [void][TzDead]::Chord([uint16[]]$chord)
             Start-Sleep -Milliseconds 120
+            if ($Capture -and $sent -eq 0 -and $ci -le 1) {
+                Start-Sleep -Milliseconds 400
+                $png = Join-Path $Out ("dead_" + $ci + ".png")
+                $n = [TzDead]::CaptureCount($h, $png, 64, 64, 128, 2)
+                $label = if ($ci -eq 0) { "dead key 직후 (표시 중 · >0 기대)" } else { "조합 직후 (0 기대)" }
+                "캡처 $label preedit 색 픽셀 = $n · $png"
+                $script:capCounts += $n
+            }
+            $ci++
         }
         [void][TzDead]::Chord([uint16[]]@($VK.Enter))
         $sent++
@@ -226,4 +270,9 @@ if (Test-Path $result) {
     "❌ 자식이 결과 파일을 남기지 않았다 ($result)"; $ok = $false
 }
 "보낸 줄 $sent / $($cases.Count) · 결과: $result · 로그: $env:APPDATA\tildaz\tildaz_stress.log"
+if ($Capture -and $capCounts.Count -eq 2) {
+    $capOk = ($capCounts[0] -gt 0) -and ($capCounts[1] -eq 0)
+    "표시 판정: dead key 직후 $($capCounts[0]) px · 조합 직후 $($capCounts[1]) px → $(if ($capOk) { 'OK' } else { 'FAIL' })"
+    if (-not $capOk) { $ok = $false }
+}
 if ($ok) { "결과: 전부 OK" } else { "결과: 실패 있음" }

--- a/dist/windows/kitty-text-check.ps1
+++ b/dist/windows/kitty-text-check.ps1
@@ -1,0 +1,215 @@
+﻿# Windows 에서 kitty keyboard protocol 이 켜졌을 때 **글자 키가 PTY 에 어떤 바이트로 나가는지** 합성 입력으로 판정한다
+# (#602 · #583 B5). `report_all` (flag 8) 이 켜지면 macOS · Linux 처럼 `a` 가 `CSI 97 u` 여야 하고, 꺼진 kitty
+# (`disambiguate` 만) 에서는 `61` 그대로여야 한다.
+#
+# ```powershell
+# dist\windows\kitty-text-check.ps1                          # zig-out\bin\tildaz.exe
+# dist\windows\kitty-text-check.ps1 -Bin C:\path\tildaz.exe
+# ```
+#
+# 무엇을 하나 —
+# 1. `--instance 9 -e <자식.py>` 로 tildaz 를 띄운다. 자식 (Python) 은 콘솔 입력을 **`ENABLE_VIRTUAL_TERMINAL_INPUT`**
+#    으로 바꿔 stdin 을 raw 바이트로 읽는다 — 그래야 앱이 PTY 에 쓴 `CSI u` 시퀀스가 ConPTY 를 지나 키 이벤트로
+#    해석되지 않고 **바이트 그대로** 온다 (`Read-Host` 로는 볼 수 없다 — 그쪽은 이미 문자로 바뀐 것이다).
+# 2. 자식이 stdout 에 `CSI > <flags> u` 를 써서 tildaz 의 터미널에 kitty 모드를 켠다 (앱의 VT 파서가 그 시퀀스를
+#    받아 `kitty_keyboard.push` 한다). 회차마다 flags 를 바꾼다 — **11** (disambiguate + report_events + report_all) ·
+#    **1** (disambiguate 만). 끝에 `CSI < u` 로 내린다.
+# 3. 회차마다 `SendInput` 으로 키를 치고 (`a` · `Shift+a` · `Space` · `Enter` · dead key `'` `e`), 자식은 각 키 뒤 짧은
+#    유휴 (300 ms 동안 바이트 없음) 를 한 항목의 끝으로 보아 hex 를 한 줄씩 기록한다. 마지막에 `Ctrl+D` 대신
+#    **정해진 개수**만큼 읽고 끝난다 — 자식이 끝나면 앱도 끝난다.
+# 4. 기대값과 견준다. 기대는 ghostty 인코더 (`src/input/key_encode.zig` 의 `kitty()`) 의 규칙이다 — `report_all`
+#    에서 글자는 `CSI <cp> u`, Shift 가 있으면 `CSI <cp>;2 u` (`:<shifted>` 는 `report_alternates` = flag 4 에서만 붙는다 —
+#    2026-09-03 실측), Enter 는 `CSI 13 u`, flags 11 은 `report_events` 라 누름 뒤에 뗌 `CSI <cp>;<mods>:3 u` 가 따라온다.
+#    dead key 는 누름이 `CSI 39 u` 로 보고되고 조합 결과 `é` 는 텍스트 (`c3 a9`) 로 온다. `disambiguate` 만이면 글자는 텍스트 그대로.
+#
+# 실기라서 **시작 전에 알리고 동의를 받는다** — 창이 두 번 뜨고 합성 키가 나간다. 키마다 포커스 가드 (foreground 가 tildaz
+# 창이 아니면 멈춤). dead key 회차는 US-International 을 잠깐 올린다 (`deadkey-check.ps1` 과 같은 방법 · 끝나면 내림).
+#
+# ⚠️ 이 파일은 UTF-8 **BOM** 으로 저장한다 (Windows PowerShell 5.1 이 BOM 없는 `.ps1` 을 cp949 로 읽는다). Python 3 이
+# `python` 으로 PATH 에 있어야 한다 (이 기기는 3.14).
+
+[CmdletBinding()]
+param(
+    [string]$Bin = "zig-out\bin\tildaz.exe",
+    [string]$Klid = "00020409"
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class TzKitty {
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x, y; }
+  public delegate bool EnumProc(IntPtr h, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref POINT p);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int cx, int cy, uint flags);
+  [DllImport("user32.dll")] public static extern int GetSystemMetrics(int i);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
+  [DllImport("user32.dll")] public static extern uint MapVirtualKeyW(uint c, uint t);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern IntPtr LoadKeyboardLayoutW(string klid, uint flags);
+  [DllImport("user32.dll")] public static extern bool UnloadKeyboardLayout(IntPtr hkl);
+  [DllImport("user32.dll")] public static extern int GetKeyboardLayoutList(int n, IntPtr[] list);
+  [DllImport("user32.dll")] public static extern IntPtr GetKeyboardLayout(uint thread);
+  [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint msg, IntPtr w, IntPtr l);
+  [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk, wScan; public uint dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx, dy; public uint mouseData, dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Explicit, Size = 40)] public struct INPUT { [FieldOffset(0)] public uint type; [FieldOffset(8)] public KEYBDINPUT ki; [FieldOffset(8)] public MOUSEINPUT mi; }
+  [DllImport("user32.dll", SetLastError = true)] public static extern uint SendInput(uint n, INPUT[] p, int cb);
+  public static IntPtr FindWindowOfPid(uint pid) {
+    IntPtr found = IntPtr.Zero;
+    EnumWindows((h, l) => {
+      uint p; GetWindowThreadProcessId(h, out p);
+      if (p != pid || !IsWindowVisible(h)) return true;
+      RECT r; if (!GetWindowRect(h, out r)) return true;
+      if (r.R - r.L < 64 || r.B - r.T < 64) return true;
+      found = h; return false;
+    }, IntPtr.Zero);
+    return found;
+  }
+  public static IntPtr[] Layouts() { var a = new IntPtr[32]; int n = GetKeyboardLayoutList(32, a); var r = new IntPtr[Math.Max(n, 0)]; Array.Copy(a, r, r.Length); return r; }
+  public static IntPtr LayoutOfWindow(IntPtr h) { uint pid; uint tid = GetWindowThreadProcessId(h, out pid); return GetKeyboardLayout(tid); }
+  static INPUT Key(ushort vk, uint flags) { var i = new INPUT(); i.type = 1; i.ki.wVk = vk; i.ki.wScan = (ushort)MapVirtualKeyW(vk, 0); i.ki.dwFlags = flags; return i; }
+  static INPUT Mouse(int nx, int ny, uint flags) { var i = new INPUT(); i.type = 0; i.mi.dx = nx; i.mi.dy = ny; i.mi.dwFlags = flags; return i; }
+  static void Norm(int x, int y, out int nx, out int ny) {
+    int vx = GetSystemMetrics(76), vy = GetSystemMetrics(77), vw = GetSystemMetrics(78), vh = GetSystemMetrics(79);
+    nx = (int)(((long)(x - vx) * 65535) / (vw > 1 ? vw - 1 : 1)); ny = (int)(((long)(y - vy) * 65535) / (vh > 1 ? vh - 1 : 1));
+  }
+  public static uint Chord(ushort[] vks) {
+    var a = new INPUT[vks.Length * 2]; int n = 0;
+    foreach (var v in vks) a[n++] = Key(v, 0);
+    for (int k = vks.Length - 1; k >= 0; k--) a[n++] = Key(vks[k], 2);
+    return SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+  }
+  // 다른 창이 덮고 있으면 SetForegroundWindow 도 클릭도 안 닿는다 (2026-09-03 실기 — 브라우저가 앞에 있던 회차).
+  // 잠깐 최상위로 올려 활성화하고, 끝나면 내린다 (compare-terminals 의 찍기 직전 TOPMOST 와 같은 수).
+  public static bool Focus(IntPtr h) {
+    if (GetForegroundWindow() == h) return true;
+    SetWindowPos(h, new IntPtr(-1), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0040);   // TOPMOST · NOSIZE|NOMOVE|SHOWWINDOW
+    SetForegroundWindow(h); System.Threading.Thread.Sleep(300);
+    bool ok = GetForegroundWindow() == h;
+    if (!ok) ok = ClickCenter(h);
+    SetWindowPos(h, new IntPtr(-2), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0010);  // NOTOPMOST · NOACTIVATE
+    return ok;
+  }
+  static bool ClickCenter(IntPtr h) {
+    RECT r; GetClientRect(h, out r);
+    var p = new POINT(); p.x = (r.R - r.L) / 2; p.y = (r.B - r.T) / 2; ClientToScreen(h, ref p);
+    POINT before; bool hc = GetCursorPos(out before);
+    int nx, ny; Norm(p.x, p.y, out nx, out ny);
+    uint mv = 0x0001 | 0x8000 | 0x4000;
+    var a = new INPUT[] { Mouse(nx, ny, mv), Mouse(nx, ny, mv | 0x0002), Mouse(nx, ny, mv | 0x0004) };
+    SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+    System.Threading.Thread.Sleep(300);
+    if (hc) { int bx, by; Norm(before.x, before.y, out bx, out by); var m = new INPUT[] { Mouse(bx, by, mv) }; SendInput(1, m, Marshal.SizeOf(typeof(INPUT))); }
+    return GetForegroundWindow() == h;
+  }
+}
+"@
+
+$VK = @{ a = 0x41; e = 0x45; Space = 0x20; Enter = 0x0D; Shift = 0x10; Apos = 0xDE }
+$Out = Join-Path $env:TEMP "tildaz-kitty-text"
+New-Item -ItemType Directory -Force -Path $Out | Out-Null
+$child = Join-Path $Out "child.py"
+# 자식 — 콘솔 입력을 VT 모드로 바꾸고 stdin 을 raw 로 읽어, 300 ms 유휴로 항목을 끊어 hex 로 기록한다.
+$childBody = @'
+import sys, os, time, ctypes, msvcrt
+from ctypes import wintypes
+out, flags, n_items = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+k32 = ctypes.windll.kernel32
+h_in = k32.GetStdHandle(-10)
+mode = wintypes.DWORD()
+k32.GetConsoleMode(h_in, ctypes.byref(mode))
+# ENABLE_VIRTUAL_TERMINAL_INPUT (0x200) 켜고 ECHO (0x4) · LINE (0x2) · PROCESSED (0x1) 끈다.
+k32.SetConsoleMode(h_in, (mode.value | 0x200) & ~0x7)
+sys.stdout.write("\x1b[>%du" % flags); sys.stdout.flush()      # kitty 모드 켬
+items, cur, last = [], b"", None
+t_start = time.time()
+while len(items) < n_items and time.time() - t_start < 40:
+    if msvcrt.kbhit():
+        ch = msvcrt.getwch()
+        cur += ch.encode("utf-8", "surrogatepass"); last = time.time()
+    elif cur and last is not None and time.time() - last > 0.3:
+        items.append(cur); cur = b""
+    else:
+        time.sleep(0.01)
+if cur: items.append(cur)
+sys.stdout.write("\x1b[<u"); sys.stdout.flush()               # kitty 모드 내림
+with open(out, "w", encoding="utf-8") as f:
+    for it in items: f.write(" ".join("%02x" % b for b in it) + "\n")
+'@
+[IO.File]::WriteAllText($child, $childBody, (New-Object System.Text.UTF8Encoding $false))
+
+if (-not (Test-Path $Bin)) { throw "바이너리 없음: $Bin" }
+function Stop-Tz { Get-CimInstance Win32_Process -Filter "Name like 'tildaz%'" | Where-Object { $_.CommandLine -match '--instance 9' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }
+$before = [TzKitty]::Layouts()
+$hkl = [TzKitty]::LoadKeyboardLayoutW($Klid, 0)
+$loadedByUs = ($hkl -ne [IntPtr]::Zero) -and -not ($before -contains $hkl)
+
+# 회차 — flags · 키 목록 (chord) · 기대 (hex 또는 정규식 접두 'RE:')
+$rounds = @(
+    # ⚠️ chord 는 `,@(…)` (단항 콤마) 로 감싼다 — PowerShell 은 원소가 하나인 배열 `@(@(a,b))` 를 평탄화해 Shift 와 a 를
+    #    따로 누르게 만든다 (2026-09-03 실측 — `Shift+a` 가 `a` 로 나왔다). 원소가 둘 이상이면 그대로 남는다.
+    # flags 11 은 `report_events` 를 포함하므로 누름 뒤에 뗌 (`CSI …;1:3 u`) 이 붙는다 — 기대는 정규식으로 둘을 다 받는다.
+    @{ flags = 11; name = "report_all + report_events (11)"; keys = @(
+        @{ n = "a";        k = @(,@($VK.a));                e = "RE:^1b 5b 39 37 75( 1b 5b 39 37 3b 31 3a 33 75)?$" },              # CSI 97 u
+        @{ n = "Shift+a";  k = @(,@($VK.Shift, $VK.a));     e = "RE:^1b 5b 39 37 3b 32 75( 1b 5b 39 37 3b 32 3a 33 75)?$" },          # CSI 97;2 u — `:65` 는 report_alternates (4) 에서만 붙는다
+        @{ n = "Space";    k = @(,@($VK.Space));            e = "RE:^1b 5b 33 32 75( 1b 5b 33 32 3b 31 3a 33 75)?$" },              # CSI 32 u
+        @{ n = "Enter";    k = @(,@($VK.Enter));            e = "RE:^1b 5b 31 33 75( 1b 5b 31 33 3b 31 3a 33 75)?$" },              # CSI 13 u
+        @{ n = "' e (dead)"; k = @(@($VK.Apos), @($VK.e));  e = "RE:c3 a9" }                                                        # 조합 결과 é 가 텍스트로 온다 (dead key 누름 CSI 39 u 는 앞에 붙는다)
+    ) },
+    @{ flags = 1; name = "disambiguate (1)"; keys = @(
+        @{ n = "a";        k = @(,@($VK.a));                e = "61" },
+        @{ n = "Shift+a";  k = @(,@($VK.Shift, $VK.a));     e = "41" },
+        @{ n = "Enter";    k = @(,@($VK.Enter));            e = "0d" },
+        @{ n = "' e (dead)"; k = @(@($VK.Apos), @($VK.e));  e = "c3 a9" }
+    ) }
+)
+$allOk = $true
+foreach ($r in $rounds) {
+    "===== $($r.name)"
+    $result = Join-Path $Out ("received_" + $r.flags + ".txt"); Remove-Item $result -Force -ErrorAction SilentlyContinue
+    Stop-Tz
+    $cmd = "python `"$child`" `"$result`" $($r.flags) $($r.keys.Count)"
+    $p = Start-Process -FilePath (Resolve-Path $Bin) -PassThru -ArgumentList '--instance', '9', '-e', "`"$cmd`""
+    $h = [IntPtr]::Zero; $sw = [Diagnostics.Stopwatch]::StartNew()
+    while ($h -eq [IntPtr]::Zero -and $sw.ElapsedMilliseconds -lt 10000) { Start-Sleep -Milliseconds 100; if ($p.HasExited) { break }; $h = [TzKitty]::FindWindowOfPid([uint32]$p.Id) }
+    if ($p.HasExited -or $h -eq [IntPtr]::Zero) { "❌ 앱/창 없음"; $allOk = $false; Stop-Tz; continue }
+    Start-Sleep -Seconds 2
+    try {
+        if (-not [TzKitty]::Focus($h)) { throw "포커스 못 잡음 — 키를 보내지 않는다" }
+        if ($hkl -ne [IntPtr]::Zero) {
+            [void][TzKitty]::PostMessageW($h, 0x0050, [IntPtr]::Zero, $hkl); Start-Sleep -Milliseconds 400
+            if ([TzKitty]::LayoutOfWindow($h) -ne $hkl) { "⚠ 창 layout 전환 실패 — dead key 항목은 무효" }
+        }
+        foreach ($c in $r.keys) {
+            foreach ($chord in $c.k) {
+                if ([TzKitty]::GetForegroundWindow() -ne $h) { throw "포커스 잃음 ($($c.n))" }
+                [void][TzKitty]::Chord([uint16[]]$chord); Start-Sleep -Milliseconds 120
+            }
+            Start-Sleep -Milliseconds 600   # 자식의 유휴 판정 (300 ms) 보다 길게
+        }
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        while (-not $p.HasExited -and $sw.ElapsedMilliseconds -lt 8000) { Start-Sleep -Milliseconds 200 }
+    } catch { "❌ $_"; $allOk = $false } finally { Stop-Tz }
+    if (Test-Path $result) {
+        $got = Get-Content $result; $i = 0
+        foreach ($c in $r.keys) {
+            $g = if ($i -lt $got.Count) { $got[$i] } else { "(없음)" }
+            $ok = if ($c.e -like "RE:*") { $g -match $c.e.Substring(3) } else { $g -eq $c.e }
+            "{0} {1,-12} 기대 [{2}]  받음 [{3}]" -f ($(if ($ok) { "OK  " } else { "FAIL" })), $c.n, $c.e, $g
+            if (-not $ok) { $allOk = $false }; $i++
+        }
+    } else { "❌ 결과 파일 없음"; $allOk = $false }
+}
+if ($loadedByUs) { "layout 내림: $([TzKitty]::UnloadKeyboardLayout($hkl))" }
+"세션 layout (후): " + (([TzKitty]::Layouts() | ForEach-Object { '0x{0:x8}' -f [int64]$_ }) -join ' ')
+if ($allOk) { "결과: 전부 OK" } else { "결과: 실패 있음" }

--- a/src/app_controller.zig
+++ b/src/app_controller.zig
@@ -800,8 +800,9 @@ pub const App = struct {
                             .scrollbar_min_thumb_h = @floatFromInt(self.SCROLLBAR_MIN_THUMB_H),
                             // 단일 탭의 컨트롤 스트립 (#329) 아래로 track 을 내린다 — 오른쪽 위 pane 만.
                             .scrollbar_top_inset = self.paneScrollbarTopInset(pr.rect, area),
-                            // IME 자모는 키보드가 가는 pane (활성) 의 cursor 옆에만 (#164).
-                            .preedit_utf8 = if (is_active) self.window.imePreeditSlice() else &.{},
+                            // IME 자모는 키보드가 가는 pane (활성) 의 cursor 옆에만 (#164). dead key 조합 중
+                            // 표시 (#530) 도 같은 자리 · 같은 모양 — IME 가 있으면 IME 가 우선이다.
+                            .preedit_utf8 = if (is_active) self.window.activePreeditSlice() else &.{},
                             // #376 — 위쪽 게이트가 이미 구한 위상을 그대로 내린다. 렌더러가
                             // 시계를 다시 읽으면 500 ms 경계에서 둘이 갈릴 수 있다.
                             .blink_faint = blink_phase_now,

--- a/src/window.zig
+++ b/src/window.zig
@@ -51,6 +51,8 @@ const WM_PAINT: UINT = 0x000F;
 const WM_KEYDOWN: UINT = 0x0100;
 const WM_KEYUP: UINT = 0x0101;
 const WM_CHAR: UINT = 0x0102;
+const WM_DEADCHAR: UINT = 0x0103;
+const WM_SYSDEADCHAR: UINT = 0x0107;
 const WM_HOTKEY: UINT = 0x0312;
 pub const WM_NEW_INSTANCE_REQUEST: UINT = 0x8000 + 267;
 pub const WM_HOTKEY_CAPTURE_BEGIN: UINT = 0x8000 + 268;
@@ -596,6 +598,13 @@ pub const Window = struct {
     /// 안에서 동기 처리해 action보다 먼저 원래 입력 대상에 반영한다 (#313).
     preedit_buf: [256]u8 = undefined,
     preedit_len: usize = 0,
+    /// #530 — dead key 를 누른 직후 OS 가 조합을 들고 있는 동안 커서 자리에 보여 주는 그 dead key 의
+    /// 문자 (UTF-8). `WM_DEADCHAR` 가 채우고 다음 `WM_CHAR` 가 지운다. IME 의 `preedit_buf` 와 **다른
+    /// 저장소**다 — `imePreeditSlice` 는 `Ctrl+C` · deferred result 정책의 판정 근거라 섞이면 IME 정책이
+    /// 흔들린다 (Linux 의 `compose_preview` 가 `preedit_text` 와 갈라진 것과 같은 이유). 렌더는
+    /// `activePreeditSlice` 로 둘을 합쳐 받는다 (IME 우선). #602 는 이 길이로 "dead key 대기 중" 을 판정한다.
+    compose_preview_buf: [8]u8 = undefined,
+    compose_preview_len: usize = 0,
     /// `imeCompleteComposition`의 ImmNotifyIME가 nested WM_IME_COMPOSITION을
     /// 동기 발생시켰는지 확인한다. 결과를 동기 처리하지 못하면 caller가 action을
     /// 보류해 queued WM_CHAR가 새 탭/새 prompt로 이동하지 않게 한다.
@@ -2024,7 +2033,31 @@ pub const Window = struct {
                 self.preedit_len = 0;
                 return 0;
             },
+            WM_DEADCHAR, WM_SYSDEADCHAR => {
+                // #530 — dead key 를 누른 직후. OS (`TranslateMessage`) 가 조합을 들고 있는 동안 그 dead key 의
+                // 문자를 커서 자리에 보여 준다 — macOS 의 marked text · Linux 의 `compose_preview` 와 같은 자리 ·
+                // 같은 모양. `wParam` 이 그 문자 (UTF-16 한 단위 — dead key 문자는 BMP 다) 라 Linux 의
+                // keysym → spacing 문자 표가 필요 없다. 다음 `WM_CHAR` (조합 결과든 조합 불가의 두 글자든) 가
+                // 지우고, 새 dead key 가 오면 바꾼다.
+                //
+                // **탭 · pane 전환 · 포커스 이탈에는 지우지 않는다 — Linux 와 다른 자리다.** Windows 의 dead key
+                // 상태는 OS (스레드 키보드 상태) 가 들고 있어 그 뒤 글자와 조합되므로, 표시가 그 상태를 따른다.
+                // Linux 는 앱이 조합 주체라 상태와 표시를 함께 버릴 수 있다 (SPEC §5.3).
+                const dead_cp: u21 = @intCast(@as(u16, @intCast(wParam)));
+                self.compose_preview_len = std.unicode.utf8Encode(dead_cp, &self.compose_preview_buf) catch 0;
+                // #602 — 이 메시지가 dead key 의 `WM_KEYDOWN` 이 세운 "짝꿍 `WM_CHAR` 삼킴" 의 짝이다. kitty
+                // `report_all` 에서 그 KEYDOWN 은 인코더로 갔는데 (`ToUnicodeEx` 가 상태 불변 플래그로는 dead
+                // key 에도 `'` 같은 글자를 돌려준다 — 2026-09-03 실측), dead key 는 `WM_CHAR` 가 아니라 이것을
+                // 만들므로 플래그가 남아 **다음 글자 (`é`) 의 `WM_CHAR` 를 삼켰다.** 여기서 소비한다.
+                self.swallow_next_wm_char = false;
+                // #282 A11 — IME 조합 시작과 같은 규칙: 스크롤백을 올린 채면 표시가 안 보인다.
+                if (self.scroll_to_bottom_fn) |f| f(self.userdata);
+                return 0;
+            },
             WM_CHAR => {
+                // #530 — 조합 결과 (또는 조합 불가의 글자) 가 왔다 — dead key 표시는 여기서 끝난다. 삼키는
+                // 경우도 같다 (그 `WM_CHAR` 를 만든 키가 OS 의 dead key 상태를 소비했다).
+                self.compose_preview_len = 0;
                 // KEYDOWN 가 같은 키를 소비했으면 짝꿍 WM_CHAR 도 swallow.
                 // (menu Enter / Escape 소비 후 PTY 로 \r / \x1b 새는
                 // 사고 방지 — 소비자 입장에선 한 번의 keypress.)
@@ -2205,6 +2238,44 @@ pub const Window = struct {
                     if (ctrl_text.len > 0 and self.sendEncodedKeyWin(@intCast(wParam), lParam, ctrl_text, keyActionFromLParam(lParam))) {
                         // TranslateMessage 가 큐에 넣을 짝꿍 `WM_CHAR`(제어문자) 를 삼킨다 —
                         // 그러지 않으면 `CSI u` 와 `\x03` 이 둘 다 나간다.
+                        self.swallow_next_wm_char = true;
+                        return 0;
+                    }
+                }
+
+                // #602 — kitty `report_all` 이면 글자 키도 인코더로 보낸다 (macOS · Linux 는 늘 그랬다 —
+                // Windows 만 글자를 `WM_CHAR` 로 따로 받아 인코더를 건너뛰었다). `report_all` 이 **꺼진**
+                // kitty 에서는 인코더가 수식키 없는 인쇄 글자를 텍스트 그대로 내므로 (`plain_text` 분기)
+                // `WM_CHAR` 경로와 결과가 같다 — 그 경우는 손대지 않는다 (#533 실기 — fish · zellij ·
+                // AZERTY `Ctrl+A` — 를 보존한다).
+                //
+                // 제외 — IME 조합 중 (글자는 `WM_IME_COMPOSITION` 으로 확정된다) · **dead key 대기 중**
+                // (`ToUnicodeEx` 는 상태 불변 플래그라 대기 중인 dead key 를 반영하지 않아 `e` 를 `e` 로
+                // 낸다 — 실제 `WM_CHAR` 는 `é` 다. #530 의 표시 길이가 그 상태다) · 글자가 없는 키 (dead key
+                // 자체 — `ToUnicodeEx` 가 음수) · 제어문자 (위 `Ctrl` 블록과 nav 경로의 몫). Alt 조합은
+                // `WM_SYSKEYDOWN` 이 이미 인코더로 보낸다.
+                if (kitty_active and
+                    self.keyEncodeOptions().kitty_flags.report_all and
+                    GetKeyState(VK_CONTROL) >= 0 and
+                    self.imePreeditSlice().len == 0 and
+                    self.compose_preview_len == 0)
+                {
+                    var text_buf: [8]u8 = undefined;
+                    const text = winCharWithoutCtrlAlt(@intCast(wParam), kd_scan, GetKeyState(VK_SHIFT) < 0, &text_buf);
+                    // Enter · Tab · Backspace · Escape 는 `WM_CHAR` 로 제어문자가 오는 키다. `report_all` 에서는
+                    // 이것도 `CSI 13 u` 같은 시퀀스여야 하므로 (인코더가 키 이름으로 만든다 — 2026-09-03 실측에서
+                    // 뗌은 `CSI 13;1:3 u` 인데 누름이 CR (`0x0d`) 로 갈려 드러났다) 글자 없이 인코더로 보낸다. 위
+                    // `maybe_key` dispatch 가 소비했으면 (command menu 등) 여기 오지 않는다.
+                    const control_key = switch (wParam) {
+                        0x0D, 0x09, 0x08, 0x1B => true,
+                        else => false,
+                    };
+                    const printable = text.len > 0 and text[0] >= 0x20 and text[0] != 0x7f;
+                    if ((printable or control_key) and
+                        self.sendEncodedKeyWin(@intCast(wParam), lParam, if (printable) text else "", keyActionFromLParam(lParam)))
+                    {
+                        // 짝꿍 `WM_CHAR` (같은 글자 · 제어문자) 를 삼킨다 — 안 그러면 `CSI u` 와 글자가 둘 다 나간다.
+                        // dead key 는 `WM_CHAR` 대신 `WM_DEADCHAR` 를 만들므로 그쪽이 이 플래그를 소비한다.
                         self.swallow_next_wm_char = true;
                         return 0;
                     }
@@ -2650,6 +2721,18 @@ pub const Window = struct {
     /// renderer 가 매 frame 호출 — 현재 IME preedit (UTF-8). 빈 slice 면 비활성.
     pub fn imePreeditSlice(self: *const Window) []const u8 {
         return self.preedit_buf[0..self.preedit_len];
+    }
+
+    /// #530 — 조합 중인 dead key 의 표시 문자 (UTF-8). 빈 slice 면 없음.
+    pub fn composePreviewSlice(self: *const Window) []const u8 {
+        return self.compose_preview_buf[0..self.compose_preview_len];
+    }
+
+    /// 렌더러에 넘길 커서 자리 표시 — IME preedit 이 있으면 그것, 없으면 dead key 표시 (#530).
+    /// Linux 의 `preedit_text` → `compose_preview` 우선 규칙과 같다 — IME 가 주인이다.
+    pub fn activePreeditSlice(self: *const Window) []const u8 {
+        const ime = self.imePreeditSlice();
+        return if (ime.len > 0) ime else self.composePreviewSlice();
     }
 
     /// IME composition / candidate window 위치 갱신 — IME 가 한자 후보 list 등


### PR DESCRIPTION
[#583](https://github.com/ensky0/tildaz/issues/583) **B4 · B5 의 Windows 몫.** 사용자 지시 (2026-09-03) 로 [#602](https://github.com/ensky0/tildaz/issues/602) (새 이슈) 와 [#530](https://github.com/ensky0/tildaz/issues/530) (재개) 을 한 브랜치에서 고쳤다 — 둘이 `window.zig` 의 같은 키 경로이고, #602 의 "dead key 대기 중이면 인코더 우회" 판정이 #530 의 표시 상태를 쓴다.

## #530 — Windows 도 조합 중인 dead key 를 보여 준다

| | |
|---|---|
| `WM_DEADCHAR` · `WM_SYSDEADCHAR` | `wParam` (그 dead key 의 문자 — OS 가 준다, Linux 의 keysym 표가 필요 없다) 을 `compose_preview_buf` 에. IME 조합 시작과 같은 규칙으로 스크롤백을 내린다 |
| 렌더 | `activePreeditSlice` — IME preedit 이 있으면 그것, 없으면 dead key 표시. 같은 자리 · 같은 모양 (보라 배경). `preedit_buf` 와 다른 저장소 (IME 정책 판정을 흔들지 않는다 — Linux 가 `compose_preview` 를 갈라 둔 것과 같은 이유) |
| 지움 | 다음 `WM_CHAR` (조합 결과든 조합 불가의 두 글자든). **탭 · pane 전환 · 포커스 이탈에는 지우지 않는다** — Windows 의 dead key 상태는 OS 가 들고 있어 그 뒤 글자와 조합되므로 표시가 상태를 따른다. SPEC §5.3 · KEYBINDINGS 에 platform 차이로 적었다. OS 상태까지 버릴지는 결정 대기 |

## #602 — kitty `report_all` 에서 글자 키도 인코더로

Windows 만 글자를 `WM_CHAR` 로 따로 받아 인코더를 건너뛰었다. `report_all` 이 **꺼진** kitty 에서는 인코더 (`ghostty` `kitty()` 의 `plain_text`) 도 텍스트를 그대로 내므로 결과가 같다 — 그 경우는 손대지 않아 #533 실기 (fish · zellij · AZERTY `Ctrl+A`) 를 보존한다. `report_all` 이면 `WM_KEYDOWN` 에서 글자 (와 Enter · Tab · Backspace · Escape) 를 `sendEncodedKeyWin` 으로 보내고 짝꿍 `WM_CHAR` 를 삼킨다. 제외 — IME 조합 중 · dead key 대기 중 · `Ctrl` (기존 블록).

`ToUnicodeEx` 는 상태 불변 플래그로 dead key 에도 글자 (`'`) 를 돌려주므로 dead key 누름도 인코더로 가 `CSI 39 u` 가 나간다 (kitty 도 dead key 누름을 보고한다). 그때 세운 `WM_CHAR` 삼킴을 `WM_DEADCHAR` 가 소비한다 — 1 회차에서 그것이 남아 다음 글자 `é` 를 삼켰다.

## 실기 (노트북 LENOVO 83JY · Ryzen AI 7 350 · Windows 11 Pro 26200 · 150 %)

**dead key 표시** (`deadkey-check.ps1 -Capture`, US-International) — `'` 직후 커서 자리 preedit 색 픽셀 **374**, `e` 직후 **0**. 바이트 네 케이스 (`c3 a9 78` · `27 78` · `c3 b4 78` · `27 78`) 그대로.

**kitty** (`kitty-text-check.ps1` — Python 자식이 `ENABLE_VIRTUAL_TERMINAL_INPUT` 으로 raw 바이트 수신)

| flags 11 (disambiguate + report_events + report_all) | 받음 |
|---|---|
| `a` | `CSI 97 u` + `CSI 97;1:3 u` |
| `Shift+a` | `CSI 97;2 u` + `CSI 97;2:3 u` (`:65` 는 `report_alternates` 에서만) |
| `Space` | `CSI 32 u` + 뗌 |
| `Enter` | `CSI 13 u` + `CSI 13;1:3 u` (1 회차는 누름이 `0d` 였다 — 고침) |
| `'` `e` | `CSI 39 u` · 뗌 · **`c3 a9`** · `e` 뗌 (1 회차는 `é` 가 없었다 — 고침) |
| **flags 1** `a` · `Shift+a` · `Enter` · `' e` | `61` · `41` · `0d` · `c3 a9` — 기존 경로 그대로 |

**modifier 단독 누름** (`Shift` 만) 은 Windows 가 보고하지 않는다 (Linux 는 `CSI 57441 u`) — 이번 범위 밖, SPEC 에 결정 대기로.

## 검증 · 문서

`zig fmt --check` · `zig build check` (6 타겟) · `zig build test` (363 passed) — 저장소 경로를 명시해 이 브랜치에서 돌렸다. SPEC §5.3 · #533 절, KEYBINDINGS "Dead keys", UNRELEASED 본문 후보 2 줄, AGENTS.md 에 도구와 함정 다섯 (PowerShell 배열 평탄화 · TOPMOST 포커스 · `ToUnicodeEx` dead key · 화면 보호기 · Bash cwd).

Refs #583 #530 #602