### PR TITLE
fix(config): config 파일이 없는 실행에도 기본 창 단축키를 채운다 (#620)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1012,48 +1012,46 @@ echo -e "\n🎉❤️🌈🎨🌞🍎🚀💎✨\n👋🏻👋🏼👋🏽👋�
 chcp 65001 >nul && echo. && echo 🎉❤️🌈🎨🌞🍎🚀💎✨ && echo 👋🏻👋🏼👋🏽👋🏾👋🏿 && echo 👨‍👩‍👧👨‍👨‍👦‍👦 && echo ABCDEFG abcdefg 0123456789 && echo 한글 ABC 가나다라마바사 && echo ▀▁▂▃▄▅▆▇█▉▊▋▌▍▎▏ && echo ▐░▒▓▔▕ && echo.
 ```
 
-# `config_N.toml` 이 없는 실행에는 창 안 단축키가 하나도 없어요
+# `config_N.toml` 이 없는 실행 — 예전엔 창 안 단축키가 0 개였어요 ([#620](https://github.com/ensky0/tildaz/issues/620) 에서 고쳤어요)
 
-**조건은 `-e` 가 아니라 "그 회차가 뜰 때 config 파일이 없었다" 예요.** `Ctrl+Shift+T` ·
-`Ctrl+Shift+W` · `Cmd+T` 같은 창 안 단축키가 **0 개**인 채로 돌아요. 세 platform 공통이고,
-버그가 아니라 두 규칙이 맞물린 결과예요.
+**2026-09-04 이후로는 파일이 없어도 기본 단축키가 그대로 들어요.** `Config.defaultOwned` 가
+`fillDefaultKeyBindings` 로 `parse` 와 **같은 기본값**을 채워요. 아래는 그 전에 무엇이 왜 안 됐는지의
+기록이에요 — 옛 빌드로 검증하거나 비슷한 증상을 만나면 여기를 보세요.
 
-- **config 파일이 없는 경로가 `[keys]` 를 채우지 않아요.** `Config.load` 는 파일이 없으면
-  `defaultOwned` 로 가는데 그 함수가 `key_bindings` · `key_binding_count` 를 건드리지 않아서
-  `Config{}` 의 기본값 `key_binding_count = 0` 이 그대로 남아요. 바인딩을 채우는 것은 `parse`
-  안의 루프뿐이고, 그 안의 `defaultBindings(action)` fallback 도 **파일을 파싱하는 경로에만**
-  있어요.
-- **측정 인스턴스 (`-e`) 가 대표 사례일 뿐이에요.** 그쪽은 *일부러* config 를 만들지 않아서
-  ([#382](https://github.com/ensky0/tildaz/issues/382) — *"측정이 사용자 설정을 만드는 주체가 되면
-  안 된다"*, `config.zig` 의 `Config.load` 주석) 매번 걸려요.
+<details>
+<summary>고치기 전 동작 (#620 · 2026-09-04 이전 빌드)</summary>
 
-**⚠️ `-e` 없이 새 인스턴스를 처음 띄우는 회차도 그대로 걸려요.** 앱이 파일을 *만들기는* 하지만
-**그 회차의 메모리 config 는 이미 빈 채**예요. 그래서 **한 번 띄웠다 내리고 다시 띄우면** 그때부터
-정상이에요. 2026-08-29 [#483](https://github.com/ensky0/tildaz/issues/483) macOS 회차에서 이것으로
-걸렸어요 — `⌘T` 조차 안 먹는데 문자 키 (`h` → `ㅗ`) 는 정상이라 포커스 문제도 아니어서 한참 갈랐어요.
-그 전까지 이 절의 제목이 `-e` 로 좁혀져 있어서 해당 없다고 읽혔던 것이 원인이에요.
+**조건은 `-e` 가 아니라 "그 회차가 뜰 때 config 파일이 없었다" 였어요.** `Ctrl+Shift+T` ·
+`Ctrl+Shift+W` · `Cmd+T` 같은 창 안 단축키가 **0 개**인 채로 돌았어요. 세 platform 공통이었어요.
 
-**그래서 단축키를 쓰는 검증은 config 를 먼저 만들어 두고 시작해요** (아래 `# 실행 환경` 의 `--instance 9`
-절차). 파일이 있으면 `-e` 여도 정상이에요 — `-e` 가 config 를 *읽는* 것은 막지 않아요.
+- **config 파일이 없는 경로가 `[keys]` 를 채우지 않았어요.** `Config.load` 는 파일이 없으면
+  `defaultOwned` 로 가는데 그 함수가 `key_bindings` · `key_binding_count` 를 건드리지 않아
+  `key_binding_count = 0` 이 그대로 남았어요. 바인딩을 채우는 것은 `parse` 안의 루프뿐이었고,
+  그 안의 `defaultBindings(action)` fallback 도 **파일을 파싱하는 경로에만** 있었어요.
+- **`-e` 없이 새 인스턴스를 처음 띄우는 회차도 걸렸어요.** 앱이 파일을 *만들기는* 하지만 **그 회차의
+  메모리 config 는 이미 빈 채**였어요. 그래서 **한 번 띄웠다 내리고 다시 띄우면** 그때부터 정상이었어요.
+- **합성 입력 문제로 오진하기 쉬웠어요.** 2026-08-26 [#506](https://github.com/ensky0/tildaz/issues/506)
+  Windows 검증에서 `SendInput` 을 세 방식으로 보내도 무반응이라 injection 을 의심하며 시간을 썼고,
+  같은 회차의 macOS 에서도 `Cmd+T` 가 안 먹어 사용자가 `+` 를 클릭했어요. 2026-08-29
+  [#483](https://github.com/ensky0/tildaz/issues/483) macOS 회차도 같은 자리에서 걸렸어요 — `⌘T` 조차
+  안 먹는데 문자 키는 정상이라 포커스 문제도 아니어서 한참 갈랐어요.
 
-**합성 입력 문제로 오진하기 쉬워요.** 2026-08-26 [#506](https://github.com/ensky0/tildaz/issues/506)
-Windows 검증에서 VK-only · VK+scancode · scancode-only 세 방식으로 `SendInput` 을 보내도
-무반응이라 injection 을 의심하며 시간을 썼어요. 같은 회차의 macOS 에서도 `Cmd+T` 가 안 먹어
-사용자가 `+` 를 클릭했어요 — 원인은 같아요.
+</details>
 
-**탭 수를 바꾸는 다른 진입점이 있어요.** 창 오른쪽 위 컨트롤 스트립이 `+` (새 탭) · `×` (활성 탭
-닫기) · `⋯` (메뉴) 순서라, 마우스 클릭으로 탭을 만들고 닫을 수 있어요. 탭 수 변화를 보는 검증
-(예: `-size` 가 탭바만큼 창을 키우는지) 에는 단축키와 동등해요.
+**측정 인스턴스 (`-e`) 는 지금도 config 파일을 만들지 않아요** ([#382](https://github.com/ensky0/tildaz/issues/382)
+— *"측정이 사용자 설정을 만드는 주체가 되면 안 된다"*). 달라진 것은 **그 회차도 기본 단축키를 갖는다**는
+것뿐이라, 이제 `-e` 로 띄운 창에서도 `Ctrl+Shift+T` 가 먹어요.
 
-단축키 자체를 써야 하면 **`-e` 없이 한 번 띄워 config 를 만든 뒤** 측정 인스턴스를 띄워요.
+**회귀 검사는 [`dist/linux/headless-check.sh first-run`](dist/linux/headless-check.sh)** 이에요 — 빈
+`XDG_CONFIG_HOME` 으로 띄워 `Ctrl+Shift+T` 를 보내고 새 셸이 생기는지 봐요. 고치기 전 판은 탭이 1 개,
+고친 판은 2 개예요 (로그의 `[tab] shell exited` 수로도 갈려요).
 
-```sh
-tildaz --instance 9              # config_9.toml 생성 (뜬 뒤 바로 내려요)
-tildaz --instance 9 -e /bin/bash -size 88x33 &
-```
+⚠️ **그 회차의 마커 파일 경로는 짧게 잡아요.** 가상 키보드가 글자당 ~25 ms 라 90 자짜리 경로는 타이핑에
+2.3 초가 걸려요 — 고정 `sleep 2` 뒤에 판정하면 **새 탭이 열렸는데도** 파일이 아직 없어서 거짓 FAIL 이
+나요 (2026-09-04 에 실제로 그렇게 오판했다가 캡처의 탭 2 개를 보고 알았어요). 판정은 대기 루프로 해요.
 
-⚠️ 이렇게 만든 `config_9.toml` 은 **끝나면 지워요** — 안 지우면 사용자 로그온 때 그 인스턴스가
-같이 떠요 (위 `# Windows — 키보드 layout 조회 실측 방법` 절의 같은 주의).
+**탭 수를 바꾸는 다른 진입점도 있어요.** 창 오른쪽 위 컨트롤 스트립이 `+` (새 탭) · `×` (활성 탭 닫기) ·
+`⋯` (메뉴) 순서라 마우스 클릭으로도 탭을 만들고 닫을 수 있어요.
 
 # Linux — headless sway · nested compositor 로 합성 입력 · 다이얼로그 · 배율을 자동 검증하는 법
 
@@ -1260,8 +1258,9 @@ tildaz --instance 1 -e <zig-out/bin/render-test> -size 88x33 &
   그래서 출력할 내용을 담은 **스크립트 파일**을 만들어 넘겨요. 스크립트 끝에 `sleep` 을 둬야
   창이 남아요 (`-e` 로 띄운 프로세스가 끝나면 앱도 끝나요).
 - **`--instance 1` 을 써요.** 평소 쓰는 daily 인스턴스 (`--instance 0`) 를 건드리지 않아요.
-- **단축키는 안 먹어요** — 위 `# config_N.toml 이 없는 실행에는 창 안 단축키가 하나도 없어요` 절. 탭을
-  만들거나 닫아야 하면 컨트롤 스트립의 `+` / `×` 를 클릭해요.
+- **단축키는 이제 먹어요** ([#620](https://github.com/ensky0/tildaz/issues/620) · 2026-09-04) — config 파일이 없어도
+  기본 바인딩이 들어가요. 그 전 빌드에서는 0 개였어요 (위 `# config_N.toml 이 없는 실행` 절). 마우스로 하려면
+  컨트롤 스트립의 `+` / `×` 를 클릭해요.
 - 입력은 **`printf` 로 UTF-8 byte 를 직접** 내요 — 편집기 · 클립보드가 cluster 를 정규화해
   버리는 것을 피해요.
 - 화면 배치는 **`[cluster]` … `base [기본문자]` 좌우 대조**로 만들어요. **좌우가 같아 보이면

--- a/dist/linux/headless-check.sh
+++ b/dist/linux/headless-check.sh
@@ -6,6 +6,7 @@
 #   dist/linux/headless-check.sh tabs                # A8  — Alt+1~9 탭 전환 (탭마다 cat > tab_N.txt · 파일로 판정)
 #   dist/linux/headless-check.sh confirm             # A7  — Alt+F4 확인 다이얼로그 펌프 중 SIGTERM (#521)
 #   dist/linux/headless-check.sh prompt              # A7  — 새 instance 핫키 캡처 다이얼로그 펌프 중 SIGTERM (#521)
+#   dist/linux/headless-check.sh first-run           # #620 — config 없는 첫 실행에서 창 안 단축키가 먹는지
 #   dist/linux/headless-check.sh scale               # A5  — 배율 1.25 · 1.5 · 2.0 · 1.7 의 띠 화면 전이 행 (#539)
 #   dist/linux/headless-check.sh seat-replug         # #347 — 가상 키보드를 뽑았다 꽂은 뒤에도 키가 닿는지 (wl_keyboard 재생성)
 #   dist/linux/headless-check.sh compositor-exit     # #613 — compositor 가 먼저 끝나면 정상 종료 (exit 0 · failed to start 없음). sway 를 내리니 마지막에
@@ -183,6 +184,39 @@ print(f'logical {$rw}x{h} × {s:.4f} = {v:.2f} → buffer 반올림 {ra} / 내�
     sleep 1
 }
 
+cmd_first_run() {   # #620 — config 파일이 없는 **첫 실행**에서 창 안 단축키가 먹는지
+    env_sway; OUT=$WORK/first-run; rm -rf $OUT; mkdir -p $OUT/xdg/config $OUT/xdg/state
+    kill_tz
+    # 빈 config 홈 — 앱이 이 회차에 config_0.toml 을 만들지만, 그 회차의 **메모리 config** 는 기본값 경로다.
+    export XDG_CONFIG_HOME=$OUT/xdg/config XDG_STATE_HOME=$OUT/xdg/state
+    local LOG0=$OUT/xdg/state/tildaz/tildaz_0.log
+    TILDAZ_VERBOSE=1 nohup "$TILDAZ" --instance 0 >/dev/null 2>&1 </dev/null & WPID=$!; sleep 4
+    kill -0 $WPID 2>/dev/null || die "worker 가 뜨지 않았다 — $LOG0"
+    focus_probe
+    # 판정 — 첫 탭에서 `cat > t1` 을 띄우고 Ctrl+Shift+T 뒤 `cat > t2` 를 친다.
+    #   새 탭이 열렸으면 새 셸이 그 줄을 **실행**해 t2 가 생긴다.
+    #   안 열렸으면 우리는 아직 첫 `cat` 안이라 그 줄이 t1 의 **내용**으로 들어가고 t2 는 없다.
+    # ⚠️ 마커 경로는 **짧게** — vkbd 가 글자당 ~25 ms 라 긴 경로 (90 자면 2.3 초) 를 타이핑하는 중에 판정하면
+    # 새 탭이 열렸는데도 파일이 아직 없다 (첫 회차에 그렇게 거짓 FAIL 이 났다). 판정도 고정 sleep 이 아니라 대기 루프다.
+    local M1=/tmp/tzfr-$$-1 M2=/tmp/tzfr-$$-2; rm -f $M1 $M2
+    snd "type cat > $M1" "key Return"; sleep 2
+    snd "key ctrl+shift+t"; sleep 2.5
+    snd "type cat > $M2" "key Return"
+    wait_file $M2 || true
+    grim $OUT/screen.png
+    local bindings; bindings=$(grep -oE 'key bindings=[0-9]+' $LOG0 | tail -1)
+    echo "   config: $(ls $OUT/xdg/config/tildaz/ | tr '\n' ' ') · $bindings"
+    # 로그의 `shell exited` 수 = 종료 시점의 탭 수 (보조 증거).
+    if [ -f $M2 ]; then
+        echo "RESULT first-run: OK — 첫 실행에서 Ctrl+Shift+T 가 새 탭을 열었다"
+    else
+        echo "RESULT first-run: FAIL — 새 탭이 안 열렸다 (#620)"
+    fi
+    rm -f $M1 $M2
+    kill -TERM $WPID; wait_exit $WPID >/dev/null
+    export XDG_CONFIG_HOME=$XDG/config XDG_STATE_HOME=$XDG/state
+}
+
 cmd_scale() {
     env_sway; OUT=$WORK/scale; rm -rf $OUT; mkdir -p $OUT $XDG/state/tildaz
     kill_tz
@@ -292,6 +326,7 @@ case ${1:-} in
     confirm) cmd_confirm ;;
     prompt) cmd_prompt ;;
     scale) cmd_scale ;;
+    first-run) cmd_first_run ;;
     seat-replug) cmd_seat_replug ;;
     compositor-exit) cmd_compositor_exit ;;
     launcher-fatal) cmd_launcher_fatal "${2:-}" ;;

