### PR TITLE
chore(stress): measure-repeat.sh --stagger — 순차 시작 대조군 · 8 pane render/call 차이는 시작 동시성 (#551)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2165,9 +2165,13 @@ AC · CPU `performance` · 64 MiB · 120x40 · scrollback 32,767 · `ReleaseFast
   `measure-repeat.sh --panes N` — barrier 러너로 N 개 producer **동시** 시작 · `split-panes.ps1` 로 4 열 × 2 행 분할 ·
   `plain` 64 MiB/pane · 5 회 절사평균, [#551 댓글](https://github.com/ensky0/tildaz/issues/551)): `render/call` 이
   1 · 2 · 4 · 8 pane 에서 **0.655 · 0.494 · 0.431 · 1.373 ms**, drain 141 · 350 · 853 · 2150 ms (8 pane 의 5 회 폭 2 %),
-  손실은 pane 당 16 byte (ConPTY 종료) 뿐. 1 · 4 pane 은 #572 회차와 같은 값인데 **8 pane 은 1.373 vs 0.894 로 갈린다** —
-  #572 회차의 격자 · 분할 순서 · 시작 동시성이 기록에 없어 원인은 **확인 필요** (후보: barrier 동시 시작이 8 producer 의
-  폭포를 한 프레임에 겹치게 한다). 8 pane 흔들림 (#583 A11 의 하네스 이봉 분포) 은 실제 앱에서 재현되지 않았다.
+  손실은 pane 당 16 byte (ConPTY 종료) 뿐. 1 · 4 pane 은 #572 회차와 같은 값인데 8 pane 은 1.373 vs 0.894 로 갈렸고,
+  **원인은 시작 동시성이다 — 같은 도구에서 producer 를 500 ms 간격으로 하나씩 시작하면 (`--stagger 500`) 8 pane 이
+  `render/call` 0.181 ms (0.177~0.184) · drain 1217 ms · 손실 같은 128 byte** 다. 동시 시작은 여덟 폭포가 매 프레임
+  화면 전체를 바꿔 프레임당 렌더가 무겁고, 순차 시작은 한 번에 한두 pane 만 바뀐다. 즉 **프레임당 렌더는 pane 수가 아니라
+  그 프레임에 바뀐 셀 수 (와 pane 마다 따로 내는 draw 세트) 에 비례한다.** #572 회차의 0.894 는 손으로 분할해 시작이
+  부분적으로 겹친 조건으로 설명된다 (그 회차는 조건을 적지 않았다). 8 pane 흔들림 (#583 A11 의 하네스 이봉 분포) 은
+  실제 앱에서 재현되지 않았다 — 동시 · 순차 모두 5 회 폭 2 % 안.
 
 합계 처리량은 격자를 고정했는데도 pane 수가 늘면 내려간다 (pane 하나의 몫이 아니라 합계다) — 격자 변화가 아니라
 producer · PTY · ring 경쟁 때문이다. `frame` 층은 프레임마다 한 번만 드레인해 (사양 A 없음) 앱의 하한이다.

--- a/dist/stress/README.md
+++ b/dist/stress/README.md
@@ -84,6 +84,9 @@ dist/stress/measure-repeat.sh --phase win-pane8 --panes 8 --workloads plain   # 
 아래 "120 열은 3 열 상태에서 더 못 갈라요" 의 순서 그대로) 하고 로그 `[pane] … has N panes` 로 수를 확인한 뒤, ③ barrier
 파일을 만들어 N 개가 함께 시작해요. 단축키가 살아야 해서 `config_9.toml` (config_0 복사 · `auto_start = false`) 을 만들고
 `--instance 9` 로 띄우며 끝나면 지워요. 덤프 라벨은 workload 라 **phase 이름에 pane 수를 넣어 조건마다 따로** 불러요.
+`--stagger <ms>` 를 주면 barrier 를 한 번에 열지 않고 러너가 얻은 슬롯 번호 순서로 그 간격을 두고 열어요 — **시작 동시성
+대조군**이에요. 8 pane 의 프레임당 렌더가 동시 시작 1.373 ms · 500 ms 순차 0.181 ms 로 갈리는 것을 이걸로 갈랐어요 (#551).
+러너가 뜨는 즉시 시작하게 두는 방식은 안 돼요 — 첫 pane 의 64 MiB 폭포가 분할 키가 닿기 전에 끝나 앱이 종료돼요.
 Linux · macOS 는 아직 손 절차예요 (합성 키 도구가 platform 별이에요 — #551 macOS 회차는 `mac-input` 으로 했어요).
 
 **`zig build stress` 를 한 번 더 불러야** 해요 — 기본 `zig build` 는 `tildaz-stress` 를

--- a/dist/stress/measure-repeat.sh
+++ b/dist/stress/measure-repeat.sh
@@ -54,6 +54,10 @@ IGNORE_HYGIENE=0
 # 파일을 기다린 뒤 producer 를 띄운다 — N 개가 함께 시작한다. 단축키가 살아야 해서 `config_9.toml`
 # 을 만들고 (`--instance 9`) 끝나면 지운다.
 PANES=1
+# `--stagger <ms>` — 분할이 끝난 뒤 producer 를 **하나씩 그 간격으로** 시작한다 (순차 시작 대조군). 동시 시작
+# (기본) 과 견줘 8 pane `render/call` 차이의 원인을 가른다 (#551). 러너가 뜨는 즉시 시작하게 두는 방식은 안 된다 —
+# 첫 pane 의 64 MiB 폭포가 분할 키가 닿기 전에 끝나 앱이 종료된다 (2026-09-03 실측 · 5 회 전부 pane 1).
+STAGGER_MS=0
 
 usage() {
     cat <<'USAGE'
@@ -69,6 +73,7 @@ usage() {
   --out <디렉터리>     결과 위치 (기본 dist/stress/shots)
   --ignore-hygiene     위생 점검에 걸려도 강행 (동작 확인용 — 기록용 측정에는 쓰지 않는다)
   --panes <N>          실제 앱을 N (1 · 2 · 4 · 8) 개 pane 으로 갈라 pane 마다 producer (#551 A11). Windows 만.
+  --stagger <ms>       --panes 에서 producer 를 함께 시작하지 않고 그 간격으로 하나씩 시작 (동시성 대조군)
                        phase 이름에 pane 수를 넣어 조건별로 따로 부른다 (덤프 라벨은 workload 다)
 USAGE
 }
@@ -85,6 +90,7 @@ while [ $# -gt 0 ]; do
         --out) OUT="$2"; shift 2 ;;
         --ignore-hygiene) IGNORE_HYGIENE=1; shift ;;
         --panes) PANES="$2"; shift 2 ;;
+        --stagger) STAGGER_MS="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "모르는 옵션: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -221,7 +227,8 @@ while [ "$i" -le "$REPEAT" ]; do
             $RUN_TIMEOUT "$EXE" -e "$(native_path "$STRESS")" -size 120x40 -scrollback "$SCROLLBACK" \
                 >/dev/null 2>&1 || echo "⚠ 회차 실패: $w ($i/$REPEAT)" >&2
         else
-            rm -f "$BARRIER"
+            rm -rf "$BARRIER" "$BARRIER".slots "$BARRIER"-[0-9]*
+            [ "$STAGGER_MS" != 0 ] && mkdir -p "$BARRIER.slots"   # 러너가 슬롯 번호를 얻어 barrier-k 를 기다린다
             _log_before=$(wc -c < "$LOG" 2>/dev/null | tr -d ' '); [ -n "$_log_before" ] || _log_before=0
             $RUN_TIMEOUT "$EXE" $INSTANCE_ARGS -e "$RUNNER_CMD $w $TILDAZ_STRESS_BYTES" -size 120x40 -scrollback "$SCROLLBACK" \
                 >/dev/null 2>&1 &
@@ -231,9 +238,13 @@ while [ "$i" -le "$REPEAT" ]; do
             _have=$(tail -c "+$((_log_before + 1))" "$LOG" 2>/dev/null | grep -o 'has [0-9]* panes' | tail -1 | awk '{print $2}')
             [ -n "$_have" ] || _have=1
             if [ "$_have" != "$PANES" ]; then echo "⚠ pane 수 $_have ≠ $PANES ($w $i/$REPEAT) — 이 회차는 버려요" >&2; fi
-            : > "$BARRIER"           # N 개 러너가 함께 시작한다
+            if [ "$STAGGER_MS" = 0 ]; then
+                : > "$BARRIER"           # N 개 러너가 함께 시작한다
+            else
+                _k=1; while [ "$_k" -le "$PANES" ]; do : > "$BARRIER-$_k"; _k=$((_k + 1)); sleep "$(awk -v ms="$STAGGER_MS" 'BEGIN{printf "%.3f", ms/1000}')"; done
+            fi
             wait "$_app_pid" || echo "⚠ 회차 실패: $w ($i/$REPEAT)" >&2
-            rm -f "$BARRIER"
+            rm -rf "$BARRIER" "$BARRIER".slots "$BARRIER"-[0-9]*
         fi
         sleep 1.5
     done

--- a/dist/stress/pane-runner.ps1
+++ b/dist/stress/pane-runner.ps1
@@ -21,8 +21,19 @@ param(
     # barrier 를 이만큼 기다려도 안 생기면 그냥 시작한다 — 분할이 실패한 회차가 조용히 걸려 있지 않게.
     [int]$TimeoutSec = 20
 )
+# 순차 시작 대조군 (`measure-repeat.sh --stagger <ms>`) — barrier 경로 옆에 `<barrier>.slots/` 가 있으면 러너는
+# 그 안에 `1` · `2` … 디렉터리를 만들어 보는 순서로 자기 번호 k 를 얻고 (`New-Item` 은 원자적이라 둘이 같은 번호를
+# 못 갖는다) `<barrier>-k` 를 기다린다. 호출자가 `-1` · `-2` … 를 간격을 두고 만들면 pane 이 하나씩 시작한다.
+# 앱이 pane 에 번호를 주지 않아 이렇게 얻는다.
+$slots = "$Barrier.slots"
+$wait = $Barrier
+if (Test-Path -LiteralPath $slots) {
+    for ($k = 1; $k -le 32; $k++) {
+        try { New-Item -ItemType Directory -Path (Join-Path $slots "$k") -ErrorAction Stop | Out-Null; $wait = "$Barrier-$k"; break } catch {}
+    }
+}
 $sw = [Diagnostics.Stopwatch]::StartNew()
-while (-not (Test-Path -LiteralPath $Barrier) -and $sw.Elapsed.TotalSeconds -lt $TimeoutSec) { Start-Sleep -Milliseconds 50 }
+while (-not (Test-Path -LiteralPath $wait) -and $sw.Elapsed.TotalSeconds -lt $TimeoutSec) { Start-Sleep -Milliseconds 50 }
 $env:TILDAZ_STRESS_WORKLOAD = $Workload
 $env:TILDAZ_STRESS_BYTES = $Bytes
 & $Stress


### PR DESCRIPTION
[#605](https://github.com/ensky0/tildaz/pull/605) 후속 — [#551](https://github.com/ensky0/tildaz/issues/551) 에서 8 pane `render/call` 이 #572 회차 (0.894 ms) 와 갈린 (1.373 ms) 원인을 가른다. 사용자 지시 *"다시 측정하면 되는 거면 바로 하자."*

## 무엇

- `measure-repeat.sh --stagger <ms>` — barrier 를 한 번에 열지 않고 `barrier-1` … `barrier-N` 을 그 간격으로 연다.
- `pane-runner.ps1` — `<barrier>.slots/` 가 있으면 `1` · `2` … 디렉터리를 원자적으로 만들어 자기 번호 k 를 얻고 `barrier-k` 를 기다린다 (앱이 pane 에 번호를 주지 않아 이렇게 얻는다).
- 러너가 뜨는 즉시 시작하게 두는 방식 (첫 시도) 은 무효였다 — 첫 pane 의 64 MiB 폭포가 분할 키가 닿기 전에 끝나 앱이 종료 (5 회 전부 pane 1). README 에 적었다.

## 실측 (main `dadba3d` · 노트북 Ryzen AI 7 350 · Windows 11 · 120 Hz · AC · 최고 성능 · plain 64 MiB/pane · 8 pane · 5 회)

| 시작 | drain ms | render/call ms | present ms | 손실 |
|---|---|---|---|---|
| 동시 (barrier 한 번에) | 2150 (2132~2176) | **1.373** | 233 | 128 |
| 500 ms 순차 | 1217 (1207~1225) | **0.181** | 390 | 128 |

**원인은 시작 동시성이다.** 여덟 폭포가 겹치면 매 프레임 화면 전체가 바뀌어 프레임당 렌더가 무겁고, 순차면 한두 pane 만 바뀐다 — 프레임당 렌더는 pane 수가 아니라 그 프레임에 바뀐 셀 수에 비례한다. #572 회차의 0.894 는 손 분할로 부분적으로 겹친 조건. SPEC §13.3.1 의 "확인 필요" 를 이 결론으로 바꿨고, 앞으로 pane 회차는 시작 방식을 함께 적는다.

Refs #551 #583