### PR TITLE
fix: portable 설치의 Shell extension 갱신 · launcher 의 TOML 오류 문구 (#583 B8 · B7)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -43,6 +43,28 @@ const vt_features_disabled = "-kitty-graphics,-glyph-protocol";
 //   zig build package -Doptimize=ReleaseFast -Dsimd=true -- 릴리즈 package + SHA256
 //   zig build check                 -- 6-target compile-only verify (#201)
 //
+/// #520 후속 (#583 B8) — **Shell extension 리소스를 바이너리에 embed 한다.**
+///
+/// 예전에는 `shell_extension.syncForCurrentUser` 가 exe 옆 `../share/tildaz/` 에서 파일을 읽었다.
+/// 그 디렉터리가 없는 배치 (레포에서 바이너리만 옮겨 쓰기 · install.sh 가 이미 복사해 둔 portable
+/// 설치) 에서는 **설치본을 그대로 두고 "오래됐을 수 있다" 고만 로그에 남겼다** — 사용자가 고칠
+/// 방법이 없는 안내였다. embed 하면 배치와 무관하게 항상 갱신되고, extension 은 자기를 실은
+/// 바이너리와 늘 같은 버전이다 (extension 이 그 바이너리의 IPC 를 부르므로 이 짝이 맞아야 한다).
+///
+/// `@embedFile` 은 module 경로 (`src/`) 를 벗어나지 못하므로 익명 import 로 넘긴다. 앱 소스를
+/// 컴파일하는 module 은 모두 이 함수를 지나야 한다 — 하나라도 빠지면 그 module 만 컴파일이 깨진다.
+fn addShellExtensionResources(b: *std.Build, mod: *std.Build.Module) void {
+    const gnome = "dist/linux/gnome-extension/tildaz@ensky0.github.io/";
+    const cinnamon = "dist/linux/cinnamon-extension/tildaz@ensky0.github.io/";
+    mod.addAnonymousImport("gnome_extension_js", .{ .root_source_file = b.path(gnome ++ "extension.js") });
+    mod.addAnonymousImport("gnome_extension_metadata", .{ .root_source_file = b.path(gnome ++ "metadata.json") });
+    mod.addAnonymousImport("gnome_extension_gschema", .{
+        .root_source_file = b.path(gnome ++ "schemas/org.gnome.shell.extensions.tildaz.gschema.xml"),
+    });
+    mod.addAnonymousImport("cinnamon_extension_js", .{ .root_source_file = b.path(cinnamon ++ "extension.js") });
+    mod.addAnonymousImport("cinnamon_extension_metadata", .{ .root_source_file = b.path(cinnamon ++ "metadata.json") });
+}
+
 pub fn build(b: *std.Build) void {
     const target = preserveResolvedWindowsAbi(b.standardTargetOptions(.{}));
     const target_os = target.result.os.tag;
@@ -77,6 +99,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    addShellExtensionResources(b, exe_mod);
 
     // 컴파일 타임 상수 — About 다이얼로그 / `--version` / tildaz.log 의 boot 엔트리에서
     // 사용. 세 값을 사람이 읽는 한 줄로 합치는 규칙은 `src/version.zig` 한 곳에 있다.
@@ -275,18 +298,17 @@ pub fn build(b: *std.Build) void {
         b.installArtifact(exe);
     }
 
-    // #520 — Linux 는 Shell extension 리소스를 exe 옆 `share/tildaz/` 에도 깐다.
+    // Linux 는 Shell extension 리소스를 exe 옆 `share/tildaz/` 에도 깐다.
     //
-    // worker 가 부팅할 때 `shell_extension.syncForCurrentUser` 가 그 경로에서 GNOME ·
-    // Cinnamon extension 을 사용자 홈으로 복사하는데 (`<exe_dir>/../share/tildaz/`),
-    // 여기가 비어 있으면 **설치본을 그대로 두고 조용히 넘어간다.** 그래서 `zig build` 로
-    // 개발하는 동안에는 레포의 extension 을 고쳐도 셸에는 옛 파일이 남았다 — 게다가
-    // 로그는 성공처럼 찍혀서 (`Shell extension synchronized and enabled`) 그 사실을
-    // 알아챌 근거가 없었다.
+    // **런타임 동기화의 소스는 더 이상 이 경로가 아니다** (#583 B8) — `shell_extension.zig` 가
+    // 같은 파일들을 바이너리에 embed 해 사용자 홈에 쓴다. #520 은 이 경로에서 읽게 두었는데,
+    // 그 디렉터리가 없는 배치 (바이너리만 옮기기 · portable 설치) 에서는 설치본을 그대로 두는
+    // 수밖에 없었다.
     //
-    // 경로 · 파일 구성은 `dist/linux/package.sh` 의 `install_extension_resources` 와
-    // 같다. 그쪽이 패키지에 넣는 것을 여기서는 `zig-out` 에 넣을 뿐이라, dev 빌드와
-    // 패키지가 같은 배치를 갖는다.
+    // 그래도 계속 깐다 — 패키지가 이 파일들을 담고 (`dist/linux/package.sh` 의
+    // `install_extension_resources` · `validate_extension_resources` 가 경로까지 검사한다)
+    // 셸에 손으로 넣으려는 사용자가 그 자리를 찾는다. 경로 · 파일 구성이 패키지와 같아
+    // dev 빌드와 패키지의 배치가 어긋나지 않는다.
     if (is_linux_target) {
         for ([_][]const u8{ "gnome-extension", "cinnamon-extension" }) |family| {
             b.installDirectory(.{
@@ -363,15 +385,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     }).module("toml"));
 
-    // #496 1-c — GNOME · Cinnamon Shell extension 의 위치 표를 `physical_key.zig` 와
-    // 견주는 test 가 원본을 읽어야 한다. `@embedFile` 은 package path 를 벗어나지
-    // 못하므로 (`src/` 밖) 익명 import 로 넘긴다.
-    test_mod.addAnonymousImport("gnome_extension_js", .{
-        .root_source_file = b.path("dist/linux/gnome-extension/tildaz@ensky0.github.io/extension.js"),
-    });
-    test_mod.addAnonymousImport("cinnamon_extension_js", .{
-        .root_source_file = b.path("dist/linux/cinnamon-extension/tildaz@ensky0.github.io/extension.js"),
-    });
+    // #496 1-c — GNOME · Cinnamon Shell extension 의 위치 표를 `physical_key.zig` 와 견주는 test 가
+    // 원본을 읽어야 한다. #583 B8 이후로는 `shell_extension.zig` 가 같은 파일들을 embed 해 사용자
+    // 홈에 쓰므로, 앱 소스를 컴파일하는 module 은 모두 이 호출이 필요하다.
+    addShellExtensionResources(b, test_mod);
     if (is_linux_target) test_mod.link_libc = true;
     if (is_macos_target) {
         test_mod.linkSystemLibrary("objc", .{});
@@ -459,6 +476,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    addShellExtensionResources(b, stress_mod);
     stress_mod.addOptions("build_options", build_opts);
     if (b.lazyDependency("ghostty", .{
         .target = target,
@@ -545,6 +563,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    addShellExtensionResources(b, render_test_mod);
     const render_test_exe = b.addExecutable(.{
         .name = "render-test",
         .root_module = render_test_mod,
@@ -596,6 +615,7 @@ pub fn build(b: *std.Build) void {
                 // type error 가 안 surface 되는 케이스 회피.
                 .optimize = .Debug,
             });
+            addShellExtensionResources(b, check_mod);
             check_mod.addOptions("build_options", build_opts);
             if (b.lazyDependency("ghostty", .{
                 .target = check_target,
@@ -651,6 +671,7 @@ pub fn build(b: *std.Build) void {
                 .target = preserveResolvedWindowsAbi(b.resolveTargetQuery(c.query)),
                 .optimize = .ReleaseSafe,
             });
+            addShellExtensionResources(b, probe_mod);
             // 네 도구 모두 libc ABI의 PTY/Win32/DynLib 경로를 직접 쓴다.
             probe_mod.link_libc = true;
             const probe_obj = b.addObject(.{

--- a/src/config.zig
+++ b/src/config.zig
@@ -2750,33 +2750,7 @@ pub const Config = struct {
         // 틀렸는지" 가 파서의 일반 오류로 퇴화한다.
         var parser: toml.Parser(toml.Table) = .init(allocator);
         defer parser.deinit();
-        var parsed = parser.parseString(content) catch |err| {
-            // TOML 파서는 구문 오류의 **위치**를 준다 (JSON 은 오류 이름만 줬다).
-            // 사용자가 어디를 고쳐야 할지 알 수 있게 line / col 을 함께 보여 준다.
-            //
-            // #495 — 경로는 본문에 넣지 않는다. `showConfigFatalMsg` 가 모든 config
-            // 오류 앞에 한 번 붙이므로 여기서 넣으면 두 번 나온다. 그리고 그 함수를
-            // 지나는 것 자체가 요점이다 — 예전엔 이 경로만 `dialog.showFatal` 을 직접
-            // 불러 형식이 갈라졌다.
-            var buf: [256]u8 = undefined;
-            const msg = if (parser.error_info) |info| switch (info) {
-                .parse => |pos| std.fmt.bufPrint(
-                    &buf,
-                    messages.config_parse_failed_at_format,
-                    .{ pos.line, pos.pos, @errorName(err) },
-                ) catch messages.config_parse_failed_fallback_msg,
-                .struct_mapping => std.fmt.bufPrint(
-                    &buf,
-                    messages.config_parse_failed_format,
-                    .{@errorName(err)},
-                ) catch messages.config_parse_failed_fallback_msg,
-            } else std.fmt.bufPrint(
-                &buf,
-                messages.config_parse_failed_format,
-                .{@errorName(err)},
-            ) catch messages.config_parse_failed_fallback_msg;
-            return recordConfigFatalMsg(rt, config_path, msg);
-        };
+        var parsed = parser.parseString(content) catch |err| return recordTomlParseFatal(rt, config_path, &parser, err);
         defer parsed.deinit();
 
         // TOML 문서의 최상위는 **항상 테이블**이라 JSON 의 "top-level must be object"
@@ -3353,6 +3327,44 @@ fn recordConfigFatalMsg(rt: Runtime, config_path: []const u8, message: []const u
         break :blk fatal_notice_buf[0..n];
     };
     return publishFatalNotice(written.len);
+}
+
+/// TOML 구문 오류를 사용자 문구로 만들어 담는다. TOML 파서는 오류의 **위치**를 주므로
+/// (JSON 은 오류 이름만 줬다 · #493) 어디를 고쳐야 하는지 함께 보여 준다.
+///
+/// #495 — 경로는 본문에 넣지 않는다. `recordConfigFatalMsg` 가 모든 config 오류 앞에 한 번
+/// 붙이므로 여기서 넣으면 두 번 나온다.
+///
+/// #583 B7 — **worker 와 launcher 가 같은 것을 쓴다.** 예전에는 이 조립이 `Config.parse` 안에만
+/// 있어서, launcher 가 config 를 읽는 세 자리 (`instances.zig` 의 `configAutoStart` ·
+/// `configHotkeyText` · `hotkeyOwner`) 는 파서 오류를 그대로 올렸다. 그러면 같은 파일의 같은
+/// 오류인데 worker 는 `Line 12, column 3` 까지 알려 주고 launcher 는
+/// `TildaZ failed to start. Error: UnexpectedToken` 만 보여 줬다 — 사용자가 첫 실행에서 보는
+/// 쪽이 후자다 (#577 후속).
+pub fn recordTomlParseFatal(
+    rt: Runtime,
+    config_path: []const u8,
+    parser: *const toml.Parser(toml.Table),
+    err: anyerror,
+) LoadError {
+    var buf: [256]u8 = undefined;
+    const msg = if (parser.error_info) |info| switch (info) {
+        .parse => |pos| std.fmt.bufPrint(
+            &buf,
+            messages.config_parse_failed_at_format,
+            .{ pos.line, pos.pos, @errorName(err) },
+        ) catch messages.config_parse_failed_fallback_msg,
+        .struct_mapping => std.fmt.bufPrint(
+            &buf,
+            messages.config_parse_failed_format,
+            .{@errorName(err)},
+        ) catch messages.config_parse_failed_fallback_msg,
+    } else std.fmt.bufPrint(
+        &buf,
+        messages.config_parse_failed_format,
+        .{@errorName(err)},
+    ) catch messages.config_parse_failed_fallback_msg;
+    return recordConfigFatalMsg(rt, config_path, msg);
 }
 
 fn recordConfigFatal(rt: Runtime, config_path: []const u8, comptime fmt: []const u8, args: anytype) LoadError {

--- a/src/host/linux/gsettings_hotkey.zig
+++ b/src/host/linux/gsettings_hotkey.zig
@@ -115,25 +115,13 @@ pub fn ensureShellExtensionReady(rt: Runtime, allocator: std.mem.Allocator) void
     const target = currentShellExtensionTarget(rt) orelse return;
     const label = target.owner.logCategory();
 
-    const outcome = shell_extension.syncForCurrentUser(rt, allocator, target.kind) catch |err| {
+    // #583 B8 — 리소스를 바이너리가 실으므로 결과는 "반영했다" 하나다. 예전에는 exe 옆
+    // `../share/tildaz/` 가 없는 배치에서 설치본을 그대로 두고 "오래됐을 수 있다" 고만
+    // 남겼는데, 사용자가 그것을 고칠 방법이 없는 안내였다.
+    shell_extension.syncForCurrentUser(rt, allocator, target.kind) catch |err| {
         log.appendLine(label, "Shell extension resource sync failed: {s}", .{@errorName(err)});
         return;
     };
-    switch (outcome) {
-        .synced => {},
-        // #520 — 진행은 하지만 **동기화한 것이 아니다.** 예전에는 이 경우도 아래의
-        // "synchronized and enabled" 로 찍혀서, dev 빌드로 extension 을 고치는 사람이
-        // 자기 변경이 반영되지 않은 것을 알 방법이 없었다.
-        .kept_installed => log.appendLine(
-            label,
-            "Shell extension resources not found next to the executable — kept the installed copy (it may be older than this build)",
-            .{},
-        ),
-        .unavailable => {
-            log.appendLine(label, "Shell extension resources not installed — enable skipped", .{});
-            return;
-        },
-    }
     const api = Api.load() orelse return;
     const source = api.schema_source_get_default() orelse return;
     const schema = api.schema_source_lookup(source, target.schema, 1) orelse return;
@@ -145,9 +133,7 @@ pub fn ensureShellExtensionReady(rt: Runtime, allocator: std.mem.Allocator) void
         return;
     };
     api.settings_sync();
-    log.appendLine(label, "Shell extension {s} and enabled", .{
-        if (outcome == .synced) "synchronized" else "left as installed",
-    });
+    log.appendLine(label, "Shell extension synchronized and enabled", .{});
 }
 
 /// GSettings custom-keybinding 등록의 DE별 차이를 담는 descriptor. GNOME 과

--- a/src/host/linux/shell_extension.zig
+++ b/src/host/linux/shell_extension.zig
@@ -11,52 +11,38 @@ const uuid = "tildaz@ensky0.github.io";
 
 const Resource = struct {
     relative_path: []const u8,
+    /// #583 B8 — 파일 **내용을 바이너리가 싣는다.** 익명 import 는 `build.zig` 의
+    /// `addShellExtensionResources` 가 넘긴다 (`@embedFile` 이 `src/` 밖을 못 읽는다).
+    content: []const u8,
 };
 
 const gnome_resources = [_]Resource{
-    .{ .relative_path = "extension.js" },
-    .{ .relative_path = "metadata.json" },
-    .{ .relative_path = "schemas/org.gnome.shell.extensions.tildaz.gschema.xml" },
+    .{ .relative_path = "extension.js", .content = @embedFile("gnome_extension_js") },
+    .{ .relative_path = "metadata.json", .content = @embedFile("gnome_extension_metadata") },
+    .{
+        .relative_path = "schemas/org.gnome.shell.extensions.tildaz.gschema.xml",
+        .content = @embedFile("gnome_extension_gschema"),
+    },
 };
 
 const cinnamon_resources = [_]Resource{
-    .{ .relative_path = "extension.js" },
-    .{ .relative_path = "metadata.json" },
+    .{ .relative_path = "extension.js", .content = @embedFile("cinnamon_extension_js") },
+    .{ .relative_path = "metadata.json", .content = @embedFile("cinnamon_extension_metadata") },
 };
 
-/// #520 — 동기화 결과. 예전에는 `bool` 이라 **"복사했다" 와 "소스가 없어 손대지 않았다"
-/// 가 같은 값**이었고, 호출자가 둘 다 `Shell extension synchronized and enabled` 로
-/// 찍었다. 그래서 dev 빌드에서 extension 이 갱신되지 않는 것을 로그로 알아챌 수 없었다.
-pub const SyncOutcome = enum {
-    /// 소스에서 대상으로 반영했다 (내용이 같아 실제 쓰기가 없었던 경우도 포함).
-    synced,
-    /// **소스가 없어 손대지 않았다.** 설치본이 이미 있어서 진행은 가능하지만, 지금 레포의
-    /// extension 이 아닐 수 있다.
-    kept_installed,
-    /// 소스도 설치본도 없다.
-    unavailable,
-};
-
-/// Package resources live at <prefix>/share/tildaz. AppImage uses the same
-/// layout below AppDir/usr, so every packaged Linux format follows this path.
-/// `zig build` 도 #520 이후 같은 배치를 `zig-out/share/tildaz` 에 만든다.
+/// 패키지 리소스를 현재 사용자의 Shell extension 디렉터리에 반영한다.
 ///
-/// 그래도 그 디렉터리가 없을 수 있다 — 레포에서 바이너리만 옮겨 쓰거나, install.sh 가
-/// 이미 복사해 둔 portable 설치가 그렇다. 그때는 설치본을 그대로 두고 `kept_installed`
-/// 를 돌려준다.
-pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind) !SyncOutcome {
-    var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    // #451 — `fs.selfExePath` ➡️ `std.process.executablePath` (길이를 돌려준다).
-    const exe_len = try std.process.executablePath(rt.io, &exe_buf);
-    const exe = exe_buf[0..exe_len];
-    const exe_dir = std.Io.Dir.path.dirname(exe) orelse return error.ExecutableDirectoryNotFound;
-    const resource_root = try std.Io.Dir.path.join(allocator, &.{ exe_dir, "..", "share", "tildaz" });
-    defer allocator.free(resource_root);
-
-    const source_family = switch (kind) {
-        .gnome => "gnome-extension",
-        .cinnamon => "cinnamon-extension",
-    };
+/// #520 은 이 함수가 exe 옆 `../share/tildaz/` 에서 파일을 읽게 두고, 그 디렉터리가 없으면
+/// 설치본을 그대로 두고 `kept_installed` 를 돌려주게 했다. 그런데 그 결과를 받은 쪽이 할 수
+/// 있는 일이 **"오래됐을 수 있다" 고 로그에 남기는 것뿐**이었다 (#583 B8) — 레포에서 바이너리만
+/// 옮겨 쓰거나 install.sh 로 깐 portable 설치는 계속 옛 extension 으로 돌았고, 사용자가 그것을
+/// 고칠 방법을 안내받지 못했다.
+///
+/// 그래서 리소스를 **바이너리가 싣는다.** 배치와 무관하게 항상 반영되고, extension 은 자기를
+/// 실은 바이너리와 늘 같은 버전이다 — extension 이 그 바이너리의 IPC 를 부르므로 이 짝이
+/// 어긋나면 안 된다. 결과 종류 (`synced` · `kept_installed` · `unavailable`) 도 함께 사라졌다:
+/// 이제 실패는 오류이고 성공은 한 가지다.
+pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind) !void {
     const home = try rt.envAlloc(allocator, "HOME");
     defer allocator.free(home);
     const destination_dir = switch (kind) {
@@ -64,19 +50,6 @@ pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind)
         .cinnamon => try std.Io.Dir.path.join(allocator, &.{ home, ".local", "share", "cinnamon", "extensions", uuid }),
     };
     defer allocator.free(destination_dir);
-
-    const source_dir = try std.Io.Dir.path.join(allocator, &.{ resource_root, source_family, uuid });
-    defer allocator.free(source_dir);
-    // #451 — `fs.accessAbsolute` ➡️ `std.Io.Dir.accessAbsolute` (릴리즈 노트 upgrade guide).
-    std.Io.Dir.accessAbsolute(rt.io, source_dir, .{}) catch |err| switch (err) {
-        error.FileNotFound => {
-            const installed_entry = try std.Io.Dir.path.join(allocator, &.{ destination_dir, "extension.js" });
-            defer allocator.free(installed_entry);
-            std.Io.Dir.accessAbsolute(rt.io, installed_entry, .{}) catch return .unavailable;
-            return .kept_installed;
-        },
-        else => return err,
-    };
 
     // #451 — `fs.Dir.makePath` ➡️ `Io.Dir.createDirPath`. 공통 helper 를 쓴다 (#282 G7).
     try paths.ensureDir(rt, destination_dir);
@@ -87,12 +60,10 @@ pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind)
         .cinnamon => cinnamon_resources[0..],
     };
     for (resources) |resource| {
-        const source = try std.Io.Dir.path.join(allocator, &.{ source_dir, resource.relative_path });
-        defer allocator.free(source);
         const destination = try std.Io.Dir.path.join(allocator, &.{ destination_dir, resource.relative_path });
         defer allocator.free(destination);
         if (std.Io.Dir.path.dirname(destination)) |parent| try paths.ensureDir(rt, parent);
-        changed = (try syncFile(rt, allocator, source, destination)) or changed;
+        changed = (try paths.writeFileIfChanged(rt, allocator, destination, resource.content)) or changed;
     }
 
     if (kind == .gnome) {
@@ -104,9 +75,10 @@ pub fn syncForCurrentUser(rt: Runtime, allocator: std.mem.Allocator, kind: Kind)
         };
         if (changed or !compiled_exists) try compileGnomeSchemas(rt, allocator, destination_dir);
     }
-    return .synced;
 }
 
+/// disk → disk 복사. #583 B8 이후 쓰임이 하나 남았다 — `glib-compile-schemas` 가 임시
+/// 디렉터리에 낸 `gschemas.compiled` 를 제자리로 옮기는 것 (그 파일은 embed 대상이 아니다).
 fn syncFile(rt: Runtime, allocator: std.mem.Allocator, source_path: []const u8, destination_path: []const u8) !bool {
     const source = try std.Io.Dir.openFileAbsolute(rt.io, source_path, .{});
     defer source.close(rt.io);
@@ -153,4 +125,20 @@ test "shell extension manifests contain required runtime files" {
     try std.testing.expectEqualStrings("metadata.json", gnome_resources[1].relative_path);
     try std.testing.expect(std.mem.startsWith(u8, gnome_resources[2].relative_path, "schemas/"));
     try std.testing.expectEqual(@as(usize, 2), cinnamon_resources.len);
+}
+
+test "#583 B8 extension 리소스는 바이너리가 싣는다 (빈 파일이 실리면 사용자 홈을 비운다)" {
+    // 내용이 비면 `writeFileIfChanged` 가 사용자 홈의 extension 을 **빈 파일로 덮는다** —
+    // 익명 import 가 잘못된 경로를 가리켜도 컴파일은 되므로 여기서 잡는다.
+    for (gnome_resources ++ cinnamon_resources) |resource| {
+        try std.testing.expect(resource.content.len > 0);
+    }
+    // 파일이 서로 바뀌지 않았는지 — 각 종류의 표식을 본다.
+    try std.testing.expect(std.mem.indexOf(u8, gnome_resources[0].content, "imports.gi") != null or
+        std.mem.indexOf(u8, gnome_resources[0].content, "import ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, gnome_resources[1].content, uuid) != null);
+    try std.testing.expect(std.mem.indexOf(u8, gnome_resources[2].content, "<schemalist") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cinnamon_resources[1].content, uuid) != null);
+    // GNOME 과 Cinnamon 의 extension.js 는 다른 셸 API 를 쓰는 다른 파일이다.
+    try std.testing.expect(!std.mem.eql(u8, gnome_resources[0].content, cinnamon_resources[0].content));
 }

--- a/src/host/linux_wayland.zig
+++ b/src/host/linux_wayland.zig
@@ -62,11 +62,16 @@ pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerro
         },
         else => {
             var buf: [256]u8 = undefined;
-            const text = messages.runFailureMessage(&buf, err);
+            const config_notice = config_mod.pendingFatalNotice();
+            const text = messages.runFailureMessage(&buf, err, config_notice);
             // stderr + 로그를 **먼저** 남긴다 — 아래 다이얼로그는 사용자가 닫을 때까지
             // 돌아오지 않으므로, 뒤에 두면 창을 안 닫고 프로세스를 죽인 회차에 아무것도
             // 안 남는다 (`dialog.showFatal` 이 같은 순서를 쓰는 이유, #510).
-            log.userFacing("fatal", text);
+            //
+            // #583 B7 — 단, 담긴 config 문구는 **담을 때 이미 나갔다** (`publishFatalNotice`).
+            // 조건 없이 내면 사용자가 같은 여섯 줄을 두 번 본다 (첫 실기에서 그랬다).
+            // worker 경로 (`wayland_minimal.zig` 의 config fatal) 가 예전부터 쓰는 규칙과 같다.
+            if (!messages.usesConfigNotice(err, config_notice)) log.userFacing("fatal", text);
             // #577 — **여기가 이 이슈의 원인 ② 다.** 예전에는 위 한 줄로 끝이라, launcher
             // 가 기동 실패를 알려도 `.desktop` 실행에서는 stderr 가 어디에도 붙지 않아
             // 사용자가 아무것도 보지 못했다. Windows (`MessageBoxW`) · macOS (`NSAlert`) 는

--- a/src/host/macos.zig
+++ b/src/host/macos.zig
@@ -63,7 +63,8 @@ pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerro
     _ = allocator;
     log.logRunFailed(err);
     var buf: [256]u8 = undefined;
-    const text = messages.runFailureMessage(&buf, err);
+    const config_notice = config.pendingFatalNotice();
+    const text = messages.runFailureMessage(&buf, err, config_notice);
     dialog.showError(rt, messages.error_title, text);
 }
 

--- a/src/host/windows.zig
+++ b/src/host/windows.zig
@@ -49,7 +49,8 @@ pub fn showFatalRunError(rt: Runtime, allocator: std.mem.Allocator, err: anyerro
     log.logRunFailed(err);
 
     var buf: [256]u8 = undefined;
-    const text = messages.runFailureMessage(&buf, err);
+    const config_notice = config_mod.pendingFatalNotice();
+    const text = messages.runFailureMessage(&buf, err, config_notice);
     dialog.showError(rt, messages.error_title, text);
 }
 

--- a/src/instances.zig
+++ b/src/instances.zig
@@ -605,7 +605,7 @@ pub fn configAutoStart(rt: Runtime, allocator: std.mem.Allocator, index: u32) !b
     defer parser.deinit();
     // 파싱 오류는 **그대로 전파**한다. `error.InvalidConfig` 로 뭉개면 런처가
     // 보여 주는 문구가 "InvalidConfig" 하나로 줄어 원인을 못 알린다 (#495).
-    var parsed = try parser.parseString(content);
+    var parsed = parser.parseString(content) catch |err| return config.recordTomlParseFatal(rt, path, &parser, err);
     defer parsed.deinit();
     const value = parsed.value.get("auto_start") orelse return error.InvalidConfig;
     if (value != .boolean) return error.InvalidConfig;
@@ -624,7 +624,7 @@ pub fn configHotkeyText(rt: Runtime, allocator: std.mem.Allocator, index: u32) !
     // #493 — TOML. 최상위는 문법상 항상 테이블이라 별도 검사가 필요 없다.
     var parser: toml.Parser(toml.Table) = .init(allocator);
     defer parser.deinit();
-    var parsed = try parser.parseString(content);
+    var parsed = parser.parseString(content) catch |err| return config.recordTomlParseFatal(rt, path, &parser, err);
     defer parsed.deinit();
     const value = parsed.value.get("hotkey") orelse return error.InvalidConfig;
     if (value != .string) return error.InvalidConfig;
@@ -643,7 +643,7 @@ pub fn hotkeyOwner(rt: Runtime, allocator: std.mem.Allocator, indices: []const u
         // #493 — TOML. 최상위는 문법상 항상 테이블이다.
         var parser: toml.Parser(toml.Table) = .init(allocator);
         defer parser.deinit();
-        var parsed = try parser.parseString(content);
+        var parsed = parser.parseString(content) catch |err| return config.recordTomlParseFatal(rt, path, &parser, err);
         defer parsed.deinit();
         const value = parsed.value.get("hotkey") orelse return error.InvalidConfig;
         if (value != .string) return error.InvalidConfig;

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -239,8 +239,24 @@ pub const size_needs_layer_shell_msg =
 pub const size_error_fallback_msg =
     "tildaz: \"-size\" cannot be honored on this screen.";
 
+/// `runFailureMessage` 가 담긴 config 문구를 쓰는 상황인지. **판단을 여기 한 곳에 둔다** —
+/// host 는 이 답으로 "이미 나간 문구를 또 내지 않기" 를 결정한다. `publishFatalNotice` 가 담는
+/// 순간 stderr + 로그에 이미 냈으므로, host 가 다시 내면 사용자가 같은 문구를 **두 번** 본다
+/// (#583 B7 첫 실기에서 그랬다 — worker 경로는 예전부터 다시 내지 않는다).
+pub fn usesConfigNotice(err: anyerror, config_notice: ?[]const u8) bool {
+    return err == error.InvalidConfig and config_notice != null;
+}
+
 /// run/launcher 오류를 세 platform에서 같은 사용자 문구로 변환한다.
-pub fn runFailureMessage(buf: []u8, err: anyerror) []const u8 {
+///
+/// `config_notice` — `config.pendingFatalNotice()` 의 값 (없으면 `null`). config 오류로 죽은
+/// 것이면 그 문구가 **더 정확하다** (경로 · 줄 · 열 · 오류) 라서 그것을 그대로 보여 준다.
+/// #583 B7 전에는 launcher 가 이 자리에서 `TildaZ failed to start. Error: UnexpectedToken` 만
+/// 보여 줬는데, worker 는 같은 파일의 같은 오류에 `Line 12, column 3` 까지 알려 줬다.
+/// `error.InvalidConfig` 로만 좁힌 이유는, 담긴 문구가 있어도 그 뒤 다른 원인으로 죽었으면
+/// 그 원인을 가려서는 안 되기 때문이다.
+pub fn runFailureMessage(buf: []u8, err: anyerror, config_notice: ?[]const u8) []const u8 {
+    if (usesConfigNotice(err, config_notice)) return config_notice.?;
     return switch (err) {
         error.RequestEndpointUnavailable => request_endpoint_unavailable_msg,
         error.WorkerExitedBeforeEndpointReady => worker_exited_before_endpoint_ready_msg,
@@ -251,32 +267,50 @@ pub fn runFailureMessage(buf: []u8, err: anyerror) []const u8 {
     };
 }
 
+test "#583 B7 config 파싱 오류는 담긴 상세 문구를 그대로 보여 준다" {
+    var buf: [256]u8 = undefined;
+    // launcher 가 config 를 읽다 죽은 경우 — `recordTomlParseFatal` 이 담아 둔 문구다.
+    const notice = "Config: /home/user/.config/tildaz/config_0.toml\n\n" ++
+        "Failed to parse config file.\n\nLine 12, column 3\nError: UnexpectedToken";
+    try std.testing.expectEqualStrings(notice, runFailureMessage(&buf, error.InvalidConfig, notice));
+    // 담긴 것이 없으면 일반 문구 (파싱이 아닌 의미 오류로 `InvalidConfig` 가 오는 경로).
+    try std.testing.expectEqualStrings(
+        "TildaZ failed to start.\n\nError: InvalidConfig",
+        runFailureMessage(&buf, error.InvalidConfig, null),
+    );
+    // 다른 원인으로 죽었으면 담긴 config 문구가 그 원인을 **가리지 않는다.**
+    try std.testing.expectEqualStrings(
+        "TildaZ failed to start.\n\nError: ExampleFailure",
+        runFailureMessage(&buf, error.ExampleFailure, notice),
+    );
+}
+
 test "request endpoint run errors have specific user messages" {
     var buf: [256]u8 = undefined;
     try std.testing.expectEqualStrings(
         request_endpoint_unavailable_msg,
-        runFailureMessage(&buf, error.RequestEndpointUnavailable),
+        runFailureMessage(&buf, error.RequestEndpointUnavailable, null),
     );
     try std.testing.expectEqualStrings(
         worker_exited_before_endpoint_ready_msg,
-        runFailureMessage(&buf, error.WorkerExitedBeforeEndpointReady),
+        runFailureMessage(&buf, error.WorkerExitedBeforeEndpointReady, null),
     );
     try std.testing.expectEqualStrings(
         request_endpoint_ready_timeout_msg,
-        runFailureMessage(&buf, error.RequestEndpointReadyTimeout),
+        runFailureMessage(&buf, error.RequestEndpointReadyTimeout, null),
     );
     // #577 — 첫 기동이 화면 없이 끝난 경우. 예전에는 generic
     // `"Error: WorkerStartTimeout"` 이었고 그것도 10 초 뒤였다.
     try std.testing.expectEqualStrings(
         worker_exited_during_startup_msg,
-        runFailureMessage(&buf, error.WorkerExitedDuringStartup),
+        runFailureMessage(&buf, error.WorkerExitedDuringStartup, null),
     );
     // 이 문구는 사용자에게 **무엇을 볼지** 말해야 한다 — 여기까지 온 실행은 화면에
     // 아무것도 남기지 않았으므로 단서가 로그뿐이다.
     try std.testing.expect(std.mem.indexOf(u8, worker_exited_during_startup_msg, "log") != null);
     try std.testing.expectEqualStrings(
         "TildaZ failed to start.\n\nError: ExampleFailure",
-        runFailureMessage(&buf, error.ExampleFailure),
+        runFailureMessage(&buf, error.ExampleFailure, null),
     );
 }
 


### PR DESCRIPTION
Refs #583 (B8 · B7) · Refs #520 · Refs #577

#583 의 남은 Linux 행 둘이다. 서로 다른 이슈의 후속이라 커밋도 둘로 나눴다.

## B8 (#520 후속) — Shell extension 리소스를 바이너리에 embed 한다

`syncForCurrentUser` 가 exe 옆 `../share/tildaz/` 에서 파일을 읽었다. 그 디렉터리가 없는 배치 (레포에서 바이너리만 옮겨 쓰기 · `install.sh` 로 깐 portable 설치) 에서는 설치본을 그대로 두고 `kept_installed` 를 돌려주었고, 받은 쪽이 할 수 있는 일은 **"오래됐을 수 있다" 고 로그에 남기는 것뿐**이었다 — 사용자가 고칠 방법을 안내받지 못했다.

이제 리소스를 바이너리가 싣는다 (GNOME 3 벌 · Cinnamon 2 벌 · 합 82 KB). 배치와 무관하게 항상 반영되고, extension 은 자기를 실은 바이너리와 늘 같은 버전이다 — extension 이 그 바이너리의 IPC 를 부르므로 이 짝이 어긋나면 안 된다. 결과 종류 (`SyncOutcome`) 도 함께 사라져 `!void` 가 됐다 (실패는 오류, 성공은 하나).

**실기** (격리 HOME · `../share/tildaz` 없는 배치):

- `XDG_CURRENT_DESKTOP=GNOME` → `~/.local/share/gnome-shell/extensions/<uuid>/` 에 3 벌 + `gschemas.compiled` · 로그 `Shell extension synchronized and enabled`
- `XDG_CURRENT_DESKTOP=X-Cinnamon` → `~/.local/share/cinnamon/extensions/<uuid>/` 에 2 벌
- **옛 설치본** (stale `extension.js` · `metadata.json`) 을 심어 두고 실행 → 세 파일이 레포 원본과 byte 일치로 갱신. GNOME 자리에 Cinnamon 파일이 들어가지 않는 것도 확인

빈 파일이 실리면 사용자 홈을 빈 파일로 덮으므로 (익명 import 가 잘못된 경로를 가리켜도 컴파일은 된다) 내용 길이 · 종류별 표식 · 두 `extension.js` 가 다른 파일인지를 테스트로 고정했다.

## B7 (#577 후속) — launcher 도 worker 와 같은 파싱 오류 문구를 보여준다

같은 config 파일의 같은 구문 오류인데 보여 주는 것이 갈렸다.

| | 사용자가 보는 것 |
|---|---|
| worker | `Config: <경로>` · `Failed to parse config file.` · `Line 12, column 6` · `Error: UnexpectedToken` |
| launcher (수정 전) | `TildaZ failed to start.` · `Error: UnexpectedToken` |

그런데 **첫 실행에서 사용자가 보는 쪽이 launcher 다.** 원인은 문구 조립이 `Config.parse` 안에만 있었던 것 — launcher 가 config 를 읽는 세 자리 (`instances.zig` 의 `configAutoStart` · `configHotkeyText` · `hotkeyOwner`) 는 파서 오류를 그대로 올렸다.

- `config.recordTomlParseFatal` 로 조립을 **한 곳에** 두고 네 자리가 모두 그것을 부른다.
- `messages.runFailureMessage` 가 `config_notice` 를 받아, `error.InvalidConfig` 로 죽었고 담긴 문구가 있으면 그것을 보여 준다. 그 오류로 좁힌 이유는 담긴 문구가 있어도 그 뒤 다른 원인으로 죽었으면 그 원인을 가려서는 안 되기 때문이다 (테스트로 고정).
- 담긴 문구는 담을 때 이미 stderr + 로그로 나가므로 host 가 다시 내지 않는다 (`messages.usesConfigNotice` 가 그 판단의 단일 지점). **첫 실기에서 같은 여섯 줄이 두 번 나왔고 그것으로 발견했다.**

**실기** (12 번째 줄을 깨뜨린 `config_0.toml` · 격리 XDG 경로): launcher stderr 가 worker 와 같은 문구이고 **1 회**만 나온다. 같은 문구가 standalone fatal 다이얼로그에도 그대로 뜬다 (화면 확인). 정상 config 회귀 — KDE 세션에서 오류 문구 0 건 · 정상 종료.

## 검증

`zig build test` · `zig build check` (6 타깃) · `zig fmt --check` 통과. Windows · macOS 는 `showFatalRunError` 가 `log.logRunFailed` + `dialog.showError` 라 중복이 없었고 시그니처만 따라간다.
