### PR TITLE
refactor(render): atlas 패킹 상태 · 찼음 표시 규칙 · 크기 정책을 glyph_atlas_common.Packer 로 (#604)

### DIFF
--- a/src/log.zig
+++ b/src/log.zig
@@ -294,9 +294,11 @@ pub fn logPrimaryFont(family: []const u8, cell_w: anytype, cell_h: anytype, asce
 ///
 /// 비우고 재사용하는 대신 키우면 **프레임 중간에 비우는 상황 자체가 없어진다** — 이미 그린
 /// 것의 UV 가 무효화될 일이 없다. 이 줄이 자주 보이면 `INITIAL_ATLAS_SIZE` 를 올릴 근거다.
-pub fn logAtlasGrew(new_size: anytype, grows: anytype, glyphs: anytype, clusters: anytype) void {
-    appendLine("gpu", "atlas grew to {d}x{d} (grows={d}, glyphs={d}, clusters={d})", .{
-        new_size, new_size, grows, glyphs, clusters,
+pub fn logAtlasGrew(kind: []const u8, new_size: anytype, grows: anytype, glyphs: anytype, clusters: anytype) void {
+    // #604 — `kind` 는 `logAtlasFull` 과 같은 자리다. Linux 는 gray · color surface 가 따로 커지므로 어느 쪽인지
+    // 없으면 `glyphs` 수로 유추해야 했다 (실측에서 `glyphs=9` 가 color 였다). macOS · Windows 는 `main`.
+    appendLine("gpu", "atlas grew to {d}x{d} ({s}, grows={d}, glyphs={d}, clusters={d})", .{
+        new_size, new_size, kind, grows, glyphs, clusters,
     });
 }
 

--- a/src/renderer/glyph_atlas_common.zig
+++ b/src/renderer/glyph_atlas_common.zig
@@ -119,6 +119,9 @@ pub const Packer = struct {
     /// **실패할 때도 커서를 움직인다** (줄바꿈 분기가 높이 검사보다 앞이다) — 그래서 "빈 atlas 였나" 는
     /// 호출 **전** 값으로 판정해야 한다 (`tryPack` 이 그렇게 한다).
     pub fn pack(self: *Packer, w: u32, h: u32) ?[2]u32 {
+        // 너비가 atlas 보다 크면 어느 줄에도 못 들어간다 — 옛 `packRow` 는 이것을 검사하지 않아 줄바꿈 뒤 x=0
+        // 에 놓고 오른쪽으로 넘쳤다 (글리프가 256 px 이하라 실제로는 걸리지 않던 잠재 결함 · #604 테스트가 드러냈다).
+        if (w + pad > self.size) return null;
         if (self.cursor_x + w + pad > self.size) {
             self.cursor_x = 0;
             self.cursor_y += self.row_height + pad;
@@ -205,17 +208,21 @@ test "Packer — 한 줄에 안 들어가면 다음 줄로, 다 차면 null (커
     try std.testing.expectEqual([2]u32{ 5, 0 }, p.pack(4, 3).?); // 4 + pad 1
     try std.testing.expectEqual([2]u32{ 0, 4 }, p.pack(4, 3).?); // 줄바꿈 — 3 + pad 1
     try std.testing.expectEqual([2]u32{ 0, 8 }, p.pack(9, 2).?); // 넓은 것 — 다음 줄
-    try std.testing.expect(p.pack(1, 3) == null); // 8 + 3 > 10
-    try std.testing.expectEqual(@as(u32, 10), p.filledY());
+    try std.testing.expect(p.pack(1, 3) == null); // 줄바꿈 (y 8 → 11) 뒤 11 + 3 > 10
+    try std.testing.expectEqual(@as(u32, 11), p.filledY()); // 실패한 호출도 커서를 옮겼다
+    try std.testing.expect(p.pack(11, 1) == null); // 너비가 atlas 보다 크면 어느 줄에도 못 들어간다
 }
 
 test "Packer.tryPack — 빈 atlas 에도 안 들어가면 too_big, 아니면 full" {
-    var p = Packer{ .size = 8 };
-    try std.testing.expect(p.tryPack(9, 1) == .too_big);
+    var p = Packer{ .size = 10 };
+    try std.testing.expect(p.tryPack(11, 1) == .too_big); // 너비
+    try std.testing.expect(p.tryPack(1, 11) == .too_big); // 높이 — 빈 atlas 라 full 이 아니다
     p.rewind();
-    try std.testing.expect(p.tryPack(4, 4) == .placed);
-    try std.testing.expect(p.tryPack(4, 4) == .placed);
-    try std.testing.expect(p.tryPack(4, 4) == .full);
+    try std.testing.expect(p.tryPack(4, 4) == .placed); // (0,0)
+    try std.testing.expect(p.tryPack(4, 4) == .placed); // (5,0)
+    try std.testing.expect(p.tryPack(4, 4) == .placed); // (0,5)
+    try std.testing.expect(p.tryPack(4, 4) == .placed); // (5,5)
+    try std.testing.expect(p.tryPack(4, 4) == .full); // 줄바꿈 뒤 10 + 4 > 10 — 담긴 것이 있으니 full
     p.rewind();
     try std.testing.expect(p.isEmpty());
 }

--- a/src/renderer/glyph_atlas_common.zig
+++ b/src/renderer/glyph_atlas_common.zig
@@ -95,27 +95,84 @@ pub const ClusterKey = struct {
     indices_hash: u64,
 };
 
-/// 단순 row-based atlas packing. cursor / row_height 상태를 포인터로 받아
-/// 갱신하고 배치 좌표 (x, y) 를 반환. 현재 row 에 안 들어가면 다음 row 로,
-/// atlas 가 가득 차면 null (caller 가 reset 후 재시도).
-pub fn packRow(cursor_x: *u32, cursor_y: *u32, row_height: *u32, atlas_size: u32, w: u32, h: u32) ?[2]u32 {
-    const pad = 1; // 글리프 간 1px padding.
+/// #586 — 시작 크기와 상한. 세 platform 이 같은 값 · 같은 정책이다 — **차면 두 배로 키운다** (`Packer.grownSize`),
+/// 상한에서만 ① 안전망 (비우기). 8192² 는 BGRA8 로 256 MB 다. 실제 상한은 platform 이 더 낮출 수 있다 (Linux 는
+/// 드라이버 `GL_MAX_TEXTURE_SIZE` 와의 최소, Windows 는 텍스처 생성 실패).
+pub const INITIAL_ATLAS_SIZE: u32 = 2048;
+pub const MAX_ATLAS_SIZE: u32 = 8192;
 
-    if (cursor_x.* + w + pad > atlas_size) {
-        cursor_x.* = 0;
-        cursor_y.* += row_height.* + pad;
-        row_height.* = 0;
+/// #604 — row-based packing 상태 + 지금 크기. 세 platform 의 atlas (Linux 는 surface 마다) 가 이 struct 하나를
+/// 들고 `pack` · `tryPack` · `rewind` · `grownSize` 를 쓴다. 예전에는 세 파일이 `cursor_x` · `cursor_y` · `row_height`
+/// 세 필드와 "찼음 표시" 규칙을 각자 들고 있어서 (`packRow` 가 포인터 세 개를 받는 시그니처였다) Windows 만 빈
+/// atlas 가드가 빠져 있던 식의 누락이 났다 (#586). 픽셀을 어디에 어떻게 두는지 (CPU 사본 · D3D 텍스처 · GL
+/// shadow) 는 여기 없다 — platform 몫이다.
+pub const Packer = struct {
+    cursor_x: u32 = 0,
+    cursor_y: u32 = 0,
+    row_height: u32 = 0,
+    /// 지금 한 변 (px).
+    size: u32 = INITIAL_ATLAS_SIZE,
+
+    pub const pad: u32 = 1; // 글리프 간 1px padding.
+
+    /// 자리를 잡고 배치 좌표 (x, y) 를 돌려준다. 현재 row 에 안 들어가면 다음 row 로, atlas 가 가득 차면 null.
+    /// **실패할 때도 커서를 움직인다** (줄바꿈 분기가 높이 검사보다 앞이다) — 그래서 "빈 atlas 였나" 는
+    /// 호출 **전** 값으로 판정해야 한다 (`tryPack` 이 그렇게 한다).
+    pub fn pack(self: *Packer, w: u32, h: u32) ?[2]u32 {
+        if (self.cursor_x + w + pad > self.size) {
+            self.cursor_x = 0;
+            self.cursor_y += self.row_height + pad;
+            self.row_height = 0;
+        }
+        if (self.cursor_y + h > self.size) return null;
+        const x = self.cursor_x;
+        const y = self.cursor_y;
+        self.cursor_x += w + pad;
+        if (h > self.row_height) self.row_height = h;
+        return .{ x, y };
     }
 
-    if (cursor_y.* + h > atlas_size) return null;
+    /// 아무것도 담지 않은 상태인가.
+    pub fn isEmpty(self: *const Packer) bool {
+        return self.cursor_x == 0 and self.cursor_y == 0 and self.row_height == 0;
+    }
 
-    const x = cursor_x.*;
-    const y = cursor_y.*;
-    cursor_x.* += w + pad;
-    if (h > row_height.*) row_height.* = h;
+    pub const PackResult = union(enum) {
+        placed: [2]u32,
+        /// 찼다 — 비울 (또는 키울) 가치가 있다.
+        full,
+        /// **이미 빈 atlas 인데 안 들어간다** — 그림 하나가 atlas 보다 크다. 비워도 소용없고, 이것을 "찼다" 로
+        /// 세우면 호출자가 글리프마다 헛되게 flush + reset 을 돈다 (#584 ①).
+        too_big,
+    };
 
-    return .{ x, y };
-}
+    /// `pack` + "찼음 표시" 규칙 (macOS `packOrMarkFull` · Linux `glAddGlyph` · Windows #586 가 같은 두 조건).
+    pub fn tryPack(self: *Packer, w: u32, h: u32) PackResult {
+        const was_empty = self.isEmpty();
+        if (self.pack(w, h)) |pos| return .{ .placed = pos };
+        return if (was_empty) .too_big else .full;
+    }
+
+    /// 커서를 처음으로 되돌린다. 픽셀은 건드리지 않는다 — 다음에 담기는 글리프가 그 위를 덮어쓴다.
+    pub fn rewind(self: *Packer) void {
+        self.cursor_x = 0;
+        self.cursor_y = 0;
+        self.row_height = 0;
+    }
+
+    /// 로그용 — 지금까지 채운 높이 (`atlas full` 의 `filled_y`).
+    pub fn filledY(self: *const Packer) u32 {
+        return self.cursor_y + self.row_height;
+    }
+
+    /// #586 — 두 배로 키울 때의 다음 크기. 상한 (`max`) 을 넘으면 null — 호출자가 ① 안전망으로 물러선다.
+    /// 좌표는 그대로 유효하다 (row-based packing 이라 (x, y) 가 보존되고 커서도 이어 쓴다) — 픽셀을 옮기는
+    /// 것은 platform 이 한다.
+    pub fn grownSize(self: *const Packer, max: u32) ?u32 {
+        const next = self.size * 2;
+        return if (next > max) null else next;
+    }
+};
 
 const std = @import("std");
 
@@ -140,6 +197,36 @@ test "fontId — 빈 이름도 값을 낸다 (이름을 못 읽은 경우)" {
     // 그림이 섞일 수 있지만 atlas 를 부풀리지는 않는다.
     try std.testing.expectEqual(fontId(""), fontId(""));
     try std.testing.expect(fontId("") != fontId("Menlo-Regular"));
+}
+
+test "Packer — 한 줄에 안 들어가면 다음 줄로, 다 차면 null (커서는 실패 뒤에도 움직인다)" {
+    var p = Packer{ .size = 10 };
+    try std.testing.expectEqual([2]u32{ 0, 0 }, p.pack(4, 3).?);
+    try std.testing.expectEqual([2]u32{ 5, 0 }, p.pack(4, 3).?); // 4 + pad 1
+    try std.testing.expectEqual([2]u32{ 0, 4 }, p.pack(4, 3).?); // 줄바꿈 — 3 + pad 1
+    try std.testing.expectEqual([2]u32{ 0, 8 }, p.pack(9, 2).?); // 넓은 것 — 다음 줄
+    try std.testing.expect(p.pack(1, 3) == null); // 8 + 3 > 10
+    try std.testing.expectEqual(@as(u32, 10), p.filledY());
+}
+
+test "Packer.tryPack — 빈 atlas 에도 안 들어가면 too_big, 아니면 full" {
+    var p = Packer{ .size = 8 };
+    try std.testing.expect(p.tryPack(9, 1) == .too_big);
+    p.rewind();
+    try std.testing.expect(p.tryPack(4, 4) == .placed);
+    try std.testing.expect(p.tryPack(4, 4) == .placed);
+    try std.testing.expect(p.tryPack(4, 4) == .full);
+    p.rewind();
+    try std.testing.expect(p.isEmpty());
+}
+
+test "Packer.grownSize — 두 배씩, 상한을 넘으면 null" {
+    var p = Packer{ .size = 2048 };
+    try std.testing.expectEqual(@as(?u32, 4096), p.grownSize(8192));
+    p.size = 8192;
+    try std.testing.expectEqual(@as(?u32, null), p.grownSize(8192));
+    p.size = 4096;
+    try std.testing.expectEqual(@as(?u32, null), p.grownSize(4096)); // 드라이버 상한이 더 낮은 경우 (Linux)
 }
 
 test "ClusterKey — 폰트만 다르면 다른 키다" {

--- a/src/renderer/linux/gl_atlas.zig
+++ b/src/renderer/linux/gl_atlas.zig
@@ -39,8 +39,8 @@ pub const AtlasEntry = atlas_common.AtlasEntry;
 /// #586 — 시작 크기와 상한. macOS · Windows 와 같은 값 · 같은 정책 — **차면 두 배로 키운다** (`Surface.grow`),
 /// 상한에서만 ① 안전망 (비우기). 실제 상한은 `MAX_ATLAS_SIZE` 와 드라이버의 `GL_MAX_TEXTURE_SIZE` 중 작은 쪽이다
 /// (`Atlas.max_size`). surface 마다 크기가 따로다 — color 는 폰트 strike 크기로 담겨 gray 보다 훨씬 먼저 찬다.
-pub const INITIAL_ATLAS_SIZE: u32 = 2048;
-pub const MAX_ATLAS_SIZE: u32 = 8192;
+pub const INITIAL_ATLAS_SIZE: u32 = atlas_common.INITIAL_ATLAS_SIZE;
+pub const MAX_ATLAS_SIZE: u32 = atlas_common.MAX_ATLAS_SIZE;
 
 /// 글리프 캐시 키. Linux 폰트 경로는 codepoint lookup 과 glyph_index lookup 두
 /// 갈래가 있어 (`Context.glyph` / `Context.glyphByIndex`) 어느 쪽인지 구분해야
@@ -96,13 +96,10 @@ const composed_source: u8 = 0xFD;
 /// 한 텍스처와 그 패킹 상태.
 const Surface = struct {
     texture: u32 = 0,
-    cursor_x: u32 = 0,
-    cursor_y: u32 = 0,
-    row_height: u32 = 0,
+    /// #604 — 패킹 상태 + 지금 크기 (`size`). 세 platform 공통 (`atlas_common.Packer`).
+    pack: atlas_common.Packer = .{},
     /// atlas 가 가득 차 초기화된 횟수. 진단용 (자주 일어나면 크기를 늘려야 한다).
     resets: u32 = 0,
-    /// #586 — 지금 한 변 (px). `grow` 가 두 배로 키운다.
-    size: u32 = INITIAL_ATLAS_SIZE,
     /// #586 — 키운 횟수 (진단).
     grows: u32 = 0,
     format: i32,
@@ -117,7 +114,7 @@ const Surface = struct {
     shadow: []u8 = &.{},
 
     fn create(api: *const egl.Api, allocator: std.mem.Allocator, format: i32, filter: i32, bpp: u32, size: u32) Surface {
-        var self: Surface = .{ .format = format, .filter = filter, .bpp = bpp, .size = size };
+        var self: Surface = .{ .format = format, .filter = filter, .bpp = bpp, .pack = .{ .size = size } };
         self.shadow = allocator.alloc(u8, @as(usize, size) * size * bpp) catch &.{};
         if (self.shadow.len > 0) @memset(self.shadow, 0);
         self.texture = self.makeTexture(api);
@@ -146,8 +143,8 @@ const Surface = struct {
             egl.GL_TEXTURE_2D,
             0,
             self.format,
-            @intCast(self.size),
-            @intCast(self.size),
+            @intCast(self.pack.size),
+            @intCast(self.pack.size),
             0,
             @bitCast(self.format),
             egl.GL_UNSIGNED_BYTE,
@@ -163,18 +160,17 @@ const Surface = struct {
     /// 상한 (`max_size`) · shadow 없음 · 할당 실패면 `false`.
     fn grow(self: *Surface, api: *const egl.Api, allocator: std.mem.Allocator, max_size: u32) bool {
         if (self.shadow.len == 0) return false;
-        if (self.size * 2 > max_size) return false;
-        const new_size = self.size * 2;
+        const new_size = self.pack.grownSize(max_size) orelse return false;
         const new_shadow = allocator.alloc(u8, @as(usize, new_size) * new_size * self.bpp) catch return false;
         @memset(new_shadow, 0);
-        const old_row = @as(usize, self.size) * self.bpp;
+        const old_row = @as(usize, self.pack.size) * self.bpp;
         const new_row = @as(usize, new_size) * self.bpp;
-        for (0..self.size) |y| {
+        for (0..self.pack.size) |y| {
             @memcpy(new_shadow[y * new_row ..][0..old_row], self.shadow[y * old_row ..][0..old_row]);
         }
         allocator.free(self.shadow);
         self.shadow = new_shadow;
-        self.size = new_size;
+        self.pack.size = new_size;
         var old_tex = self.texture;
         self.texture = self.makeTexture(api);
         api.deleteTextures(1, @ptrCast(&old_tex));
@@ -186,7 +182,7 @@ const Surface = struct {
     /// 같은 순서 (color 는 이미 RGBA 로 바뀐 것) 다.
     fn writeShadow(self: *Surface, x: u32, y: u32, w: u32, h: u32, pixels: [*]const u8) void {
         if (self.shadow.len == 0) return;
-        const row = @as(usize, self.size) * self.bpp;
+        const row = @as(usize, self.pack.size) * self.bpp;
         const src_row = @as(usize, w) * self.bpp;
         for (0..h) |r| {
             const dst = (y + r) * row + @as(usize, x) * self.bpp;
@@ -196,9 +192,7 @@ const Surface = struct {
 
     /// 패킹 커서를 처음으로 되돌린다. 텍스처 내용은 그대로 두고 덮어쓴다.
     fn rewind(self: *Surface) void {
-        self.cursor_x = 0;
-        self.cursor_y = 0;
-        self.row_height = 0;
+        self.pack.rewind();
     }
 
     /// 가득 차서 비우는 경우 — 진단 카운터를 올린다. 폰트가 바뀌어 비우는
@@ -352,7 +346,7 @@ pub const Atlas = struct {
         // 로그 값은 **비우기 전에** 읽는다 — 그것이 이 surface 가 실제로 담을 수 있었던 양이다.
         // Linux 는 cluster 를 별도 맵에 두지 않는다 (인덱스 캐시 하나다) — cluster · fonts 칸은 0.
         const held = cache.count();
-        const filled_y = surface.cursor_y + surface.row_height;
+        const filled_y = surface.pack.filledY();
         cache.clearRetainingCapacity();
         surface.reset();
         // 사용자 로그에 남긴다 — 문구는 세 platform 공통 정의를 쓴다 (#576).
@@ -396,42 +390,29 @@ pub const Atlas = struct {
         }
 
         const surface = self.surfaceFor(is_color);
-        // `packRow` 는 **실패할 때도 커서를 움직인다** (줄바꿈 분기가 높이 검사보다 앞이다).
-        // 그래서 "비우면 들어갈 여지가 있었나" 는 호출 **전** 값으로 판정해야 한다.
-        const before_x = surface.cursor_x;
-        const before_y = surface.cursor_y;
+        // #604 — "빈 surface 였나" 는 호출 **전** 값으로 판정한다 (`Packer.pack` 은 실패할 때도 커서를 움직인다).
+        const was_empty = surface.pack.isEmpty();
 
-        const placed = atlas_common.packRow(
-            &surface.cursor_x,
-            &surface.cursor_y,
-            &surface.row_height,
-            surface.size,
-            bmp.w,
-            bmp.h,
-        ) orelse blk: {
+        const placed = surface.pack.pack(bmp.w, bmp.h) orelse blk: {
             // #586 — **먼저 키운다** (macOS #584 ② · Windows 와 같다). 키우면 프레임 중간에 비우는 상황이
             // 없어 이미 쌓인 정점의 UV 가 무효화되지 않는다 — UV 는 픽셀 좌표고 셰이더가 `u_atlas_size`
-            // 로 정규화한다 (`gl_text`). `packRow` 가 실패하며 옮긴 커서는 그대로 두고 (더 큰 atlas 안에서
+            // 로 정규화한다 (`gl_text`). `pack` 이 실패하며 옮긴 커서는 그대로 두고 (더 큰 atlas 안에서
             // 여전히 유효한 자리다) 이어서 담는다. 상한이면 아래 ① 로.
             while (surface.grow(api, allocator, self.max_size)) {
-                log.logAtlasGrew(surface.size, surface.grows, cache.count(), 0);
-                if (atlas_common.packRow(&surface.cursor_x, &surface.cursor_y, &surface.row_height, surface.size, bmp.w, bmp.h)) |p| break :blk p;
+                log.logAtlasGrew(if (is_color) "color" else "gray", surface.pack.size, surface.grows, cache.count(), 0);
+                if (surface.pack.pack(bmp.w, bmp.h)) |p| break :blk p;
             }
             // #584 ① — 가득 찼다. **그 자리에서 비우지 않는다.**
             //
-            // 이 프레임이 이미 emit 한 정점들이 이 atlas 좌표를 가리키고 있고, UV 는
-            // `gl_text.Batch.add` 시점에 굽는다. 여기서 rewind 하면 뒤이어 올라오는
-            // 글리프가 그 자리를 덮어써서 **앞의 글자들이 다른 글자로 바뀐다** (Linux 는
-            // 텍스처를 0 으로 지우지 않으므로 사라지는 대신 바뀐다). 2026-09-02 KDE 실기에서
-            // 화면 위쪽 6.22 줄이 그렇게 어긋나는 것을 확인했다.
+            // 이 프레임이 이미 emit 한 정점들이 이 atlas 좌표를 가리키고 있고, 여기서 rewind 하면 뒤이어
+            // 올라오는 글리프가 그 자리를 덮어써서 **앞의 글자들이 다른 글자로 바뀐다** (Linux 는 텍스처를
+            // 0 으로 지우지 않으므로 사라지는 대신 바뀐다). 2026-09-02 KDE 실기에서 화면 위쪽 6.22 줄이
+            // 그렇게 어긋나는 것을 확인했다. 그래서 표시만 하고 돌아간다 — 호출자가 batch 를 flush 해
+            // 그린 뒤 `resetFull` 을 부르고 한 번만 재시도한다 (SPEC §12.6 ①).
             //
-            // 그래서 표시만 하고 돌아간다. 호출자가 batch 를 flush 해 그린 뒤 `resetFull`
-            // 을 부르고 한 번만 재시도한다 (SPEC §12.6 ①).
-            //
-            // **이미 빈 surface 인데도 안 들어가면 표시하지 않는다** — 비워도 못 담는다는
-            // 뜻이라 (그림 하나가 atlas 보다 크다), 표시하면 호출자가 글리프마다 헛되게
-            // flush + reset 을 한다.
-            if (before_x != 0 or before_y != 0) {
+            // **이미 빈 surface 인데도 안 들어가면 표시하지 않는다** (`Packer.tryPack` 의 `too_big` 과 같은
+            // 규칙) — 비워도 못 담는다는 뜻이라, 표시하면 호출자가 글리프마다 헛되게 flush + reset 을 한다.
+            if (!was_empty) {
                 self.full = if (is_color) .color else .gray;
             }
             return null;
@@ -492,11 +473,11 @@ pub const Atlas = struct {
 
     /// #586 — 셰이더의 `u_atlas_size` 에 줄 지금 크기 (surface 별).
     pub fn graySize(self: *const Atlas) u32 {
-        return self.gray.size;
+        return self.gray.pack.size;
     }
 
     pub fn colorSize(self: *const Atlas) u32 {
-        return self.color.size;
+        return self.color.pack.size;
     }
 
     /// 진단용 — atlas 가 몇 번 가득 차 비워졌는지. `grow` 가 상한에 닿은 뒤에만 일어난다.

--- a/src/renderer/macos.zig
+++ b/src/renderer/macos.zig
@@ -279,7 +279,7 @@ pub const MetalRenderer = struct {
     staging_bytes: u32 = 0,
     tab_staging_buffer: objc.id,
     tab_staging_bytes: u32 = 0,
-    /// #584 ② — `atlas_texture` 를 만들 때의 한 변. `atlas.size` 가 이보다 커지면
+    /// #584 ② — `atlas_texture` 를 만들 때의 한 변. `atlas.pack.size` 가 이보다 커지면
     /// (`grow`) 텍스처를 새로 만들어야 한다 (`syncAtlasTexture`).
     atlas_texture_size: u32 = INITIAL_ATLAS_SIZE,
     tab_atlas_texture: objc.id,
@@ -1914,8 +1914,8 @@ pub const MetalRenderer = struct {
             data.* = .{
                 @floatFromInt(self.vp_width),
                 @floatFromInt(self.vp_height),
-                @floatFromInt(self.atlas.size),
-                @floatFromInt(self.atlas.size),
+                @floatFromInt(self.atlas.pack.size),
+                @floatFromInt(self.atlas.pack.size),
             };
         }
         // #584 ② — 탭 atlas 는 크기가 따로다 (`grow` 는 본문만 커진다). 셰이더가 UV 를 크기로
@@ -1925,8 +1925,8 @@ pub const MetalRenderer = struct {
             data.* = .{
                 @floatFromInt(self.vp_width),
                 @floatFromInt(self.vp_height),
-                @floatFromInt(self.tab_atlas.size),
-                @floatFromInt(self.tab_atlas.size),
+                @floatFromInt(self.tab_atlas.pack.size),
+                @floatFromInt(self.tab_atlas.pack.size),
             };
         }
     }
@@ -1935,15 +1935,15 @@ pub const MetalRenderer = struct {
     /// `syncAtlasTexture` 와 같은 자리다). 픽셀 좌표는 `grow` 가 보존하므로, 셰이더가 새
     /// 크기로 정규화하면 이미 emit 한 인스턴스의 UV 도 그대로 맞는다.
     fn syncAtlasTexture(self: *MetalRenderer, atlas: *GlyphAtlas, texture: *objc.id, texture_size: *u32) void {
-        if (atlas.size <= texture_size.*) return;
-        const new_tex = createAtlasTexture(self.device, atlas.size);
+        if (atlas.pack.size <= texture_size.*) return;
+        const new_tex = createAtlasTexture(self.device, atlas.pack.size);
         if (new_tex == null) return; // 못 만들면 옛 텍스처를 그대로 쓴다 (그림이 잘릴 수 있다)
         objc.msgSendVoid(texture.*, objc.sel("release"));
         texture.* = new_tex;
-        texture_size.* = atlas.size;
+        texture_size.* = atlas.pack.size;
         atlas.dirty = true; // 새 텍스처는 비어 있다 — 전체를 다시 올린다
         atlas.dirty_min_y = 0;
-        atlas.dirty_max_y = atlas.size;
+        atlas.dirty_max_y = atlas.pack.size;
     }
 
     /// #585 — atlas 픽셀을 텍스처로 올린다. **blit encoder 를 쓴다.**
@@ -1970,20 +1970,20 @@ pub const MetalRenderer = struct {
         if (cmd_buf == null) return;
 
         // dirty 구간만 — 줄 단위다 (`packRow` 가 줄로 채우므로 x 는 늘 전폭이 맞다).
-        const y0 = @min(atlas.dirty_min_y, atlas.size);
-        const y1 = @min(atlas.dirty_max_y, atlas.size);
+        const y0 = @min(atlas.dirty_min_y, atlas.pack.size);
+        const y1 = @min(atlas.dirty_max_y, atlas.pack.size);
         if (y1 <= y0) return;
-        const row_bytes: usize = @as(usize, atlas.size) * 4;
+        const row_bytes: usize = @as(usize, atlas.pack.size) * 4;
         const rows: usize = y1 - y0;
         const bytes = rows * row_bytes;
 
         // staging 이 작으면 키운다 (`grow` 뒤).
-        if (staging_bytes.* < atlas.size * atlas.size * 4) {
-            const new_buf = createBuffer(self.device, atlas.size * atlas.size * 4);
+        if (staging_bytes.* < atlas.pack.size * atlas.pack.size * 4) {
+            const new_buf = createBuffer(self.device, atlas.pack.size * atlas.pack.size * 4);
             if (new_buf == null) return;
             objc.msgSendVoid(staging.*, objc.sel("release"));
             staging.* = new_buf;
-            staging_bytes.* = atlas.size * atlas.size * 4;
+            staging_bytes.* = atlas.pack.size * atlas.pack.size * 4;
         }
 
         const dst = objc.msgSend(staging.*, objc.sel("contents")) orelse return;
@@ -2015,7 +2015,7 @@ pub const MetalRenderer = struct {
             0,
             row_bytes,
             bytes,
-            MTLSize{ .w = atlas.size, .h = rows, .d = 1 },
+            MTLSize{ .w = atlas.pack.size, .h = rows, .d = 1 },
             texture,
             0,
             0,
@@ -2024,7 +2024,7 @@ pub const MetalRenderer = struct {
         objc.msgSendVoid(blit, objc.sel("endEncoding"));
 
         // 올린 구간은 깨끗해졌다.
-        atlas.dirty_min_y = atlas.size;
+        atlas.dirty_min_y = atlas.pack.size;
         atlas.dirty_max_y = 0;
     }
 

--- a/src/renderer/macos/glyph_atlas.zig
+++ b/src/renderer/macos/glyph_atlas.zig
@@ -19,12 +19,12 @@ const atlas_common = @import("../glyph_atlas_common.zig");
 const log = @import("../../log.zig");
 
 /// atlas 텍스처의 **처음** 한 변 (px). 차면 `grow` 가 두 배로 키운다 (#584 ②).
-pub const INITIAL_ATLAS_SIZE: u32 = 2048;
+pub const INITIAL_ATLAS_SIZE: u32 = atlas_common.INITIAL_ATLAS_SIZE;
 
 /// 키울 수 있는 상한. Metal 의 텍스처 상한은 기종에 따라 16384 이지만, 8192² 는 이미
 /// **256 MB** (BGRA8) 라 그 위로 가면 메모리가 화면 이득을 넘는다. 여기 닿으면 더 키우지
 /// 않고 ① 안전망 (찬 것을 표시하고 호출자가 flush → 비우기 → 재시도) 으로 물러선다.
-pub const MAX_ATLAS_SIZE: u32 = 8192;
+pub const MAX_ATLAS_SIZE: u32 = atlas_common.MAX_ATLAS_SIZE;
 
 // #282 G5 — AtlasEntry / GlyphKey / packing 은 Windows atlas 와 공통(라인 동일).
 pub const AtlasEntry = atlas_common.AtlasEntry;
@@ -45,14 +45,8 @@ pub const GlyphAtlas = struct {
     /// **프레임 중간에 비우는 상황 자체가 없어지기** 때문이다. 이미 emit 한 인스턴스의 UV 가
     /// 무효화될 일이 없다.
     ///
-    /// 셰이더는 이 값을 `atlas_w` · `atlas_h` uniform 으로 받아 UV 를 정규화하므로, 크기가
-    /// 바뀌면 renderer 가 그 uniform 과 Metal 텍스처를 함께 갱신해야 한다.
-    size: u32 = INITIAL_ATLAS_SIZE,
-
-    // 단순 row-based packing 상태.
-    cursor_x: u32 = 0,
-    cursor_y: u32 = 0,
-    row_height: u32 = 0,
+    /// #604 — 패킹 상태 + 지금 크기 (`size`). 세 platform 공통 (`atlas_common.Packer`).
+    pack: atlas_common.Packer = .{},
 
     // 라스터 시 사용할 폰트 메트릭.
     font_size: f32,
@@ -214,7 +208,7 @@ pub const GlyphAtlas = struct {
         const pos = self.packOrMarkFull(size, size, "icon") orelse return null;
         const atlas_x = pos[0];
         const atlas_y = pos[1];
-        const atlas_row_bytes = self.size * 4;
+        const atlas_row_bytes = self.pack.size * 4;
         for (0..size) |row| {
             const src_off = row * bytes_per_row;
             const dst_off = (atlas_y + @as(u32, @intCast(row))) * atlas_row_bytes + atlas_x * 4;
@@ -243,9 +237,7 @@ pub const GlyphAtlas = struct {
         self.cache.clearRetainingCapacity();
         // cluster 맵도 함께 비운다 — 빠뜨리면 폰트 · scale 이 바뀐 뒤 죽은 좌표가 남는다.
         self.cluster_cache.clearRetainingCapacity();
-        self.cursor_x = 0;
-        self.cursor_y = 0;
-        self.row_height = 0;
+        self.pack.rewind();
         self.is_full = false;
         // #584 — **픽셀을 0 으로 밀지 않는다.** 예전에는 `@memset(self.pixels, 0)` 을 했는데,
         // 이 atlas 는 프레임 시작에 한 번만 업로드되므로 (2-frame 정책) 비운 직후의 0 이 다음
@@ -253,7 +245,7 @@ pub const GlyphAtlas = struct {
         // 그 위를 덮어쓴다 — 아무도 참조하지 않는 옛 픽셀이 남는 것은 무해하다.
         self.dirty = true;
         self.dirty_min_y = 0;
-        self.dirty_max_y = self.size;
+        self.dirty_max_y = self.pack.size;
     }
 
     /// cluster 키에 실린 **서로 다른 폰트 id 수**. 진단 전용 (`resetFull` 에서만 부른다).
@@ -290,7 +282,7 @@ pub const GlyphAtlas = struct {
         self.resets += 1;
         const kind = self.full_kind;
         // `reset` 전에 읽는다 — 그 값이 이 atlas 가 실제로 담을 수 있었던 양이다.
-        log.logAtlasFull(kind, self.resets, self.cache.count(), self.cluster_cache.count(), self.distinctClusterFonts(), self.cursor_y + self.row_height);
+        log.logAtlasFull(kind, self.resets, self.cache.count(), self.cluster_cache.count(), self.distinctClusterFonts(), self.pack.filledY());
         self.reset();
     }
 
@@ -443,7 +435,7 @@ pub const GlyphAtlas = struct {
         const pos = self.packOrMarkFull(gw, gh, "cluster") orelse return null;
         const atlas_x = pos[0];
         const atlas_y = pos[1];
-        const atlas_row_bytes = self.size * 4;
+        const atlas_row_bytes = self.pack.size * 4;
         for (0..gh) |row| {
             const src_off = row * bytes_per_row;
             const dst_off = (atlas_y + @as(u32, @intCast(row))) * atlas_row_bytes + atlas_x * 4;
@@ -581,7 +573,7 @@ pub const GlyphAtlas = struct {
         // BGRA temp_buf (4 bytes per pixel) 를 atlas (BGRA8) 로 row 단위 복사.
         const atlas_x = pos[0];
         const atlas_y = pos[1];
-        const atlas_row_bytes = self.size * 4;
+        const atlas_row_bytes = self.pack.size * 4;
         for (0..gh) |row| {
             const src_off = row * bytes_per_row;
             const dst_off = (atlas_y + @as(u32, @intCast(row))) * atlas_row_bytes + atlas_x * 4;
@@ -606,10 +598,6 @@ pub const GlyphAtlas = struct {
     }
 
     /// #282 G5 — 공통 row-based packing 에 위임.
-    fn packGlyph(self: *GlyphAtlas, w: u32, h: u32) ?[2]u32 {
-        return atlas_common.packRow(&self.cursor_x, &self.cursor_y, &self.row_height, self.size, w, h);
-    }
-
     /// #584 ② — atlas 를 **두 배로 키운다.** ghostty 가 쓰는 방식이다 (`font.Atlas.grow`).
     ///
     /// **비우고 재사용하는 것보다 나은 이유.** 비우면 이미 emit 한 인스턴스의 UV 가 무효가
@@ -624,46 +612,41 @@ pub const GlyphAtlas = struct {
     ///
     /// 상한 (`MAX_ATLAS_SIZE`) 에 닿으면 `false` 를 돌려준다 — 호출자는 ① 안전망으로 물러선다.
     pub fn grow(self: *GlyphAtlas) bool {
-        if (self.size >= MAX_ATLAS_SIZE) return false;
-        const new_size = self.size * 2;
+        const new_size = self.pack.grownSize(MAX_ATLAS_SIZE) orelse return false;
         const new_pixels = self.alloc.alloc(u8, @as(usize, new_size) * new_size * 4) catch return false;
         @memset(new_pixels, 0);
 
         // 옛 내용을 같은 좌표로 복사한다 — row stride 만 달라진다.
-        const old_row = @as(usize, self.size) * 4;
+        const old_row = @as(usize, self.pack.size) * 4;
         const new_row = @as(usize, new_size) * 4;
-        for (0..self.size) |y| {
+        for (0..self.pack.size) |y| {
             @memcpy(new_pixels[y * new_row ..][0..old_row], self.pixels[y * old_row ..][0..old_row]);
         }
 
         self.alloc.free(self.pixels);
         self.pixels = new_pixels;
-        self.size = new_size;
+        self.pack.size = new_size;
         self.grows += 1;
         // 전체를 다시 올려야 한다 — 텍스처가 새로 만들어진다.
         self.dirty = true;
         self.dirty_min_y = 0;
         self.dirty_max_y = new_size;
-        log.logAtlasGrew(new_size, self.grows, self.cache.count(), self.cluster_cache.count());
+        log.logAtlasGrew("main", new_size, self.grows, self.cache.count(), self.cluster_cache.count());
         return true;
     }
 
-    /// 자리를 잡고, 못 잡으면 **비울 가치가 있을 때만** `is_full` 을 세운다 (#584 ①).
-    ///
-    /// 규칙 둘이 Linux 판 (`gl_atlas.upload`) 과 같다.
-    ///
-    /// 1. **판정은 호출 *전* 값으로 한다.** `packRow` 는 실패할 때도 커서를 움직인다 (줄바꿈
-    ///    분기가 높이 검사보다 앞이다). 실패 후 값을 보면 "빈 atlas 였는지" 를 알 수 없다.
-    /// 2. **이미 빈 atlas 인데 안 들어가면 세우지 않는다.** 그림 하나가 atlas 보다 크다는
-    ///    뜻이라 비워도 소용없고, 세우면 호출자가 글리프마다 헛되게 flush + reset 을 돈다.
+    /// 자리를 잡고, 못 잡으면 **비울 가치가 있을 때만** `is_full` 을 세운다 (#584 ①). 두 조건은 공통
+    /// `Packer.tryPack` 에 있다 (#604 — 세 platform 이 같은 규칙).
     fn packOrMarkFull(self: *GlyphAtlas, w: u32, h: u32, kind: []const u8) ?[2]u32 {
-        const was_empty = self.cursor_x == 0 and self.cursor_y == 0 and self.row_height == 0;
-        if (self.packGlyph(w, h)) |pos| return pos;
-        if (!was_empty) {
-            self.is_full = true;
-            self.full_kind = kind;
+        switch (self.pack.tryPack(w, h)) {
+            .placed => |pos| return pos,
+            .full => {
+                self.is_full = true;
+                self.full_kind = kind;
+                return null;
+            },
+            .too_big => return null,
         }
-        return null;
     }
 };
 

--- a/src/renderer/windows.zig
+++ b/src/renderer/windows.zig
@@ -2145,7 +2145,7 @@ pub const D3d11Renderer = struct {
         self.ctx.OMSetRenderTargets(1, &rtvs, null);
 
         // Update constant buffer — 본문 atlas 크기로. text draw 는 자기 atlas 크기로 다시 쓴다 (`writeConstants`).
-        self.writeConstants(self.atlas.size);
+        self.writeConstants(self.atlas.pack.size);
 
         // Bind constant buffer to both VS and PS
         const cbs = [1]?*d3d.ID3D11Buffer{self.cb};
@@ -2222,7 +2222,7 @@ pub const D3d11Renderer = struct {
     fn drawTextInstancesWithAtlas(self: *D3d11Renderer, instances: []const TextInstance, atlas: *const GlyphAtlas) void {
         if (instances.len == 0) return;
         // #586 — 이 atlas 의 크기로 UV 를 정규화한다 (`grow` 뒤 본문과 탭 atlas 크기가 갈린다).
-        self.writeConstants(atlas.size);
+        self.writeConstants(atlas.pack.size);
 
         // Upload instance data
         var mapped: d3d.D3D11_MAPPED_SUBRESOURCE = .{};

--- a/src/renderer/windows/glyph_atlas.zig
+++ b/src/renderer/windows/glyph_atlas.zig
@@ -28,8 +28,8 @@ const atlas_common = @import("../glyph_atlas_common.zig");
 /// 키운다** (`grow`) 그리고 상한에서만 ① 안전망 (비우기) 으로 물러선다. 지금 크기는 `size` 필드다.
 /// 8192² 는 BGRA8 로 256 MB 다 (`BIND_RENDER_TARGET` 까지 붙는다) — 실제 상한은 `CreateTexture2D` 가
 /// 실패하는 지점이고, 그러면 `grow` 가 `false` 를 돌려 ① 로 간다 (feature level 은 조회하지 않는다).
-pub const INITIAL_ATLAS_SIZE: u32 = 2048;
-pub const MAX_ATLAS_SIZE: u32 = 8192;
+pub const INITIAL_ATLAS_SIZE: u32 = atlas_common.INITIAL_ATLAS_SIZE;
+pub const MAX_ATLAS_SIZE: u32 = atlas_common.MAX_ATLAS_SIZE;
 
 /// cluster 하나가 가질 수 있는 글리프 수 — shaping 쪽 상한과 같은 값을 쓴다.
 const MAX_CLUSTER_GLYPHS = dwrite_font.MAX_CLUSTER_GLYPHS;
@@ -56,12 +56,8 @@ pub const GlyphAtlas = struct {
     cache: std.AutoHashMap(GlyphKey, AtlasEntry),
     cluster_cache: std.AutoHashMap(ClusterKey, AtlasEntry),
 
-    // Atlas packing state (simple row-based)
-    cursor_x: u32 = 0,
-    cursor_y: u32 = 0,
-    row_height: u32 = 0,
-    /// #586 — 지금 한 변. `grow` 가 두 배로 키운다.
-    size: u32 = INITIAL_ATLAS_SIZE,
+    /// #604 — 패킹 상태 + 지금 크기 (`size`). 세 platform 공통 (`atlas_common.Packer`).
+    pack: atlas_common.Packer = .{},
     /// #586 — 키운 횟수 (진단).
     grows: u32 = 0,
 
@@ -355,11 +351,10 @@ pub const GlyphAtlas = struct {
     ///
     /// 상한 (`MAX_ATLAS_SIZE`) 이거나 텍스처 생성이 실패하면 `false` — 호출자가 ① 안전망으로 물러선다.
     pub fn grow(self: *GlyphAtlas) bool {
-        if (self.size >= MAX_ATLAS_SIZE) return false;
-        const new_size = self.size * 2;
+        const new_size = self.pack.grownSize(MAX_ATLAS_SIZE) orelse return false;
         const gpu = createGpu(self.d3d_device, new_size, self.d2d_factory, self.rendering_params, self.pixels_per_dip) catch return false;
 
-        const box = d3d.D3D11_BOX{ .left = 0, .top = 0, .right = self.size, .bottom = self.size };
+        const box = d3d.D3D11_BOX{ .left = 0, .top = 0, .right = self.pack.size, .bottom = self.pack.size };
         self.d3d_ctx.CopySubresourceRegion(@ptrCast(gpu.texture), 0, 0, 0, 0, @ptrCast(self.texture), 0, &box);
 
         // 옛 객체는 command list 가 참조를 들고 있어 지연 파괴는 드라이버가 처리한다.
@@ -371,10 +366,10 @@ pub const GlyphAtlas = struct {
         self.atlas_dc = gpu.dc;
         self.atlas_dc4 = gpu.dc4;
         self.atlas_brush = gpu.brush;
-        self.size = new_size;
+        self.pack.size = new_size;
         self.grows += 1;
         self.is_full = false;
-        log.logAtlasGrew(new_size, self.grows, self.cache.count(), self.cluster_cache.count());
+        log.logAtlasGrew("main", new_size, self.grows, self.cache.count(), self.cluster_cache.count());
         return true;
     }
 
@@ -685,13 +680,11 @@ pub const GlyphAtlas = struct {
             self.cache.count(),
             self.cluster_cache.count(),
             self.distinctClusterFonts(),
-            self.cursor_y + self.row_height,
+            self.pack.filledY(),
         );
         self.cache.clearRetainingCapacity();
         self.cluster_cache.clearRetainingCapacity();
-        self.cursor_x = 0;
-        self.cursor_y = 0;
-        self.row_height = 0;
+        self.pack.rewind();
         self.is_full = false;
     }
 
@@ -1083,24 +1076,17 @@ pub const GlyphAtlas = struct {
         };
     }
 
-    /// #282 G5 — 공통 row-based packing 에 위임.
-    fn packGlyph(self: *GlyphAtlas, w: u32, h: u32) ?[2]u32 {
-        return atlas_common.packRow(&self.cursor_x, &self.cursor_y, &self.row_height, self.size, w, h);
-    }
-
-    /// 자리를 잡고, 못 잡으면 **비울 가치가 있을 때만** `is_full` 을 세운다 (#586 — macOS `packOrMarkFull` ·
-    /// Linux `glAddGlyph` 와 같은 규칙, 전에는 Windows 만 이 가드가 없었다).
-    ///
-    /// 1. **판정은 호출 *전* 값으로 한다.** `packRow` 는 실패할 때도 커서를 움직인다.
-    /// 2. **이미 빈 atlas 인데 안 들어가면 세우지 않는다.** 그림 하나가 atlas 보다 크다는 뜻이라 비워도
-    ///    (키워도) 소용없고, 세우면 호출자가 글리프마다 헛되게 flush + reset 을 돈다.
+    /// 자리를 잡고, 못 잡으면 **비울 가치가 있을 때만** `is_full` 을 세운다 (#584 ①). 두 조건은 공통
+    /// `Packer.tryPack` 에 있다 (#604 — 세 platform 이 같은 규칙. #586 전에는 Windows 만 빈 atlas 가드가 없었다).
     fn packOrMarkFull(self: *GlyphAtlas, w: u32, h: u32, kind: []const u8) ?[2]u32 {
-        const was_empty = self.cursor_x == 0 and self.cursor_y == 0 and self.row_height == 0;
-        if (self.packGlyph(w, h)) |pos| return pos;
-        if (!was_empty) {
-            self.is_full = true;
-            self.full_kind = kind;
+        switch (self.pack.tryPack(w, h)) {
+            .placed => |pos| return pos,
+            .full => {
+                self.is_full = true;
+                self.full_kind = kind;
+                return null;
+            },
+            .too_big => return null,
         }
-        return null;
     }
 };


### PR DESCRIPTION
[#604](https://github.com/ensky0/tildaz/issues/604) — 세 platform 의 atlas 가 각자 들고 있던 패킹 상태 (`cursor_x` · `cursor_y` · `row_height` · `size`) · "찼음 표시" 규칙 · 크기 정책 (`INITIAL` · `MAX` · 두 배) 을 **`atlas_common.Packer`** 하나로 뽑았습니다. **동작 무변경 리팩터링**입니다.

## 무엇이 공통이 됐나

| Packer | 전에는 |
|---|---|
| `pack(w, h)` | `packRow(&cursor_x, &cursor_y, &row_height, size, w, h)` — 포인터 세 개 |
| `tryPack(w, h)` → `placed` / `full` / `too_big` | macOS · Windows `packOrMarkFull` 의 두 조건 · Linux `before_x/before_y` 판정 (세 벌) |
| `rewind` · `filledY` | `reset` 의 세 대입 · `cursor_y + row_height` (세 벌) |
| `grownSize(max)` | macOS · Windows `size >= MAX` · Linux `size * 2 > max_size` (같은 뜻 · 다른 표현) |
| `INITIAL_ATLAS_SIZE` · `MAX_ATLAS_SIZE` | 세 파일에 각각 |
| `logAtlasGrew(kind, …)` (**Q6**) | Linux 는 gray · color 중 어느 쪽인지 없어 `glyphs` 수로 유추 |

뽑지 않은 것 — 픽셀 보관 · 복사 (macOS CPU `pixels` / Windows `CopySubresourceRegion` / Linux GL shadow) 와 dirty 추적 (macOS 전용). platform 몫입니다.

## 검증 (MacBook Pro M5 Pro · macOS 26.6.2 · 서명 빌드)

| 회차 | 결과 |
|---|---|
| main `df4863e` vs 리팩터 · `many` (2,938 종 · 88×33) | **`0 / 2,251,390 px`** |
| 리팩터 `INITIAL` 512 판 vs 4096 판 · `many` | **`0 px`** · `atlas grew to 1024x1024 (main, grows=1, …)` → `2048x2048 (main, grows=2, …)` · full 0 |

`zig build check` (6 타겟) · `zig build test` (372 통과 — Packer 테스트 셋 포함) · `zig fmt --check` 통과.

**정정** — 첫 커밋은 `zig build test` 가 실패한 채 올라갔다 (체인이 결과를 막지 않았다). 실패 둘은 테스트 기대값이 틀린 것이었고 그중 하나가 잠재 결함을 드러냈다: 옛 `packRow` 는 높이만 검사해 atlas 보다 넓은 그림도 x=0 에 놓고 오른쪽으로 넘쳤다. `Packer.pack` 에 너비 가드를 넣었다 — 이 PR 의 유일한 동작 변화이고, 글리프 (≤ 256 px) 가 atlas (≥ 2048) 보다 넓을 수 없어 실사용 경로에는 닿지 않는다 (두 번째 커밋).

**Windows · Linux 실기 생략을 제안한다** (사용자 판단 대기 — 확정 전에는 머지하지 않는다) — 공통 로직은 단위 테스트와 macOS 실기로 검증됐고, 두 platform 의 변경은 `.size → .pack.size` 같은 기계적 치환과 같은 뜻의 로직 이전 (`before_x/before_y` → `isEmpty`) 이라 세 platform 네이티브 빌드 (CI `verify`) 로 충분하다고 판단했다.

Closes #604
