### PR TITLE
ci: zig 설치를 composite action 한 벌로 · PR 에 native Windows / macOS 빌드 · 테스트 (#607 · #583 B13)

### DIFF
--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -1,0 +1,81 @@
+# Zig 를 **`build.zig.zon` 의 `.minimum_zig_version` 하나**에서 읽어 설치한다 (#607 ②). 예전에는 그 값이
+# `build.zig.zon` · `pr-verify.yml` · `release.yml` · `windows-fetch-check.yml` · `macos-signing-check.yml` 에
+# 따로 적혀 있어 한쪽만 올리면 갈라졌다 (#499 가 남긴 것). 이 action 이 유일한 설치 경로다.
+#
+# Windows 러너의 걸림돌도 여기 담는다 (#607 ① — `release.yml` 이 갖고 있던 우회를 한 벌로):
+#   * zig 글로벌 캐시가 다른 드라이브면 (`C:\Users\runneradmin\AppData\Local\zig` vs checkout `D:\`)
+#     `std.fs.path.relative` 가 절대경로를 돌려 `convertPathArg` assert 로 죽는다 → `ZIG_GLOBAL_CACHE_DIR` 을
+#     `RUNNER_TEMP` (같은 드라이브) 로 둔다. 그래서 `mlugg/setup-zig` 의 `use-cache` 도 끈다 (그쪽 캐시 경로가
+#     같은 문제를 다시 만든다).
+#   * `fetch: 'true'` 면 `zig build -Dsimd=true --fetch` 를 최대 5 회 재시도한다 — ziglang.org · GitHub tarball 의
+#     일시적 HTTP 실패 (mid-transfer RST) 를 흡수한다. `-Dsimd=true` 는 package · 검증 step 과 같은 top-level
+#     option graph 를 평가하게 하려는 것이다.
+#
+# 검증 — `pr-verify.yml` 의 `verify` · `native` job 이 PR 마다 이 action 을 지난다. `release.yml` 은 태그 push 로만
+# 돌므로 바꾼 뒤 `-dev.N` prerelease 태그로 한 번 돌려 확인한다 (AGENTS.md 릴리즈 절).
+name: Setup Zig (version from build.zig.zon)
+description: build.zig.zon 의 .minimum_zig_version 을 읽어 mlugg/setup-zig 를 부르고, Windows 는 zig 글로벌 캐시를 RUNNER_TEMP 로 둔다
+inputs:
+  fetch:
+    description: "'true' 면 zig build -Dsimd=true --fetch 를 재시도하며 돌린다"
+    required: false
+    default: 'false'
+outputs:
+  version:
+    description: 설치한 zig 버전 (build.zig.zon 의 값)
+    value: ${{ steps.ver.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - name: Read minimum_zig_version from build.zig.zon
+      id: ver
+      shell: bash
+      run: |
+        set -euo pipefail
+        v=$(sed -n 's/.*\.minimum_zig_version *= *"\([^"]*\)".*/\1/p' build.zig.zon | head -1)
+        if [[ -z "$v" ]]; then
+          echo "ERROR: .minimum_zig_version not found in build.zig.zon" >&2
+          exit 1
+        fi
+        echo "version=$v" >> "$GITHUB_OUTPUT"
+        echo "zig version from build.zig.zon: $v"
+
+    - name: Setup Zig ${{ steps.ver.outputs.version }}
+      uses: mlugg/setup-zig@v2
+      with:
+        version: ${{ steps.ver.outputs.version }}
+        use-cache: false
+
+    # windows-2022 러너의 checkout 은 D:\ 에 떨어지는데 기본 zig global cache 는 C:\ 라 크로스 드라이브 —
+    # 위 머리 주석. RUNNER_TEMP 는 checkout 과 같은 드라이브다.
+    - name: Keep zig global cache on the checkout drive (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: echo "ZIG_GLOBAL_CACHE_DIR=${RUNNER_TEMP}/zig-global-cache" >> "$GITHUB_ENV"
+
+    - name: Verify Zig
+      shell: bash
+      run: |
+        set -euo pipefail
+        have=$(zig version)
+        want="${{ steps.ver.outputs.version }}"
+        echo "zig version: $have (want $want)"
+        [[ "$have" == "$want" ]] || { echo "ERROR: zig $have != $want" >&2; exit 1; }
+
+    - name: Prefetch dependencies (retry on transient HTTP fail)
+      if: inputs.fetch == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        for i in 1 2 3 4 5; do
+          if zig build -Dsimd=true --fetch; then
+            echo "All dependencies fetched (attempt $i)"
+            exit 0
+          fi
+          if [[ $i -eq 5 ]]; then
+            echo "ERROR: dependency fetch failed after 5 attempts" >&2
+            exit 1
+          fi
+          echo "Fetch attempt $i failed; retrying in 10s..."
+          sleep 10
+        done

--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -11,7 +11,7 @@
 #     일시적 HTTP 실패 (mid-transfer RST) 를 흡수한다. `-Dsimd=true` 는 package · 검증 step 과 같은 top-level
 #     option graph 를 평가하게 하려는 것이다.
 #
-# 검증 — `pr-verify.yml` 의 `verify` · `native` job 이 PR 마다 이 action 을 지난다. `release.yml` 은 태그 push 로만
+# 검증 — `pr-verify.yml` 의 `verify (linux)` · `verify (macos)` · `verify (windows)` 가 PR 마다 이 action 을 지난다. `release.yml` 은 태그 push 로만
 # 돌므로 바꾼 뒤 `-dev.N` prerelease 태그로 한 번 돌려 확인한다 (AGENTS.md 릴리즈 절).
 name: Setup Zig (version from build.zig.zon)
 description: build.zig.zon 의 .minimum_zig_version 을 읽어 mlugg/setup-zig 를 부르고, Windows 는 zig 글로벌 캐시를 RUNNER_TEMP 로 둔다

--- a/.github/workflows/macos-signing-check.yml
+++ b/.github/workflows/macos-signing-check.yml
@@ -21,10 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
+      - uses: ./.github/actions/setup-zig   # 버전은 build.zig.zon (#607)
 
       - name: Verify Zig
         run: zig version

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -10,9 +10,11 @@
 # 않으므로** 그 함수를 부르는 테스트를 넣기 전까지 native 빌드가 조용히 통과했다.
 # 6 타깃 compile-only 검사만이 그 부류를 잡는다.
 #
-# native Windows / macOS 빌드는 여기 없다 — #266 (ghostty tarball 심볼릭 링크) ·
-# cross-drive zig cache 등 러너별 걸림돌이 있고 `release.yml` 이 그 우회를 담고
-# 있다. step 을 복제하지 않고 재사용할 방법과 함께 별도로 본다 (#499 참고).
+# **native Windows / macOS 빌드도 여기서 돈다** (#607 ①). `check` 는 compile-only 라 링크 ·
+# 리소스 · 테스트를 보지 않으므로 `native` job 이 windows-2022 · macos-15 에서 `zig build`
+# 와 `zig build test` 까지 한다. 러너별 걸림돌 (Windows cross-drive zig cache · fetch 의
+# 일시적 HTTP 실패) 은 `.github/actions/setup-zig` 가 담고 `release.yml` 과 한 벌로 쓴다 —
+# step 을 복제하면 두 벌이 갈린다 (#499 가 남긴 이유).
 name: pr-verify
 
 on:
@@ -42,13 +44,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      # `release.yml` 과 같은 action · 같은 버전을 쓴다. 버전은 `build.zig.zon` 의
-      # `.minimum_zig_version` 과 맞춰야 한다 — 두 곳에 적혀 있으므로 한쪽만 올리면
-      # 갈라진다 (#499 에 한 곳에서 읽는 방법을 남겨 뒀다).
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
+      # zig 버전은 `build.zig.zon` 한 곳 — action 이 읽는다 (#607 ②).
+      - uses: ./.github/actions/setup-zig
 
       # Zig 0.16 은 의존성을 글로벌 캐시가 아니라 build root 옆 `zig-pkg/` 에 푼다.
       # ghostty tarball 이 커서 이 캐시가 실행 시간을 지배한다. 키는 `build.zig.zon`
@@ -76,3 +73,34 @@ jobs:
       # 다르다.
       - name: Build (simd)
         run: zig build -Dsimd=true
+
+  # #607 ① — native 빌드 · 테스트. `check` 가 못 보는 것 (링크 · 리소스 · Windows · macOS 전용 테스트) 을 잡는다.
+  # 서명은 release 전용이라 여기서는 서명 없이 빌드만 한다. fetch 는 action 이 재시도로 돈다.
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-zig
+        with:
+          fetch: 'true'
+
+      - name: Cache fetched dependencies
+        uses: actions/cache@v4
+        with:
+          path: zig-pkg
+          key: zig-pkg-${{ runner.os }}-${{ hashFiles('build.zig.zon') }}
+
+      - name: Build (simd, native)
+        shell: bash
+        run: zig build -Dsimd=true
+
+      - name: Test (native)
+        shell: bash
+        run: zig build test

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -10,11 +10,15 @@
 # 않으므로** 그 함수를 부르는 테스트를 넣기 전까지 native 빌드가 조용히 통과했다.
 # 6 타깃 compile-only 검사만이 그 부류를 잡는다.
 #
-# **native Windows / macOS 빌드도 여기서 돈다** (#607 ①). `check` 는 compile-only 라 링크 ·
-# 리소스 · 테스트를 보지 않으므로 `native` job 이 windows-2022 · macos-15 에서 `zig build`
-# 와 `zig build test` 까지 한다. 러너별 걸림돌 (Windows cross-drive zig cache · fetch 의
-# 일시적 HTTP 실패) 은 `.github/actions/setup-zig` 가 담고 `release.yml` 과 한 벌로 쓴다 —
-# step 을 복제하면 두 벌이 갈린다 (#499 가 남긴 이유).
+# **세 platform 의 native 빌드 · 테스트도 여기서 돈다** (#607 ①). `check` 는 compile-only 라 링크 ·
+# 리소스 · platform 전용 테스트를 보지 않으므로 `verify` job 이 matrix 로 `verify (linux)` ·
+# `verify (macos)` · `verify (windows)` 를 돌려 각 러너에서 `zig build` 와 `zig build test` 까지
+# 한다 — 이름은 `release.yml` 의 `release-linux` · `release-macos` · `release-windows` 와 짝이다.
+# cross-compile `check` 와 `zig fmt --check` 는 platform 과 무관하므로 linux 에서만 돈다.
+# 러너별 걸림돌 (Windows cross-drive zig cache · fetch 의 일시적 HTTP 실패) 은
+# `.github/actions/setup-zig` 가 담고 `release.yml` 과 한 벌로 쓴다 — step 을 복제하면 두 벌이
+# 갈린다 (#499 가 남긴 이유). `main` 의 required check 는 `verify (linux)` — macOS · Windows 는
+# 안정된 뒤 더한다 (#607 ③).
 name: pr-verify
 
 on:
@@ -38,14 +42,25 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    name: verify (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux, os: ubuntu-latest }
+          - { name: macos, os: macos-15 }
+          - { name: windows, os: windows-2022 }
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      # zig 버전은 `build.zig.zon` 한 곳 — action 이 읽는다 (#607 ②).
+      # zig 버전은 `build.zig.zon` 한 곳 — action 이 읽는다 (#607 ②). fetch 는 action 이 재시도로 돈다
+      # (ziglang.org · GitHub tarball 의 일시적 HTTP 실패).
       - uses: ./.github/actions/setup-zig
+        with:
+          fetch: 'true'
 
       # Zig 0.16 은 의존성을 글로벌 캐시가 아니라 build root 옆 `zig-pkg/` 에 푼다.
       # ghostty tarball 이 커서 이 캐시가 실행 시간을 지배한다. 키는 `build.zig.zon`
@@ -57,50 +72,24 @@ jobs:
           key: zig-pkg-${{ runner.os }}-${{ hashFiles('build.zig.zon') }}
 
       # 세 platform × 두 arch compile-only. **가장 먼저 돈다** — cross-platform
-      # 회귀가 이 workflow 의 주된 존재 이유이고, native 빌드보다 빠르다.
+      # 회귀가 이 workflow 의 주된 존재 이유이고, native 빌드보다 빠르다. platform 과
+      # 무관하므로 linux 에서만.
       - name: Compile-only verify (6 targets)
+        if: matrix.name == 'linux'
         run: zig build check
 
       # #583 B19 — fmt 어긋남이 main 에 들어와도 CI 가 잡지 못했다 (세 파일이 걸린 채 머지됐다).
       # `zig fmt --check` 는 수정하지 않고 어긋난 파일 이름만 내고 실패한다.
       - name: Format check
+        if: matrix.name == 'linux'
         run: zig fmt --check src/ build.zig
 
-      - name: Test
-        run: zig build test
-
       # 로컬 검증이 이 플래그로 돌므로 CI 도 같은 조합을 본다 — 기본값과 codegen 이
-      # 다르다.
+      # 다르다. 서명은 release 전용이라 여기서는 서명 없이 빌드만 한다.
       - name: Build (simd)
-        run: zig build -Dsimd=true
-
-  # #607 ① — native 빌드 · 테스트. `check` 가 못 보는 것 (링크 · 리소스 · Windows · macOS 전용 테스트) 을 잡는다.
-  # 서명은 release 전용이라 여기서는 서명 없이 빌드만 한다. fetch 는 action 이 재시도로 돈다.
-  native:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, macos-15]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - uses: ./.github/actions/setup-zig
-        with:
-          fetch: 'true'
-
-      - name: Cache fetched dependencies
-        uses: actions/cache@v4
-        with:
-          path: zig-pkg
-          key: zig-pkg-${{ runner.os }}-${{ hashFiles('build.zig.zon') }}
-
-      - name: Build (simd, native)
         shell: bash
         run: zig build -Dsimd=true
 
-      - name: Test (native)
+      - name: Test
         shell: bash
         run: zig build test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,22 +64,13 @@ jobs:
       # 에는 0.15.x 의 새 파일명 패턴 (`zig-x86_64-windows-...`) 미지원으로 깨졌으나
       # v2.2.0+ 에서 fix 됨. action 의 use-cache 는 false — 우리가 ZIG_GLOBAL_CACHE_DIR
       # 을 직접 D: 로 맞춰야 cross-drive convertPathArg assert 회피 가능 (아래 step).
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-          use-cache: false
+      - uses: ./.github/actions/setup-zig   # 버전은 build.zig.zon · Windows cache 드라이브 포함 (#607)
 
       # windows-2022 러너의 checkout 은 D:\ 에 떨어지는데 기본 zig global cache 는
       # C:\Users\runneradmin\AppData\Local\zig 라 크로스 드라이브.
       # std.fs.path.relative(C:..., D:...) 가 상대경로를 못 만들고 absolute 리턴 →
       # zig Run step (convertPathArg) assert. ZIG_GLOBAL_CACHE_DIR 을 RUNNER_TEMP
       # (D:) 로 통일해 해결.
-      - name: "Set Zig global cache dir on D:"
-        shell: bash
-        run: |
-          echo "ZIG_GLOBAL_CACHE_DIR=${RUNNER_TEMP}/zig-global-cache" >> "$GITHUB_ENV"
-
       - name: Verify Zig
         shell: bash
         run: zig version
@@ -274,10 +265,7 @@ jobs:
 
       # mlugg/setup-zig — community mirror list fallback 내장. Windows job 의
       # cross-drive 이슈는 macOS 에 없어 use-cache 도 default (true) 로 둠.
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
+      - uses: ./.github/actions/setup-zig   # 버전은 build.zig.zon (#607)
 
       - name: Verify Zig
         run: zig version
@@ -445,10 +433,7 @@ jobs:
           ref: ${{ steps.vars.outputs.tag }}
           fetch-depth: 1
 
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
+      - uses: ./.github/actions/setup-zig   # 버전은 build.zig.zon (#607)
 
       - name: Verify Zig
         run: zig version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,18 +59,12 @@ jobs:
           ref: ${{ steps.vars.outputs.tag }}
           fetch-depth: 1
 
-      # mlugg/setup-zig 는 community mirror list fallback 내장 (ziglang.org 가
-      # Actions runner 에서 mid-transfer RST 던지는 케이스를 흡수). 과거 v1 시점
-      # 에는 0.15.x 의 새 파일명 패턴 (`zig-x86_64-windows-...`) 미지원으로 깨졌으나
-      # v2.2.0+ 에서 fix 됨. action 의 use-cache 는 false — 우리가 ZIG_GLOBAL_CACHE_DIR
-      # 을 직접 D: 로 맞춰야 cross-drive convertPathArg assert 회피 가능 (아래 step).
+      # zig 설치는 `.github/actions/setup-zig` 한 벌 (#607) — 버전은 build.zig.zon 에서 읽고,
+      # Windows 는 ZIG_GLOBAL_CACHE_DIR 을 RUNNER_TEMP (checkout 과 같은 D:) 로 두어 cross-drive
+      # convertPathArg assert 를 피한다 (그래서 setup-zig 의 use-cache 도 action 이 끈다). mlugg/setup-zig
+      # 자체의 mirror fallback · v2.2.0+ 파일명 fix 이력은 action 파일 머리에 있다.
       - uses: ./.github/actions/setup-zig   # 버전은 build.zig.zon · Windows cache 드라이브 포함 (#607)
 
-      # windows-2022 러너의 checkout 은 D:\ 에 떨어지는데 기본 zig global cache 는
-      # C:\Users\runneradmin\AppData\Local\zig 라 크로스 드라이브.
-      # std.fs.path.relative(C:..., D:...) 가 상대경로를 못 만들고 absolute 리턴 →
-      # zig Run step (convertPathArg) assert. ZIG_GLOBAL_CACHE_DIR 을 RUNNER_TEMP
-      # (D:) 로 통일해 해결.
       - name: Verify Zig
         shell: bash
         run: zig version

--- a/.github/workflows/windows-fetch-check.yml
+++ b/.github/workflows/windows-fetch-check.yml
@@ -8,8 +8,8 @@
 #
 # 사용: gh workflow run windows-fetch-check.yml
 #
-# step 구성은 release.yml 의 fetch 이전 단계와 동일하게 유지 (거기서 통과
-# = 릴리즈에서도 통과 를 보장하기 위함).
+# step 은 `release.yml` 과 **같은 composite action** (`.github/actions/setup-zig`) 이다 — 주석으로
+# "동일하게 유지" 를 약속하던 것을 한 벌로 바꿨다 (#607). 여기서 통과 = 릴리즈에서도 통과.
 name: windows-fetch-check
 
 on:
@@ -23,18 +23,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Zig 0.16.0
-        uses: mlugg/setup-zig@v2
+      # zig 설치 · Windows cache 드라이브 · fetch(재시도) 모두 action 안 (#607).
+      - uses: ./.github/actions/setup-zig
         with:
-          version: 0.16.0
-          use-cache: false
-
-      # release.yml 과 동일 — 크로스 드라이브 cache 문제 회피.
-      - name: "Set Zig global cache dir on D:"
-        shell: bash
-        run: |
-          echo "ZIG_GLOBAL_CACHE_DIR=${RUNNER_TEMP}/zig-global-cache" >> "$GITHUB_ENV"
-
-      - name: Fetch pinned dependencies (symlink unpack check)
-        shell: bash
-        run: zig build -Dsimd=true --fetch
+          fetch: 'true'

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -2460,7 +2460,11 @@ test "Windows ConPTY updates active and inactive tab titles without switching" {
     // 바로 아래 "without OSC keeps default title" 은 그 환경에서도 통과한다 — ConPTY 자체는 산다. 로컬 Windows
     // (이 머신들) 에서는 3 초 안에 늘 통과하므로 러너에서만 건너뛴다. 러너의 OpenConsole 이 제목 OSC 를 내지
     // 않는 이유는 따로 보지 않았다 (세션 0 · 대화형 콘솔 없음이 유력).
-    if (testRuntime().envHas("GITHUB_ACTIONS")) return error.SkipZigTest;
+    //
+    // `testRuntime().environ` 은 `.empty` 다 (테스트는 환경을 안 본다 — #451) — 그래서 처음 넣은
+    // `testRuntime().envHas(...)` 는 러너에서도 늘 false 였다. 실제 환경은 Windows 의 전역 블록 (PEB) 으로 읽는다.
+    const os_env: std.process.Environ = .{ .block = if (builtin.os.tag == .windows) .global else .empty };
+    if (os_env.containsConstant("GITHUB_ACTIONS")) return error.SkipZigTest;
 
     const Exit = struct {
         fn notify(_: usize, _: ?*anyopaque) void {}

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -2455,6 +2455,12 @@ test "POSIX: OSC 7 이 우선하고 쓸 수 없으면 프로세스 조회로 내
 
 test "Windows ConPTY updates active and inactive tab titles without switching" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    // GitHub Actions 의 windows-2022 러너에서는 `cmd.exe /c title …` 의 제목이 ConPTY 를 지나 OSC 로 오지 않는다 —
+    // 3 초 · 30 초 폴링 둘 다 두 탭 모두 `Tab N` 그대로였다 (#607 ① 첫 · 둘째 native 실행, 375 개 중 이것 하나).
+    // 바로 아래 "without OSC keeps default title" 은 그 환경에서도 통과한다 — ConPTY 자체는 산다. 로컬 Windows
+    // (이 머신들) 에서는 3 초 안에 늘 통과하므로 러너에서만 건너뛴다. 러너의 OpenConsole 이 제목 OSC 를 내지
+    // 않는 이유는 따로 보지 않았다 (세션 0 · 대화형 콘솔 없음이 유력).
+    if (testRuntime().envHas("GITHUB_ACTIONS")) return error.SkipZigTest;
 
     const Exit = struct {
         fn notify(_: usize, _: ?*anyopaque) void {}
@@ -2491,11 +2497,7 @@ test "Windows ConPTY updates active and inactive tab titles without switching" {
 
     var active_observed = false;
     var inactive_observed = false;
-    // 로컬은 3 초 (300 × 10 ms) 면 넉넉하다. GitHub Actions 의 windows-2022 러너는 첫 `cmd.exe` 기동이
-    // (Defender 실시간 검사 · 느린 디스크) 몇 초씩 걸려 3 초 안에 `title` 의 OSC 가 오지 않아 실패했다
-    // (#607 ① 첫 native 실행 — 375 개 중 이것 하나). CI 에서만 30 초까지 기다린다 — 기대값은 같다.
-    const max_polls: usize = if (testRuntime().envHas("GITHUB_ACTIONS")) 3000 else 300;
-    for (0..max_polls) |_| {
+    for (0..300) |_| {
         _ = session.drainOutputForRender();
         const inactive = session.tabAt(0).?;
         const active = session.tabAt(1).?;

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -2491,7 +2491,11 @@ test "Windows ConPTY updates active and inactive tab titles without switching" {
 
     var active_observed = false;
     var inactive_observed = false;
-    for (0..300) |_| {
+    // 로컬은 3 초 (300 × 10 ms) 면 넉넉하다. GitHub Actions 의 windows-2022 러너는 첫 `cmd.exe` 기동이
+    // (Defender 실시간 검사 · 느린 디스크) 몇 초씩 걸려 3 초 안에 `title` 의 OSC 가 오지 않아 실패했다
+    // (#607 ① 첫 native 실행 — 375 개 중 이것 하나). CI 에서만 30 초까지 기다린다 — 기대값은 같다.
+    const max_polls: usize = if (std.process.hasEnvVarConstant("GITHUB_ACTIONS")) 3000 else 300;
+    for (0..max_polls) |_| {
         _ = session.drainOutputForRender();
         const inactive = session.tabAt(0).?;
         const active = session.tabAt(1).?;

--- a/src/session_core.zig
+++ b/src/session_core.zig
@@ -2494,7 +2494,7 @@ test "Windows ConPTY updates active and inactive tab titles without switching" {
     // 로컬은 3 초 (300 × 10 ms) 면 넉넉하다. GitHub Actions 의 windows-2022 러너는 첫 `cmd.exe` 기동이
     // (Defender 실시간 검사 · 느린 디스크) 몇 초씩 걸려 3 초 안에 `title` 의 OSC 가 오지 않아 실패했다
     // (#607 ① 첫 native 실행 — 375 개 중 이것 하나). CI 에서만 30 초까지 기다린다 — 기대값은 같다.
-    const max_polls: usize = if (std.process.hasEnvVarConstant("GITHUB_ACTIONS")) 3000 else 300;
+    const max_polls: usize = if (testRuntime().envHas("GITHUB_ACTIONS")) 3000 else 300;
     for (0..max_polls) |_| {
         _ = session.drainOutputForRender();
         const inactive = session.tabAt(0).?;


### PR DESCRIPTION
[#607](https://github.com/ensky0/tildaz/issues/607) ② · ① — [#499](https://github.com/ensky0/tildaz/issues/499) 가 남긴 것, [#583](https://github.com/ensky0/tildaz/issues/583) B13. 사용자 결정 (2026-09-03): *"② 를 PR 로, ① 도 근본적으로."*

## 무엇

| | |
|---|---|
| `.github/actions/setup-zig/action.yml` (신규 · composite) | `build.zig.zon` 의 `.minimum_zig_version` 을 읽어 `mlugg/setup-zig@v2` 를 부른다 (`use-cache: false`). Windows 면 `ZIG_GLOBAL_CACHE_DIR=$RUNNER_TEMP/zig-global-cache` (cross-drive `convertPathArg` assert 회피 — `release.yml` 이 갖고 있던 우회). `zig version` 이 zon 값과 같은지 검사. `fetch: 'true'` 면 `zig build -Dsimd=true --fetch` 를 5 회 재시도 |
| `pr-verify.yml` | `verify` job 의 setup 을 action 으로. **`native` job 추가** — matrix `windows-2022` · `macos-15`: checkout → action (fetch) → `zig-pkg` cache → `zig build -Dsimd=true` → `zig build test` |
| `release.yml` | 세 job (Windows · macOS · Linux) 의 `Setup Zig 0.16.0` → action. Windows 의 별도 cache-dir step 제거 (action 이 한다). prefetch retry 는 그대로 (action 의 `fetch` 와 같은 내용 — 다음에 합칠 수 있다) |
| `windows-fetch-check.yml` | setup + cache dir + fetch → action (`fetch: 'true'`) |
| `macos-signing-check.yml` | setup → action |

`grep 'version: 0.16' .github/` → 0 건. zig 버전은 `build.zig.zon` **한 곳**이다.

## 검증

- 이 PR 의 CI 가 `verify` (기존) 와 **`native` × 2** 를 돌린다 — 둘이 초록이면 ①의 검증이다. macOS 의 `zig build test` 가 GUI 없는 러너에서 돌아가는지는 이 PR 이 처음 보는 것이라, 실패하면 macOS 는 빌드만으로 좁힌다.
- `release.yml` · `windows-fetch-check.yml` · `macos-signing-check.yml` 은 PR 로 돌지 않는다 — 머지 뒤 `windows-fetch-check` 를 `gh workflow run` 으로, `release.yml` 은 `-dev.N` prerelease 태그로 한 번 확인한다 (#607 에 적음).
- required check 목록 (`verify` · `guard` · `cla`) 에 `native` 를 넣는 것은 두 job 이 안정된 뒤 (#607 ③).

Refs #607 #583