### PR TITLE
fix(linux): compositor 가 먼저 끝나면 시작 실패가 아니라 정상 종료로 (#613)

### DIFF
--- a/src/host/linux/unix_socket.zig
+++ b/src/host/linux/unix_socket.zig
@@ -120,13 +120,22 @@ pub fn connect(fd: posix.fd_t, path: []const u8) error{ PathTooLong, ConnectFail
 }
 
 /// 버퍼 전체를 쓴다. 예전 `std.net.Stream.writeAll` 자리 — 짧은 쓰기를 이어서 마저 쓴다.
-pub fn writeAll(fd: posix.fd_t, bytes: []const u8) error{WriteFailed}!void {
+/// `PeerClosed` 는 상대가 소켓을 닫은 것 (EPIPE · ECONNRESET) — Wayland 쪽은 이것을 `WaylandConnectionClosed`
+/// 로 바꿔 compositor 종료를 read 가 아닌 write 로 먼저 만난 경우도 정상 종료로 보낸다 (#613 — 통합 회차에서
+/// 가상 키보드가 붙은 채 `swaymsg exit` 하면 poll 전에 write 가 먼저 실패했다).
+pub fn writeAll(fd: posix.fd_t, bytes: []const u8) error{ WriteFailed, PeerClosed }!void {
     var off: usize = 0;
     while (off < bytes.len) {
-        const rc = posix.system.write(fd, bytes.ptr + off, bytes.len - off);
+        // #613 — `write(2)` 는 peer 가 닫힌 소켓에 쓰면 EPIPE 와 함께 **SIGPIPE** 를 보내고, 기본 동작은
+        // 프로세스 종료다. compositor 가 먼저 끝난 뒤 `deinit` 이 destroy 요청을 보내는 그 순간이 바로 그
+        // 경우라, `deinit` 이 송신 실패를 무시해도 시그널로 죽어 PTY 자식 정리 (#129) 를 못 한다. unix
+        // stream 소켓에 주소 없는 `sendto` 는 `write` 와 같고 `MSG_NOSIGNAL` 로 시그널만 막는다 — 실패는
+        // EPIPE 로 돌아와 아래 `WriteFailed` 가 된다.
+        const rc = posix.system.sendto(fd, bytes.ptr + off, bytes.len - off, std.os.linux.MSG.NOSIGNAL, null, 0);
         if (checkErr(rc)) |e| switch (e) {
             // 시그널에 끊긴 것은 실패가 아니다 — 이어서 다시 쓴다.
             .INTR => continue,
+            .PIPE, .CONNRESET => return error.PeerClosed,
             else => return error.WriteFailed,
         };
         const n: usize = @intCast(rc);

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1988,7 +1988,21 @@ const Client = struct {
         // #386 ②). 유휴에서 첫 출력이 최대 16 ms 늦는 것은 별개 축이라 #439 에서 다룬다.
         var poll_timeout: i32 = frame_poll_ms;
         while (self.running) {
-            try self.pollAndDispatch(poll_timeout);
+            self.pollAndDispatch(poll_timeout) catch |err| switch (err) {
+                // #613 — compositor 가 먼저 끝났다 (로그아웃 · compositor 종료 · `swaymsg exit`).
+                // 실행 중 연결이 끊긴 것은 *시작 실패* 가 아니라 따라 끝날 일이다. 예전엔 이 오류가
+                // `host.run` 밖으로 나가 `showFatalRunError` 의 `TildaZ failed to start … WaylandConnectionClosed`
+                // 가 stderr · 로그에 남아, 로그를 읽는 사용자가 기동 실패로 오해했다. SIGTERM (#458) 과 같은
+                // 정상 종료 경로로 간다 — `deinit` 이 돌아 PTY 자식 정리 (#129). 그 뒤의 Wayland 요청은
+                // 닫힌 소켓에 써서 EPIPE 로 실패하는데 `deinit` 은 송신 실패를 무시하고, `sendmsg` 에
+                // `MSG_NOSIGNAL` 을 주어 SIGPIPE 로 죽지 않는다.
+                error.WaylandConnectionClosed => {
+                    log.appendLine("exit", "compositor closed the connection — shutting down", .{});
+                    self.running = false;
+                    break;
+                },
+                else => return err,
+            };
             // #203 Phase C — dialog dismiss 가 pending 이면 *여기서* 실제 처리.
             // pointer button / dialog key / layer-surface closed handler 들은
             // dispatchBuffered 의 reentrant context 안이라 inner roundtrip 시
@@ -10301,7 +10315,17 @@ pub fn runBaselineWindow(
     // custom keybinding (GSettings)
     // 으로 자동 등록. 그 외 DE 면 no-op.
     if (!opts.isStressRun()) gsettings_hotkey.registerToggleHotkey(rt, allocator, cfg);
-    try client.run();
+    client.run() catch |err| switch (err) {
+        // #613 — main loop 의 `pollAndDispatch` 는 이 오류를 안에서 잡지만, 종료를 **write 로 먼저** 만나면
+        // (`maybeRedraw` · `maybeRepeatKey` 등 `try` 로 올라오는 송신) 여기까지 온다. 어느 쪽이든 compositor 가
+        // 먼저 끝난 것이라 정상 종료다 — 위 `defer client.deinit()` 이 PTY 자식을 거둔다 (#129). 통합 회차
+        // `headless-check.sh compositor-exit` 가 이 경로를 잡아냈다 (가상 키보드가 붙은 채 `swaymsg exit`).
+        error.WaylandConnectionClosed => {
+            log.appendLine("exit", "compositor closed the connection — shutting down", .{});
+            return;
+        },
+        else => return err,
+    };
 }
 
 /// #577 — **창도 PTY 도 없이 fatal 다이얼로그 하나만 띄운다.**
@@ -10390,7 +10414,12 @@ const Msg = struct {
     }
 
     fn send(self: *Msg, wayland_fd: posix.fd_t) !void {
-        try unix_socket.writeAll(wayland_fd, self.finish());
+        unix_socket.writeAll(wayland_fd, self.finish()) catch |err| switch (err) {
+            // #613 — compositor 가 먼저 끝난 것을 read (poll 의 HUP) 가 아니라 write 로 먼저 만난 경우.
+            // 같은 이름으로 올려야 main loop · `runBaselineWindow` 의 정상 종료 판정이 한 자리에 모인다.
+            error.PeerClosed => return error.WaylandConnectionClosed,
+            error.WriteFailed => return error.WriteFailed,
+        };
     }
 
     fn sendWithFd(self: *Msg, wayland_fd: posix.fd_t, fd: posix.fd_t) !void {
@@ -10420,9 +10449,13 @@ const Msg = struct {
             .flags = 0,
         };
         // #451 — `posix.sendmsg` 도 없어졌다. `SCM_RIGHTS` 를 표현할 길이 `Io.net` 에
-        // 없으므로 (`unix_socket.zig`) raw syscall 로 내린다.
-        const rc = posix.system.sendmsg(wayland_fd, &msg, 0);
-        if (unix_socket.checkErr(rc) != null) return error.WaylandFdWriteFailed;
+        // 없으므로 (`unix_socket.zig`) raw syscall 로 내린다. `MSG_NOSIGNAL` 은 #613 — compositor 가
+        // 먼저 끝난 뒤의 송신이 SIGPIPE 로 프로세스를 죽이지 않게 (`unix_socket.writeAll` 과 같은 이유).
+        const rc = posix.system.sendmsg(wayland_fd, &msg, linux.MSG.NOSIGNAL);
+        if (unix_socket.checkErr(rc)) |e| switch (e) {
+            .PIPE, .CONNRESET => return error.WaylandConnectionClosed, // #613 — `Msg.send` 와 같은 판정
+            else => return error.WaylandFdWriteFailed,
+        };
         if (@as(usize, @intCast(rc)) != bytes.len) return error.WaylandShortFdWrite;
     }
 };


### PR DESCRIPTION
[#613](https://github.com/ensky0/tildaz/issues/613) — compositor 가 먼저 끝나면 (로그아웃 · `swaymsg exit`) `WaylandConnectionClosed` 가 main loop 를 빠져나가 `TildaZ failed to start … WaylandConnectionClosed` 로 남았다. 실행 중 연결 종료는 시작 실패가 아니라 따라 끝날 일이라 SIGTERM (#458) 과 같은 정상 종료 경로로 보낸다. **종료를 read (poll 의 HUP) 로 만나는 경로와 write (`try` 송신의 EPIPE) 로 만나는 경로 둘 다** 다룬다 — 후자는 통합 회차 `headless-check.sh compositor-exit` 가 잡아냈다 (가상 키보드가 붙은 채 `swaymsg exit`).

| 변경 | 무엇 |
|---|---|
| main loop | `pollAndDispatch` 의 `WaylandConnectionClosed` → `[exit] compositor closed the connection — shutting down` · `running = false` |
| `unix_socket.writeAll` | `write(2)` → `sendto(MSG_NOSIGNAL)` (peer 가 닫힌 소켓에 쓰면 SIGPIPE 가 프로세스를 죽여 `deinit` 이 끝나지 못한다) · EPIPE · ECONNRESET 은 `PeerClosed` 로 가른다 |
| `Msg.send` · `sendWithFd` | `PeerClosed` / sendmsg 의 EPIPE · ECONNRESET → `WaylandConnectionClosed` (read 경로와 같은 이름) · `sendmsg` 에도 `MSG_NOSIGNAL` |
| `runBaselineWindow` | `client.run()` 이 `WaylandConnectionClosed` 로 나오면 정상 종료 — `defer client.deinit()` 이 PTY 자식 정리 (#129). 기동 단계의 연결 실패 (`WaylandSocketUnavailable`) 는 그대로 fatal |

실기 (미니PC · headless sway 1.12 · 2026-09-03): 손 회차 (앱만) 와 통합 회차 (가상 키보드 붙은 채) 둘 다 `swaymsg exit` → exit 0 · 자식 셸 정리 · stderr 비어 있음 · 로그 `compositor closed the connection — shutting down` · `failed to start` 없음. `zig fmt` · `zig build test` · `zig build check` 통과.

Refs #613 #583 #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
