### PR TITLE
chore(stress): measure-repeat.sh --panes N — 실제 앱 pane 분할 · barrier 동시 시작 자동화 (Windows · #551 A11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -737,6 +737,9 @@ dist\windows\launcher-fatal-check.ps1 -Bin zig-out\bin\tildaz.exe   # 다이얼�
 - **PowerShell 은 원소가 하나인 배열을 평탄화해요** — `@(@($Shift, $A))` 는 `@(16, 65)` 가 되어 chord 가 **키 두 개를 따로**
   누르는 것으로 바뀌어요 (2026-09-03: `Shift+a` 가 `a` 로 나와 앱 결함으로 보일 뻔했어요). chord 는 `,@(…)` (단항 콤마) 로
   감싸요. 원소가 둘 이상인 배열은 그대로 남아서 `deadkey-check` 의 `Shift+6` 은 우연히 살아남았어요.
+  **`switch` 의 출력도 같아요** — `$seq = switch ($n) { 2 { @(,$chord) } }` 는 파이프라인을 지나며 풀려 `@(17, 16, 39)` 가
+  돼요 (2026-09-03 `split-panes.ps1` — pane 2 회차 5 회가 전부 분할 실패). 블록 안에서 `$seq = ,$chord` 로 **직접 대입**해요.
+  단항 콤마 · 직접 대입 뒤에는 `$seq.Count` 와 `$seq[0] -is [array]` 를 한 번 찍어 보고 시작해요.
 - **다른 창이 tildaz 창을 덮고 있으면 `SetForegroundWindow` 도 창 중앙 클릭도 안 닿아요** — 사용자가 브라우저를 앞에 두고
   머지하던 회차에서 포커스 가드가 막았어요. 도구들은 잠깐 `HWND_TOPMOST` 로 올려 활성화하고 끝나면 내려요.
 - **`ToUnicodeEx` 는 상태 불변 플래그 (bit 2) 로 부르면 dead key 에도 글자 (`'`) 를 돌려줘요** — 반환값으로 dead key 를

--- a/SPEC.md
+++ b/SPEC.md
@@ -2161,6 +2161,13 @@ AC · CPU `performance` · 64 MiB · 120x40 · scrollback 32,767 · `ReleaseFast
   Linux 0.368 → 0.430 ms 로 pane 수에 비례하지 않는다. Windows 4 · 8 pane 은 중간 pane 종료 전
   ring 을 마저 소화하도록 고친 뒤 120 Hz 에서 다시 잰 유효값이다 ([#572](https://github.com/ensky0/tildaz/issues/572)).
   즉 pane 을 늘려도 밀리는 것은 렌더가 아니라 위의 드레인 공정성이다.
+  **2026-09-03 Windows 자동화 재측정** (main `1f7d223` · 노트북 Ryzen AI 7 350 · 120 Hz · AC · 최고 성능 ·
+  `measure-repeat.sh --panes N` — barrier 러너로 N 개 producer **동시** 시작 · `split-panes.ps1` 로 4 열 × 2 행 분할 ·
+  `plain` 64 MiB/pane · 5 회 절사평균, [#551 댓글](https://github.com/ensky0/tildaz/issues/551)): `render/call` 이
+  1 · 2 · 4 · 8 pane 에서 **0.655 · 0.494 · 0.431 · 1.373 ms**, drain 141 · 350 · 853 · 2150 ms (8 pane 의 5 회 폭 2 %),
+  손실은 pane 당 16 byte (ConPTY 종료) 뿐. 1 · 4 pane 은 #572 회차와 같은 값인데 **8 pane 은 1.373 vs 0.894 로 갈린다** —
+  #572 회차의 격자 · 분할 순서 · 시작 동시성이 기록에 없어 원인은 **확인 필요** (후보: barrier 동시 시작이 8 producer 의
+  폭포를 한 프레임에 겹치게 한다). 8 pane 흔들림 (#583 A11 의 하네스 이봉 분포) 은 실제 앱에서 재현되지 않았다.
 
 합계 처리량은 격자를 고정했는데도 pane 수가 늘면 내려간다 (pane 하나의 몫이 아니라 합계다) — 격자 변화가 아니라
 producer · PTY · ring 경쟁 때문이다. `frame` 층은 프레임마다 한 번만 드레인해 (사양 A 없음) 앱의 하한이다.

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -73,7 +73,18 @@ zig build -Doptimize=ReleaseFast -Dsimd=true
 zig build stress -Doptimize=ReleaseFast -Dsimd=true -- throughput --layer parser --mb 1
 dist/stress/measure-repeat.sh --phase before
 dist/stress/measure-repeat.sh --phase after --workloads zwj,plain
+dist/stress/measure-repeat.sh --phase win-pane8 --panes 8 --workloads plain   # 실제 앱 8 pane (Windows · 아래)
 ```
+
+**`--panes N` (Windows) 은 실제 앱을 N 개 pane 으로 갈라 pane 마다 producer 를 하나씩 띄워요** ([#551](https://github.com/ensky0/tildaz/issues/551) A11 · 2026-09-03).
+앱은 pane 을 만들 때 producer 에 barrier 환경변수 (`TILDAZ_STRESS_START_BARRIER` · `PANE_ID`) 를 넣지 않아서 (그건
+`frame --panes N` 하네스의 내부 TabGroup 몫이에요) `-e` 에 producer 를 직접 넘기면 첫 pane 의 폭포가 분할 전에 흘러요.
+그래서 셋으로 나눠요 — ① [`pane-runner.ps1`](pane-runner.ps1) 을 `-e` 로 넘겨 pane 마다 러너가 barrier 파일을 50 ms 로 기다리고,
+② [`split-panes.ps1`](split-panes.ps1) 이 `SendInput` 으로 분할 (`Ctrl+Shift+→/↓` · `Alt+방향` 포커스 · `Shift+Alt+0` 균등 —
+아래 "120 열은 3 열 상태에서 더 못 갈라요" 의 순서 그대로) 하고 로그 `[pane] … has N panes` 로 수를 확인한 뒤, ③ barrier
+파일을 만들어 N 개가 함께 시작해요. 단축키가 살아야 해서 `config_9.toml` (config_0 복사 · `auto_start = false`) 을 만들고
+`--instance 9` 로 띄우며 끝나면 지워요. 덤프 라벨은 workload 라 **phase 이름에 pane 수를 넣어 조건마다 따로** 불러요.
+Linux · macOS 는 아직 손 절차예요 (합성 키 도구가 platform 별이에요 — #551 macOS 회차는 `mac-input` 으로 했어요).
 
 **`zig build stress` 를 한 번 더 불러야** 해요 — 기본 `zig build` 는 `tildaz-stress` 를
 `zig-out/bin` 에 install 하지 않아서, 예전에 빌드해 둔 producer 가 남아 있으면 그게 그대로 쓰여요.
@@ -362,7 +373,9 @@ perf 스냅숏에 답이 있어요 (측정 인스턴스는 종료할 때 자동�
 
 현재는 [#572](https://github.com/ensky0/tildaz/issues/572) / [PR #575](https://github.com/ensky0/tildaz/pull/575)에서
 `closePane`도 제거 전에 남은 출력을 끝까지 드레인하도록 고쳤어요. 실제 앱의 Windows pane 4 · 8을
-각 5회 다시 측정해 모두 `push − drain = 0`을 확인했어요. 다만 scheduler 공정성 측정은 종료 callback을 완료
+각 5회 다시 측정해 모두 `push − drain = 0`을 확인했어요. 2026-09-03 에 `measure-repeat.sh --panes N` (위) 으로
+pane 1 · 2 · 4 · 8 을 5 회씩 다시 잰 회차도 손실이 pane 당 16 byte (ConPTY 종료) 뿐이었어요 — main `1f7d223` ·
+노트북 Ryzen AI 7 350 · 120 Hz · AC · 최고 성능 ([#551 댓글](https://github.com/ensky0/tildaz/issues/551)). 다만 scheduler 공정성 측정은 종료 callback을 완료
 시점으로 쓰지 않아요. `frame --panes N` producer는 마지막 OSC marker가 모든 pane에서 파싱될 때까지 살아 있고,
 그 marker의 `PaneId`별 반영 시점을 비교해 close-time drain이 측정 꼬리를 가리는 일을 막아요 (#574).
 
@@ -548,6 +561,8 @@ Intel i5-1240P · `--repeat 5` · 배경 정리).
 (`split right rejected: pane would be under 20x5`). 3 열에서 균등(`Shift+Alt+0` · `⇧⌘0`) 을 해도
 39 열이라 반으로 가르면 19 열이에요. **120 → 59|59 로 먼저 나누고 각 59 를 다시 갈라야** 29 열 넷이 돼요.
 pane 수는 앱이 남기는 `[pane] … has N panes` 로그로 확인해요 — 거부도 `[pane] … rejected` 로 남아요.
+Windows 는 [`split-panes.ps1`](split-panes.ps1) 이 이 순서 (2: `→` · 4: `→ ↓ Alt+← ↓` · 8: 그 뒤 `→ Alt+↑ → Alt+→ → Alt+↓ →` + 균등)
+를 자동으로 쳐요 — 새 pane 이 활성이 되는 규칙 (`session_core.splitActive`) 에 맞춘 순서라 8 pane 이 4 열 × 2 행 (30x20 근사) 이 돼요.
 
 [#362 에서 실제로 겪은 것들](https://github.com/ensky0/tildaz/issues/362#issuecomment-5154477404)
 이에요.

--- a/dist/stress/measure-repeat.sh
+++ b/dist/stress/measure-repeat.sh
@@ -49,6 +49,11 @@ HOLD_MS=0
 LEAD_IN=8
 OUT=""
 IGNORE_HYGIENE=0
+# #551 A11 — 실제 앱을 N 개 pane 으로 갈라 pane 마다 producer 하나. **Windows 만** (합성 키 분할이
+# `split-panes.ps1`). 앱은 pane 에 barrier 환경변수를 넣지 않으므로 `pane-runner.ps1` 이 barrier
+# 파일을 기다린 뒤 producer 를 띄운다 — N 개가 함께 시작한다. 단축키가 살아야 해서 `config_9.toml`
+# 을 만들고 (`--instance 9`) 끝나면 지운다.
+PANES=1
 
 usage() {
     cat <<'USAGE'
@@ -63,6 +68,8 @@ usage() {
   --lead-in <초>       측정 시작 전 가라앉히는 시간 (기본 8)
   --out <디렉터리>     결과 위치 (기본 dist/stress/shots)
   --ignore-hygiene     위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
+  --panes <N>          실제 앱을 N (1 · 2 · 4 · 8) 개 pane 으로 갈라 pane 마다 producer (#551 A11). Windows 만.
+                       phase 이름에 pane 수를 넣어 조건별로 따로 부른다 (덤프 라벨은 workload 다)
 USAGE
 }
 
@@ -77,6 +84,7 @@ while [ $# -gt 0 ]; do
         --lead-in) LEAD_IN="$2"; shift 2 ;;
         --out) OUT="$2"; shift 2 ;;
         --ignore-hygiene) IGNORE_HYGIENE=1; shift ;;
+        --panes) PANES="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -122,6 +130,10 @@ case "$HYG_PLATFORM" in
 esac
 
 [ -x "$EXE" ] || { echo "tildaz 없음: $EXE  (먼저 zig build)" >&2; exit 1; }
+case "$PANES" in 1|2|4|8) ;; *) echo "--panes 는 1 · 2 · 4 · 8 만" >&2; exit 2 ;; esac
+if [ "$PANES" != 1 ] && [ "$HYG_PLATFORM" != windows ]; then
+    echo "--panes 는 아직 Windows 만 돌아요 (합성 키 분할이 split-panes.ps1) — Linux · macOS 는 #551 회차의 손 절차" >&2; exit 2
+fi
 [ -x "$STRESS" ] || { echo "tildaz-stress 없음: $STRESS  (먼저 zig build stress)" >&2; exit 1; }
 
 # 이름을 미리 검증한다. 오타 하나로 회차 전부가 날아가지 않게 — 모르는 이름은
@@ -149,8 +161,24 @@ hygiene_check || {
 
 # 복원은 어떤 경로로 끝나든 돌아야 한다 (Ctrl+C 포함) — 안 그러면 CPU 가 performance 인
 # 채로, 창이 내려간 채로 남는다.
-trap hygiene_end EXIT INT TERM
+PANE_CLEANUP=""
+pane_cleanup() { [ -n "$PANE_CLEANUP" ] && rm -f $PANE_CLEANUP; PANE_CLEANUP=""; }
+trap 'hygiene_end; pane_cleanup' EXIT INT TERM
 hygiene_begin
+INSTANCE_ARGS=""
+RUNNER_CMD=""
+BARRIER=""
+if [ "$PANES" != 1 ]; then
+    # config_9 — config_0 복사 · auto_start 끔 · hotkey 는 등록되지 않지만 (stress run) 충돌 여지를 없앤다.
+    _cfgdir="$(cygpath -u "$APPDATA")/tildaz"
+    if [ -f "$_cfgdir/config_9.toml" ]; then echo "config_9.toml 이 이미 있어요 — 사용자 설정일 수 있어 덮지 않아요" >&2; exit 1; fi
+    sed -e 's/^hotkey *=.*/hotkey = "shift+f11"/' -e 's/^auto_start *=.*/auto_start = false/' "$_cfgdir/config_0.toml" > "$_cfgdir/config_9.toml"
+    PANE_CLEANUP="$_cfgdir/config_9.toml $_cfgdir/tildaz_9.log"
+    INSTANCE_ARGS="--instance 9"
+    mkdir -p "$OUT"
+    BARRIER="$OUT/pane-barrier"
+    RUNNER_CMD="powershell -NoProfile -ExecutionPolicy Bypass -File $(native_path "$REPO_ROOT/dist/stress/pane-runner.ps1") $(native_path "$BARRIER") $(native_path "$STRESS")"
+fi
 
 mkdir -p "$OUT"
 
@@ -189,8 +217,24 @@ while [ "$i" -le "$REPEAT" ]; do
         export TILDAZ_STRESS_WORKLOAD
         # 실패해도 남은 회차는 계속 돈다 — 한 회차가 죽었다고 나머지를 버리지 않는다.
         # 그 회차는 로그에 스냅숏을 안 남기므로 표의 회차 수로 드러난다.
-        $RUN_TIMEOUT "$EXE" -e "$(native_path "$STRESS")" -size 120x40 -scrollback "$SCROLLBACK" \
-            >/dev/null 2>&1 || echo "⚠ 회차 실패: $w ($i/$REPEAT)" >&2
+        if [ "$PANES" = 1 ]; then
+            $RUN_TIMEOUT "$EXE" -e "$(native_path "$STRESS")" -size 120x40 -scrollback "$SCROLLBACK" \
+                >/dev/null 2>&1 || echo "⚠ 회차 실패: $w ($i/$REPEAT)" >&2
+        else
+            rm -f "$BARRIER"
+            _log_before=$(wc -c < "$LOG" 2>/dev/null | tr -d ' '); [ -n "$_log_before" ] || _log_before=0
+            $RUN_TIMEOUT "$EXE" $INSTANCE_ARGS -e "$RUNNER_CMD $w $TILDAZ_STRESS_BYTES" -size 120x40 -scrollback "$SCROLLBACK" \
+                >/dev/null 2>&1 &
+            _app_pid=$!
+            powershell -NoProfile -ExecutionPolicy Bypass -File "$(native_path "$REPO_ROOT/dist/stress/split-panes.ps1")" -Panes "$PANES" 2>&1 | tr -d '\r'
+            sleep 0.8
+            _have=$(tail -c "+$((_log_before + 1))" "$LOG" 2>/dev/null | grep -o 'has [0-9]* panes' | tail -1 | awk '{print $2}')
+            [ -n "$_have" ] || _have=1
+            if [ "$_have" != "$PANES" ]; then echo "⚠ pane 수 $_have ≠ $PANES ($w $i/$REPEAT) — 이 회차는 버려요" >&2; fi
+            : > "$BARRIER"           # N 개 러너가 함께 시작한다
+            wait "$_app_pid" || echo "⚠ 회차 실패: $w ($i/$REPEAT)" >&2
+            rm -f "$BARRIER"
+        fi
         sleep 1.5
     done
     i=$((i + 1))

--- a/dist/stress/pane-runner.ps1
+++ b/dist/stress/pane-runner.ps1
@@ -1,0 +1,29 @@
+﻿# 실제 앱의 pane 마다 하나씩 뜨는 **producer 러너** (Windows · `measure-repeat.sh --panes N` 이 `-e` 로 넘긴다).
+#
+#   tildaz.exe --instance 9 -e "powershell -NoProfile -ExecutionPolicy Bypass -File pane-runner.ps1 <barrier> <stress.exe> <workload> <bytes>" -size 120x40
+#
+# **왜 러너인가** — `frame --panes N` 하네스는 내부 TabGroup 에 producer 를 만들고 파일 barrier 로 함께 시작하지만,
+# 실제 앱은 pane 을 만들 때 producer 에 `TILDAZ_STRESS_START_BARRIER` · `PANE_ID` 를 넣지 않는다. 그래서 `-e` 에
+# producer 를 직접 넘기면 **첫 pane 의 폭포가 분할이 끝나기 전에 흐른다.** 이 러너는 barrier 파일이 생길 때까지
+# 50 ms 폴링으로 기다린 뒤 producer 를 띄운다 — 새 pane 의 셸도 같은 `-e` 명령이라 pane 마다 러너 하나가 뜨고,
+# `measure-repeat.sh` 가 분할을 끝내고 파일을 만들면 N 개가 함께 (≤ 50 ms + 프로세스 시작 지터) 시작한다.
+#
+# producer 모드는 환경변수 둘 (`TILDAZ_STRESS_WORKLOAD` · `TILDAZ_STRESS_BYTES`) 로만 켜지고 인자가 있으면 독립 측정
+# 모드가 되어 앱 PTY 로 폭포가 흐르지 않는다 (README "producer 는 환경변수 두 개로만 켜져요"). 그래서 여기서 환경변수를
+# 심고 인자 없이 실행한다. producer 가 끝나면 러너도 끝나 그 pane 이 닫히고, 마지막 pane 이 닫히면 앱이 종료 덤프를 남긴다.
+#
+# ⚠️ UTF-8 BOM 으로 저장한다 (Windows PowerShell 5.1).
+param(
+    [Parameter(Mandatory)][string]$Barrier,
+    [Parameter(Mandatory)][string]$Stress,
+    [string]$Workload = "plain",
+    [string]$Bytes = "67108864",
+    # barrier 를 이만큼 기다려도 안 생기면 그냥 시작한다 — 분할이 실패한 회차가 조용히 걸려 있지 않게.
+    [int]$TimeoutSec = 20
+)
+$sw = [Diagnostics.Stopwatch]::StartNew()
+while (-not (Test-Path -LiteralPath $Barrier) -and $sw.Elapsed.TotalSeconds -lt $TimeoutSec) { Start-Sleep -Milliseconds 50 }
+$env:TILDAZ_STRESS_WORKLOAD = $Workload
+$env:TILDAZ_STRESS_BYTES = $Bytes
+& $Stress
+exit $LASTEXITCODE

--- a/dist/stress/split-panes.ps1
+++ b/dist/stress/split-panes.ps1
@@ -1,0 +1,126 @@
+﻿# 떠 있는 측정 인스턴스 (`TildaZ-stress` 창) 의 활성 탭을 **합성 키로 N 개 pane 으로 가른다** (Windows ·
+# `measure-repeat.sh --panes N` 이 부른다). 앱은 pane 을 만들 때 producer 의 barrier 환경변수를 넣지 않으므로
+# 실제 앱 회차는 이렇게 분할한 뒤 `pane-runner.ps1` 의 barrier 파일을 만들어 N 개 producer 를 함께 시작한다.
+#
+#   split-panes.ps1 -Panes 8            # 2 · 4 · 8
+#
+# 분할 순서 — 새 pane 이 활성이 된다 (`session_core.splitActive`). 포커스 이동은 기하 기반 이웃 (SPEC §? pane 표).
+#   2: →                           → [L | R]
+#   4: → ↓ Alt+← ↓                 → 2 × 2  (60x20 근사)
+#   8: 4 뒤 → Alt+↑ → Alt+→ → Alt+↓ →   → 4 열 × 2 행 (30x20 근사)   그리고 Shift+Alt+0 (균등)
+# 120 열은 3 열 상태에서 더 못 가른다 (`MIN_PANE_COLS` 20 — #551 macOS 회차) 라 반씩 가르는 순서를 지킨다.
+#
+# 단축키는 기본 바인딩 (`config.zig` Linux · Windows 기본값 — `ctrl+shift+방향` 분할 · `alt+방향` 포커스 ·
+# `shift+alt+0` 균등) 이고 **`config_9.toml` 이 있어야 산다** — `measure-repeat.sh` 가 만들고 지운다.
+#
+# 규칙 — 키마다 foreground 가 그 창인지 확인하고 어긋나면 멈춘다 (`send-keys.ps1` 과 같다). 덮인 창은 잠깐 TOPMOST
+# 로 올려 활성화한다. chord 는 `,@(…)` 로 감싼다 (PowerShell 이 원소 하나인 배열을 평탄화한다 — AGENTS.md).
+# pane 수는 호출자가 앱 로그 `[pane] split … — tab 0 has N panes` 로 확인한다.
+#
+# ⚠️ UTF-8 BOM 으로 저장한다 (Windows PowerShell 5.1).
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int]$Panes,
+    [string]$WindowTitle = 'TildaZ-stress',
+    [string]$WindowClass = 'TildaZWindow',
+    # 창이 뜨기를 기다릴 시간.
+    [int]$WaitMs = 15000,
+    # 키 사이 간격 (ms). 분할은 새 셸 spawn 을 동반하니 넉넉히.
+    [int]$GapMs = 350
+)
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class TzSplit {
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x, y; }
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern IntPtr FindWindowW(string cls, string title);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int cx, int cy, uint flags);
+  [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref POINT p);
+  [DllImport("user32.dll")] public static extern int GetSystemMetrics(int i);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
+  [DllImport("user32.dll")] public static extern uint MapVirtualKeyW(uint c, uint t);
+  [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk, wScan; public uint dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx, dy; public uint mouseData, dwFlags, time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Explicit, Size = 40)] public struct INPUT { [FieldOffset(0)] public uint type; [FieldOffset(8)] public KEYBDINPUT ki; [FieldOffset(8)] public MOUSEINPUT mi; }
+  [DllImport("user32.dll", SetLastError = true)] public static extern uint SendInput(uint n, INPUT[] p, int cb);
+  static INPUT Key(ushort vk, uint flags) {
+    var i = new INPUT(); i.type = 1; i.ki.wVk = vk; i.ki.wScan = (ushort)MapVirtualKeyW(vk, 0);
+    // 화살표는 extended key — scan code 에 KEYEVENTF_EXTENDEDKEY 를 붙여야 numpad 와 안 섞인다.
+    if (vk >= 0x25 && vk <= 0x28) flags |= 0x0001;
+    i.ki.dwFlags = flags; return i;
+  }
+  static INPUT Mouse(int nx, int ny, uint flags) { var i = new INPUT(); i.type = 0; i.mi.dx = nx; i.mi.dy = ny; i.mi.dwFlags = flags; return i; }
+  static void Norm(int x, int y, out int nx, out int ny) {
+    int vx = GetSystemMetrics(76), vy = GetSystemMetrics(77), vw = GetSystemMetrics(78), vh = GetSystemMetrics(79);
+    nx = (int)(((long)(x - vx) * 65535) / (vw > 1 ? vw - 1 : 1)); ny = (int)(((long)(y - vy) * 65535) / (vh > 1 ? vh - 1 : 1));
+  }
+  public static uint Chord(ushort[] vks) {
+    var a = new INPUT[vks.Length * 2]; int n = 0;
+    foreach (var v in vks) a[n++] = Key(v, 0);
+    for (int k = vks.Length - 1; k >= 0; k--) a[n++] = Key(vks[k], 2);
+    return SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+  }
+  public static bool Focus(IntPtr h) {
+    if (GetForegroundWindow() == h) return true;
+    SetWindowPos(h, new IntPtr(-1), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0040);
+    SetForegroundWindow(h); System.Threading.Thread.Sleep(300);
+    bool ok = GetForegroundWindow() == h;
+    if (!ok) {
+      RECT r; GetClientRect(h, out r);
+      var p = new POINT(); p.x = (r.R - r.L) / 2; p.y = (r.B - r.T) / 2; ClientToScreen(h, ref p);
+      POINT before; bool hc = GetCursorPos(out before);
+      int nx, ny; Norm(p.x, p.y, out nx, out ny);
+      uint mv = 0x0001 | 0x8000 | 0x4000;
+      var a = new INPUT[] { Mouse(nx, ny, mv), Mouse(nx, ny, mv | 0x0002), Mouse(nx, ny, mv | 0x0004) };
+      SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT)));
+      System.Threading.Thread.Sleep(300);
+      if (hc) { int bx, by; Norm(before.x, before.y, out bx, out by); var m = new INPUT[] { Mouse(bx, by, mv) }; SendInput(1, m, Marshal.SizeOf(typeof(INPUT))); }
+      ok = GetForegroundWindow() == h;
+    }
+    SetWindowPos(h, new IntPtr(-2), 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0010);
+    return ok;
+  }
+}
+"@
+
+if ($Panes -notin 1, 2, 4, 8) { Write-Output "  ❌ --panes 는 1 · 2 · 4 · 8 만"; exit 2 }
+$VK = @{ Ctrl = 0x11; Shift = 0x10; Alt = 0x12; Left = 0x25; Up = 0x26; Right = 0x27; Down = 0x28; D0 = 0x30 }
+$SR = @($VK.Ctrl, $VK.Shift, $VK.Right)   # split_right
+$SD = @($VK.Ctrl, $VK.Shift, $VK.Down)    # split_down
+$FL = @($VK.Alt, $VK.Left); $FR = @($VK.Alt, $VK.Right); $FU = @($VK.Alt, $VK.Up); $FD = @($VK.Alt, $VK.Down)
+$EQ = @($VK.Shift, $VK.Alt, $VK.D0)       # equalize_panes
+# ⚠️ `$seq = switch (…) { 2 { @(,$SR) } }` 는 안 돼요 — switch 의 **출력**은 파이프라인을 지나며 풀려서 원소가 하나인
+# 배열이 `@(17, 16, 39)` 가 되고 Ctrl · Shift · → 가 따로 눌려요 (2026-09-03 실측 — pane 2 회차 5 회가 전부 분할 실패).
+# 블록 안에서 변수에 **직접 대입**하면 풀리지 않아요. 4 · 8 은 원소가 여럿이라 우연히 살아남았어요.
+$seq = @()
+switch ($Panes) {
+    2 { $seq = ,$SR }
+    4 { $seq = @($SR, $SD, $FL, $SD) }
+    8 { $seq = @($SR, $SD, $FL, $SD, $SR, $FU, $SR, $FR, $SR, $FD, $SR, $EQ) }
+}
+
+# 창 대기 — owner 창 (0x0) 도 같은 class 라 제목까지 준다.
+$h = [IntPtr]::Zero; $sw = [Diagnostics.Stopwatch]::StartNew()
+while ($h -eq [IntPtr]::Zero -and $sw.ElapsedMilliseconds -lt $WaitMs) {
+    $h = [TzSplit]::FindWindowW($WindowClass, $WindowTitle)
+    if ($h -eq [IntPtr]::Zero) { Start-Sleep -Milliseconds 100 }
+}
+if ($h -eq [IntPtr]::Zero) { Write-Output "  ❌ 측정 창을 못 찾았어요 (class=$WindowClass title=$WindowTitle)"; exit 3 }
+Start-Sleep -Milliseconds 800   # 첫 셸 (러너) 이 뜨고 레이아웃이 자리 잡을 시간
+if ($seq.Count -eq 0) { Write-Output "  pane 1 — 분할 없음"; exit 0 }
+if (-not [TzSplit]::Focus($h)) { Write-Output "  ❌ 측정 창이 활성이 아니에요 — 키를 보내지 않았어요"; exit 4 }
+$sent = 0
+foreach ($chord in $seq) {
+    if ([TzSplit]::GetForegroundWindow() -ne $h) { Write-Output "  ❌ 포커스를 잃었어요 — $sent 번째 뒤 중단"; exit 5 }
+    [void][TzSplit]::Chord([uint16[]]$chord)
+    $sent++
+    Start-Sleep -Milliseconds $GapMs
+}
+Write-Output "  분할 키 $sent 개 보냄 (pane $Panes 목표)"
+exit 0


