### PR TITLE
fix(wayland): 배율이 바뀌면 work-area latch 를 다시 받는다 (#631)

### DIFF
--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -1411,6 +1411,11 @@ const Client = struct {
     /// 의 종료 조건. 값이 안 바뀌는 100%(120→120) 케이스도 event 수신 자체로 확정
     /// 처리하려고 applyScaleChange 의 값 비교와 별개로 event handler 가 set 한다.
     preferred_scale_received: bool = false,
+    /// #631 — `screen_logical_*` 를 latch 한 시점의 배율. 배율이 바뀌면 그 논리 크기는 옛 값이라
+    /// 버려야 하는데 (compositor 의 논리 화면 = 물리 ÷ 배율), boot 처럼 *방금 그 배율로* 받은
+    /// latch 까지 버리면 첫 layout 이 fallback 추정을 쓴다. 그래서 "값이 있는가" 가 아니라
+    /// **어느 배율에서 받은 latch 인가**로 판단한다.
+    screen_logical_scale: u32 = 0,
     /// #619 — **마지막 layer-surface configure 의 논리 크기.** buffer 크기 계산이
     /// configure 핸들러 한 곳에만 있으면, 배율만 바뀌고 우리가 요청한 layout 이
     /// 그대로일 때 compositor 가 configure 를 다시 보내지 않아 buffer 가 옛 배율의
@@ -3117,6 +3122,27 @@ const Client = struct {
             (new_scale * 100 / 120) % 100,
             source,
         });
+        // #631 — **배율이 바뀌면 논리 화면 크기도 바뀐다** (compositor 의 논리 화면 = 물리 ÷ 배율).
+        // #351 의 work-area latch 는 한 번만 받으므로, 그대로 두면 이 함수가 **옛 배율 기준의
+        // 논리 화면**으로 layout 을 다시 계산해 보낸다. latch 를 버리는 `applyScreenDimsChange` 는
+        // `wl_output.mode` (물리 해상도) 와 basis output 전환에서만 불렸고 — 배율만 바뀌는 경로가
+        // 빠져 있었다 (`xdg_output` 도 bind 하지 않아 다른 갱신 경로가 없다).
+        //
+        // 2026-09-05 실측 (KDE 6.7.4 · `width_percent = 50`): 1.7 에서 뜬 창의 latch 는 2259 다.
+        // 사용자가 배율을 1.6 으로 바꾸면 논리 화면이 2400 이 되는데, 우리는 옛 2259 로 계산한
+        // 여백 1129 를 그대로 보내 compositor 가 `2400 − 1129 = 1271` 을 준다 — **50 % 요청이
+        // 53 % 로 뜬다** (사용자가 "너비가 늘어났다" 로 알아봤다). 새로 띄운 창은 그 배율로 latch
+        // 하므로 정상이라, 증상이 "배율을 바꾼 그때 켜져 있던 창" 에만 남는 것도 이 때문이다.
+        //
+        // 배율이 실제로 달라졌을 때만 버린다 — boot 는 배율 event 가 첫 configure 보다 **먼저**
+        // 오는 compositor 도 있고 (KWin 실측), 방금 그 배율로 받은 latch 를 버리면 첫 layout 이
+        // fallback 추정을 쓴다.
+        if (self.screen_logical_w != 0 and self.screen_logical_scale != new_scale) {
+            // 순서 주의 — latch 를 **먼저** 버려야 아래 layout 재송신이 옛 work-area 를 안 쓴다
+            // (`applyBasisOutput` 이 같은 순서다). `caller_resends_layout = true` 는 이 함수가
+            // 아래에서 다시 보내기 때문이다.
+            try self.applyScreenDimsChange("preferred_scale", true);
+        }
         // #619 — **buffer 크기를 새 배율로 다시 계산한다.** compositor 는 우리가 요청한 논리
         // layout 이 그대로면 configure 를 다시 보내지 않는다 (배율이 바뀌어도 논리 크기는
         // 안 바뀌므로 흔한 경우다 — `height_percent = 100` 이 늘 그렇다). 그런데 buffer
@@ -3203,6 +3229,7 @@ const Client = struct {
         //    그 사이의 layout 계산은 physical → logical 추정 fallback 을 쓴다.
         self.screen_logical_w = 0;
         self.screen_logical_h = 0;
+        self.screen_logical_scale = 0;
         // ② #241 판정 보정 — compositor 가 stale margin 으로 폭 0 을 계산해 `closed` 를
         //    보내면, 그 `closed` 는 **같은 dispatch batch** 안에 있다 (KWin 실기: mode /
         //    closed / drainQuitRequest 가 같은 ms). topology 플래그를 안 세우면 main
@@ -5652,6 +5679,7 @@ const Client = struct {
                     self.initial_safe_pending = false;
                     self.screen_logical_w = w_logical;
                     self.screen_logical_h = h_logical;
+                    self.screen_logical_scale = self.preferred_scale;
                     log.appendLineVerbose("wayland", "logical work-area latched {}x{} (initial-safe configure, #351)", .{ w_logical, h_logical });
                     // continuation — 보류했던 실제 layout 을 이제 정확한 work-area 로
                     // 보낸다. 이 지점이 초기 안전 commit 을 보내는 모든 경로

--- a/src/host/linux/wayland_minimal.zig
+++ b/src/host/linux/wayland_minimal.zig
@@ -249,6 +249,10 @@ const fractional_scale_denominator: u32 = 120;
 /// 않도록 상한을 둔다.
 const max_grid_wait_configures: u8 = 8;
 
+/// #631 — work-area latch 가 낡았다고 보고 다시 받는 시도의 상한. 다시 받은 뒤에도 계속 어긋나는
+/// compositor 에서 무한 재생성이 되지 않게 둔다 (맞는 configure 가 한 번 오면 되돌아온다).
+const work_area_recheck_max: u8 = 3;
+
 // L8-β — wl_output 의 mode / done event. geometry / scale 은 아직 안 씀.
 const wl_output_event_geometry: u16 = 0;
 const wl_output_event_mode: u16 = 1;
@@ -1411,6 +1415,15 @@ const Client = struct {
     /// 의 종료 조건. 값이 안 바뀌는 100%(120→120) 케이스도 event 수신 자체로 확정
     /// 처리하려고 applyScaleChange 의 값 비교와 별개로 event handler 가 set 한다.
     preferred_scale_received: bool = false,
+    /// #631 — 마지막으로 보낸 layout 이 **함의하는 크기** (논리). 4-edge anchor + `size=0` 이면
+    /// compositor 가 주는 크기는 정의상 `work-area − (양쪽 여백)` 이다. 그것과 다른 configure 가
+    /// 오면 우리 latch 가 낡은 것이다 — 배율뿐 아니라 **패널의 exclusive zone 이 바뀔 때**도
+    /// work-area 가 달라지는데, 그 변화에는 우리에게 오는 직접 신호가 없다 (다른 client 의 zone 은
+    /// 프로토콜상 보이지 않는다). 0 이면 검사하지 않는다 (fullscreen · 초기 안전 commit).
+    expected_logical_w: i32 = 0,
+    expected_logical_h: i32 = 0,
+    /// 그 감지로 다시 받는 시도의 남은 횟수 (`work_area_recheck_max`).
+    work_area_recheck_left: u8 = work_area_recheck_max,
     /// #631 — `screen_logical_*` 를 latch 한 시점의 배율. 배율이 바뀌면 그 논리 크기는 옛 값이라
     /// 버려야 하는데 (compositor 의 논리 화면 = 물리 ÷ 배율), boot 처럼 *방금 그 배율로* 받은
     /// latch 까지 버리면 첫 layout 이 fallback 추정을 쓴다. 그래서 "값이 있는가" 가 아니라
@@ -2727,6 +2740,16 @@ const Client = struct {
         // 0 이다 — spec: 0 이면 compositor 가 정하고 configure 로 알려준다.)
         const logical_w: u32 = if (fullscreen) 0 else layout.width;
         const logical_h: u32 = if (fullscreen) 0 else layout.height;
+        // #631 — 이 layout 이 함의하는 크기를 기록해 둔다. configure 가 이것과 어긋나면 latch 가
+        // 낡은 것이다 (필드 주석 참고). 4-edge anchor + `size=0` 이고 latch 를 실제로 들고 있을
+        // 때만 뜻이 있다 — fullscreen · 초기 안전 commit · latch 를 버린 구간은 검사하지 않는다.
+        if (!fullscreen and logical_w == 0 and logical_h == 0 and self.screen_logical_w > 0 and self.screen_logical_h > 0) {
+            self.expected_logical_w = self.screen_logical_w - (layout.margin_left + layout.margin_right);
+            self.expected_logical_h = self.screen_logical_h - (layout.margin_top + layout.margin_bottom);
+        } else {
+            self.expected_logical_w = 0;
+            self.expected_logical_h = 0;
+        }
         try self.sendArgs(
             self.layer_surface_id,
             zwlr_layer_surface_v1_request_set_size,
@@ -5686,6 +5709,43 @@ const Client = struct {
                     // (boot 의 bringUpInitialSurface, #241/#295 의 swapMainSurfaceSeamless)
                     // 에서 실제 layout 송신을 보장하는 단일 위치다.
                     try self.sendLayerSurfaceLayout(false);
+                }
+                // #631 — **받은 크기가 우리가 보낸 layout 의 산술과 어긋나면 latch 가 낡았다.**
+                // 4-edge anchor + `size=0` 에서 compositor 가 주는 크기는 정의상 `work-area − 여백`
+                // 이므로, 그것과 다르면 work-area 가 우리 모르게 바뀐 것이다. 배율 변경은 위(#631 의
+                // `applyScaleChange` 훅)가 선제로 막지만, **패널이 생기거나 사라지거나 높이가 바뀌면**
+                // 신호가 없어 이 사후 검사만이 잡는다.
+                //
+                // 2026-09-05 실측 (KDE · 배율 1.6 · `height_percent = 60`): 패널 높이를 46 → 34 로
+                // 줄이자 work-area 가 1304 → 1316 이 됐는데 우리는 옛 여백 524 를 그대로 들고 있어
+                // compositor 가 `1316 − 524 = 792` 를 줬다 (60 % 가 아니라 60.2 %). 이 검사가 그
+                // 792 ≠ 780 을 보고 latch 를 다시 받는다.
+                //
+                // 1 px 은 봐준다 — compositor 의 반올림 차이를 재생성으로 되갚지 않는다. 상한
+                // (`work_area_recheck_max`) 을 둔 이유는 다시 받은 뒤에도 계속 어긋나는 환경에서
+                // 무한 재생성이 되지 않게 하기 위해서다.
+                if (self.configured and self.expected_logical_w > 0 and self.expected_logical_h > 0 and w > 0 and h > 0) {
+                    const dw = @abs(w_logical - self.expected_logical_w);
+                    const dh = @abs(h_logical - self.expected_logical_h);
+                    if (dw > 1 or dh > 1) {
+                        if (self.work_area_recheck_left > 0) {
+                            self.work_area_recheck_left -= 1;
+                            log.appendLine("wayland", "configure {}x{} differs from the layout we sent ({}x{}) — work-area latch is stale, re-latching ({d} left)", .{
+                                w_logical,
+                                h_logical,
+                                self.expected_logical_w,
+                                self.expected_logical_h,
+                                self.work_area_recheck_left,
+                            });
+                            try self.applyScreenDimsChange("work-area changed", false);
+                        } else {
+                            log.appendLine("wayland", "configure {}x{} still differs from the layout we sent ({}x{}) — following the compositor", .{
+                                w_logical, h_logical, self.expected_logical_w, self.expected_logical_h,
+                            });
+                        }
+                    } else {
+                        self.work_area_recheck_left = work_area_recheck_max;
+                    }
                 }
                 // 아래 크기 적용 / grid 생성 / `configured` 는 이 configure 로 그대로
                 // 진행한다 (#351 이 바꾸지 않음). `width_percent`=`height_percent`=100


### PR DESCRIPTION
Fixes #631

## 문제

세션 중에 디스플레이 배율을 바꾸면 **그때 떠 있던 창**이 옛 논리 화면 기준으로 배치된다. 새로 띄운 창은 정상이라, 증상이 그 인스턴스에만 남는다.

#351 의 work-area latch (`screen_logical_w/h`) 는 초기 안전 commit 의 configure 에서 한 번만 채워지고, 그것을 버리는 `applyScreenDimsChange` 는 `wl_output.mode` (물리 해상도) 와 basis output 전환에서만 불렸다 — **배율만 바뀌는 경로가 빠져 있었다.** `zxdg_output_manager_v1` 도 bind 하지 않아 논리 크기를 갱신할 다른 경로가 없다. compositor 의 논리 화면은 `물리 ÷ 배율` 이라 배율이 바뀌면 반드시 달라진다 (3840 → 1.7 에서 2259, 1.6 에서 2400).

## 실기 (KDE Plasma · KWin 6.7.4 · DP-3 3840x2160 · `width_percent = 50`)

| | 논리 화면 | 보낸 여백 | compositor 가 준 크기 | 점유 |
|---|---|---|---|---|
| 1.7 에서 뜸 | 2259 | 1129 | 1130 | 50 % |
| 켜 둔 채 1.6 으로 (수정 전) | 2400 | 1129 (옛 값) | 1271 | **53 %** |
| 켜 둔 채 1.6 으로 (수정 후) | 2400 | **1200** | **1200** | **50 %** |

수정 후 로그: `screen dims changed while mapped — seamless recreate scheduled` → `logical work-area latched 2400x1304` → `margin=(0,0,0,1200)` → `configure logical_w=1200`. 화면 실측 `x 1920..3839` (논리 1200 · 오른쪽 여백 0).

## 판단 기준

배율이 **실제로 달라졌을 때만** 버린다 (`screen_logical_scale`). boot 는 배율 event 가 첫 configure 보다 먼저 오는 compositor 가 있어서 (KWin 실측), 방금 그 배율로 받은 latch 까지 버리면 첫 layout 이 fallback 추정을 쓴다.

## 다른 플랫폼 · 다른 DE

캐시를 두는 곳이 **Linux layer-shell 경로 하나뿐**이라, 그 하나를 배율 변경 시점에 무효화하는 것으로 끝난다.

| 대상 | 화면 기하 | 이 결함 |
|---|---|---|
| Linux layer-shell (KDE · Hyprland · COSMIC) | 초기 안전 commit 으로 한 번 latch | 있었음 → 이 PR (경로가 공통이라 세 compositor 모두) |
| Linux xdg (sway · GNOME · Cinnamon) | compositor 의 xdg configure 가 매번 준다 | 없음 |
| Windows | `GetMonitorInfo` 를 레이아웃마다 조회 | 없음 |
| macOS | `visibleFrame` 을 레이아웃마다 조회 | 없음 |

## 두 번째 커밋 — 같은 부류를 불변식 하나로 닫는다

work area 는 **패널의 exclusive zone 이 바뀔 때도** 달라지는데 (패널 추가 · 제거 · 높이 변경 · 자동 숨김) 그 변화에는 우리에게 오는 직접 신호가 없다 — 다른 client 의 zone 은 프로토콜상 보이지 않는다.

관측할 수 있는 것은 하나다: 4-edge anchor + `size=0` 으로 요청하면 compositor 가 주는 크기는 **정의상 `work-area − (양쪽 여백)`** 이다. 그것과 다른 configure 가 오면 latch 가 낡은 것이다. 이 불변식이 배율 · 패널 · 그 밖의 변화를 모두 덮는다 (배율 훅은 틀린 layout 을 한 번도 안 보내는 선제 방어로 남고, 이것은 사후 감지다).

**실기** (KDE · 배율 1.6 · `height_percent = 60` · 패널 높이를 46 ↔ 34 로 바꿔 가며):

| | 작업 영역 | 보낸 여백 | 받은 크기 | 점유 |
|---|---|---|---|---|
| 패널 46 | 1304 | 524 | 780 | 60.0 % |
| 34 로 줄임 (수정 전) | 1316 | 524 (옛 값) | **792** | **60.2 %** |
| 46 으로 복구 (수정 후) | 1304 | 526 → **524** | **780** | **60.0 %** |

```
configure 1200x778 differs from the layout we sent (1200x790) — work-area latch is stale, re-latching (2 left)
screen dims changed (work-area changed) — work-area latch dropped + topology pending (#356)
logical work-area latched 2400x1304 (initial-safe configure, #351)
margin=(0,0,524,1200) → layer-surface configure logical_w=1200 logical_h=780
```

1 px 은 봐주고 (반올림 차이를 재생성으로 되갚지 않는다), 시도에 상한 (3) 을 둔다 — 다시 받은 뒤에도 계속 어긋나는 환경에서 무한 재생성이 되지 않게. 맞는 configure 가 한 번 오면 예산이 되돌아온다.

## 검증

`zig build test` · `zig build check` (6 타깃) · `zig fmt --check` 통과. 실기는 위 표 (KDE 에서 배율을 켜 둔 채 바꿔 확인).