--- a/src/config.zig
+++ b/src/config.zig
@@ -1017,6 +1017,36 @@ test "#496 위치 표기 파싱" {
     );
 }
 
+test "#620 config 파일이 없는 실행도 창 안 단축키를 갖는다" {
+    // 파일이 없거나 못 읽으면 `Config.load` 가 `defaultOwned` 로 떨어진다. 그 회차도 `parse` 와 **같은**
+    // 기본 바인딩을 가져야 한다 — 예전에는 0 개라 첫 실행에서 새 탭 · 복사 · 분할이 전부 안 먹었다.
+    const shell = try std.testing.allocator.dupe(u8, "/bin/bash");
+    var c = Config.defaultOwned(std.testing.allocator, shell);
+    defer c.deinit(std.testing.allocator);
+
+    // 위 테스트가 고정한 기본값 개수와 같아야 한다 — 두 길이 갈리면 여기서 걸린다.
+    var expected: usize = 0;
+    for (std.enums.values(KeyAction)) |action| expected += defaultBindings(action).len;
+    try std.testing.expectEqual(expected, @as(usize, c.key_binding_count));
+    try std.testing.expect(c.key_binding_count > 0);
+
+    // 대표 하나 — 새 탭이 실제로 들어 있고 액션이 맞는지 (개수만 보면 엉뚱한 값이 채워져도 통과한다).
+    const new_tab_text = defaultBindings(.new_tab)[0];
+    const parsed = switch (parseHotkeyString(new_tab_text, .app_binding)) {
+        .ok => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    const want = Hotkey.fromParsed(parsed);
+    var found = false;
+    for (c.key_bindings[0..c.key_binding_count]) |b| {
+        if (std.meta.eql(b.hotkey, want)) {
+            try std.testing.expectEqual(KeyAction.new_tab, b.action);
+            found = true;
+        }
+    }
+    try std.testing.expect(found);
+}
+
 test "#493 default [keys] has no conflicting bindings" {
     // 액션 → 키 방향을 택한 대가로 충돌 감지가 우리 몫이다 (키 → 액션이면 TOML 이
     // 중복 키로 잡아 준다). 기본값끼리 충돌하면 첫 실행부터 fatal 이므로 고정한다.
@@ -2681,7 +2711,36 @@ pub const Config = struct {
         for (c.font_families[0..c.font_family_count]) |*f| {
             f.* = allocator.dupe(u8, f.*) catch f.*;
         }
+        fillDefaultKeyBindings(&c);
         return c;
+    }
+
+    /// [#620](https://github.com/ensky0/tildaz/issues/620) — 기본값 경로에도 **창 안 단축키**를 채운다.
+    ///
+    /// config 를 만드는 길이 둘인데 예전에는 한쪽만 채웠다. `parse` 는 액션마다 `[keys]` 에 있으면 그
+    /// 값을, 없으면 `defaultBindings(action)` 을 넣는다. `defaultOwned` 는 그 자리를 통째로 건너뛰어
+    /// `key_binding_count` 가 0 이었고, **config 파일이 없는 첫 실행은 새 탭 · 복사 · 붙여넣기 · 분할이
+    /// 하나도 안 먹었다** (전역 hotkey 는 따로 채워서 멀쩡했으므로 "창 안에서만 안 먹는" 증상이었다).
+    /// 조건은 `-e` 가 아니라 *파일이 있었는지*라 보통 사용자의 첫 실행도 걸렸고, 한 번 내렸다 다시
+    /// 띄우면 그때부터 정상이라 재현이 헷갈렸다 (#483 · #506 · #555 가 각각 여기 걸렸다).
+    ///
+    /// 파싱 실패를 조용히 건너뛰는 이유: 여기 오는 문자열은 우리 상수뿐이고
+    /// `test "#493 default [keys] has no conflicting bindings"` 가 40 개 전부 파싱되고 충돌하지 않음을
+    /// 고정한다. 사용자 입력이 아니므로 알릴 대상도 없다.
+    fn fillDefaultKeyBindings(config: *Config) void {
+        var count: usize = 0;
+        for (std.enums.values(KeyAction)) |action| {
+            for (defaultBindings(action)) |text| {
+                if (count >= MAX_KEY_BINDINGS) break;
+                const parsed = switch (parseHotkeyString(text, .app_binding)) {
+                    .ok => |v| v,
+                    else => continue,
+                };
+                config.key_bindings[count] = .{ .hotkey = Hotkey.fromParsed(parsed), .action = action };
+                count += 1;
+            }
+        }
+        config.key_binding_count = @intCast(count);
     }
 
     fn parse(rt: Runtime, allocator: std.mem.Allocator, content: []const u8, config_path: []const u8) LoadError!Config {


### PR DESCRIPTION
[#620](https://github.com/ensky0/tildaz/issues/620) — **config 파일이 없는 첫 실행은 창 안 단축키가 0 개**였다. 새 탭 · 복사 · 붙여넣기 · 분할이 전부 안 먹고, 한 번 내렸다 다시 띄우면 정상이 된다. 전역 hotkey (F1) 는 멀쩡해서 "창 안에서만 안 먹는" 증상이라 합성 입력 문제로 오진하기 쉬웠다 — [#483](https://github.com/ensky0/tildaz/issues/483) · [#506](https://github.com/ensky0/tildaz/issues/506) · [#555](https://github.com/ensky0/tildaz/issues/555) 가 각각 여기 걸렸고 [#583 B1](https://github.com/ensky0/tildaz/issues/583) 이 문서 기록으로만 남겨 둔 항목이다.

## 원인

config 를 만드는 길이 둘인데 **한쪽만 `[keys]` 를 채웠다.**

| 길 | 언제 | `key_bindings` |
|---|---|---|
| `parse` | 파일이 있고 읽힘 | 액션마다 `[keys]` 의 값, 없으면 `defaultBindings(action)` → 40 개 |
| `defaultOwned` | 파일 없음 · 읽기 실패 · 파싱 실패 · 경로 실패 | **건드리지 않음** → `key_binding_count = 0` |

조건이 `-e` 가 아니라 *파일이 있었는지*라 보통 사용자의 첫 실행도 걸린다. 세 platform 공통 (`config.zig` 는 host 무관).

## 수정

`fillDefaultKeyBindings` 를 `defaultOwned` 끝에서 부른다. `parse` 의 else 분기와 **같은 `defaultBindings` 목록**을 쓰므로 두 길이 갈리지 않는다. 기본값은 우리 상수라 파싱 실패는 건너뛰고, 그 안전성은 기존 `test "#493 default [keys] has no conflicting bindings"` (40 개 파싱 · 충돌 없음) 가 고정한다.

문서도 같은 PR 에 — AGENTS.md 의 `# config_N.toml 이 없는 실행` 절을 고친 뒤 상태로 바꾸고 옛 동작은 기록으로 접어 두었다 (`-e` 절의 "단축키는 안 먹어요" 교차 참조도 갱신).

## 검증

- 단위 — `defaultOwned` 의 바인딩 수가 `defaultBindings` 합계와 같고, 새 탭 바인딩이 실제로 들어 있는지 (개수만 보면 엉뚱한 값이 채워져도 통과한다).
- **실기 A/B** (미니PC Firebat ZY-A8 · headless sway 1.12 · 2026-09-04) — 빈 `XDG_CONFIG_HOME` 으로 띄워 `Ctrl+Shift+T` 뒤 새 셸이 생기는지.

  | 판 | 결과 | 탭 수 (`[tab] shell exited`) |
  |---|---|---|
  | 수정 전 | FAIL | 1 |
  | 수정 후 | OK | 2 |

  회차는 `dist/linux/headless-check.sh first-run` 으로 넣었다 ([#583](https://github.com/ensky0/tildaz/issues/583) 도구).

`zig fmt` · `zig build test` · `zig build check` (6 타깃) 통과.

Refs #620 #583 #483 #506 #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