### PR DESCRIPTION
[#583](https://github.com/ensky0/tildaz/issues/583) **A11** — #551 의 Windows 실제 앱 pane 4 · 8 을 자동화로 재측정하고 그 도구를 레포에 둔다. 코드 변경 없음 (스크립트 · 문서).

## 도구

| | |
|---|---|
| `measure-repeat.sh --panes N` | 새 옵션 (Windows 만). `config_9.toml` (config_0 복사 · `auto_start = false`) 을 만들고 `--instance 9` 로 앱을 띄워 분할 → barrier → 종료 덤프 파싱 (기존 파서 그대로). 끝나면 config 를 지운다 |
| `pane-runner.ps1` | `-e` 로 넘기는 러너 — barrier 파일을 50 ms 로 기다린 뒤 환경변수를 심고 producer 를 인자 없이 띄운다. 새 pane 의 셸도 같은 `-e` 라 pane 마다 러너 하나 → 파일 하나로 N 개가 **함께** 시작 |
| `split-panes.ps1` | `TildaZ-stress` 창을 찾아 (TOPMOST 로 포커스) `SendInput` 으로 분할 — 2: `→` · 4: `→ ↓ Alt+← ↓` · 8: 그 뒤 `→ Alt+↑ → Alt+→ → Alt+↓ →` + `Shift+Alt+0` (새 pane 이 활성이 되는 규칙에 맞춘 순서 → 4 열 × 2 행). 키마다 포커스 가드 |

## 실측 (main `1f7d223` · 노트북 Ryzen AI 7 350 · Windows 11 Pro 26200 · 120 Hz · AC · 최고 성능 · plain 64 MiB/pane · 5 회 절사평균)

| pane | drain ms | render/call ms | present ms | 손실 byte |
|---:|---|---|---|---|
| 1 | 141.1 (139~143) | 0.655 | 15.0 | 16 |
| 2 | 349.8 (343~357) | 0.494 | 29.5 | 32 |
| 4 | 853.3 (814~924) | 0.431 | 92.2 | 64 |
| 8 | 2150.1 (2132~2176) | 1.373 | 232.7 | 128 |

- 손실 = pane 당 16 byte (ConPTY 종료) → **미소화 0** — #572 수정이 동시 시작 회차에서도 유효.
- 8 pane 5 회 폭 2 % → A11 의 "8 pane 25 % 흔들림" 은 **실제 앱에서 재현되지 않는다** (하네스 쪽 현상으로 남음).
- 8 pane `render/call` 1.373 은 SPEC 의 #572 회차 값 0.894 와 갈린다 — 그 회차의 격자 · 분할 · 시작 동시성이 기록에 없어 원인은 **확인 필요** (후보: barrier 동시 시작). SPEC §13.3.1 에 두 값을 나란히 적었다.

## 함정 (AGENTS.md)

PowerShell 은 `switch` 블록의 **출력**으로 돌려받은 원소 하나짜리 배열도 파이프라인에서 풀어 버린다 — pane 2 첫 회차 5 회가 Ctrl · Shift · → 를 따로 눌러 분할이 안 됐다. 블록 안에서 `$seq = ,$chord` 로 직접 대입한다. 고친 뒤 pane 2 를 다시 5 회 잰 값이 위 표다.

README (`--panes` 사용법 · 분할 순서 · #572 서술) · SPEC §13.3.1 · #551 댓글.

Refs #583 #551