### PR TITLE
test(linux): headless sway · 가상 키보드로 #583 의 Linux 몫을 자동 검증하는 도구

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1042,6 +1042,95 @@ tildaz --instance 9 -e /bin/bash -size 88x33 &
 ⚠️ 이렇게 만든 `config_9.toml` 은 **끝나면 지워요** — 안 지우면 사용자 로그온 때 그 인스턴스가
 같이 떠요 (위 `# Windows — 키보드 layout 조회 실측 방법` 절의 같은 주의).
 
+# Linux — headless sway · nested compositor 로 합성 입력 · 다이얼로그 · 배율을 자동 검증하는 법
+
+macOS (`cliclick`) · Windows (`SendInput`) 절에 대응하는 Linux 몫이에요 ([#583](https://github.com/ensky0/tildaz/issues/583)
+A5 · A7 · A8 · A2, 2026-09-03 미니PC Firebat ZY-A8). 핵심은 **사용자 세션을 전혀 건드리지 않는 것**이에요 — `ydotool`
+은 `/dev/uinput` 이라 그 순간 포커스된 사용자 창에 타이핑되지만, headless sway 안의 가상 키보드는 그 sway 로만 가요.
+
+| 도구 | 무엇 |
+|---|---|
+| [`dist/linux/vkbd.py`](dist/linux/vkbd.py) | `zwp_virtual_keyboard_v1` 가상 키보드를 **한 번 꽂고 유지**하며 FIFO 로 `type …` · `key ctrl+shift+t` 를 받는 데몬 |
+| [`dist/screens/clusters.py bands`](dist/screens/clusters.py) | 밝은 230 / 어두운 20 띠를 3 줄씩 번갈아 채운 화면 — 배율 리샘플 (#539) 판정용 |
+| [`dist/linux/bands-check.py`](dist/linux/bands-check.py) | 그 캡처의 세로 단면에서 띠 경계 전이 행의 밝기 종류를 세요 (한 종류 이하 = 리샘플 없음) |
+| [`dist/linux/headless-check.sh`](dist/linux/headless-check.sh) | 위를 엮은 회차 — `tabs` (Alt+1~9) · `confirm` · `prompt` (SIGTERM 펌프) · `scale` (배율) · `launcher-fatal gnome\|cinnamon` |
+
+```sh
+R=/run/user/$(id -u)/tz583; mkdir -m 700 -p $R                       # ⚠️ 짧은 경로 — 아래
+env -u XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR=$R WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 \
+    setsid sway -c sw.conf &                                          # sw.conf: output HEADLESS-1 resolution 1600x1000
+export XDG_RUNTIME_DIR=$R WAYLAND_DISPLAY=wayland-1 XDG_CURRENT_DESKTOP=sway SWAYSOCK=$(ls $R/sway-ipc.*.sock)
+export XDG_CONFIG_HOME=$T/xdg/config XDG_STATE_HOME=$T/xdg/state        # config_0.toml 은 사용자 것을 복사 (auto_start=false)
+python3 dist/linux/vkbd.py --fifo $R/vkbd.fifo &                      # ① 키보드를 먼저 꽂고
+TILDAZ_VERBOSE=1 ./zig-out/bin/tildaz --instance 0 &                  # ② 그다음 앱 — seat 에 keyboard 가 처음부터 있게
+echo "type touch /tmp/probe" > $R/vkbd.fifo; echo "key Return" > $R/vkbd.fifo   # 포커스 확인 — 파일이 생겨야 시작
+grim shot.png                                                          # sway 는 screencopy 를 내줘요
+```
+
+- **격리 `XDG_RUNTIME_DIR` 은 짧아야 해요.** scratchpad 경로 (90 자 남짓) 를 주면 sway 가 `Socket path won't fit into
+  ipc_sockaddr->sun_path` 로 **세그폴트**해요 (`sun_path` 108 바이트). `/run/user/<uid>/tz583` 처럼 실제 runtime dir 아래
+  짧은 디렉터리를 만들어요 — tmpfs 이고 사용자 소유라 lock · 소켓 격리도 그대로예요. tildaz 의 lock · toggle 소켓 · 앱이
+  붙는 `wayland-1` 이 전부 그 안에 생겨 사용자 instance 0 과 부딪히지 않아요 (그래서 `--instance 0` 을 써도 돼요 —
+  new-instance prompt 는 worker 0 만 처리하니 A7 prompt 회차에는 0 이 필요해요).
+- **sway 에 `timeout` 을 걸었으면 그 시간을 기억해요.** 30 분으로 걸어 둔 sway 가 회차 도중 내려가 뒤 회차가 전부
+  `ConnectFailed` 였어요 — 앱이 안 뜬 것이 아니라 compositor 가 없는 거예요. 길게 (4 시간) 걸고 끝나면 `swaymsg exit`.
+- **`wtype` 은 쓰지 말아요 — 두 가지가 실측으로 걸렸어요.** ① 새 글자가 나올 때마다 keymap 을 다시 올려서 그 사이의 키가
+  빠지거나 다른 글자로 읽혀요 (`touch …` 가 `ouch …` 로). ② 호출마다 가상 키보드를 꽂고 뽑아 두 번째 호출부터 키가 아예
+  안 닿아요 — seat 의 keyboard capability 가 빠졌다 붙는 왕복을 앱이 처리하지 않기 때문이에요 (아래 결함 후보).
+  `vkbd.py` 는 us keymap 을 연결 직후 한 번 올리고 프로세스가 살아 있는 동안 유지해요.
+- **modifier 는 `modifiers` 요청으로 보내야 해요.** 프로토콜이 modifier 상태를 client 책임으로 두고 wlroots 는 가상
+  키보드의 key 이벤트로 xkb 상태를 갱신하지 않아서, Shift 키 press 만 보내면 `Ctrl+Shift+T` 가 `t` 로 · `>` 가 `.` 로
+  들어가요. `vkbd.py` 가 mask (Shift 0 · Control 2 · Mod1 3 · Mod4 6 비트) 를 함께 보내요.
+- **⚠️ 결함 후보 (2026-09-03 발견 · #583 에 기록)** — [`wayland_minimal.zig`](src/host/linux/wayland_minimal.zig) 의
+  `handleSeatEvent` 는 capability 가 바뀔 때 `keyboard_id == 0` 일 때만 `wl_keyboard` 를 만들고, capability 가 빠질 때
+  release 하는 코드가 없어요 (`keyboard_id = 0` 으로 되돌리는 자리가 없어요). wlroots 는 keyboard capability 가 빠지는
+  순간 그 client 의 keyboard 객체를 inert 로 만들므로, **유일한 키보드를 뽑았다 다시 꽂으면 sway · Hyprland 계열에서 키
+  입력이 영원히 죽어요.** 노트북 내장 키보드가 있으면 capability 가 안 빠져 드러나지 않아요.
+- **sway 는 layer-shell 을 우리가 일부러 안 써서** (#454) `-size` · dock 배치가 안 먹고 창은 tiling 으로 출력 전체예요. 그래도
+  xdg_toplevel · layer-surface · dialog 가 **같은 `logicalToPhysicalSize`** 를 쓰므로 배율 검증은 성립해요.
+- **단축키 판정은 파일로 해요.** 탭마다 `cat > tab_N.txt` 를 띄워 두고 `Alt+N` 뒤 글자를 보내면 어느 파일에 들어갔는지로
+  전환이 확정돼요 — 캡처의 탭 강조 위치를 읽는 것보다 확실해요. 새 탭은 `Ctrl+Shift+T` 뒤 bash 가 뜨는 2.5 초를 둬요.
+- **다이얼로그 펌프의 SIGTERM (#521) 은 로그 한 줄로 판정해요** — `[exit] SIGTERM received while a dialog pump was running
+  — leaving the pump`. confirm 은 `Alt+F4`, prompt 는 **worker 0 을 띄운 채 인자 없는 `tildaz` (launcher)** 를 같은 격리
+  환경에서 실행하면 launcher 가 worker 소켓에 new-instance 를 보내 핫키 캡처 다이얼로그가 떠요. `tail` 로 볼 때 그 줄이
+  `confirm result=Cancel` **앞**에 있어서 잘리기 쉬워요 — `grep` 으로 봐요. map 대기 펌프는 `mapped` 가 attach+commit
+  직후 참이 되고 compositor 를 `SIGSTOP` 하면 그 앞의 blocking `readAndDispatch` 에서 먼저 막히므로 **인위로 진입시킬
+  수 없어요** — 같은 헬퍼 한 줄이라 코드 판정으로 둬요.
+- **띠 화면은 시작 1.5 초 뒤에 그려요.** `-e` 프로세스는 세션 생성 직후 뜨고 창 크기는 그 뒤 configure 로 확정돼요
+  (`terminal session created cols=68 rows=21` → `terminal resized cols=86 rows=52`). 바로 `stty size` 를 읽으면 21 줄만
+  채워 아래가 배경으로 남고, 자동 기준값을 쓰는 판정이 배경을 띠로 오인해요. `bands` 는 기다린 뒤 그리고 `SIGWINCH` 에
+  다시 그려요. `bands-check.py` 는 기준을 230 / 20 으로 고정하고 띠가 아닌 행이 1/4 을 넘으면 경고해요.
+- **배율 검증 (#539) 은 sway 에서 세 가지를 맞춰야 성립해요** — 하나라도 어긋나면 *모든* client 가 리샘플되어 (foot 대조군도
+  같은 서명을 냈어요) 우리 buffer 가 스펙대로여도 "여러 종류" 가 나와요. 2026-09-03 에 셋을 차례로 밟았어요.
+  ① **출력 물리 해상도가 scale 로 정확히 나눠져야** 해요 (1.5 → `1500x999` · 1.7 → `1700x1020`). 안 나눠지면 sway 가 출력
+  논리 크기를 내림하고 프레임 전체를 늘려 그려요 — `grim` 캡처가 `1600x999` 처럼 1 px 작게 나오면 이거예요.
+  ② **창은 floating 으로 정수 논리 크기를 줘요** (`swaymsg '[app_id="^tildaz"] floating enable, resize set width 800 px
+  height 798 px'`). tiling 컨테이너는 논리 높이가 소수 (1000/1.5 = 666.67) 라 sway 가 창을 그 크기에 맞춰 늘려요.
+  `-e` 측정 인스턴스의 app_id 는 `tildaz.instance0` 이 아니라 역할별 이름이라 접두어 `^tildaz` 로 잡고, 창이 트리에
+  나타난 뒤 (`get_tree` 에 `"app_id": "tildaz`) 앱 자신의 `move position` IPC 뒤에 보내요.
+  ③ **floating 폭이 출력 논리 폭을 넘으면 clamp 되어 ② 가 무효**예요 (1.7 의 논리 폭 941 에 1200 을 주면 컨테이너가 출력
+  전체로 돌아가요). `get_tree` 의 rect 가 요청과 같은지 회차마다 확인해요.
+  셋을 맞추면 목적지 = `round(H × scale)` 이라, 논리 높이 H 를 골라 소수부를 .5 이상으로 만들면 (1.25 · H 798 → 997.5,
+  1.7 · H 585 → 994.5) 내림 (#539 이전) 과 반올림 (스펙) 이 갈리는 조합이 돼요. 소수부 0 인 회차를 대조로 함께 둬요.
+- **nested Hyprland 는 KWin 에서 창이 가려지면 프레임을 그리지 않아요** — `grim` 이 screencopy 를 영원히 기다려요
+  (`timeout 3 grim …` 이 124 로 끝나면 이거예요). 그 창이 앞에 보이는 동안만 캡처가 돼요. 사용자에게 알리지 않고 KWin
+  스크립트로 창을 올리면 사용자의 포커스를 빼앗아 타이핑이 nested 안으로 들어가니 하지 말아요.
+- **mutter devkit (`gnome-shell --devkit`) 은 runtime dir 을 격리하면 죽어요.** 화면을 pipewire 로 뷰어 창에 보내는데
+  `XDG_RUNTIME_DIR` 을 돌리면 pipewire 소켓을 못 찾아 (`Failed to connect pipewire context`) 셸이 곧 내려가요. 실제
+  runtime dir 을 쓰고 `--wayland-display=wayland-77` 처럼 특이한 소켓 이름으로 겹침을 피해요. tildaz 쪽 config · 로그만
+  `XDG_CONFIG_HOME` · `XDG_STATE_HOME` 으로 격리해요. 그리고 **`spectacle` 은 `dbus-run-session` 안에서 안 돼요** —
+  KWin 과 사용자 세션 버스로 말하니 바깥 셸에서 타이머로 찍어요. 다만 devkit 뷰어는 검게, Cinnamon nested 는 희게 찍혀서
+  (2026-09-03) **다이얼로그의 픽셀 증거는 못 얻었어요** — 판정은 로그의 `[dialog] configured logical=… physical=…` (configure
+  를 받고 buffer 를 만든 것) 과 `layer_shell=false` (= xdg_toplevel fallback 만 가능) 로 해요.
+- **Cinnamon nested (`cinnamon --nested --wayland`) 의 소켓은 `ss -xlp` 의 pid 로 찾아요.** 이름을 지정할 수 없고 로그에도
+  안 남으며, 실제 runtime dir 의 **기존 `wayland-N` 파일을 재사용**하기도 해서 (`wayland-0.lock` 실패 뒤 `wayland-1` 을
+  집었어요) "새로 생긴 소켓" 을 목록 비교로 찾는 방식은 빈손이에요. `ss -xlp | grep "pid=<cinnamon pid>,"` 로 봐요.
+- **GNOME 50.4 nested (mutter devkit) 는 `wp_fractional_scale_v1` 을 내줘요** — 다이얼로그 로그가 `source=fractional/dialog`
+  로 부모 KWin 의 1.7 을 받았어요. 위 `# 렌더링` 절의 scale 표 ("GNOME · fractional 미advertise → `wl_output` 정수
+  fallback") 는 그 이전 버전 기준이라, 실제 GNOME 세션에서도 그런지는 **확인 필요**예요 (nested 만 봤어요).
+- 끝나면 `echo quit > $R/vkbd.fifo` · 앱 `kill -TERM` · `swaymsg exit` · `rm -rf $R` 순서로 치우고 `pgrep -a tildaz` 로
+  사용자 instance 0 만 남았는지 봐요.
+
 # Linux — 글리프 · cluster 렌더 실기 검증 방법
 
 폰트 / shaping / cluster 관련 변경 (#401 등) 을 검증하는 절차예요. **소스 판정 → 드라이버로

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1053,7 +1053,7 @@ A5 · A7 · A8 · A2, 2026-09-03 미니PC Firebat ZY-A8). 핵심은 **사용자 
 | [`dist/linux/vkbd.py`](dist/linux/vkbd.py) | `zwp_virtual_keyboard_v1` 가상 키보드를 **한 번 꽂고 유지**하며 FIFO 로 `type …` · `key ctrl+shift+t` 를 받는 데몬 |
 | [`dist/screens/clusters.py bands`](dist/screens/clusters.py) | 밝은 230 / 어두운 20 띠를 3 줄씩 번갈아 채운 화면 — 배율 리샘플 (#539) 판정용 |
 | [`dist/linux/bands-check.py`](dist/linux/bands-check.py) | 그 캡처의 세로 단면에서 띠 경계 전이 행의 밝기 종류를 세요 (한 종류 이하 = 리샘플 없음) |
-| [`dist/linux/headless-check.sh`](dist/linux/headless-check.sh) | 위를 엮은 회차 — `tabs` (Alt+1~9) · `confirm` · `prompt` (SIGTERM 펌프) · `scale` (배율) · `launcher-fatal gnome\|cinnamon` |
+| [`dist/linux/headless-check.sh`](dist/linux/headless-check.sh) | 위를 엮은 회차 — `tabs` (Alt+1~9) · `confirm` · `prompt` (SIGTERM 펌프) · `scale` (배율) · `seat-replug` (#347 착탈) · `compositor-exit` (#613) · `launcher-fatal gnome\|cinnamon` |
 
 ```sh
 R=/run/user/$(id -u)/tz583; mkdir -m 700 -p $R                       # ⚠️ 짧은 경로 — 아래
@@ -1081,11 +1081,13 @@ grim shot.png                                                          # sway �
 - **modifier 는 `modifiers` 요청으로 보내야 해요.** 프로토콜이 modifier 상태를 client 책임으로 두고 wlroots 는 가상
   키보드의 key 이벤트로 xkb 상태를 갱신하지 않아서, Shift 키 press 만 보내면 `Ctrl+Shift+T` 가 `t` 로 · `>` 가 `.` 로
   들어가요. `vkbd.py` 가 mask (Shift 0 · Control 2 · Mod1 3 · Mod4 6 비트) 를 함께 보내요.
-- **⚠️ 결함 후보 (2026-09-03 발견 · #583 에 기록)** — [`wayland_minimal.zig`](src/host/linux/wayland_minimal.zig) 의
-  `handleSeatEvent` 는 capability 가 바뀔 때 `keyboard_id == 0` 일 때만 `wl_keyboard` 를 만들고, capability 가 빠질 때
-  release 하는 코드가 없어요 (`keyboard_id = 0` 으로 되돌리는 자리가 없어요). wlroots 는 keyboard capability 가 빠지는
-  순간 그 client 의 keyboard 객체를 inert 로 만들므로, **유일한 키보드를 뽑았다 다시 꽂으면 sway · Hyprland 계열에서 키
-  입력이 영원히 죽어요.** 노트북 내장 키보드가 있으면 capability 가 안 빠져 드러나지 않아요.
+- **이 도구로 찾은 결함 — [#347](https://github.com/ensky0/tildaz/issues/347) (2026-09-03).** `wtype` 이 호출마다 가상
+  키보드를 꽂고 뽑는 바람에 seat 의 keyboard capability 가 빠졌다 붙는 왕복이 생겼고, 앱이 그때 `wl_keyboard` 를 놓고
+  다시 만들지 않아 두 번째부터 키가 영원히 닿지 않았어요 — 유일한 키보드를 뽑았다 꽂는 데스크톱과 같은 조건이에요.
+  `fix/347-seat-capability-release` 가 잃으면 `release` · 돌아오면 재생성으로 고쳤고, **`headless-check.sh seat-replug`**
+  (vkbd 를 띄우고 · 내리고 · 다시 띄워 세 번째에 `wl_keyboard … created` 와 키 도착을 봐요) 가 그 회귀 검사예요.
+  compositor 가 먼저 끝나는 경우 (#613 — `swaymsg exit` 뒤 `failed to start` 가 아니라 정상 종료) 는
+  **`headless-check.sh compositor-exit`** 로 봐요 — 그 회차는 sway 를 내리므로 마지막에 돌리고 다시 `up` 해요.
 - **sway 는 layer-shell 을 우리가 일부러 안 써서** (#454) `-size` · dock 배치가 안 먹고 창은 tiling 으로 출력 전체예요. 그래도
   xdg_toplevel · layer-surface · dialog 가 **같은 `logicalToPhysicalSize`** 를 쓰므로 배율 검증은 성립해요.
 - **단축키 판정은 파일로 해요.** 탭마다 `cat > tab_N.txt` 를 띄워 두고 `Alt+N` 뒤 글자를 보내면 어느 파일에 들어갔는지로
@@ -1113,8 +1115,24 @@ grim shot.png                                                          # sway �
   셋을 맞추면 목적지 = `round(H × scale)` 이라, 논리 높이 H 를 골라 소수부를 .5 이상으로 만들면 (1.25 · H 798 → 997.5,
   1.7 · H 585 → 994.5) 내림 (#539 이전) 과 반올림 (스펙) 이 갈리는 조합이 돼요. 소수부 0 인 회차를 대조로 함께 둬요.
 - **nested Hyprland 는 KWin 에서 창이 가려지면 프레임을 그리지 않아요** — `grim` 이 screencopy 를 영원히 기다려요
-  (`timeout 3 grim …` 이 124 로 끝나면 이거예요). 그 창이 앞에 보이는 동안만 캡처가 돼요. 사용자에게 알리지 않고 KWin
-  스크립트로 창을 올리면 사용자의 포커스를 빼앗아 타이핑이 nested 안으로 들어가니 하지 말아요.
+  (`timeout 3 grim …` 이 124 로 끝나면 이거예요). 사용자에게 알리지 않고 KWin 스크립트로 창을 올리면 포커스를 빼앗아
+  타이핑이 nested 안으로 들어가니 하지 말고, **headless 출력을 하나 더 만들어 거기서 재요** — 그 출력은 부모 창과 무관하게
+  그려요.
+
+    ```sh
+    hyprctl output create headless HL-1
+    hyprctl keyword monitor "HL-1,1500x999,2000x0,1.5"      # 해상도는 scale 의 배수 (아래 배율 검증 조건 ①)
+    hyprctl dispatch focusmonitor HL-1                       # layer surface 는 포커스된 모니터에 떠요
+    grim -o HL-1 shot.png
+    ```
+
+    배율을 바꾼 뒤 **3 초**는 두고, 회차마다 앱 로그의 `logical_h` 가 `height_percent` 와 맞는지 봐요 — 전환 직후에
+    옛 work-area 로 뜬 회차 (60 % 인데 논리 높이 180) 가 있었어요. 그리고 **이 출력의 1.25 배율에서는 foot 도 리샘플
+    서명**을 냈어요 (1.5 · 1.7 은 둘 다 깨끗) — 그 조건의 "여러 종류" 는 우리 결함이 아니고 실제 Hyprland 세션의 1.25 는
+    따로 봐야 해요. **대조군 (foot) 없이 배율 판정을 내리지 않아요.**
+- **COSMIC nested (`cosmic-comp`) 는 `cosmic-randr mode X11-0 1280 800 --scale 1.25` 로 배율을 바꿔요.** 출력이 winit
+  창 크기 (1280x800) 로 고정이라 배율은 그 둘을 나누는 값 (1.25 · 1.6 · 2.0) 만 돼요. `grim` 은 wlr-screencopy 가 아니라
+  `ext_image_copy_capture_manager_v1` 로 돼요 (grim 1.5). runtime dir 은 격리해도 돼요 (pipewire 불필요).
 - **mutter devkit (`gnome-shell --devkit`) 은 runtime dir 을 격리하면 죽어요.** 화면을 pipewire 로 뷰어 창에 보내는데
   `XDG_RUNTIME_DIR` 을 돌리면 pipewire 소켓을 못 찾아 (`Failed to connect pipewire context`) 셸이 곧 내려가요. 실제
   runtime dir 을 쓰고 `--wayland-display=wayland-77` 처럼 특이한 소켓 이름으로 겹침을 피해요. tildaz 쪽 config · 로그만

--- a/dist/linux/bands-check.py
+++ b/dist/linux/bands-check.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""#539 — 띠 화면 캡처의 세로 단면에서 **리샘플 서명**을 읽는다.
+
+`dist/screens/clusters.py bands` 화면 (밝은 230 / 어두운 20 띠가 3 줄씩) 을 띄운 창을 캡처해 넘긴다.
+창 안 x 구간의 행별 평균 밝기를 내고, 두 띠 값 사이에 있는 행 (= 전이 행) 의 밝기를 모은다.
+
+    python3 dist/linux/bands-check.py shot.png            # 캡처 전체가 창일 때
+    python3 dist/linux/bands-check.py shot.png 2136x1261+744+0   # 창 영역 (ImageMagick geometry)
+    python3 dist/linux/bands-check.py shot.png --x 400 --w 100     # 단면 x 구간 (기본 창 폭의 중앙 100 px)
+
+판정 (#539 마감 댓글의 방법 그대로):
+
+- 전이 행 밝기가 **한 종류** (또는 0 행) 이면 리샘플 없음 — 앱이 그리는 셀 경계의 고유값 하나만 남는다.
+- 여러 종류이고 창 위→아래로 **단조 증가 뒤 wrap** 이면 창 전체에 걸친 1 px 선형 리샘플이다.
+
+두 띠의 기준값은 화면이 칠하는 값 그대로 230 / 20 이다 (`--lo` · `--hi` 로 바꿀 수 있다). 캡처에서 가장 흔한 두 밝기로
+자동 추정하는 방식 (`--auto`) 은 창이 출력을 다 덮지 않아 배경 행이 많으면 배경을 띠로 오인한다 — 2026-09-03 headless
+sway 회차에서 그렇게 어두운 띠 (20) 전체가 "전이 행" 으로 잡혔다.
+"""
+import argparse
+import collections
+import re
+import sys
+
+from PIL import Image
+
+
+def parse_geometry(g):
+    m = re.fullmatch(r"(\d+)x(\d+)\+(\d+)\+(\d+)", g)
+    if not m:
+        raise SystemExit(f"geometry 형식이 아니다: {g} (예: 2136x1261+744+0)")
+    w, h, x, y = map(int, m.groups())
+    return x, y, w, h
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("png")
+    ap.add_argument("geometry", nargs="?", help="창 영역 WxH+X+Y (없으면 캡처 전체)")
+    ap.add_argument("--x", type=int, help="단면 x 시작 (창 기준)")
+    ap.add_argument("--w", type=int, default=100, help="단면 폭 (기본 100)")
+    ap.add_argument("--top", type=int, default=0, help="위에서 건너뛸 행 (탭바 등)")
+    ap.add_argument("--dump", action="store_true", help="행별 밝기를 전부 찍는다")
+    ap.add_argument("--lo", type=int, default=20, help="어두운 띠의 밝기 (기본 20 — bands 화면이 칠하는 값)")
+    ap.add_argument("--hi", type=int, default=230, help="밝은 띠의 밝기 (기본 230)")
+    ap.add_argument("--auto", action="store_true", help="기준값을 캡처에서 가장 흔한 두 밝기로 추정 (배경 행이 많으면 틀린다)")
+    args = ap.parse_args()
+
+    im = Image.open(args.png).convert("L")
+    if args.geometry:
+        x, y, w, h = parse_geometry(args.geometry)
+        im = im.crop((x, y, x + w, y + h))
+    W, H = im.size
+    x0 = args.x if args.x is not None else max(0, W // 2 - args.w // 2)
+    strip = im.crop((x0, args.top, x0 + args.w, H))
+    px = strip.load()
+    rows = []
+    for yy in range(strip.size[1]):
+        s = 0
+        for xx in range(strip.size[0]):
+            s += px[xx, yy]
+        rows.append(s / strip.size[0])
+
+    hist = collections.Counter(round(v) for v in rows)
+    if args.auto:
+        common = [v for v, _ in hist.most_common(2)]
+        if len(common) < 2:
+            raise SystemExit(f"띠가 둘로 안 갈린다 — 밝기 분포 {hist.most_common(5)}")
+        lo, hi = sorted(common)
+    else:
+        lo, hi = args.lo, args.hi
+    margin = max(3, (hi - lo) // 20)
+    band_rows = sum(c for v, c in hist.items() if abs(v - lo) <= margin or abs(v - hi) <= margin)
+    other_rows = len(rows) - band_rows
+
+    transitions = []   # (row, brightness)
+    for yy, v in enumerate(rows):
+        if lo + margin < v < hi - margin:
+            transitions.append((yy + args.top, round(v, 1)))
+
+    print(f"창 {W}x{H} · 단면 x={x0}..{x0 + args.w - 1} · 띠 기준 어두움={lo} 밝음={hi} · 행 {len(rows)} (띠 {band_rows} · 그 밖 {other_rows})")
+    if other_rows > len(rows) // 4:
+        print(f"⚠️ 띠가 아닌 행이 {other_rows} 개 — 화면이 창을 다 채우지 않았거나 단면이 창 밖이다. 판정을 믿지 말 것")
+    if args.dump:
+        for yy, v in enumerate(rows):
+            print(f"  y={yy + args.top:5d} {v:7.1f}")
+    kinds = sorted({round(v) for _, v in transitions})
+    print(f"전이 행 {len(transitions)} 개 · 밝기 종류 {len(kinds)} 종: {kinds}")
+    if transitions:
+        print("위→아래 순서: " + " ".join(f"{round(v)}" for _, v in transitions))
+    if len(kinds) <= 1:
+        print("판정: 리샘플 없음 (전이 행 밝기가 한 종류 이하)")
+    else:
+        print("판정: 전이 행 밝기가 여러 종류 — 창 위→아래 단조 변화 + wrap 이면 1 px 리샘플 서명")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dist/linux/headless-check.sh
+++ b/dist/linux/headless-check.sh
@@ -7,6 +7,8 @@
 #   dist/linux/headless-check.sh confirm             # A7  — Alt+F4 확인 다이얼로그 펌프 중 SIGTERM (#521)
 #   dist/linux/headless-check.sh prompt              # A7  — 새 instance 핫키 캡처 다이얼로그 펌프 중 SIGTERM (#521)
 #   dist/linux/headless-check.sh scale               # A5  — 배율 1.25 · 1.5 · 2.0 · 1.7 의 띠 화면 전이 행 (#539)
+#   dist/linux/headless-check.sh seat-replug         # #347 — 가상 키보드를 뽑았다 꽂은 뒤에도 키가 닿는지 (wl_keyboard 재생성)
+#   dist/linux/headless-check.sh compositor-exit     # #613 — compositor 가 먼저 끝나면 정상 종료 (exit 0 · failed to start 없음). sway 를 내리니 마지막에
 #   dist/linux/headless-check.sh launcher-fatal gnome|cinnamon   # A2 — nested GNOME / Cinnamon 의 xdg_toplevel fatal 다이얼로그 (#577)
 #   dist/linux/headless-check.sh down                # 앱 · vkbd · sway 정리
 #
@@ -200,6 +202,45 @@ cmd_scale() {
     echo "RESULT scale: 위 회차의 '판정:' 줄이 전부 '리샘플 없음' 이어야 한다 (⚠️ 줄이 있으면 그 회차는 무효)"
 }
 
+vk_up() { setsid nohup python3 "$ROOT/dist/linux/vkbd.py" --fifo $FIFO >>$WORK/vkbd.log 2>&1 </dev/null & sleep 1.5; }
+vk_down() { [ -p $FIFO ] && echo quit > $FIFO; sleep 1; }
+wait_file() { local f=$1 i; for i in $(seq 16); do sleep 0.5; [ -f "$f" ] && return 0; done; return 1; }
+
+cmd_seat_replug() {   # #347 — seat 의 keyboard capability 가 빠졌다 붙어도 새 wl_keyboard 가 만들어지는지
+    env_sway; OUT=$WORK/seat-replug; rm -rf $OUT; mkdir -p $OUT
+    # 앱을 keyboard 없는 seat 에서 먼저 띄운다 — vkbd 가 떠 있으면 내린다.
+    pgrep -f "vkbd.py --fifo $FIFO" >/dev/null && vk_down
+    kill_tz
+    mark=$(wc -l < $LOG 2>/dev/null || echo 0)
+    TILDAZ_VERBOSE=1 nohup "$TILDAZ" --instance 0 >/dev/null 2>&1 </dev/null & WPID=$!; sleep 3
+    echo "① 꽂음"; vk_up; rm -f $OUT/p1; snd "type touch $OUT/p1" "key Return"; wait_file $OUT/p1 && echo "   키 도착" || echo "   키 없음"
+    echo "② 뽑음"; vk_down
+    echo "③ 다시 꽂음"; vk_up; rm -f $OUT/p2; snd "type touch $OUT/p2" "key Return"; wait_file $OUT/p2 && echo "   키 도착" || echo "   키 없음"
+    tail -n +$((mark+1)) $LOG | grep -E 'wl_seat capabilities|wl_keyboard id=' | sed -E 's/^\[[^]]+\] /   /'
+    if [ -f $OUT/p1 ] && [ -f $OUT/p2 ]; then echo "RESULT seat-replug: OK — 뽑았다 꽂은 뒤에도 키가 닿는다"; else echo "RESULT seat-replug: FAIL (p1=$([ -f $OUT/p1 ] && echo 1 || echo 0) p2=$([ -f $OUT/p2 ] && echo 1 || echo 0)) — 수정 전 판은 p2 가 0 이다 (#347)"; fi
+    kill -TERM $WPID; wait_exit $WPID >/dev/null
+}
+
+cmd_compositor_exit() {   # #613 — compositor 가 먼저 끝나면 시작 실패가 아니라 정상 종료. sway 를 내리므로 마지막에 돌린다.
+    env_sway; OUT=$WORK/compositor-exit; rm -rf $OUT; mkdir -p $OUT
+    kill_tz
+    TILDAZ_VERBOSE=1 "$TILDAZ" --instance 0 >$OUT/stderr.txt 2>&1 </dev/null & WPID=$!; sleep 4
+    kill -0 $WPID 2>/dev/null || die "앱이 뜨지 않았다 — $LOG"
+    local child; child=$(pgrep -P $WPID | tr '\n' ' ')
+    echo "swaymsg exit ($(date +%T.%N))"; swaymsg exit >/dev/null 2>&1
+    local r; r=$(wait_exit $WPID); wait $WPID; local rc=$?
+    local alive=0 c; for c in $child; do kill -0 $c 2>/dev/null && alive=1; done
+    echo "   $r · exit code $rc · 자식 셸 $([ $alive = 0 ] && echo 정리됨 || echo 남음)"
+    tail -4 $LOG | sed -E 's/^\[[^]]+\] /   /'
+    if [ $rc -eq 0 ] && grep -q 'compositor closed the connection' $LOG && ! grep -q 'failed to start' $LOG $OUT/stderr.txt; then
+        echo "RESULT compositor-exit: OK"
+    else
+        echo "RESULT compositor-exit: FAIL — exit $rc · stderr: $(head -c 120 $OUT/stderr.txt)"
+    fi
+    pkill -f "vkbd.py --fifo $FIFO" 2>/dev/null; rm -rf $R
+    echo "   (sway 를 내렸으니 다음 회차 전에 'up')"
+}
+
 cmd_launcher_fatal() {   # $1 gnome|cinnamon — 실제 runtime dir (mutter devkit 은 pipewire 가 필요해 격리 불가) · 자기 세션 버스
     local de=$1 XCD COMP WD=wayland-77
     case $de in
@@ -250,6 +291,8 @@ case ${1:-} in
     confirm) cmd_confirm ;;
     prompt) cmd_prompt ;;
     scale) cmd_scale ;;
+    seat-replug) cmd_seat_replug ;;
+    compositor-exit) cmd_compositor_exit ;;
     launcher-fatal) cmd_launcher_fatal "${2:-}" ;;
     *) sed -n '2,16p' "$0"; exit 2 ;;
 esac

--- a/dist/linux/headless-check.sh
+++ b/dist/linux/headless-check.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# #583 — headless sway · nested compositor 로 Linux 몫을 자동 검증하는 회차 모음 (AGENTS.md `# Linux — headless sway …` 절).
+# 사용자 세션 (KWin) 을 건드리지 않는다: 격리 runtime dir · 격리 XDG config/state · 가상 키보드는 headless sway 로만 간다.
+#
+#   dist/linux/headless-check.sh up                  # headless sway 1600x1000 + vkbd 데몬 (한 번)
+#   dist/linux/headless-check.sh tabs                # A8  — Alt+1~9 탭 전환 (탭마다 cat > tab_N.txt · 파일로 판정)
+#   dist/linux/headless-check.sh confirm             # A7  — Alt+F4 확인 다이얼로그 펌프 중 SIGTERM (#521)
+#   dist/linux/headless-check.sh prompt              # A7  — 새 instance 핫키 캡처 다이얼로그 펌프 중 SIGTERM (#521)
+#   dist/linux/headless-check.sh scale               # A5  — 배율 1.25 · 1.5 · 2.0 · 1.7 의 띠 화면 전이 행 (#539)
+#   dist/linux/headless-check.sh launcher-fatal gnome|cinnamon   # A2 — nested GNOME / Cinnamon 의 xdg_toplevel fatal 다이얼로그 (#577)
+#   dist/linux/headless-check.sh down                # 앱 · vkbd · sway 정리
+#
+# 환경변수: TILDAZ (기본 zig-out/bin/tildaz) · TZHL_WORK (작업 디렉터리 · 기본 ${TMPDIR:-/tmp}/tildaz-headless).
+# 결과는 stdout + $TZHL_WORK/<회차>/ (캡처 · 파일 · 로그). 판정 줄은 `RESULT <회차>: …` 로 시작한다.
+set -u
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TILDAZ=${TILDAZ:-$ROOT/zig-out/bin/tildaz}
+WORK=${TZHL_WORK:-${TMPDIR:-/tmp}/tildaz-headless}
+# ⚠️ sway 의 IPC 소켓 경로는 sun_path (108 바이트) 를 넘으면 세그폴트 — runtime dir 은 짧게.
+R=/run/user/$(id -u)/tzhl
+FIFO=$R/vkbd.fifo
+XDG=$WORK/xdg
+LOG=$XDG/state/tildaz/tildaz_0.log
+SLOG=$XDG/state/tildaz/tildaz_stress.log
+CFG=$XDG/config/tildaz/config_0.toml
+
+die() { echo "$*" >&2; exit 1; }
+[ -x "$TILDAZ" ] || die "빌드가 없다: $TILDAZ  (zig build -Doptimize=ReleaseFast -Dsimd=true)"
+
+env_sway() {
+    export XDG_RUNTIME_DIR=$R WAYLAND_DISPLAY=wayland-1 XDG_CURRENT_DESKTOP=sway
+    export XDG_CONFIG_HOME=$XDG/config XDG_STATE_HOME=$XDG/state
+    SWAYSOCK=$(ls $R/sway-ipc.*.sock 2>/dev/null | head -1); export SWAYSOCK
+    unset HYPRLAND_INSTANCE_SIGNATURE
+    [ -S "$R/wayland-1" ] || die "headless sway 가 없다 — 먼저 'up'"
+}
+snd() { printf '%s\n' "$@" > $FIFO; }
+# 격리 앱만 잡는다 — 사용자의 /usr/bin/tildaz instance 0 은 cmdline 이 다르다. `pkill -f` 는 자기 명령줄을 매치하니 쓰지 않는다.
+tz_pids() { for p in $(pgrep -x "$(basename "$TILDAZ")" 2>/dev/null); do tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null | grep -q -- "$TILDAZ" && echo $p; done; }
+kill_tz() { for p in $(tz_pids); do kill -TERM $p 2>/dev/null; done; sleep 1; }
+wait_exit() {   # $1 pid — 3 초 안에 끝나면 ms 를 찍는다
+    for i in 1 2 3 4 5 6; do sleep 0.5; kill -0 $1 2>/dev/null || { echo "exited after ~$((i*500)) ms"; return 0; }; done
+    echo "STILL ALIVE after 3 s"; return 1
+}
+start_worker() {   # 격리 instance 0 · 로그 verbose
+    TILDAZ_VERBOSE=1 nohup "$TILDAZ" --instance 0 >/dev/null 2>&1 </dev/null &
+    WPID=$!; sleep 4
+    kill -0 $WPID 2>/dev/null || die "worker 가 뜨지 않았다 — $LOG"
+    echo "worker pid=$WPID"
+}
+focus_probe() {   # 가상 키보드가 앱에 닿는지 — 파일이 생겨야 회차를 시작한다
+    # vkbd 는 글자당 ~25 ms 라 긴 경로는 2 초를 넘긴다 — 파일이 생길 때까지 최대 8 초 기다린다 (2 초로 잡아 거짓 실패한 적 있다).
+    rm -f $WORK/probe; snd "type touch $WORK/probe" "key Return"
+    for i in $(seq 16); do sleep 0.5; [ -f $WORK/probe ] && return 0; done
+    die "가상 키보드가 앱에 닿지 않는다 (probe 파일 없음) — $WORK/vkbd.log · 포커스를 확인"
+}
+
+cmd_up() {
+    mkdir -m 700 -p $R; mkdir -p $WORK $XDG/config/tildaz $XDG/state
+    [ -f "$CFG" ] || {
+        src=${XDG_CONFIG_HOME:-$HOME/.config}/tildaz/config_0.toml
+        [ -f "$src" ] || die "복사할 config_0.toml 이 없다: $src"
+        sed 's|^auto_start  *= .*|auto_start       = false|' "$src" > "$CFG"
+        echo "config: $CFG (auto_start=false · 나머지는 사용자 config_0 그대로)"
+    }
+    if [ ! -S $R/wayland-1 ]; then
+        printf 'output HEADLESS-1 resolution 1600x1000\ndefault_border none\nfocus_follows_mouse no\n' > $WORK/sway.conf
+        env -u XDG_CURRENT_DESKTOP -u HYPRLAND_INSTANCE_SIGNATURE -u SWAYSOCK XDG_RUNTIME_DIR=$R \
+            WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 setsid nohup timeout 14400 sway -c $WORK/sway.conf >$WORK/sway.log 2>&1 </dev/null &
+        sleep 2
+        [ -S $R/wayland-1 ] || die "sway 가 뜨지 않았다 — $WORK/sway.log"
+        echo "sway: headless 1600x1000 · $R/wayland-1 (timeout 4 h)"
+    fi
+    env_sway
+    if ! pgrep -f "vkbd.py --fifo $FIFO" >/dev/null; then
+        rm -f $FIFO
+        setsid nohup python3 "$ROOT/dist/linux/vkbd.py" --fifo $FIFO >$WORK/vkbd.log 2>&1 </dev/null &
+        sleep 1.5; head -1 $WORK/vkbd.log
+    fi
+    echo "환경: XDG_RUNTIME_DIR=$R WAYLAND_DISPLAY=wayland-1 XDG_CONFIG_HOME=$XDG/config"
+}
+
+cmd_down() {
+    env_sway 2>/dev/null || true
+    kill_tz
+    [ -p $FIFO ] && echo quit > $FIFO
+    pkill -f "vkbd.py --fifo $FIFO" 2>/dev/null
+    [ -n "${SWAYSOCK:-}" ] && swaymsg exit >/dev/null 2>&1
+    sleep 1; rm -rf $R
+    echo "남은 tildaz: $(pgrep -a tildaz | tr '\n' ';')"
+}
+
+cmd_tabs() {
+    env_sway; OUT=$WORK/tabs; rm -rf $OUT; mkdir -p $OUT
+    kill_tz; start_worker; focus_probe
+    snd "type cat > $OUT/tab_1.txt" "key Return"; sleep 2
+    for n in 2 3 4 5 6 7 8 9; do
+        snd "key ctrl+shift+t"; sleep 2.5
+        snd "type cat > $OUT/tab_$n.txt" "key Return"; sleep 2
+    done
+    grim $OUT/tabs9.png
+    for n in 1 5 9 3 7 2 8 4 6; do
+        snd "key alt+$n"; sleep 1
+        snd "type T$n" "key Return"; sleep 1
+    done
+    ok=0; bad=0
+    for n in 1 2 3 4 5 6 7 8 9; do
+        got=$(tr '\n' '|' < $OUT/tab_$n.txt 2>/dev/null)
+        if [ "$got" = "T$n|" ]; then ok=$((ok+1)); else echo "tab $n: FAIL (got '$got')"; bad=$((bad+1)); fi
+    done
+    echo "RESULT tabs: ok=$ok bad=$bad (Alt+1~9 → 각 탭의 cat 에 T<n> 이 들어갔는지)"
+    kill -TERM $WPID; wait_exit $WPID >/dev/null
+}
+
+cmd_confirm() {
+    env_sway; OUT=$WORK/confirm; rm -rf $OUT; mkdir -p $OUT
+    kill_tz; start_worker; focus_probe
+    mark=$(wc -l < $LOG)
+    snd "key alt+F4"; sleep 2
+    grim $OUT/confirm.png
+    tail -n +$((mark+1)) $LOG | grep -E '\[dialog\] open confirm' || echo "confirm 다이얼로그 로그 없음"
+    kill -TERM $WPID; r=$(wait_exit $WPID)
+    if tail -n +$((mark+1)) $LOG | grep -q 'SIGTERM received while a dialog pump was running'; then
+        echo "RESULT confirm: OK — 펌프에서 SIGTERM 으로 빠짐 · $r"
+    else
+        echo "RESULT confirm: FAIL — 'leaving the pump' 로그 없음 · $r"; tail -n +$((mark+1)) $LOG | tail -6
+    fi
+}
+
+cmd_prompt() {
+    env_sway; OUT=$WORK/prompt; rm -rf $OUT; mkdir -p $OUT
+    kill_tz; start_worker
+    mark=$(wc -l < $LOG)
+    "$TILDAZ" >$OUT/launcher.out 2>&1; echo "launcher exit=$?"     # worker 0 이 떠 있으면 new-instance 요청이 간다
+    sleep 3; grim $OUT/prompt.png
+    tail -n +$((mark+1)) $LOG | grep -E '\[dialog\] open prompt' || echo "prompt 다이얼로그 로그 없음"
+    kill -TERM $WPID; r=$(wait_exit $WPID)
+    if tail -n +$((mark+1)) $LOG | grep -q 'SIGTERM received while a dialog pump was running'; then
+        echo "RESULT prompt: OK — 펌프에서 SIGTERM 으로 빠짐 · $r"
+    else
+        echo "RESULT prompt: FAIL — 'leaving the pump' 로그 없음 · $r"; tail -n +$((mark+1)) $LOG | tail -6
+    fi
+}
+
+scale_case() {   # $1 scale  $2 출력 WxH (scale 로 나눠지는 값)  $3 논리 높이 H  $4 tag — 창은 floating 800xH (논리)
+    local s=$1 res=$2 H=$3 tag=$4
+    # ⚠️ 출력 물리 해상도는 scale 로 정확히 나눠져야 한다 — 아니면 sway 가 출력 논리 크기를 내림하고 프레임 전체를 늘려
+    # 그려 **모든 client** 가 리샘플된다 (foot 도 같았다 · 2026-09-03). 1.5 → 1500x999 · 1.7 → 1700x1020.
+    swaymsg output HEADLESS-1 resolution ${res%x*} ${res#*x} scale $s >/dev/null; sleep 1
+    : > $SLOG
+    TILDAZ_VERBOSE=1 nohup "$TILDAZ" --instance 0 -e $WORK/bands.sh >/dev/null 2>&1 </dev/null &
+    local pid=$! i
+    for i in $(seq 20); do swaymsg -t get_tree | grep -q '"app_id": "tildaz' && break; sleep 0.3; done
+    sleep 0.5    # 앱 자신의 `move position 50 ppt` IPC 뒤에 우리 배치가 와야 한다
+    # ⚠️ tiling 컨테이너는 논리 높이가 소수 (1000/1.5 = 666.67) 라 sway 가 창을 그 크기에 맞춰 **늘린다** — 우리 buffer 가
+    # 스펙대로여도 리샘플이 난다. floating 으로 정수 논리 크기를 주면 목적지 = round(H × scale) 이라 검증이 성립한다.
+    # `-e` 측정 인스턴스의 app_id 는 `tildaz.instance0` 이 아니다 (역할별 이름) — 접두어로 잡는다.
+    swaymsg "[app_id=\"^tildaz\"] floating enable, resize set width 800 px height $H px, move position 0 px 0 px" > $OUT/$tag.sway 2>&1
+    sleep 4
+    grim $OUT/$tag.png
+    local rect; rect=$(swaymsg -t get_tree | python3 -c '
+import json,sys
+def walk(n):
+    if str(n.get("app_id") or "").startswith("tildaz"): print(n["rect"]["x"], n["rect"]["y"], n["rect"]["width"], n["rect"]["height"]); return True
+    return any(walk(c) for c in n.get("nodes",[])+n.get("floating_nodes",[]))
+walk(json.load(sys.stdin))')
+    kill -TERM $pid 2>/dev/null
+    [ -n "$rect" ] || { echo "--- [$tag] scale=$s output=$res H=$H · 앱 창이 없다 ($SLOG)"; sleep 1; return; }
+    local scl; scl=$(grep -E 'scale preferred' $SLOG | tail -1 | sed -E 's/.*preferred=([0-9]+)\/120.*/\1/')
+    read rx ry rw rh <<<"$rect"
+    [ "$rh" = "$H" ] || echo "    ⚠️ floating 크기가 요청과 다르다 (rect ${rw}x${rh}) — $(tr -d '\n ' < $OUT/$tag.sway | head -c 120)"
+    local info px
+    info=$(python3 -c "
+import math; s=$scl/120; h=$rh
+v=h*s; ra=math.floor(v+0.5)
+print(f'logical {$rw}x{h} × {s:.4f} = {v:.2f} → buffer 반올림 {ra} / 내림 {int(v)} · 소수부 {round(v%1,3)}')")
+    px=$(python3 -c "print(round(($rx + $rw/2) * $scl/120) - 50)")
+    echo "--- [$tag] scale=$s output=$res H=$H · $info"
+    python3 "$ROOT/dist/linux/bands-check.py" $OUT/$tag.png --x $px --w 100 | sed 's/^/    /'
+    sleep 1
+}
+
+cmd_scale() {
+    env_sway; OUT=$WORK/scale; rm -rf $OUT; mkdir -p $OUT $XDG/state/tildaz
+    kill_tz
+    python3 "$ROOT/dist/screens/clusters.py" bands > $WORK/bands.sh && chmod +x $WORK/bands.sh
+    # 논리 높이 H 를 골라 H × scale 의 소수부가 .5 이상인 회차 (내림과 반올림이 갈리는 곳) 와 0 인 대조 회차를 나란히 둔다.
+    scale_case 1.25 1600x1000 800 a-125-h800    # 1000.0 · 대조
+    scale_case 1.25 1600x1000 798 b-125-h798    # 997.5  → 반올림 998 / 내림 997
+    scale_case 1.25 1600x1000 799 c-125-h799    # 998.75 → 999 / 998
+    scale_case 1.5  1500x999  666 d-150-h666    # 999.0  · 대조
+    scale_case 1.5  1500x999  665 e-150-h665    # 997.5  → 998 / 997
+    scale_case 2.0  1600x1000 500 f-200-h500    # 1000 · 정수 배율
+    scale_case 1.7  1700x1020 600 g-170-h600    # 1020.0 · 대조
+    scale_case 1.7  1700x1020 588 h-170-h588    # 999.6  → 1000 / 999
+    scale_case 1.7  1700x1020 585 i-170-h585    # 994.5  → 995 / 994 (#539 의 .5 꼴)
+    scale_case 1.7  1700x1020 587 j-170-h587    # 997.9  → 998 / 997
+    swaymsg output HEADLESS-1 resolution 1600 1000 scale 1 >/dev/null
+    echo "RESULT scale: 위 회차의 '판정:' 줄이 전부 '리샘플 없음' 이어야 한다 (⚠️ 줄이 있으면 그 회차는 무효)"
+}
+
+cmd_launcher_fatal() {   # $1 gnome|cinnamon — 실제 runtime dir (mutter devkit 은 pipewire 가 필요해 격리 불가) · 자기 세션 버스
+    local de=$1 XCD COMP WD=wayland-77
+    case $de in
+        gnome)    XCD=GNOME;      COMP=(gnome-shell --devkit --wayland --wayland-display=$WD) ;;
+        cinnamon) XCD=X-Cinnamon; COMP=(cinnamon --nested --wayland) ;;
+        *) die "launcher-fatal gnome|cinnamon" ;;
+    esac
+    OUT=$WORK/launcher-fatal-$de; rm -rf $OUT; mkdir -p $OUT $WORK/xdg-$de/config/tildaz $WORK/xdg-$de/state
+    printf 'this is not toml [[[\n' > $WORK/xdg-$de/config/tildaz/config_9.toml      # launcher 단독 실패 (#577)
+    # spectacle 은 사용자 세션 버스로 KWin 과 말하므로 dbus-run-session 안에서는 실패 — 바깥에서 타이머로 찍는다.
+    # (전체 화면이라 사용자의 다른 창이 담긴다 — 이슈에는 nested 창만 crop. mutter devkit 뷰어는 검게 나올 수 있다 — 2026-09-03 실측.)
+    ( sleep 14; spectacle -b -n -f -o $OUT/full.png >/dev/null 2>&1 && echo "spectacle: $OUT/full.png" ) &
+    env -u SWAYSOCK -u HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY=wayland-0 XDG_CURRENT_DESKTOP=$XCD \
+        TZ_BIN="$TILDAZ" TZ_CFG=$WORK/xdg-$de/config TZ_STATE=$WORK/xdg-$de/state \
+        dbus-run-session -- bash -c '
+        set -u
+        OUT=$1; WD=$2; DE=$3; shift 3
+        "$@" >$OUT/comp.log 2>&1 &
+        CPID=$!; sleep 9
+        kill -0 $CPID 2>/dev/null || { echo "compositor died:"; tail -5 $OUT/comp.log; exit 1; }
+        if [ "$DE" = cinnamon ]; then
+            # muffin 은 어느 wayland-N 을 잡았는지 로그에 안 남기고 (AGENTS.md), 기존 소켓 파일을 재사용하기도 해서 목록
+            # 비교로는 못 찾는다 — LISTEN 소켓의 소유 pid 로 찾는다.
+            WD=$(ss -xlp 2>/dev/null | grep "pid=$CPID," | grep -oE "wayland-[0-9]+" | head -1)
+            [ -n "$WD" ] || { echo "RESULT launcher-fatal $DE: FAIL — cinnamon 의 wayland 소켓을 찾지 못했다"; kill $CPID; exit 1; }
+        fi
+        echo "compositor pid=$CPID · WAYLAND_DISPLAY=$WD"
+        WAYLAND_DISPLAY=$WD XDG_CONFIG_HOME=$TZ_CFG XDG_STATE_HOME=$TZ_STATE TILDAZ_VERBOSE=1 "$TZ_BIN" >$OUT/launcher.out 2>&1 &
+        LPID=$!; sleep 6
+        LOG=$TZ_STATE/tildaz/tildaz_0.log
+        if kill -0 $LPID 2>/dev/null && grep -q "\[dialog\] configured logical=" $LOG; then
+            echo "RESULT launcher-fatal $DE: OK — $(grep -E "layer_shell=(true|false)" $LOG | sed -E "s/.*(layer_shell=[a-z]+).*/\1/" | tail -1) · $(grep "\[dialog\] configured" $LOG | tail -1 | sed -E "s/.*(logical=[0-9x]+ physical=[0-9x]+).*/\1/")"
+        else
+            echo "RESULT launcher-fatal $DE: FAIL — 다이얼로그 configure 로그 없음 (launcher alive=$(kill -0 $LPID 2>/dev/null && echo yes || echo no))"; tail -4 $LOG
+        fi
+        kill -TERM $LPID 2>/dev/null
+        for i in 1 2 3 4 5 6; do sleep 0.5; kill -0 $LPID 2>/dev/null || { echo "launcher exited after ~$((i*500)) ms (fatal 펌프의 SIGTERM · #521)"; break; }; done
+        grep -q "leaving the pump" $LOG && echo "  leaving the pump: yes"
+        kill -TERM $CPID; sleep 2; kill -0 $CPID 2>/dev/null && kill -KILL $CPID
+    ' _ $OUT $WD $de "${COMP[@]}"
+    wait
+}
+
+case ${1:-} in
+    up) cmd_up ;;
+    down) cmd_down ;;
+    tabs) cmd_tabs ;;
+    confirm) cmd_confirm ;;
+    prompt) cmd_prompt ;;
+    scale) cmd_scale ;;
+    launcher-fatal) cmd_launcher_fatal "${2:-}" ;;
+    *) sed -n '2,16p' "$0"; exit 2 ;;
+esac

--- a/dist/linux/headless-check.sh
+++ b/dist/linux/headless-check.sh
@@ -224,6 +224,7 @@ cmd_seat_replug() {   # #347 — seat 의 keyboard capability 가 빠졌다 붙�
 cmd_compositor_exit() {   # #613 — compositor 가 먼저 끝나면 시작 실패가 아니라 정상 종료. sway 를 내리므로 마지막에 돌린다.
     env_sway; OUT=$WORK/compositor-exit; rm -rf $OUT; mkdir -p $OUT
     kill_tz
+    local mark; mark=$(wc -l < $LOG 2>/dev/null || echo 0)     # 같은 로그 파일에 앞 회차 줄이 남아 있다 — 이 회차 줄만 본다
     TILDAZ_VERBOSE=1 "$TILDAZ" --instance 0 >$OUT/stderr.txt 2>&1 </dev/null & WPID=$!; sleep 4
     kill -0 $WPID 2>/dev/null || die "앱이 뜨지 않았다 — $LOG"
     local child; child=$(pgrep -P $WPID | tr '\n' ' ')
@@ -232,7 +233,7 @@ cmd_compositor_exit() {   # #613 — compositor 가 먼저 끝나면 시작 실�
     local alive=0 c; for c in $child; do kill -0 $c 2>/dev/null && alive=1; done
     echo "   $r · exit code $rc · 자식 셸 $([ $alive = 0 ] && echo 정리됨 || echo 남음)"
     tail -4 $LOG | sed -E 's/^\[[^]]+\] /   /'
-    if [ $rc -eq 0 ] && grep -q 'compositor closed the connection' $LOG && ! grep -q 'failed to start' $LOG $OUT/stderr.txt; then
+    if [ $rc -eq 0 ] && tail -n +$((mark+1)) $LOG | grep -q 'compositor closed the connection' && ! tail -n +$((mark+1)) $LOG | grep -q 'failed to start' && ! grep -q 'failed to start' $OUT/stderr.txt; then
         echo "RESULT compositor-exit: OK"
     else
         echo "RESULT compositor-exit: FAIL — exit $rc · stderr: $(head -c 120 $OUT/stderr.txt)"

--- a/dist/linux/vkbd.py
+++ b/dist/linux/vkbd.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Wayland 가상 키보드 (`zwp_virtual_keyboard_v1`) 를 **한 번 꽂고 유지**하며 FIFO 로 키를 넣는 데몬.
+
+headless sway · nested Hyprland 같은 wlroots 계열 compositor 안에서 tildaz 에 합성 키를 보낼 때 쓴다
+(#583 A7 · A8). 사용자 세션 (KWin) 의 실제 입력 장치를 건드리지 않는다 — `ydotool` (`/dev/uinput`) 은
+**포커스된 사용자 창**으로 가지만, 이 도구는 `WAYLAND_DISPLAY` 가 가리키는 compositor 에만 붙는다.
+
+    XDG_RUNTIME_DIR=/run/user/1000/tz583 WAYLAND_DISPLAY=wayland-1 \\
+        python3 dist/linux/vkbd.py --fifo /run/user/1000/tz583/vkbd.fifo &     # 데몬 (먼저 띄운다)
+    echo 'type touch /tmp/probe'   > /run/user/1000/tz583/vkbd.fifo            # 글자 · 기호 (us 배열)
+    echo 'key Return'              > /run/user/1000/tz583/vkbd.fifo            # 키 하나
+    echo 'key ctrl+shift+t'        > /run/user/1000/tz583/vkbd.fifo            # 조합 (ctrl · shift · alt · super)
+    echo 'key alt+F4'              > /run/user/1000/tz583/vkbd.fifo
+    echo 'quit'                    > /run/user/1000/tz583/vkbd.fifo
+
+왜 `wtype` 이 아닌가 — 두 가지가 실측으로 걸렸다 (2026-09-03 · 미니PC Firebat ZY-A8 · headless sway 1.12).
+
+1. `wtype` 은 **새 글자가 나올 때마다 keymap 을 다시 올린다.** keymap 이 바뀌는 사이의 키가 빠지거나 다른
+   글자로 읽혀 `touch …` 가 `ouch …` 로 들어갔다.
+2. `wtype` 은 호출마다 가상 키보드를 **꽂고 뽑는다.** 그래서 두 번째 호출부터는 seat 의 keyboard capability
+   가 "빠졌다 다시 붙는" 왕복이 되는데, tildaz 가 그 왕복에서 `wl_keyboard` 를 다시 만들지 않아 키가 아예
+   닿지 않았다 (앱 결함 후보 — #583 에 적었다). 이 도구는 한 번 꽂고 유지하므로 그 경로를 밟지 않는다.
+
+keymap 은 `xkbcli compile-keymap --layout us` 로 만든 표준 us 배열을 **연결 직후 한 번** 올린다. 그래서
+`type` 은 us 배열에서 칠 수 있는 ASCII 만 받는다 — 대문자 · 기호는 Shift 조합으로 낸다.
+
+**modifier 는 `modifiers` 요청으로 직접 보낸다.** `zwp_virtual_keyboard_v1` 은 modifier · group 상태를 client
+책임으로 두고, wlroots 는 가상 키보드의 key 이벤트로 xkb 상태를 갱신하지 않는다 (`update_state = false`).
+Shift 키의 press 만 보내면 compositor 는 그 뒤 키를 **Shift 없이** 해석한다 — 첫 회차에서 `Ctrl+Shift+T` 가 `t`
+로, `>` 가 `.` 로 들어갔다 (2026-09-03 실측). 그래서 modifier 키 press → `modifiers(mask)` → 키 → `modifiers(0)`
+→ modifier 키 release 순서로 낸다 (실제 키보드에서 client 가 받는 순서와 같다). mask 비트는 xkb 의 real
+modifier 순서다 — Shift 0 · Lock 1 · Control 2 · Mod1 (Alt) 3 · Mod4 (Super) 6.
+
+FIFO 는 줄 단위다. 한 줄이 한 명령이고, 명령 사이에 `sleep <ms>` 를 둘 수 있다. 처리한 명령은 stdout 에
+한 줄씩 남긴다 — 회차 로그로 쓴다.
+"""
+import argparse
+import array
+import os
+import select
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+# ── evdev keycode (linux/input-event-codes.h). Wayland 는 이 값을 그대로 쓰고 xkb 쪽이 +8 한다 ──
+KEY = {
+    "esc": 1, "escape": 1,
+    "1": 2, "2": 3, "3": 4, "4": 5, "5": 6, "6": 7, "7": 8, "8": 9, "9": 10, "0": 11,
+    "minus": 12, "equal": 13, "backspace": 14, "tab": 15,
+    "q": 16, "w": 17, "e": 18, "r": 19, "t": 20, "y": 21, "u": 22, "i": 23, "o": 24, "p": 25,
+    "bracketleft": 26, "bracketright": 27, "return": 28, "enter": 28, "ctrl": 29,
+    "a": 30, "s": 31, "d": 32, "f": 33, "g": 34, "h": 35, "j": 36, "k": 37, "l": 38,
+    "semicolon": 39, "apostrophe": 40, "grave": 41, "shift": 42, "backslash": 43,
+    "z": 44, "x": 45, "c": 46, "v": 47, "b": 48, "n": 49, "m": 50,
+    "comma": 51, "period": 52, "slash": 53, "alt": 56, "space": 57,
+    "f1": 59, "f2": 60, "f3": 61, "f4": 62, "f5": 63, "f6": 64, "f7": 65, "f8": 66, "f9": 67, "f10": 68,
+    "f11": 87, "f12": 88,
+    "home": 102, "up": 103, "pageup": 104, "left": 105, "right": 106, "end": 107, "down": 108,
+    "pagedown": 109, "insert": 110, "delete": 111, "super": 125, "logo": 125,
+}
+MOD_NAMES = {"ctrl", "shift", "alt", "super", "logo"}
+# xkb real modifier 비트 — `modifiers(mods_depressed, …)` 에 넣는 값. keycode → mask.
+MOD_MASK = {KEY["shift"]: 1 << 0, KEY["ctrl"]: 1 << 2, KEY["alt"]: 1 << 3, KEY["super"]: 1 << 6}
+
+# ── us 배열 — 글자 → (keycode, shift 필요) ──
+CHARS = {}
+for ch, name in zip("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"):
+    CHARS[ch] = (KEY[name], False)
+    CHARS[ch.upper()] = (KEY[name], True)
+for ch in "1234567890":
+    CHARS[ch] = (KEY[ch], False)
+for ch, base in zip("!@#$%^&*()", "1234567890"):
+    CHARS[ch] = (KEY[base], True)
+for ch, name, shifted in [
+    ("-", "minus", False), ("_", "minus", True), ("=", "equal", False), ("+", "equal", True),
+    ("[", "bracketleft", False), ("{", "bracketleft", True), ("]", "bracketright", False), ("}", "bracketright", True),
+    (";", "semicolon", False), (":", "semicolon", True), ("'", "apostrophe", False), ('"', "apostrophe", True),
+    ("`", "grave", False), ("~", "grave", True), ("\\", "backslash", False), ("|", "backslash", True),
+    (",", "comma", False), ("<", "comma", True), (".", "period", False), (">", "period", True),
+    ("/", "slash", False), ("?", "slash", True), (" ", "space", False), ("\t", "tab", False), ("\n", "return", False),
+]:
+    CHARS[ch] = (KEY[name], shifted)
+
+
+def wl_string(s):
+    b = s.encode() + b"\0"
+    pad = (-len(b)) % 4
+    return struct.pack("<I", len(b)) + b + b"\0" * pad
+
+
+class Wayland:
+    """필요한 만큼만 구현한 Wayland wire client — registry · seat · virtual keyboard · sync."""
+
+    def __init__(self):
+        run_dir = os.environ.get("XDG_RUNTIME_DIR")
+        display = os.environ.get("WAYLAND_DISPLAY", "wayland-0")
+        path = display if display.startswith("/") else os.path.join(run_dir or "", display)
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(path)
+        self.path = path
+        self.next_id = 2
+        self.buf = b""
+        self.globals = {}      # interface → (name, version)
+        self.done = set()      # callback ids that fired
+        self.registry = self.alloc()
+        self.send(1, 1, struct.pack("<I", self.registry))          # wl_display.get_registry
+        self.roundtrip()
+
+    def alloc(self):
+        i = self.next_id
+        self.next_id += 1
+        return i
+
+    def send(self, obj, opcode, payload=b"", fds=None):
+        size = 8 + len(payload)
+        data = struct.pack("<II", obj, (size << 16) | opcode) + payload
+        if fds:
+            self.sock.sendmsg([data], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))])
+        else:
+            self.sock.sendall(data)
+
+    def roundtrip(self):
+        cb = self.alloc()
+        self.send(1, 0, struct.pack("<I", cb))                       # wl_display.sync
+        deadline = time.monotonic() + 5.0
+        while cb not in self.done:
+            if time.monotonic() > deadline:
+                raise SystemExit("vkbd: roundtrip timed out (compositor not answering)")
+            self.pump(0.5)
+
+    def pump(self, timeout=0.0):
+        r, _, _ = select.select([self.sock], [], [], timeout)
+        if r:
+            chunk = self.sock.recv(65536)
+            if not chunk:
+                raise SystemExit("vkbd: compositor closed the connection")
+            self.buf += chunk
+        while len(self.buf) >= 8:
+            obj, word = struct.unpack_from("<II", self.buf, 0)
+            size, opcode = word >> 16, word & 0xFFFF
+            if len(self.buf) < size:
+                break
+            payload = self.buf[8:size]
+            self.buf = self.buf[size:]
+            self.handle(obj, opcode, payload)
+
+    def handle(self, obj, opcode, payload):
+        if obj == 1 and opcode == 0:                                  # wl_display.error
+            bad, code = struct.unpack_from("<II", payload, 0)
+            n = struct.unpack_from("<I", payload, 8)[0]
+            msg = payload[12:12 + n - 1].decode(errors="replace")
+            raise SystemExit(f"vkbd: wl_display.error object={bad} code={code}: {msg}")
+        if obj == self.registry and opcode == 0:                      # wl_registry.global
+            name = struct.unpack_from("<I", payload, 0)[0]
+            n = struct.unpack_from("<I", payload, 4)[0]
+            iface = payload[8:8 + n - 1].decode()
+            off = 8 + n + ((-n) % 4)
+            version = struct.unpack_from("<I", payload, off)[0]
+            self.globals[iface] = (name, version)
+            return
+        if opcode == 0 and obj not in (1, self.registry):             # wl_callback.done (we only make callbacks besides seat/vk)
+            self.done.add(obj)
+
+    def bind(self, iface, want_version):
+        if iface not in self.globals:
+            raise SystemExit(f"vkbd: compositor does not advertise {iface}")
+        name, version = self.globals[iface]
+        v = min(version, want_version)
+        new_id = self.alloc()
+        self.send(self.registry, 0, struct.pack("<I", name) + wl_string(iface) + struct.pack("<II", v, new_id))
+        return new_id, v
+
+
+class VirtualKeyboard:
+    def __init__(self, wl, layout):
+        self.wl = wl
+        self.seat, _ = wl.bind("wl_seat", 7)
+        self.manager, _ = wl.bind("zwp_virtual_keyboard_manager_v1", 1)
+        self.vk = wl.alloc()
+        wl.send(self.manager, 0, struct.pack("<II", self.seat, self.vk))   # create_virtual_keyboard(seat, id)
+        keymap = subprocess.run(["xkbcli", "compile-keymap", "--layout", layout], capture_output=True, check=True).stdout
+        keymap += b"\0"
+        fd = os.memfd_create("vkbd-keymap")
+        os.write(fd, keymap)
+        wl.send(self.vk, 0, struct.pack("<II", 1, len(keymap)), fds=[fd])   # keymap(format=xkb_v1, fd, size)
+        os.close(fd)
+        wl.roundtrip()
+        self.t0 = time.monotonic()
+        self.down = []
+
+    def now_ms(self):
+        return int((time.monotonic() - self.t0) * 1000) & 0xFFFFFFFF
+
+    def key(self, code, pressed):
+        self.wl.send(self.vk, 1, struct.pack("<III", self.now_ms(), code, 1 if pressed else 0))
+        if pressed:
+            self.down.append(code)
+        elif code in self.down:
+            self.down.remove(code)
+        self.wl.pump(0.0)
+
+    def modifiers(self, depressed):
+        # modifiers(mods_depressed, mods_latched, mods_locked, group) — 프로토콜이 client 에게 맡긴 상태.
+        self.wl.send(self.vk, 2, struct.pack("<IIII", depressed, 0, 0, 0))
+
+    def tap(self, code, mods=(), hold_ms=8):
+        mask = 0
+        for m in mods:
+            self.key(m, True)
+            mask |= MOD_MASK[m]
+            self.modifiers(mask)
+            time.sleep(0.004)
+        self.key(code, True)
+        time.sleep(hold_ms / 1000.0)
+        self.key(code, False)
+        for m in reversed(mods):
+            time.sleep(0.004)
+            mask &= ~MOD_MASK[m]
+            self.modifiers(mask)
+            self.key(m, False)
+        self.wl.roundtrip()
+
+    def type_text(self, text, delay_ms):
+        for ch in text:
+            if ch not in CHARS:
+                print(f"  ! skipped (not on us layout): {ch!r}", flush=True)
+                continue
+            code, shifted = CHARS[ch]
+            self.tap(code, (KEY["shift"],) if shifted else ())
+            time.sleep(delay_ms / 1000.0)
+
+    def combo(self, spec):
+        parts = [p.strip() for p in spec.split("+") if p.strip()]
+        mods = [KEY[p.lower()] for p in parts[:-1]]
+        for p in parts[:-1]:
+            if p.lower() not in MOD_NAMES:
+                raise ValueError(f"not a modifier: {p}")
+        last = parts[-1]
+        code = KEY.get(last.lower())
+        if code is None and len(last) == 1 and last in CHARS:
+            code, shifted = CHARS[last]
+            if shifted and KEY["shift"] not in mods:
+                mods.append(KEY["shift"])
+        if code is None:
+            raise ValueError(f"unknown key: {last}")
+        self.tap(code, mods)
+
+    def release_all(self):
+        for code in list(reversed(self.down)):
+            self.key(code, False)
+        self.wl.roundtrip()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--fifo", required=True, help="명령을 읽을 FIFO 경로 (없으면 만든다)")
+    ap.add_argument("--layout", default="us", help="올릴 xkb layout (기본 us — CHARS 표가 us 기준이다)")
+    ap.add_argument("--delay", type=int, default=12, help="type 의 글자 사이 ms (기본 12)")
+    args = ap.parse_args()
+
+    wl = Wayland()
+    vk = VirtualKeyboard(wl, args.layout)
+    if not os.path.exists(args.fifo):
+        os.mkfifo(args.fifo, 0o600)
+    print(f"vkbd: attached to {wl.path} · seat={vk.seat} · keymap={args.layout} · fifo={args.fifo}", flush=True)
+
+    while True:
+        with open(args.fifo, "r") as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                if not line:
+                    continue
+                cmd, _, rest = line.partition(" ")
+                try:
+                    if cmd == "type":
+                        vk.type_text(rest, args.delay)
+                    elif cmd == "key":
+                        vk.combo(rest)
+                    elif cmd == "sleep":
+                        time.sleep(int(rest) / 1000.0)
+                    elif cmd == "quit":
+                        vk.release_all()
+                        print("vkbd: quit", flush=True)
+                        return
+                    else:
+                        print(f"  ! unknown command: {line}", flush=True)
+                        continue
+                    print(f"  {line}", flush=True)
+                except Exception as e:  # noqa: BLE001 — 한 줄이 틀려도 데몬은 산다
+                    print(f"  ! {line}: {e}", flush=True)
+                wl.pump(0.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/dist/screens/clusters.py
+++ b/dist/screens/clusters.py
@@ -68,6 +68,37 @@ def stack2(cols=150):
     emit(rows(items[:6000], cols))
 
 
+def bands():
+    """#539 — 밝은 띠 / 어두운 띠를 3 줄씩 번갈아 채운 화면. 글리프가 없어 안티에일리어싱이 판정에 안 섞인다.
+
+    compositor 가 창을 리샘플하면 (버퍼가 목적지보다 1 px 짧을 때 — `logicalToPhysicalSize` 의 반올림)
+    세로 단면에서 띠 경계의 전이 행 밝기가 창 위→아래로 흘러가고, 없으면 모든 경계가 같다.
+    `dist/linux/bands-check.py` 가 그 단면을 읽는다. 터미널 크기를 스크립트 안에서 `stty size` 로 읽으므로
+    Linux · macOS 의 `-e` 전용이다 (Windows `--cmd` 는 지원하지 않는다).
+    """
+    # `-e` 프로세스는 세션 생성 직후 뜨고 창 크기는 그 뒤 configure 로 확정된다 (로그: `terminal session created
+    # cols=68 rows=21` → 수 ms 뒤 `terminal resized cols=86 rows=52`). 시작하자마자 `stty size` 를 읽으면 옛 크기의
+    # 줄 수만 채워 아래가 배경으로 남는다 (2026-09-03 headless sway 회차 — 판정의 기준 밝기가 그것에 끌려갔다).
+    # 그래서 잠깐 기다린 뒤 그리고, 이후 크기가 바뀌면 (SIGWINCH) 다시 그린다.
+    head = "\n".join([
+        "draw() {",
+        "  size=$(stty size)",
+        "  rows=${size% *}; cols=${size#* }",
+        "  printf '\\033[H\\033[2J'",
+        "  i=0",
+        "  while [ $i -lt $((rows - 1)) ]; do",
+        "    if [ $(( (i / 3) % 2 )) -eq 0 ]; then printf '\\033[48;2;230;230;230m'; else printf '\\033[48;2;20;20;20m'; fi",
+        "    printf '%*s\\033[0m\\n' \"$cols\" ''",
+        "    i=$((i + 1))",
+        "  done",
+        "}",
+        "trap draw WINCH",
+        "sleep 1.5",
+        "draw",
+    ])
+    emit([], head=head, tail="while :; do sleep 1; done")
+
+
 def overflow(cols=150, screens=17):
     # 화면마다 base 를 바꿔 조합이 겹치지 않게 한다. 각 화면 5,692 종 (= 4 base × 29 × 30 × ... 를 cols 줄로).
     bases_all = [chr(c) for c in range(0x0100, 0x0100 + 4 * screens)]   # Ā Ă Ą Ć … 화면마다 4 개
@@ -104,5 +135,9 @@ if __name__ == "__main__":
         overflow(cols or 150)
     elif which == "mini":
         mini()
+    elif which == "bands":
+        if CMD_TXT:
+            sys.exit("bands 는 sh 전용이다 (stty size 로 터미널 크기를 읽는다) — --cmd 와 함께 쓸 수 없다")
+        bands()
     else:
-        sys.exit("사용법: clusters.py many|stack2|overflow|mini [cols] [--cmd <본문.txt>]")
+        sys.exit("사용법: clusters.py many|stack2|overflow|mini|bands [cols] [--cmd <본문.txt>]")


### PR DESCRIPTION
[#583](https://github.com/ensky0/tildaz/issues/583) 의 Linux 몫 (A2 · A5 · A7 · A8) 을 **사용자 세션을 건드리지 않고** 자동으로 검증하는 도구와 AGENTS.md 절. headless sway (`WLR_BACKENDS=headless`) 안에 tildaz 를 띄우고 `zwp_virtual_keyboard_v1` 가상 키보드로 키를 넣는다 — `ydotool` 처럼 포커스된 사용자 창에 타이핑되는 일이 없다.

| 파일 | 무엇 |
|---|---|
| `dist/linux/vkbd.py` | 가상 키보드를 한 번 꽂고 FIFO 로 `type …` · `key ctrl+shift+t` 를 받는 데몬. `wtype` 은 새 글자마다 keymap 을 다시 올려 글자가 빠지고, 호출마다 키보드를 꽂고 뽑아 두 번째부터 키가 닿지 않는다 (앱 결함 후보 — #583 B21) |
| `dist/linux/headless-check.sh` | `up` · `tabs` (Alt+1~9 · 탭마다 `cat > tab_N.txt` 로 판정) · `confirm` · `prompt` (#521 펌프의 SIGTERM) · `scale` (#539 배율) · `launcher-fatal gnome\|cinnamon` (#577) · `down` |
| `dist/screens/clusters.py bands` · `dist/linux/bands-check.py` | 밝은/어두운 띠 화면과 세로 단면 전이 행 판정 |
| `AGENTS.md` | 절차와 함정 — 격리 runtime dir 은 짧게 (`sun_path`) · sway 배율 검증의 세 조건 · nested Hyprland 는 가려지면 렌더가 멈춤 · mutter devkit 은 runtime dir 격리 불가 · Cinnamon 소켓은 `ss` 로 |

실측 (미니PC Firebat ZY-A8 · CachyOS · KDE Plasma 6.7.4 · 2026-09-03 · main `42697d8`) — 손으로 짠 회차와 이 통합 스크립트 둘 다 같은 결과.

| 회차 | 결과 |
|---|---|
| `tabs` | `Alt+1`~`Alt+9` 9/9 |
| `confirm` · `prompt` | 두 펌프 모두 `leaving the pump` 로그 뒤 500 ms 안 종료 |
| `scale` | 1.25 · 1.5 · 2.0 · 1.7 × 10 회차 (반올림 경로 포함) 전이 행 0 |
| `launcher-fatal cinnamon` (gnome 은 손 회차) | `layer_shell=false` 인 채 xdg_toplevel 다이얼로그 configure |

코드 변경 없음 (문서 · 스크립트만). 세부는 #583 의 진행 댓글.

Refs #583 #521 #533 #539 #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
