### PR TITLE
fix(conpty): 자식이 close 이벤트를 놓쳐도 탭 닫기가 멈추지 않는다 (#611)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1340,9 +1340,13 @@ binding은 같은 accelerator를 재사용하면 새 TildaZ command로 덮이고
 
 | 항목 | 동작 정의 | Windows | macOS | Linux | Win | Mac | Linux |
 |---|---|---|---|---|---|---|---|
-| 탭 닫기 시 자식 정리 | 즉시 종료 + read thread join | `ClosePseudoConsole(hpc)` 한 호출 | 공통 `Pty.deinit`: `kill(-pid, SIGHUP)` + `wait_thread.join()` + `read_thread.join()` | macOS와 같은 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `Pty.deinit` | ✅ | ✅ | ✅ |
-| Polling sleep 회피 | join 직접 동기화 | (OS API 자동) | wait_thread blocking `waitpid` 으로 즉시 깨어남 | 동일 (`waitpid` blocking + `child_exited` atomic 으로 grace loop break) | ✅ | ✅ | ✅ |
-| SIGHUP 무시 셸 fallback | SIGKILL 강제 | (자동) | 공통 `Pty.deinit`: 500ms grace (5ms polling, `child_exited` atomic) → SIGKILL | macOS와 같은 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `Pty.deinit` | ✅ | ✅ | ✅ |
+| 탭 닫기 시 자식 정리 | 즉시 종료 + read thread join | `ClosePseudoConsole(hpc)` → 자식 종료 확인 (1초 유예) → 안 끝나면 `TerminateProcess` → `CancelIoEx` → `read_thread.join()` + `wait_thread.join()` | 공통 `Pty.deinit`: `kill(-pid, SIGHUP)` + `wait_thread.join()` + `read_thread.join()` | macOS와 같은 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `Pty.deinit` | ✅ | ✅ | ✅ |
+| Polling sleep 회피 | join 직접 동기화 | 자식 종료는 `WaitForSingleObject` 블로킹 대기 (polling 없음) | wait_thread blocking `waitpid` 으로 즉시 깨어남 | 동일 (`waitpid` blocking + `child_exited` atomic 으로 grace loop break) | ✅ | ✅ | ✅ |
+| SIGHUP 무시 셸 fallback | SIGKILL 강제 | `CTRL_CLOSE_EVENT` 를 놓친 자식은 1초 유예 뒤 `TerminateProcess` ([#611](https://github.com/ensky0/tildaz/issues/611)) | 공통 `Pty.deinit`: 500ms grace (5ms polling, `child_exited` atomic) → SIGKILL | macOS와 같은 [`terminal/posix/pty.zig`](src/terminal/posix/pty.zig)의 `Pty.deinit` | ✅ | ✅ | ✅ |
+
+**Windows — `ClosePseudoConsole` 하나로는 자식이 정리되지 않는다** ([#611](https://github.com/ensky0/tildaz/issues/611) · 2026-09-05 확정). 그 API 는 [문서](https://learn.microsoft.com/en-us/windows/console/closepseudoconsole)대로 **연결된 클라이언트에게 `CTRL_CLOSE_EVENT` 를 보낼 뿐**이고, 자식이 **막 시작해 콘솔 컨트롤 핸들러를 세우기 전**이면 그 이벤트를 놓쳐 계속 연결된 채 남는다. 그러면 conpty 가 출력 pipe 를 닫지 않아 `readLoop` 의 overlapped read 가 끝나지 않고, `deinit` 의 `read_thread.join()` · `wait_thread.join()` 이 **영원히** 안 풀린다 — 탭 닫기가 UI 스레드에서 멈춰 앱 전체가 얼어붙는다 (실기 재현: 탭 생성 직후 닫기, `WM_NULL` 40초 무응답). Windows 11 24H2 부터 `ClosePseudoConsole` 자체는 즉시 반환하므로 그 호출이 아니라 **join** 에서 막힌다.
+
+그래서 Windows 도 macOS · Linux 와 **같은 모양**이 됐다 — 정상 종료를 기다리고, 유예 안에 안 끝나면 강제로 끝낸다 (POSIX 의 `SIGHUP` → 500ms → `SIGKILL` 에 대응). 유예가 1초인 근거는 [`pty.zig`](src/terminal/windows/pty.zig) 의 `CHILD_EXIT_GRACE_MS` 주석에 있다 — 이벤트를 *놓친* 자식은 더 기다려도 끝나지 않으므로, 값의 근거는 "종료 훅을 도는 셸에게 주는 시간" 뿐이다. 참고로 Windows Terminal (`ConptyConnection::Close`) 은 자식을 강제 종료하지 않는 대신 출력 스레드를 `CancelIoEx` + 타임아웃 루프로 깨우고, WezTerm 은 스레드 join 자체를 하지 않는다. 우리는 join 을 하므로 자식 정리까지 책임져야 한다.
 
 ---
 

--- a/dist/release-notes/UNRELEASED.md
+++ b/dist/release-notes/UNRELEASED.md
@@ -25,3 +25,4 @@ Internal changes belong in neither.
 - Windows: programs that enable the kitty keyboard protocol with "report all keys" now receive letters, Enter, Tab, Backspace and Escape as `CSI u` sequences, matching macOS and Linux ([#602](https://github.com/ensky0/tildaz/issues/602)).
 - Linux: unplugging the only keyboard or mouse and plugging it back in no longer leaves TildaZ without input on wlroots-based compositors (sway, Hyprland) — the seat's keyboard and pointer objects are released and recreated with the device ([#347](https://github.com/ensky0/tildaz/issues/347)).
 - Linux: when the compositor exits first (logout, `swaymsg exit`), TildaZ shuts down cleanly instead of reporting `TildaZ failed to start … WaylandConnectionClosed` ([#613](https://github.com/ensky0/tildaz/issues/613)).
+- Windows: closing a tab right after opening it no longer freezes TildaZ, and no longer leaves an `OpenConsole.exe` process behind ([#611](https://github.com/ensky0/tildaz/issues/611)).

--- a/dist/windows/tab-churn-check.ps1
+++ b/dist/windows/tab-churn-check.ps1
@@ -1,0 +1,285 @@
+﻿# 탭을 만들자마자 닫아 ConPTY teardown 이 어긋나지 않는지 보는 회귀 검사 (#611).
+#
+# ## 무엇을 재나
+#
+# `ClosePseudoConsole` 은 연결된 클라이언트에게 `CTRL_CLOSE_EVENT` 를 **보낼 뿐**이라, 자식이
+# 막 시작해 콘솔 컨트롤 핸들러를 세우기 전이면 그것을 놓치고 계속 연결된 채 남는다. 그러면
+# conpty 가 출력 pipe 를 닫지 않아 `readLoop` 이 끝나지 않고 `deinit` 의 join 이 영원히 안
+# 풀린다 — **탭 닫기가 UI 스레드에서 멈춰 앱이 얼어붙는다.** 이 스크립트는 `Ctrl+Shift+T`
+# 직후 `Ctrl+Shift+W` 를 반복하며 두 가지를 본다.
+#
+#   1. `WM_NULL` 이 돌아오는가 (= UI 스레드가 살아 있는가). 안 돌아오면 최대 40 초 재확인해
+#      **일시적 지연**과 **영구 정지**를 가른다.
+#   2. tildaz 경로의 `OpenConsole.exe` 가 쌓이는가 (자식이 안 죽으면 남는다).
+#
+# 수정 전 판: 사이클 1 에서 UI 영구 무응답 · 앱 강제 종료 뒤에도 OpenConsole 1 잔존.
+# 수정 후 판: 전 사이클 UI 정상 · 앱 종료 뒤 0.
+#
+# ```powershell
+# dist\windows\tab-churn-check.ps1 -Probe               # ① 조건 확인 (단축키가 먹는지) — 먼저 돌린다
+# dist\windows\tab-churn-check.ps1                      # ② 본 회차 20 사이클 · 간격 1.5 초
+# dist\windows\tab-churn-check.ps1 -Cycles 10 -GapMs 2000
+# ```
+#
+# ## 함정 — 빠뜨리면 반대 결론이 나온다
+#
+#  - **`SendInput` 은 `wScan` 을 `MapVirtualKeyW` 로 채워야 한다.** 안 채우면 `Ctrl+Shift+T` 가
+#    앱에 닿지 않는데 화면상 아무 일도 안 일어나서 **"앱이 정상" 으로 오독**한다. 실제로 회차를
+#    하나 그렇게 버렸다 (`dist/stress/send-keys.ps1` 이 같은 주의를 적어 두었다).
+#  - **탭 생성은 성공 시 로그를 남기지 않는다** (`log.zig` 는 실패만 적는다). 그래서 로그로는
+#    "단축키가 안 먹었다" 와 "먹었다" 를 못 가른다. 판정은 `-Probe` 의 **ConPTY 개수 (1 → 2)** 로
+#    하고, 본 회차 전에 반드시 한 번 돌린다.
+#  - **간격 없이 몰아 돌리면 자식 `cmd.exe` 가 `0xc0000142` 로 시작에 실패**하고 Windows 오류
+#    다이얼로그가 **사용자 화면에** 뜬다. 그 회차는 정지 원인을 가릴 수 없어 무효다. 그래서
+#    `#32770` 창을 매 사이클 확인해 뜨면 멈추고, 기본 간격을 1.5 초로 둔다.
+#
+# ## 안전 규칙 (AGENTS.md `# 실행 환경`)
+#
+#  - `--instance 9` + `-e` 회차라 `config_9.toml` 도 전역 hotkey 도 만들지 않는다.
+#  - 키마다 포커스 가드 — foreground 가 우리 창이 아니면 그 자리에서 멈춘다 (사용자 창에
+#    타이핑되는 것을 막는다).
+#  - 끝나면 인스턴스 9 만 내리고 남은 프로세스를 정리한다.
+#  - 실기라 **시작 전에 사용자에게 알리고 동의를 받는다** — 창이 뜨고 합성 키가 나간다.
+#
+# 이 파일은 UTF-8 **BOM** 으로 저장한다 (PowerShell 5.1 은 BOM 이 없으면 CP949 로 읽어 한글 주석이 깨진다).
+
+param(
+    [string]$Bin = (Join-Path $PSScriptRoot '..\..\zig-out\bin\tildaz.exe'),
+    [int]$Cycles = 20,
+    # 새 탭을 만든 뒤 닫기까지의 간격 (ms). 0 에 가까울수록 자식이 콘솔 컨트롤 핸들러를
+    # 세우기 전에 CTRL_CLOSE_EVENT 를 받는다.
+    [int]$HoldMs = 0,
+    # 사이클 사이 간격 (ms). 짧으면 콘솔 프로세스가 몰려 세션 자원이 모자라고
+    # 자식이 0xc0000142 로 시작 실패한다 — 그 회차는 측정이 성립하지 않는다.
+    [int]$GapMs = 1500,
+    # 조건 확인 — 단축키가 실제로 먹는지를 단계별 ConPTY 개수로 본다.
+    [switch]$Probe
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
+public static class TzWin
+{
+    [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+    [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+    [StructLayout(LayoutKind.Sequential)] public struct HARDWAREINPUT { public uint uMsg; public ushort wParamL; public ushort wParamH; }
+    [StructLayout(LayoutKind.Explicit)] public struct INPUTUNION {
+        [FieldOffset(0)] public MOUSEINPUT mi;
+        [FieldOffset(0)] public KEYBDINPUT ki;
+        [FieldOffset(0)] public HARDWAREINPUT hi;
+    }
+    [StructLayout(LayoutKind.Sequential)] public struct INPUT { public uint type; public INPUTUNION u; }
+
+    [DllImport("user32.dll", SetLastError = true)] private static extern uint SendInput(uint n, INPUT[] inputs, int cb);
+    [DllImport("user32.dll")] private static extern uint MapVirtualKeyW(uint code, uint mapType);
+    private const uint INPUT_KEYBOARD = 1;
+    private const uint KEYEVENTF_KEYUP = 0x0002;
+
+    // `wScan` 을 반드시 채운다 (`dist/stress/send-keys.ps1` 의 같은 주석) — scan code 가 0 이면
+    // 키가 제대로 해석되지 않는다. 그리고 구조체 배열은 **C# 안에서** 채운다: PowerShell 로
+    // `$arr[$i].field = x` 를 하면 값 타입이 복사돼 원본이 안 바뀔 수 있다.
+    private static INPUT One(ushort vk, uint flags)
+    {
+        INPUT i = new INPUT();
+        i.type = INPUT_KEYBOARD;
+        i.u.ki.wVk = vk;
+        i.u.ki.wScan = (ushort)MapVirtualKeyW(vk, 0); // MAPVK_VK_TO_VSC
+        i.u.ki.dwFlags = flags;
+        return i;
+    }
+
+    /// chord — downs 를 순서대로, ups 를 역순으로 한 번에 보낸다.
+    public static uint SendChord(ushort[] keys)
+    {
+        INPUT[] inputs = new INPUT[keys.Length * 2];
+        int n = 0;
+        for (int k = 0; k < keys.Length; k++) inputs[n++] = One(keys[k], 0);
+        for (int k = keys.Length - 1; k >= 0; k--) inputs[n++] = One(keys[k], KEYEVENTF_KEYUP);
+        return SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT r);
+    [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hWnd, IntPtr after, int x, int y, int cx, int cy, uint flags);
+    [DllImport("user32.dll", SetLastError = true)] public static extern IntPtr SendMessageTimeoutW(IntPtr hWnd, uint msg, IntPtr wp, IntPtr lp, uint flags, uint timeoutMs, out IntPtr result);
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int left, top, right, bottom; }
+
+    private delegate bool EnumProc(IntPtr hWnd, IntPtr lp);
+    [DllImport("user32.dll")] private static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint pid);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassNameW(IntPtr hWnd, System.Text.StringBuilder buf, int max);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowTextW(IntPtr hWnd, System.Text.StringBuilder buf, int max);
+
+    /// 자식 셸이 시작에 실패하면 Windows 가 `#32770` 오류 다이얼로그를 띄운다
+    /// (0xc0000142 — 콘솔 프로세스를 몰아서 만들면 세션 자원이 모자라 난다).
+    /// 그 상태의 회차는 측정이 성립하지 않으므로 감지하면 멈춘다.
+    public static string FindShellErrorDialog()
+    {
+        string hit = null;
+        EnumWindows((h, l) => {
+            if (!IsWindowVisible(h)) return true;
+            var cls = new System.Text.StringBuilder(64);
+            GetClassNameW(h, cls, cls.Capacity);
+            if (cls.ToString() != "#32770") return true;
+            var txt = new System.Text.StringBuilder(256);
+            GetWindowTextW(h, txt, txt.Capacity);
+            string t = txt.ToString();
+            if (t.IndexOf("cmd.exe", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                t.IndexOf("powershell", StringComparison.OrdinalIgnoreCase) >= 0) { hit = t; return false; }
+            return true;
+        }, IntPtr.Zero);
+        return hit;
+    }
+
+    // AGENTS.md — Process.MainWindowHandle 은 owner 가 달린 진짜 창을 건너뛰어 0 이고,
+    // FindWindow(class) 는 숨은 owner 창 (TildaZOwner) 을 집는다. pid + 보임 + 크기로 찾는다.
+    public static List<IntPtr> WindowsOf(uint pid)
+    {
+        var found = new List<IntPtr>();
+        EnumWindows((h, l) => {
+            uint p; GetWindowThreadProcessId(h, out p);
+            if (p != pid) return true;
+            if (!IsWindowVisible(h)) return true;
+            RECT r; if (!GetWindowRect(h, out r)) return true;
+            if ((r.right - r.left) < 100 || (r.bottom - r.top) < 100) return true;
+            found.Add(h);
+            return true;
+        }, IntPtr.Zero);
+        return found;
+    }
+}
+'@
+
+$VK = @{ Control = 0x11; Shift = 0x10; T = 0x54; W = 0x57 }
+$KEYEVENTF_KEYUP = 0x0002
+
+function Send-Chord {
+    param([uint16[]]$Keys)
+    # 보낸 이벤트 수가 기대와 다르면 SendInput 이 거부된 것이다 — 조용히 넘어가지 않는다.
+    $n = [TzWin]::SendChord($Keys)
+    if ($n -ne ($Keys.Count * 2)) { throw "SendInput 거부: 보낸 수 $n (기대 $($Keys.Count * 2))" }
+}
+
+function Get-TzConsole {
+    Get-CimInstance Win32_Process -Filter "Name='OpenConsole.exe'" | Where-Object { $_.ExecutablePath -like '*tildaz*' }
+}
+
+function Test-UiAlive {
+    param([IntPtr]$Hwnd)
+    # WM_NULL 을 타임아웃과 함께 보내 UI 스레드가 메시지 펌프에 응답하는지 본다.
+    # deinit 이 join 에서 막히면 여기서 0 (타임아웃) 이 돌아온다.
+    $res = [IntPtr]::Zero
+    $ok = [TzWin]::SendMessageTimeoutW($Hwnd, 0, [IntPtr]::Zero, [IntPtr]::Zero, 0x0002, 2000, [ref]$res)
+    return ($ok -ne [IntPtr]::Zero)
+}
+
+# ── 시작 전 위생
+$before = @(Get-TzConsole).Count
+"시작 전 tildaz OpenConsole = $before"
+if (-not (Test-Path $Bin)) { throw "바이너리 없음: $Bin" }
+
+# -e 회차 — config_9.toml 도 전역 hotkey 도 만들지 않는다 (AGENTS.md).
+$proc = Start-Process -FilePath $Bin -ArgumentList '--instance', '9', '-e', 'cmd.exe' -PassThru
+Start-Sleep -Seconds 3
+
+$hwnds = [TzWin]::WindowsOf([uint32]$proc.Id)
+if ($hwnds.Count -eq 0) { $proc | Stop-Process -Force -ErrorAction SilentlyContinue; throw '창을 못 찾았어요 — 앱이 떴는지 로그를 보세요.' }
+$hwnd = $hwnds[0]
+"창 hwnd=$hwnd pid=$($proc.Id)"
+
+# 다른 창이 덮고 있으면 SetForegroundWindow 도 클릭도 안 닿는다 — 잠깐 TOPMOST 로 올린다.
+[void][TzWin]::SetWindowPos($hwnd, [IntPtr](-1), 0, 0, 0, 0, 0x0003)
+[void][TzWin]::SetForegroundWindow($hwnd)
+Start-Sleep -Milliseconds 500
+
+if ([TzWin]::GetForegroundWindow() -ne $hwnd) {
+    [void][TzWin]::SetForegroundWindow($hwnd)
+    Start-Sleep -Milliseconds 500
+}
+if ([TzWin]::GetForegroundWindow() -ne $hwnd) {
+    $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+    throw '포커스를 못 잡았어요 — blind 로 키를 보내지 않고 멈춥니다.'
+}
+
+# ── 조건 확인 모드 — 단축키가 실제로 먹는지를 ConPTY 개수로 확정한다.
+# 탭 생성은 **성공 시 로그를 남기지 않으므로** (log.zig 는 실패만 적는다) 로그로는
+# "안 먹었다" 와 "먹었다" 를 가를 수 없다. 새 탭이 생기면 OpenConsole 이 하나 늘어난다.
+if ($Probe) {
+    "① 시작 상태: OpenConsole = $(@(Get-TzConsole).Count)  (탭 1 개 = 1 이 정상)"
+    Send-Chord @([uint16]$VK.Control, [uint16]$VK.Shift, [uint16]$VK.T)
+    Start-Sleep -Seconds 2
+    "② Ctrl+Shift+T 뒤: OpenConsole = $(@(Get-TzConsole).Count)  (2 여야 단축키가 먹은 것)"
+    Send-Chord @([uint16]$VK.Control, [uint16]$VK.Shift, [uint16]$VK.W)
+    Start-Sleep -Seconds 2
+    "③ Ctrl+Shift+W 뒤: OpenConsole = $(@(Get-TzConsole).Count)  (1 이면 정상 정리)"
+    Get-CimInstance Win32_Process -Filter "Name='tildaz.exe'" | Where-Object { $_.CommandLine -like '*--instance 9*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Seconds 1
+    "④ 앱 종료 뒤: OpenConsole = $(@(Get-TzConsole).Count)"
+    foreach ($x in (Get-TzConsole)) {
+        Get-CimInstance Win32_Process -Filter "ParentProcessId=$($x.ProcessId)" -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+        Stop-Process -Id $x.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+    exit 0
+}
+
+$hangCycle = -1
+$maxLeft = 0
+for ($c = 1; $c -le $Cycles; $c++) {
+    if ([TzWin]::GetForegroundWindow() -ne $hwnd) { "사이클 ${c}: 포커스 이탈 — 중단"; break }
+    Send-Chord @([uint16]$VK.Control, [uint16]$VK.Shift, [uint16]$VK.T)   # 새 탭
+    if ($HoldMs -gt 0) { Start-Sleep -Milliseconds $HoldMs }
+    if ([TzWin]::GetForegroundWindow() -ne $hwnd) { "사이클 ${c}: 포커스 이탈 — 중단"; break }
+    Send-Chord @([uint16]$VK.Control, [uint16]$VK.Shift, [uint16]$VK.W)   # 그 탭 닫기
+    Start-Sleep -Milliseconds 400
+
+    $err = [TzWin]::FindShellErrorDialog()
+    if ($err) {
+        "사이클 ${c}: **자식 셸 시작 실패 다이얼로그** [$err] — 자원 고갈이라 이 회차는 무효. 중단합니다."
+        break
+    }
+
+    $alive = Test-UiAlive -Hwnd $hwnd
+    $left = @(Get-TzConsole).Count
+    if ($left -gt $maxLeft) { $maxLeft = $left }
+    if (-not $alive) {
+        # 일시적 지연과 영구 정지를 가른다 — 최대 40 초까지 다시 물어본다.
+        $waited = 2
+        $recovered = $false
+        while ($waited -lt 40) {
+            if (Test-UiAlive -Hwnd $hwnd) { $recovered = $true; break }
+            $waited += 2
+        }
+        if ($recovered) {
+            "사이클 ${c}: UI 무응답 ${waited}초 뒤 회복 (일시적) · OpenConsole=$left"
+        } else {
+            $hangCycle = $c
+            "사이클 ${c}: **UI 영구 무응답** (40초 재확인 실패) · OpenConsole=$left"
+            break
+        }
+    }
+    if ($c % 5 -eq 0) { "사이클 ${c}: UI 정상 · OpenConsole=$left" }
+    Start-Sleep -Milliseconds $GapMs
+}
+
+$leftEnd = @(Get-TzConsole).Count
+"결과: 사이클=$Cycles hold=${HoldMs}ms · UI무응답=$(if ($hangCycle -gt 0) { "사이클 $hangCycle" } else { '없음' }) · OpenConsole 최대=$maxLeft 최종=$leftEnd"
+
+# ── 정리: 인스턴스 9 만 내린다
+Get-CimInstance Win32_Process -Filter "Name='tildaz.exe'" | Where-Object { $_.CommandLine -like '*--instance 9*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-Sleep -Seconds 1
+$after = @(Get-TzConsole).Count
+"앱 종료 뒤 남은 OpenConsole = $after"
+foreach ($x in (Get-TzConsole)) {
+    Get-CimInstance Win32_Process -Filter "ParentProcessId=$($x.ProcessId)" -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Stop-Process -Id $x.ProcessId -Force -ErrorAction SilentlyContinue
+}
+"정리 완료"

--- a/src/terminal/windows/pty.zig
+++ b/src/terminal/windows/pty.zig
@@ -231,6 +231,14 @@ extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(.c) BOOL;
 
 extern "kernel32" fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) callconv(.c) DWORD;
 
+// #611 — teardown 에서만 쓴다. `deinit` 주석에 왜 필요한지 적어 두었다.
+extern "kernel32" fn TerminateProcess(hProcess: HANDLE, uExitCode: c_uint) callconv(.c) BOOL;
+extern "kernel32" fn CancelIoEx(hFile: HANDLE, lpOverlapped: ?*OVERLAPPED) callconv(.c) BOOL;
+/// 회귀 테스트 전용 — `deinit` 이 자기 프로세스 핸들을 닫으므로 자식 종료를 밖에서 확인하려면
+/// 별도 핸들이 필요하다.
+extern "kernel32" fn OpenProcess(dwDesiredAccess: DWORD, bInheritHandle: BOOL, dwProcessId: DWORD) callconv(.c) ?HANDLE;
+const SYNCHRONIZE: DWORD = 0x00100000;
+
 extern "kernel32" fn GetLastError() callconv(.c) DWORD;
 
 extern "kernel32" fn CreateNamedPipeW(
@@ -288,6 +296,20 @@ const GENERIC_WRITE: DWORD = 0x40000000;
 const OPEN_EXISTING: DWORD = 3;
 const WAIT_OBJECT_0: DWORD = 0;
 const ERROR_IO_PENDING: DWORD = 997;
+
+/// `ClosePseudoConsole` 이 보낸 `CTRL_CLOSE_EVENT` 를 자식이 처리할 시간 (#611).
+///
+/// Windows 는 콘솔 창을 닫을 때 핸들러에 5 초를 주지만 ([`HandlerRoutine`](https://learn.microsoft.com/en-us/windows/console/handlerroutine)),
+/// 그때는 창이 이미 사라져 **아무도 기다리지 않는다.** 우리는 UI 스레드가 `deinit` 안에서
+/// 기다리므로 그 값을 그대로 쓸 수 없다. 그리고 이벤트를 *놓친* 자식은 더 기다려도 끝나지
+/// 않는다 — 전달 자체가 안 된 것이라 시간 문제가 아니다. 그래서 이 값의 근거는 "종료 훅을
+/// 도는 셸에게 주는 시간" 하나뿐이고, 그 몫으로 1 초를 둔다. 정상 경로는 자식이 곧바로 죽어
+/// 이 상한에 닿지 않는다.
+const CHILD_EXIT_GRACE_MS: DWORD = 1000;
+
+/// `TerminateProcess` 뒤 커널이 프로세스를 내리는 것을 기다리는 상한. 강제 종료라 즉시
+/// 끝나지만, 그래도 안 끝나면 기다려도 소용없으므로 짧게 둔다.
+const CHILD_TERMINATE_WAIT_MS: DWORD = 500;
 const READ_BUF_SIZE: usize = 128 * 1024;
 
 pub const ConPty = struct {
@@ -675,8 +697,37 @@ pub const ConPty = struct {
     /// 호출이 자식 정리까지 OS API 추상화. macOS 는 fd 직접 다루므로 시그널
     /// (`kill(-pid, SIGHUP)`) 로 자식 종료를 직접 trigger 해야 함.
     pub fn deinit(self: *ConPty) void {
-        // ClosePseudoConsole 가 output pipe 를 끊어주므로 readLoop 가 빠져나옴
+        // `ClosePseudoConsole` 은 **아직 연결된 클라이언트에게 `CTRL_CLOSE_EVENT` 를 보낼
+        // 뿐**이다. 자식이 끊기면 conpty 가 자기 쪽 pipe 를 닫아 readLoop 이 EOF 로 빠져나온다.
+        // ([문서](https://learn.microsoft.com/en-us/windows/console/closepseudoconsole) Remarks —
+        // 부르는 쪽은 ① 미리 output pipe 를 닫거나 ② 반환한 뒤에도 계속 읽어야 한다. 우리는 ② 다.)
         conpty_close_fn.?(self.hpc);
+
+        // ⚠️ 자식이 **막 시작해 콘솔 컨트롤 핸들러를 세우기 전**이면 그 이벤트를 놓치고 계속
+        // 연결된 채 남는다. 그러면 conpty 가 pipe 를 닫지 않아 readLoop 의 overlapped read 가
+        // 끝나지 않고, 아래 두 join 이 **영원히** 안 풀린다 ([#611](https://github.com/ensky0/tildaz/issues/611)).
+        // 실기에서 탭 생성 직후 닫기로 재현했다 — UI 스레드가 여기서 멈춰 앱 전체가 얼어붙었다
+        // (`WM_NULL` 40 초 무응답). Windows 11 24H2 부터 `ClosePseudoConsole` 자체는 즉시
+        // 반환하므로 그 호출이 아니라 **join** 에서 막힌다.
+        //
+        // 그래서 자식이 실제로 끝났는지 확인하고, 유예 안에 안 끝나면 강제로 끝낸다. 자식이
+        // 끝나야 conpty 가 pipe 를 닫고 readLoop 도 `processWaitLoop` 도 스스로 풀린다.
+        // **정상 경로에서는 자식이 곧바로 죽으므로 이 대기가 사실상 0 이다.**
+        if (WaitForSingleObject(self.process_info.hProcess, CHILD_EXIT_GRACE_MS) != WAIT_OBJECT_0) {
+            log.appendLine(
+                "conpty",
+                "child still attached {d}ms after CTRL_CLOSE_EVENT — terminating (pid={d})",
+                .{ CHILD_EXIT_GRACE_MS, self.process_info.dwProcessId },
+            );
+            _ = TerminateProcess(self.process_info.hProcess, 1);
+            _ = WaitForSingleObject(self.process_info.hProcess, CHILD_TERMINATE_WAIT_MS);
+        }
+
+        // 자식이 끝나면 conpty 가 pipe 를 닫아 readLoop 이 스스로 나오지만, 그 시점에 걸려
+        // 있던 overlapped read 는 명시로 깨워 준다 — Windows Terminal 의 `ConptyConnection::Close`
+        // 도 출력 스레드를 `CancelIoEx` 로 깨운다. 취소된 read 는 `GetOverlappedResult` 실패로
+        // 돌아와 readLoop 의 `break` 를 탄다.
+        if (self.read_thread != null) _ = CancelIoEx(self.pipe_out_read, null);
 
         if (self.read_thread) |t| {
             t.join();
@@ -880,4 +931,31 @@ test "conpty create and destroy" {
     };
     defer pty.deinit();
     try std.testing.expect(pty.isProcessAlive());
+}
+
+// #611 — `deinit` 이 **자식을 남기지 않는다.** 이 테스트가 원래 증상이 나오던 자리다:
+// `init` 직후 곧바로 `deinit` 하면 자식이 `CTRL_CLOSE_EVENT` 를 놓칠 수 있고, 그러면
+// 예전 코드는 `zig build test` 회차마다 `OpenConsole.exe` 를 하나씩 남기거나 (read
+// thread 가 없는 이 경로) 아예 join 에서 멈췄다 (앱 경로).
+//
+// 자식 핸들은 `deinit` 이 닫으므로 **미리 따로 열어 두고** 그것으로 종료를 확인한다.
+// `deinit` 이 유한 시간에 반환하는 것 자체도 이 테스트가 검사한다 — 회귀하면 테스트가
+// 끝나지 않는다.
+test "#611 conpty deinit leaves no attached client" {
+    const shell = std.unicode.utf8ToUtf16LeStringLiteral("cmd.exe");
+    var pty = ConPty.init(std.testing.allocator, 80, 24, shell, null, null) catch |err| switch (err) {
+        error.ConptyRuntimeUnavailable => return error.SkipZigTest,
+        else => return err,
+    };
+    const child = OpenProcess(SYNCHRONIZE, .FALSE, pty.process_info.dwProcessId);
+    defer if (child) |h| {
+        _ = CloseHandle(h);
+    };
+
+    pty.deinit(); // 대기 없이 곧바로 — 자식이 아직 핸들러를 못 세운 창이다
+
+    if (child) |h| {
+        // `deinit` 이 돌아왔다면 자식은 이미 끝났어야 한다 (스스로 끝났든 강제로 끝났든).
+        try std.testing.expectEqual(WAIT_OBJECT_0, WaitForSingleObject(h, 2000));
+    }
 }


### PR DESCRIPTION
`ClosePseudoConsole` 은 [문서](https://learn.microsoft.com/en-us/windows/console/closepseudoconsole)대로 **연결된 클라이언트에게 `CTRL_CLOSE_EVENT` 를 보낼 뿐**이다. 자식이 막 시작해 콘솔 컨트롤 핸들러를 세우기 전이면 그 이벤트를 놓치고 계속 연결된 채 남고, 그러면 conpty 가 출력 pipe 를 닫지 않아 `readLoop` 의 overlapped read 가 끝나지 않는다. `deinit` 은 그 스레드를 **무제한 join** 하고 있어서 거기서 영원히 막혔다 — **탭 닫기가 UI 스레드에서 멈춰 앱 전체가 얼어붙는다.**

[#611](https://github.com/ensky0/tildaz/issues/611) 에 처음 보고된 증상은 `zig build test` 가 회차마다 `OpenConsole.exe` 를 하나 남기는 것이었는데, 그것은 read thread 가 없는 테스트 경로에서 같은 원인이 가볍게 나타난 것이었다. 원인 규명 전말은 [#611 댓글](https://github.com/ensky0/tildaz/issues/611#issuecomment-5548314307)에 있다.

## 고친 것

`ClosePseudoConsole` 뒤에 자식이 실제로 끝났는지 확인하고, 유예 (1 초) 안에 안 끝나면 `TerminateProcess` 로 끝낸다. 자식이 끝나야 conpty 가 pipe 를 닫고 `readLoop` 도 `processWaitLoop` 도 스스로 풀린다. 그다음 `CancelIoEx` 로 걸려 있던 overlapped read 를 깨운다 (Windows Terminal 의 `ConptyConnection::Close` 와 같은 자리). **정상 경로에서는 자식이 곧바로 죽으므로 이 대기가 사실상 0 이다.**

유예 값의 근거는 `CHILD_EXIT_GRACE_MS` 주석에 적었다 — 이벤트를 *놓친* 자식은 더 기다려도 끝나지 않으므로 (전달 자체가 안 된 것이라 시간 문제가 아니다), 이 값이 지키는 것은 "종료 훅을 도는 셸에게 주는 시간" 뿐이다.

이로써 Windows 도 macOS · Linux 와 **같은 모양**이 됐다 (POSIX 는 `SIGHUP` → 500 ms → `SIGKILL`). 관례로 보면 Windows Terminal 은 자식을 강제 종료하지 않는 대신 출력 스레드를 `CancelIoEx` + 타임아웃 루프로 깨우고, WezTerm 은 스레드 join 자체를 하지 않는다. **우리는 join 을 하므로 자식 정리까지 책임져야 한다.**

## 검증 (노트북 i5-1240P · Windows 11 Education 10.0.26200 · 60 Hz · zig 0.16.0)

`pty.zig` 만 태우는 드라이버로 수정 전 조건을 그대로 다시 쟀다.

| 조건 | 수정 전 | 수정 후 |
|---|---|---|
| read thread 있음 · 대기 0 ms · 한 프로세스 10 회 연속 | `deinit` 이 **10 분 넘게 멈춤** | 정상 종료 · 잔존 0 |
| read thread 없음 · 대기 0 ms · 10 회 | 잔존 **1~2/10** | HANG 0/10 · 잔존 **0/10** |
| read thread 있음 · 대기 0 ms · 10 회 | (조건 1 에서 멈춤) | HANG 0/10 · 잔존 **0/10** |

앱 실기 (`--instance 9 -e cmd.exe` 로 `Ctrl+Shift+T` 직후 `Ctrl+Shift+W`) 는 수정 전 **사이클 1 에서 UI 영구 무응답** (`WM_NULL` 40 초) 이었고 앱을 강제 종료한 뒤에도 OpenConsole 이 남았는데, 수정 뒤 같은 조건에서 UI 무응답 없이 지나갔다. 다만 그 회차는 3 사이클에서 자식 `cmd.exe` 가 `0xc0000142` 로 시작 실패해 무효 처리됐으므로, **통계의 근거는 위 드라이버 표**다.

`zig fmt --check` · `zig build check` (6 타겟) · `zig build test` (368 passed / 12 skipped / 0 failed, 회차 뒤 잔존 0) 통과.

## 함께 넣은 것

- **회귀 테스트** `#611 conpty deinit leaves no attached client` — `init` 직후 `deinit` 하고, 미리 열어 둔 핸들로 자식 종료를 확인한다. `deinit` 이 유한 시간에 반환하는 것도 이 테스트가 검사한다 (회귀하면 테스트가 끝나지 않는다). 다만 원 증상의 재현율이 낮아 (수정 전 1/10) **매 회차 잡지는 못한다** — 강한 쪽은 아래 실기 하네스다.
- **실기 하네스** [`dist/windows/tab-churn-check.ps1`](dist/windows/tab-churn-check.ps1) — 탭 생성 직후 닫기를 반복하며 `WM_NULL` 로 UI 생존을 본다. 밟은 함정 셋을 머리 주석에 적었다.
  - `SendInput` 의 `wScan` 미기입 — 키가 앱에 안 닿는데 화면상 아무 일도 안 일어나 **"정상" 으로 오독**한다 (회차 하나를 그렇게 버렸다).
  - **탭 생성은 성공 시 로그를 남기지 않는다** (`log.zig` 는 실패만 적는다) — 판정은 ConPTY 개수 1 → 2 로 한다.
  - 간격 없이 몰아 돌리면 자식이 `0xc0000142` 로 시작 실패해 **사용자 화면에** 오류 다이얼로그가 뜬다 — 그 회차는 무효이고 `#32770` 감지로 멈춘다.
- **`SPEC.md` §8** — Windows 칸이 "`ClosePseudoConsole` 한 호출" · fallback "(자동)" 이었는데 **둘 다 사실이 아니었다.** 실제 순서와 근거를 적었다.
- **`UNRELEASED.md`** 본문 후보 한 줄.

Closes #611
