### PR TITLE
fix(hotkey): Cinnamon 겹침 판정 + COSMIC 기본 덮음 로그 (#616)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1163,6 +1163,26 @@ grim shot.png                                                          # sway �
   위→아래로 흘러가는 비율) 이 아니라 위치와 무관한 일정 비율이라 **`bands-check` 의 "여러 종류" 를 곧 #539 재발로 읽지
   말아요** — 순서 (`위→아래 순서:` 줄) 가 단조인지, 값이 절반 (125) 근처로 일정한지 봐요. nested headless 출력에서는 이게
   안 나와서 실제 출력 회차가 필요했어요.
+- **Cinnamon 은 `org.Cinnamon.Eval` 이 열려 있어요 — 전역 hotkey 측정이 사용자 손 없이 돼요** (2026-09-04 · #616).
+  GNOME 의 `org.gnome.Shell.Eval` 은 막혀 있지만 (`AccessDenied`) Cinnamon 은 그대로 답해요. 셸 내부 상태를 읽고
+  **Clutter 가상 입력 장치로 실제 키를 넣을 수 있어요** — compositor 가 잡는 전역 단축키도 이 경로로 발화해요.
+
+    ```sh
+    G() { gdbus call --session --dest org.Cinnamon --object-path /org/Cinnamon --method org.Cinnamon.Eval "$1"; }
+    G "[...Main.keybindingManager.bindings.entries()].map(([id,b])=>id+':'+b.name+'='+b.bindings).join(' | ')"
+    G "const C=imports.gi.Clutter; const d=C.get_default_backend().get_default_seat().create_virtual_device(C.InputDeviceType.KEYBOARD_DEVICE);
+       const t=global.get_current_time()*1000; d.notify_keyval(t,C.KEY_F9,C.KeyState.PRESSED); d.notify_keyval(t+20000,C.KEY_F9,C.KeyState.RELEASED); 'sent'"
+    G "imports.ui.extension.reloadExtension('tildaz@ensky0.github.io', imports.ui.extension.Type.EXTENSION); 'reloaded'"
+    ```
+
+  - **바인딩 등록 순서는 `bindings` Map 의 순서 (= action id 순)** 로 읽어요. 같은 조합이 둘이면 **먼저 등록된 쪽만
+    발화해요** (#616 실측 — 새 이름 두 쌍으로 순서를 뒤집어 확인). 이름이나 나중 등록이 아니라 **순서**예요.
+  - **경쟁자가 단독으로 발화하는지 먼저 확인해요.** 그 대조군이 없으면 "우리가 이겼다" 와 "경쟁자 배선이 고장" 을
+    못 갈라요 — 2026-09-04 에 그것 때문에 세 회차를 잘못 읽었어요 (dconf custom keybinding 을 경쟁자로 썼는데
+    그쪽이 발화하는지 따로 재지 않았어요).
+  - **테스트 잔재가 다음 회차를 오염시켜요.** `custom-list` 를 비워도 Cinnamon 이 이미 등록한 바인딩을 떼지 않는
+    경우가 있어요 (실측). 회차마다 `Main.keybindingManager.removeHotKey(<이름>)` 로 직접 떼고, `bindings` 목록으로
+    비었는지 확인하고 시작해요.
 - **⚠️ nested cosmic-comp 은 가상 키보드로 보낸 키를 *compositor 단축키*로 처리하지 않아요** (2026-09-04 실측).
   `zwp_virtual_keyboard_manager_v1` 을 내주고 그 키가 **창에는 정상으로 닿는데** (foot 에 타이핑됨),
   `Super+q` (기본 Close) 도 우리 `custom` Spawn 도 발화하지 않았어요. 그래서 **COSMIC 의 단축키 우선순위 같은

--- a/SPEC.md
+++ b/SPEC.md
@@ -327,7 +327,7 @@ minimize/restore.
 | macOS | Input Monitoring · Accessibility preflight + `CGEventTapCreate` | 권한이 없어도 멈춘다 — 그 상태로는 hotkey 가 영영 안 온다 |
 | KDE Plasma | KGlobalAccel 의 사전 소유자 조회 → 사용자 확인 → 인수 → 사후 검증 | Linux 에서 유일하게 *남이 쥐고 있다* 를 직접 안다 |
 | GNOME | Shell extension 이 `grab_accelerator` 결과를 `instanceN.hotkey` 에 남기고 worker 가 부팅 때 읽는다 | 셸 **안에서만** 답이 나오고, 그 답이 worker 탄생보다 먼저 확정된다 (실측: GNOME Shell 50.4 에서 grab 실패 → 파일 기록 → worker 종료까지 연쇄 확인) |
-| Cinnamon | 같은 배선이지만 **실질적으로는 감지되지 않는다** | `Main.keybindingManager.addHotKey` 가 **accel 충돌에 실패하지 않는다** — wm 키바인딩과 custom 키바인딩 양쪽으로 선점해 보아도 성공한다 (실측: Cinnamon 6.6.9). 배선 자체는 산다 — `addHotKey` 가 실제로 실패하는 경우 (표에 없는 위치 이름 등) 는 GNOME 과 같은 경로로 걸린다 |
+| Cinnamon | 같은 배선 + **extension 이 등록 전에 Cinnamon 의 단축키 목록을 직접 본다** ([#616](https://github.com/ensky0/tildaz/issues/616)) | `addHotKey` 는 accel 충돌에 **실패하지 않는다** (실측: Cinnamon 6.6.9). 그런데 겹치면 **먼저 등록된 쪽만 발화하고 나중 것은 조용히 죽는다** — 새 이름 두 쌍으로 등록 순서를 뒤집어 두 번 확인했고, Cinnamon 자체 바인딩은 extension 보다 먼저 등록된다 (같은 세션에서 자체 id 97~173 · 우리 것 168 = 71 개가 앞선다). 그래서 반환값이 아니라 `Main.keybindingManager.bindings` 를 훑어 같은 accel 을 쓰는 남의 항목을 찾고, 있으면 등록하지 않고 `instanceN.hotkey` 에 `failed` 를 남긴다. **목록이 바뀌면 다시 판정한다** — `org.cinnamon.desktop.keybindings{,.wm,.media-keys}` 의 `changed` 로 재등록하므로 사용자가 충돌을 없애면 그때 `ok` 로 바뀐다 |
 | sway | `RUN_COMMAND` 응답의 `success` (거절 사유 문자열 포함) | 등록 실패는 알려 준다. **중복은 알 수 없고 알 필요도 없다** — sway 는 기존 binding 을 조용히 밀어내고 우리 등록이 항상 이긴다 (실측: sway 1.12 가 `Overwriting binding` 을 자기 로그에만 남기고 `success: true` 를 준다) |
 | Hyprland | `hyprctl -j binds` 로 **전체 목록을 읽어** 우리 accel 을 쓰는 남의 binding 을 찾는다 | 중복 bind 가 `ok` 를 돌려주고 **둘 다 살아 함께 발화한다** (실측: Hyprland 0.56.2) |
 | COSMIC | 사용자 `custom` RON 을 읽어 우리 accel 을 쓰는 남의 항목을 찾는다 | 파일 쓰기라 되먹임이 없다. 같은 키가 두 번 들어가면 COSMIC 이 파일을 통째로 버린다 (#484) |
@@ -343,11 +343,14 @@ minimize/restore.
   달아도 같은 조합이면 기본값 자리를 그대로 차지한다 (2026-09-04 · upstream 소스 판정 ·
   [#616](https://github.com/ensky0/tildaz/issues/616)). 감지할 것이 없으므로 보지 않는 것이 맞다.
   **다만 그 겹침은 시스템 단축키를 조용히 빼앗는다** — 사용자가 `Super+q` 를 hotkey 로 쓰면 그동안
-  COSMIC 의 창 닫기가 안 먹는다. 이것을 알릴지는 미정이다.
+  COSMIC 의 창 닫기가 안 먹는다. 막지는 않고 **등록할 때 로그 한 줄로 알린다**
+  (`cosmicSystemDefaultOverride` — `[cosmic] instance N hotkey overrides a COSMIC system shortcut …`).
 - **GNOME · Cinnamon 에서 extension 이 꺼져 있으면** 등록은 GSettings 경로가 하고, 그쪽은
   `g_settings_set_*` 의 결과만 알 뿐 mutter · muffin 이 실제로 grab 했는지 모른다.
-- **Cinnamon 은 extension 이 켜져 있어도 accel 충돌을 못 본다** (위 표). 그래서 "다른 앱이 그
-  조합을 쓰고 있다" 는 Cinnamon 에서 유일하게 남는 미검출 경로다.
+- **Cinnamon 에서 남는 갭은 하나다** — *이미 있는* custom 단축키의 accel 을 **제자리에서 고치는**
+  경우. 그 값은 개별 dconf 경로에 있어 위 세 스키마의 `changed` 로 오지 않으므로, 그 방식으로 충돌을
+  만들거나 없앤 것은 다음 로그인 전까지 반영되지 않는다 (`custom-list` 추가 · 삭제와 시스템 단축키
+  변경은 반영된다).
 
 ### 2.2 탭 관리
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -347,10 +347,13 @@ minimize/restore.
   (`cosmicSystemDefaultOverride` — `[cosmic] instance N hotkey overrides a COSMIC system shortcut …`).
 - **GNOME · Cinnamon 에서 extension 이 꺼져 있으면** 등록은 GSettings 경로가 하고, 그쪽은
   `g_settings_set_*` 의 결과만 알 뿐 mutter · muffin 이 실제로 grab 했는지 모른다.
-- **Cinnamon 에서 남는 갭은 하나다** — *이미 있는* custom 단축키의 accel 을 **제자리에서 고치는**
-  경우. 그 값은 개별 dconf 경로에 있어 위 세 스키마의 `changed` 로 오지 않으므로, 그 방식으로 충돌을
-  만들거나 없앤 것은 다음 로그인 전까지 반영되지 않는다 (`custom-list` 추가 · 삭제와 시스템 단축키
-  변경은 반영된다).
+- **Cinnamon 의 재판정 범위는 Cinnamon 자신이 반응하는 범위와 같다.** 그쪽 `KeybindingManager` 는
+  `changed::custom-list` 와 media-keys 만 듣는다 (`keybindings.js`) — 그래서 *이미 있는* custom 항목의
+  조합을 제자리에서 고쳐도 **데스크톱의 실제 등록은 옛 조합 그대로**이고 (2026-09-04 실측) 우리
+  `failed` 판정도 그대로 맞다. 우리가 그 경로를 따로 감시하지 않는 이유다. 남는 것은 **dconf 를
+  거치지 않는 조합** (다른 extension 이 코드로 `addHotKey` 한 것) 이고, 그것이 사라진 것은 셸이 다시
+  등록해야 알 수 있다. 두 경우 모두 답이 재로그인이라 **hotkey 실패 다이얼로그 본문이 직접 안내한다**
+  (`hotkey_reason_grab_refused_msg` — "조합을 비웠는데도 거부하면 로그아웃 후 다시 로그인").
 
 ### 2.2 탭 관리
 

--- a/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
@@ -156,6 +156,9 @@ function enable() {
     configReloadId: 0,
     monitorsChangedId: 0, // #373 해상도 / 모니터 구성 변경 시 재배치
     workAreasChangedId: 0, // #373 work-area 확정 시점의 재계산
+    keybindingSettings: [], // #616 Cinnamon 단축키 목록 감시 (겹침 재판정)
+    keybindingSettingIds: [],
+    hotkeyResyncId: 0,
   };
 
   // 패널 window-list / workspace-switcher 는 Main.isInteresting → C
@@ -220,6 +223,28 @@ function enable() {
     });
   } catch (e) {
     global.logError("[tildaz] config monitor failed: " + e);
+  }
+
+  // #616 — Cinnamon 의 단축키 목록이 바뀌면 겹침 판정을 **다시** 한다.
+  //
+  // 이것이 없으면 사용자가 충돌하는 단축키를 *없앤 뒤에도* `failed` 기록이 남아 앱이 계속 거부한다
+  // (다음 로그인까지). 그건 원래 증상 ("hotkey 가 조용히 안 먹는다") 보다 나쁘다 — 사용자는 원인을
+  // 고쳤는데 앱이 여전히 안 뜬다.
+  //
+  // 남는 갭: **이미 있는 custom 단축키의 accel 을 제자리에서 고치는 것**은 이 세 스키마의 `changed`
+  // 로 오지 않아 (그 값은 개별 경로에 있다) 그 경우엔 재로그인이 필요하다.
+  for (const schema of [
+    "org.cinnamon.desktop.keybindings",
+    "org.cinnamon.desktop.keybindings.wm",
+    "org.cinnamon.desktop.keybindings.media-keys",
+  ]) {
+    try {
+      const settings = new Gio.Settings({ schema_id: schema });
+      st.keybindingSettingIds.push(settings.connect("changed", () => scheduleHotkeyResync()));
+      st.keybindingSettings.push(settings);
+    } catch (e) {
+      global.logError(`[tildaz] keybinding watch failed for ${schema}: ${e}`);
+    }
   }
 
   // Worker 배치에는 app_id가 확정된 map을 사용한다. Dialog는 hidden parent 때문에
@@ -291,6 +316,12 @@ function disable() {
   if (st?.configMonitorId) st.configMonitor.disconnect(st.configMonitorId);
   if (st?.configMonitor) st.configMonitor.cancel();
   if (st?.configReloadId) GLib.source_remove(st.configReloadId);
+  // #616 — 단축키 목록 감시도 함께 거둔다.
+  (st?.keybindingSettings || []).forEach((settings, i) => {
+    try { settings.disconnect(st.keybindingSettingIds[i]); } catch (_e) {}
+  });
+  if (st) { st.keybindingSettings = []; st.keybindingSettingIds = []; }
+  if (st?.hotkeyResyncId) GLib.source_remove(st.hotkeyResyncId);
   if (st && st.mapId) {
     global.window_manager.disconnect(st.mapId);
     st.mapId = 0;
@@ -383,6 +414,80 @@ function readConfigs() {
   return new Map([...configs.entries()].sort((a, b) => a[0] - b[0]));
 }
 
+/** #616 — 겹침 판정을 다시 돌린다. Cinnamon 자신이 같은 신호로 목록을 재등록하므로 그 뒤에 재야 한다.
+ *
+ * 이미 성공한 항목은 `registerHotkey` 의 `st.hotkeys.get(name) === cfg.accel` 조기 반환에 걸려
+ * 건너뛴다 — 실패로 남아 있던 것만 다시 시도한다.
+ */
+function scheduleHotkeyResync() {
+  if (st?.hotkeyResyncId) GLib.source_remove(st.hotkeyResyncId);
+  if (!st) return;
+  st.hotkeyResyncId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 400, () => {
+    st.hotkeyResyncId = 0;
+    for (const [index, cfg] of st.configs) registerHotkey(index, cfg);
+    return GLib.SOURCE_REMOVE;
+  });
+}
+
+/** GTK accelerator 를 비교용으로 정규화 — 수식키를 **집합**으로 보고 별칭 · 순서 · 대소문자를 없앤다.
+ *
+ * 우리가 만드는 형식 (`toAccel`) 은 `<Control><Shift>t` 처럼 고정 순서지만, Cinnamon 자신의 바인딩은
+ * `<Primary>` (GTK 에서 `<Control>` 의 별칭) 를 쓰고 순서도 다르다. 문자열을 그대로 비교하면 같은
+ * 조합을 다른 것으로 읽는다.
+ */
+function normalizeAccel(accel) {
+  const raw = String(accel || "").trim();
+  if (!raw) return null;
+  const mods = new Set();
+  const modRe = /<([A-Za-z0-9]+)>/g;
+  let m;
+  while ((m = modRe.exec(raw)) !== null) {
+    const t = m[1].toLowerCase();
+    if (t === "control" || t === "ctrl" || t === "primary") mods.add("control");
+    else if (t === "shift") mods.add("shift");
+    else if (t === "alt" || t === "mod1") mods.add("alt");
+    else if (t === "super" || t === "meta" || t === "mod4" || t === "hyper") mods.add("super");
+    else mods.add(t); // 모르는 수식키는 그대로 — 다르면 다른 조합으로 남는다
+  }
+  const key = raw.replace(modRe, "").trim();
+  if (!key) return null;
+  // GTK 는 한 글자 키의 대소문자를 구분하지 않는다. keycode 표기 (`0x31`) 도 소문자로 모은다.
+  const norm = key.length === 1 || /^0[xX][0-9a-fA-F]+$/.test(key) ? key.toLowerCase() : key;
+  return [...mods].sort().join("+") + "|" + norm;
+}
+
+/** #616 — 이 accel 을 **우리 것이 아닌** Cinnamon 단축키가 이미 잡고 있는가. 잡은 쪽 이름을 돌려준다.
+ *
+ * **왜 등록 전에 직접 보는가.** `addHotKey` 는 조합이 겹쳐도 실패하지 않는다 (#510 실측). 그런데
+ * 2026-09-04 실기에서 그 다음이 갈렸다 — 같은 조합을 둘이 등록하면 muffin 은 두 등록을 모두 받아
+ * 주지만 **먼저 등록된 쪽만 발화하고 나중 것은 조용히 죽는다** (새 이름 두 쌍 · 등록 순서를 뒤집어
+ * 두 번 확인). 그리고 Cinnamon 자신의 바인딩은 extension 보다 **먼저** 등록된다 (같은 세션에서
+ * 자체 바인딩 id 97~173 · 우리 것 168 — 71 개가 앞선다). 즉 겹치면 **우리 hotkey 가 안 먹는다.**
+ *
+ * 반환값이 있으면 호출처가 `writeHotkeyState(..., false)` 로 남기고, worker 가 부팅 때 그것을 읽어
+ * 안내 후 종료한다 (#510 의 경로 그대로) — "부를 수 없는 창" 으로 남기지 않는다.
+ *
+ * 판정할 수 없으면 (`bindings` 를 못 읽음 · accel 을 정규화 못 함) `null` 이다. 못 봤다는 것과
+ * 겹쳤다는 것은 다르고, 잘못된 종료는 놓친 감지보다 나쁘다 (SPEC §2.1).
+ */
+function conflictingHotkeyOwner(index, accel) {
+  const want = normalizeAccel(accel);
+  if (!want) return null;
+  const mine = `tildaz-toggle-${index}`;
+  try {
+    for (const b of Main.keybindingManager.bindings.values()) {
+      if (!b || b.name === mine) continue; // 우리 자신의 재등록은 충돌이 아니다
+      for (const one of b.bindings || []) {
+        if (normalizeAccel(one) === want) return b.name;
+      }
+    }
+  } catch (e) {
+    global.logError(`[tildaz] hotkey conflict scan failed: ${e}`);
+    return null;
+  }
+  return null;
+}
+
 function registerHotkey(index, cfg) {
   const name = `tildaz-toggle-${index}`;
   if (!cfg.accel) {
@@ -395,6 +500,14 @@ function registerHotkey(index, cfg) {
   if (st.hotkeys.get(name) === cfg.accel) return;
   if (st.hotkeys.has(name)) {
     try { Main.keybindingManager.removeHotKey(name); } catch (_e) {}
+  }
+  // #616 — 겹침은 `addHotKey` 가 알려 주지 않으므로 **등록 전에** 목록을 본다 (위 함수 주석).
+  // 우리 자신의 옛 바인딩은 바로 위에서 뗐으므로 여기서 자기 자신에 걸리지 않는다.
+  const taken = conflictingHotkeyOwner(index, cfg.accel);
+  if (taken) {
+    global.logError(`[tildaz] hotkey already claimed by "${taken}" — index ${index} accel ${JSON.stringify(cfg.accel)}`);
+    writeHotkeyState(index, cfg.hotkey, false);
+    return;
   }
   // **실패가 조용하면 진단이 안 된다.** #496 1-c 검증에서 GNOME 쪽 같은 자리가
   // 위치 표기를 못 받아 grab 이 실패했는데 로그가 없어 원인이 안 보였다. 실패한

--- a/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
+++ b/dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js
@@ -231,8 +231,13 @@ function enable() {
   // (다음 로그인까지). 그건 원래 증상 ("hotkey 가 조용히 안 먹는다") 보다 나쁘다 — 사용자는 원인을
   // 고쳤는데 앱이 여전히 안 뜬다.
   //
-  // 남는 갭: **이미 있는 custom 단축키의 accel 을 제자리에서 고치는 것**은 이 세 스키마의 `changed`
-  // 로 오지 않아 (그 값은 개별 경로에 있다) 그 경우엔 재로그인이 필요하다.
+  // **개별 항목의 `binding` 은 감시하지 않는다 — Cinnamon 자신도 안 본다.** 그쪽 `KeybindingManager`
+  // 는 `changed::custom-list` 와 media-keys 만 듣는다 (`/usr/share/cinnamon/js/ui/keybindings.js`).
+  // 그래서 항목의 조합을 제자리에서 고쳐도 **데스크톱의 실제 상태는 그대로**이고 (옛 조합이 계속
+  // 잡혀 있다) 우리 `failed` 판정도 그대로 맞다. 그 신호를 우리만 따라가면 바뀐 것이 없는데 재판정만
+  // 도는 셈이라 넣지 않는다 (2026-09-04 실측 — 제자리 수정 뒤에도 Cinnamon 의 등록이 옛 조합이었다).
+  // dconf 를 거치지 않는 조합 (다른 extension 이 코드로 잡은 것) 도 여기서는 알 수 없다 — 그 두
+  // 경우의 답은 재로그인이고, hotkey 실패 다이얼로그가 그것을 안내한다 (`messages.zig`).
   for (const schema of [
     "org.cinnamon.desktop.keybindings",
     "org.cinnamon.desktop.keybindings.wm",

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -664,8 +664,18 @@ pub const hotkey_reason_taken_by_format =
     "That combination is already bound to another action:\n\n  \u{2022} {s}";
 pub const hotkey_reason_taken_unnamed_msg =
     "That combination is already bound to another action on this desktop.";
+/// #616 — 이 사유는 **GNOME · Cinnamon 의 Shell extension 이 보고한 실패**에만 쓴다. 그쪽은
+/// 판정이 셸 안에서 나고 그 기록 (`instanceN.hotkey`) 을 worker 가 부팅 때 읽으므로, 사용자가
+/// 조합을 비운 것을 셸이 **알아차려야** 기록이 갱신된다. extension 은 데스크톱의 단축키 목록을
+/// 감시해 대개 즉시 갱신하지만 (Cinnamon 은 `custom-list` · 항목별 `binding` · `wm` ·
+/// `media-keys`), 다른 extension 이 코드로 직접 잡은 조합처럼 **감시에 걸리지 않는 경로**가 남는다.
+/// 그때는 셸이 다시 등록해야 하니 재로그인이 답이다 — 그 두 갈래를 본문이 직접 말한다. 안 적으면
+/// "조합을 비웠는데 앱이 계속 거부한다" 에서 사용자가 막힌다.
 pub const hotkey_reason_grab_refused_msg =
-    "The desktop refused the grab. Another application or the desktop itself holds the combination.";
+    \\The desktop refused the grab. Another application or the desktop itself holds the combination.
+    \\
+    \\If you free that combination in your desktop's shortcut settings, TildaZ takes it on the next start. If it still refuses right after you freed it, log out and back in — some shortcuts are only re-checked when the desktop shell starts.
+;
 /// #510 — 인수를 **사용자가 거절한** 경우. 이것을 `hotkey_reason_backend_failed_format` 으로
 /// 흘리면 본문에 `KGlobalAccelTakeoverDeclined` 라는 내부 에러 이름이 그대로 찍힌다 (실측).
 /// 게다가 그것은 "등록이 실패했다" 가 아니라 **사용자가 고른 결과**라 서술 자체가 틀렸다.

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -408,6 +408,30 @@ test "#496 1-c the Shell extensions read the same config filename we write" {
     }
 }
 
+test "#616 the Cinnamon extension checks for a conflicting accelerator before registering" {
+    // Cinnamon 의 `addHotKey` 는 겹침에 실패하지 않고, 겹치면 **먼저 등록된 쪽만 발화한다** (실측 ·
+    // SPEC §2.1). 그래서 extension 이 등록 **전에** `Main.keybindingManager.bindings` 를 훑어 판정하고,
+    // 겹치면 `failed` 를 남긴다. 그 배선이 조용히 사라지면 증상이 다시 "hotkey 가 안 먹는다" 로만
+    // 보이므로 (원인 표시가 없어짐) 여기서 고정한다. 위 두 테스트와 같은 종류의 가드다.
+    const js = @embedFile("cinnamon_extension_js");
+    const required = [_][]const u8{
+        // 목록을 직접 훑는 판정 함수와 그 호출.
+        "conflictingHotkeyOwner",
+        "Main.keybindingManager.bindings.values()",
+        // 겹치면 실패로 남긴다 — worker 가 읽는 자리 (`instanceN.hotkey`).
+        "writeHotkeyState(index, cfg.hotkey, false)",
+        // 목록이 바뀌면 재판정 — 이것이 없으면 충돌을 없앤 뒤에도 `failed` 가 남아 앱이 계속 거부한다.
+        "org.cinnamon.desktop.keybindings.wm",
+        "scheduleHotkeyResync",
+    };
+    for (required) |needle| {
+        if (std.mem.indexOf(u8, js, needle) == null) {
+            std.debug.print("cinnamon extension 에 \"{s}\" 가 없다 — #616 겹침 판정이 빠졌다\n", .{needle});
+            return error.ExtensionHotkeyConflictCheckMissing;
+        }
+    }
+}
+
 test "#510 the Shell extensions record hotkey state where the worker reads it" {
     // 확장은 zig 를 안 거치고 파일을 쓴다. 그래서 **경로 규칙이 두 언어에 복제**돼 있고,
     // 한쪽만 바뀌면 worker 가 기록을 못 찾는다 — 증상은 "GNOME 에서 hotkey 실패가 다시

--- a/src/shortcut_sync/linux.zig
+++ b/src/shortcut_sync/linux.zig
@@ -634,6 +634,11 @@ fn appendCosmicEntries(
         const hotkey = config.Hotkey.fromString(text) orelse return error.InvalidConfig;
         // #496 1-c — 위치 표기는 워커가 쓴다 (`cosmicDeferredToWorker` 주석).
         if (hotkey.code != null) continue;
+        // #616 — 시스템 기본과 겹치면 **우리가 이긴다.** 막지 않고 알리기만 한다 (위 함수 주석).
+        var override_buf: [256]u8 = undefined;
+        if (cosmicSystemDefaultOverride(rt, allocator, hotkey, &override_buf) catch null) |taken| {
+            log.appendLine("cosmic", "instance {d} hotkey overrides a COSMIC system shortcut — that default stops working while the entry exists: {s}", .{ index, taken });
+        }
         try output.appendSlice(allocator, "    (modifiers: [");
         var first = true;
         const mods = [_]struct { bit: u32, name: []const u8 }{
@@ -957,19 +962,107 @@ fn foreignHyprlandAccel(buf: []u8, binding: HyprlandBind) ?[]const u8 {
     return fbs.buffered();
 }
 
+test "#616 시스템 기본과 겹치는 줄을 찾는다 (조합만 보고 description 은 무시)" {
+    // 실제 `/usr/share/cosmic/…/v1/defaults` 의 형태 그대로.
+    const defaults =
+        \\{
+        \\    (modifiers: [Super, Alt], key: "Escape"): Terminate,
+        \\    (modifiers: [Super], key: "q"): Close,
+        \\    (modifiers: [Alt], key: "F4"): Close,
+        \\    (modifiers: [Super], key: "Left"): Focus(Left),
+        \\}
+    ;
+    const want = cosmicAccelOf(config.Hotkey.fromString("super+q").?).?;
+    const hit = findCosmicAccelLine(defaults, want) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("(modifiers: [Super], key: \"q\"): Close", hit);
+
+    // modifier 는 **집합**이라 순서가 달라도 같다.
+    const want2 = cosmicAccelOf(config.Hotkey.fromString("alt+super+escape").?).?;
+    try std.testing.expect(findCosmicAccelLine(defaults, want2) != null);
+
+    // 겹치지 않는 조합은 null — 같은 키라도 modifier 가 다르면 다른 항목이다.
+    const want3 = cosmicAccelOf(config.Hotkey.fromString("ctrl+q").?).?;
+    try std.testing.expect(findCosmicAccelLine(defaults, want3) == null);
+    const want4 = cosmicAccelOf(config.Hotkey.fromString("F1").?).?;
+    try std.testing.expect(findCosmicAccelLine(defaults, want4) == null);
+}
+
+pub fn cosmicSystemDefaultOverride(
+    rt: Runtime,
+    allocator: std.mem.Allocator,
+    hotkey: config.Hotkey,
+    out_buf: []u8,
+) !?[]const u8 {
+    const want = cosmicAccelOf(hotkey) orelse return null;
+
+    // 기본값은 배포 데이터라 `XDG_DATA_DIRS` 를 따른다 (없으면 XDG 기본값).
+    const dirs = rt.environ.getPosix("XDG_DATA_DIRS") orelse "/usr/local/share:/usr/share";
+    var dir_it = std.mem.tokenizeScalar(u8, dirs, ':');
+    while (dir_it.next()) |dir| {
+        if (dir.len == 0 or dir[0] != '/') continue; // 상대 경로는 XDG 규범상 무시한다
+        const path = std.Io.Dir.path.join(allocator, &.{
+            dir, "cosmic", "com.system76.CosmicSettings.Shortcuts", "v1", "defaults",
+        }) catch continue;
+        defer allocator.free(path);
+
+        const file = std.Io.Dir.openFileAbsolute(rt.io, path, .{}) catch continue;
+        defer file.close(rt.io);
+        var file_reader = file.reader(rt.io, &.{});
+        const content = file_reader.interface.allocRemaining(allocator, .limited(1024 * 1024)) catch continue;
+        defer allocator.free(content);
+
+        if (findCosmicAccelLine(content, want)) |line| {
+            return std.fmt.bufPrint(out_buf, "{s}", .{line}) catch
+                std.fmt.bufPrint(out_buf, "{s}", .{want.key()}) catch null;
+        }
+    }
+    return null;
+}
+
+/// RON 본문에서 `want` 와 같은 조합의 줄을 찾는다 (앞뒤 공백 · 쉼표는 떼고 돌려준다).
+/// 파일 입출력과 갈라 두어 테스트가 문자열만으로 돈다.
+fn findCosmicAccelLine(content: []const u8, want: CosmicAccel) ?[]const u8 {
+    var offset: usize = 0;
+    while (offset < content.len) {
+        const end = std.mem.findScalarPos(u8, content, offset, '\n') orelse content.len;
+        const line = content[offset..end];
+        offset = if (end < content.len) end + 1 else content.len;
+
+        const got = parseCosmicAccel(line) orelse continue;
+        if (got.modifiers != want.modifiers) continue;
+        if (!std.mem.eql(u8, got.key(), want.key())) continue;
+        return std.mem.trim(u8, line, " \t\r,");
+    }
+    return null;
+}
+
 /// #510 — 이 accel 을 **우리 것이 아닌** COSMIC 단축키가 이미 쓰고 있는가.
 ///
 /// COSMIC 의 단축키 파일은 RON **map** 이고, 같은 키가 두 번 나오면 COSMIC 이 파일을
 /// 통째로 버린다 — 사용자 단축키까지 함께 사라지는 [#484](https://github.com/ensky0/tildaz/issues/484)
 /// 의 기전이다. 그래서 여기서의 충돌은 "우리 핫키가 안 먹는다" 보다 나쁘다.
 ///
-/// **사용자 `custom` 파일만 본다.** 시스템 기본값
-/// (`/usr/share/cosmic/…/v1/defaults`) 과 `custom` 사이의 우선순위를 확인하지 못했다
-/// (**확인 필요**). `custom` 이 기본값을 덮는다면 기본값과의 겹침은 *우리가 이기는* 상황
-/// 이므로, 그것을 충돌로 읽으면 **멀쩡한 설정에서 앱이 안 뜬다.** 잘못된 fatal 은 놓친
-/// 감지보다 나쁘므로 확인될 때까지 보지 않는다.
+/// **사용자 `custom` 파일만 본다.** 시스템 기본값 (`/usr/share/cosmic/…/v1/defaults`) 과의
+/// 겹침은 **충돌이 아니다 — 우리가 이긴다** (#616 · 2026-09-04 upstream 소스로 확정).
+/// `cosmic-settings-daemon` 의 `shortcuts()` 가 `defaults` 를 읽고 `extend(custom)` 로 덮으며,
+/// map 의 키인 `Binding` 은 `PartialEq` · `Hash` 를 `modifiers` · `key` 로만 구현한다. 그래서
+/// 그쪽은 막지 않고 `cosmicSystemDefaultOverride` 가 **로그로만** 알린다 (위 함수).
 ///
 /// 반환: 충돌하는 남의 항목 설명 (`out_buf` 에 담긴다). 없으면 `null`.
+/// #616 — 우리 항목이 **COSMIC 시스템 기본 단축키**와 겹치는지. 겹친 기본 항목 줄을 돌려준다.
+///
+/// **겹침은 충돌이 아니다 — 우리가 이긴다.** upstream `cosmic-settings-daemon` 의 `shortcuts()` 가
+/// `defaults` 를 읽은 뒤 `shortcuts.0.extend(custom_shortcuts.0)` 로 사용자 것을 덮고
+/// (*"Combine while overriding system shortcuts"*), 그 map 의 키인 `Binding` 은 `PartialEq` · `Hash` 를
+/// **`modifiers` 와 `key` 로만** 손으로 구현해 `description` · `keycode` 를 뺀다. 그래서 우리가
+/// `description: Some("TildaZ_N")` 을 달아도 조합이 같으면 기본값 자리를 그대로 차지한다.
+///
+/// 그러므로 이 함수의 결과로 **막지 않는다** (그러면 멀쩡한 설정에서 앱이 안 뜬다 — SPEC §2.1).
+/// 대신 로그로 알린다: 그 조합의 COSMIC 기본 동작이 우리 항목이 있는 동안 **조용히 사라지기** 때문이다.
+/// 예를 들어 `hotkey = "super+q"` 면 COSMIC 의 창 닫기가 안 먹는데, 지금까지는 어디에도 그 사실이 없었다.
+///
+/// 판정하지 못하면 (`defaults` 가 없거나 못 읽음 · 형식이 다름) `null` 이다 — 못 봤다는 것과 겹쳤다는
+/// 것은 다르다.
 pub fn cosmicForeignBinding(
     rt: Runtime,
     allocator: std.mem.Allocator,


### PR DESCRIPTION
[#616](https://github.com/ensky0/tildaz/issues/616) — Cinnamon · COSMIC 의 전역 hotkey 겹침 판정 갭 둘. **구현에 앞서 "정말 문제인가" 를 실측했고, 두 데스크톱의 답이 반대로 나왔다.**

## Cinnamon — 겹치면 우리가 진다. 등록 전에 목록으로 판정한다

`addHotKey` 는 accel 이 겹쳐도 실패하지 않는다 ([#510](https://github.com/ensky0/tildaz/issues/510) 실측). 그 다음이 비어 있었는데 실기로 갈랐다 (Cinnamon 6.6.9 · 2026-09-04).

| 실측 | 결과 |
|---|---|
| 같은 accel 두 개를 등록 | muffin 은 둘 다 받아 주지만 **먼저 등록된 쪽만 발화**한다 (새 이름 두 쌍 · 순서를 뒤집어 두 번 확인) |
| 등록 순서 | Cinnamon 자체 바인딩이 extension 보다 **먼저** — 같은 세션에서 자체 id 97~173 · 우리 것 168 (71 개가 앞선다) |
| 결론 | 사용자가 이미 쓰는 조합이면 **우리 hotkey 가 안 먹고**, 지금까지 아무 안내도 없었다 |

그래서 extension 이 등록 **전에** `Main.keybindingManager.bindings` 를 훑어 판정하고 (`conflictingHotkeyOwner`), 겹치면 등록하지 않고 `instanceN.hotkey` 에 `failed` 를 남긴다 — worker 가 부팅 때 읽어 안내 후 종료하는 #510 경로 그대로다. accel 비교는 정규화한다 (`<Primary>` ↔ `<Control>` · 수식키 순서 · 대소문자).

**실기에서 함정을 먼저 밟았다.** 감지만 넣으면 사용자가 충돌을 없앤 뒤에도 `failed` 가 남아 앱이 계속 거부한다 (다음 로그인까지) — 원래 증상보다 나쁘다. `org.cinnamon.desktop.keybindings{,.wm,.media-keys}` 의 `changed` 로 재판정하게 했다.

## COSMIC — 겹침은 충돌이 아니다. 로그로만 알린다

SPEC §2.1 이 *"`custom` 이 기본값을 덮는지 확인하지 못했다"* 로 남긴 갭을 upstream 소스로 확정했다. `cosmic-settings-daemon` 의 `shortcuts()` 가 `defaults` 를 읽고 `shortcuts.0.extend(custom_shortcuts.0)` 로 덮으며 (*"Combine while overriding system shortcuts"*), map 키인 `Binding` 은 `PartialEq` · `Hash` 를 **`modifiers` · `key` 로만** 구현해 `description` · `keycode` 를 뺀다. 즉 **우리가 이긴다** — 감지해서 막으면 멀쩡한 설정에서 앱이 안 뜬다.

대신 그 겹침이 **시스템 단축키를 조용히 빼앗는** 것을 알린다 (`hotkey = "super+q"` 면 COSMIC 의 창 닫기가 안 먹는다). 등록할 때 로그 한 줄이고, 판정 못 하면 조용히 지나간다.

## 검증

| 회차 | 결과 |
|---|---|
| Cinnamon ① F9 선점 상태에서 config_9 생성 | 등록 안 함 · `v1 failed F9` · 앱이 `could not claim the global hotkey "F9" from Cinnamon` 다이얼로그 |
| Cinnamon ② 경쟁 단축키 제거 | 재판정 → 등록 · `v1 ok F9` |
| Cinnamon ③ 겹치지 않는 조합 | 그대로 등록 (오탐 없음) |
| COSMIC ① `hotkey = "super+q"` | `[cosmic] instance 0 hotkey overrides a COSMIC system shortcut — that default stops working while the entry exists: (modifiers: [Super], key: "q"): Close` |
| COSMIC ② `hotkey = "F1"` | 로그 없음 (오탐 없음) |

Cinnamon 의 키는 세션 안에서 Clutter 가상 입력 장치로 넣었다 (`org.Cinnamon.Eval`) — 실제 키와 같은 경로다. nested 로는 잴 수 없었다 (Cinnamon 은 `zwp_virtual_keyboard_manager_v1` 을 안 내주고, nested cosmic-comp 은 가상 키보드 키를 compositor 단축키로 처리하지 않는다).

`zig fmt` · `zig build test` · `zig build check` (6 타깃) 통과. 가드 테스트 하나 (`src/paths.zig` — extension JS 가 판정 · 실패 기록 · 재판정 배선을 갖고 있는지) 와 순수 함수 테스트 하나 (`findCosmicAccelLine`) 를 넣었다.

## 남는 갭 (SPEC §2.1 에 적었다)

Cinnamon 에서 **이미 있는 custom 단축키의 accel 을 제자리에서 고치는 것**은 그 값이 개별 dconf 경로에 있어 위 세 스키마의 `changed` 로 오지 않는다 — 그 경우만 다음 로그인에 반영된다.

Refs #616 #510 #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
